### PR TITLE
FIX(propal): values lost when editing HT price

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1935,7 +1935,7 @@ if (empty($reshook)) {
 			$price_base_type = $product->price_base_type;
 
 			// If base type TTc, we change pu value to define the TTC one
-			if ($price_base_type == 'TTC') {
+			if ($price_base_type == 'TTC' && !empty($pu_ttc)) {
 				$pu = $pu_ttc;
 			}
 


### PR DESCRIPTION
Following PR #36525, all values were lost if HT price was edited.

This new PR fixes that bug.