### PR TITLE
Fix #36550 - Multiline-text from substitution variables in ODT has arbitrary spaces at beginnings of some lines

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -293,6 +293,7 @@ class Odf
 			// Check if the current item is a tag or just plain text
 			if (isset($tag['text'])) {
 				$text = $this->encode_chars($tag['text'], $encode, $charset);
+				$text = preg_replace('/(\r\n|\r|\n)/i', "<text:line-break/>", $text);
 				$odtResult .= $text;
 			} elseif (isset($tag['name'])) {
 				switch ($tag['name']) {


### PR DESCRIPTION
When using the html-editor for product descriptions and extrafields, multiline text in odt documents coming from these fields has preceding spaces in some of the lines, making the text looking like not properly left aligned.

For example:
<img width="103" height="142" alt="image" src="https://github.com/user-attachments/assets/d0a0ea46-230c-4ae4-b56d-3b84bd7595a1" />


The spaces in line 1 and 3 do not exist in the original data.

Further researching into this has shown that the original text has invisible \n characters, coming from the multiline entry field of the data. In the substitution process for creating the odt, if the field is of type text, the \n are filtered out, if it is of type html, the <br> are dealt with, but the \n characters remain.

Since these are not allowed in the ODT substitution text, they get replaced in a later stage with spaces, thus showing a space for each \n.

Fix is simple, just add the same filter line that is already used for plain text fields.