### PR TITLE
Fix: Margin rounding error and division by zero

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -171,12 +171,13 @@ class FormMargin
 		}
 
 		// Prevent rounding error and division by zero
-		$marginInfos['pa_products'] = (float) price2num($marginInfos['pa_products'], 'MT');
-		$marginInfos['pv_products'] = (float) price2num($marginInfos['pv_products'], 'MT');
-		$marginInfos['pa_services'] = (float) price2num($marginInfos['pa_services'], 'MT');
-		$marginInfos['pv_services'] = (float) price2num($marginInfos['pv_services'], 'MT');
-		$marginInfos['pa_total'] = (float) price2num($marginInfos['pa_total'], 'MT');
-		$marginInfos['pv_total'] = (float) price2num($marginInfos['pv_total'], 'MT');
+		$precision = getDolGlobalInt('MAIN_MAX_DECIMALS_SHOWN', 8);
+		$marginInfos['pa_products'] = (float) price2num($marginInfos['pa_products'], $precision);
+		$marginInfos['pv_products'] = (float) price2num($marginInfos['pv_products'], $precision);
+		$marginInfos['pa_services'] = (float) price2num($marginInfos['pa_services'], $precision);
+		$marginInfos['pv_services'] = (float) price2num($marginInfos['pv_services'], $precision);
+		$marginInfos['pa_total'] = (float) price2num($marginInfos['pa_total'], $precision);
+		$marginInfos['pv_total'] = (float) price2num($marginInfos['pv_total'], $precision);
 
 		if ($marginInfos['pa_products'] > 0) {
 			$marginInfos['margin_rate_products'] = 100 * $marginInfos['margin_on_products'] / $marginInfos['pa_products'];

--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -171,12 +171,12 @@ class FormMargin
 		}
 
 		// Prevent rounding error and division by zero
-		$marginInfos['pa_products'] = (float) price2num($marginInfos['pa_products'], 'MAIN_MAX_DECIMALS_TOT');
-		$marginInfos['pv_products'] = (float) price2num($marginInfos['pv_products'], 'MAIN_MAX_DECIMALS_TOT');
-		$marginInfos['pa_services'] = (float) price2num($marginInfos['pa_services'], 'MAIN_MAX_DECIMALS_TOT');
-		$marginInfos['pv_services'] = (float) price2num($marginInfos['pv_services'], 'MAIN_MAX_DECIMALS_TOT');
-		$marginInfos['pa_total'] = (float) price2num($marginInfos['pa_total'], 'MAIN_MAX_DECIMALS_TOT');
-		$marginInfos['pv_total'] = (float) price2num($marginInfos['pv_total'], 'MAIN_MAX_DECIMALS_TOT');
+		$marginInfos['pa_products'] = (float) price2num($marginInfos['pa_products'], 'MT');
+		$marginInfos['pv_products'] = (float) price2num($marginInfos['pv_products'], 'MT');
+		$marginInfos['pa_services'] = (float) price2num($marginInfos['pa_services'], 'MT');
+		$marginInfos['pv_services'] = (float) price2num($marginInfos['pv_services'], 'MT');
+		$marginInfos['pa_total'] = (float) price2num($marginInfos['pa_total'], 'MT');
+		$marginInfos['pv_total'] = (float) price2num($marginInfos['pv_total'], 'MT');
 
 		if ($marginInfos['pa_products'] > 0) {
 			$marginInfos['margin_rate_products'] = 100 * $marginInfos['margin_on_products'] / $marginInfos['pa_products'];

--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -169,6 +169,15 @@ class FormMargin
 				}
 			}
 		}
+
+		// Prevent rounding error and division by zero
+		$marginInfos['pa_products'] = (float) price2num($marginInfos['pa_products'], 'MAIN_MAX_DECIMALS_TOT');
+		$marginInfos['pv_products'] = (float) price2num($marginInfos['pv_products'], 'MAIN_MAX_DECIMALS_TOT');
+		$marginInfos['pa_services'] = (float) price2num($marginInfos['pa_services'], 'MAIN_MAX_DECIMALS_TOT');
+		$marginInfos['pv_services'] = (float) price2num($marginInfos['pv_services'], 'MAIN_MAX_DECIMALS_TOT');
+		$marginInfos['pa_total'] = (float) price2num($marginInfos['pa_total'], 'MAIN_MAX_DECIMALS_TOT');
+		$marginInfos['pv_total'] = (float) price2num($marginInfos['pv_total'], 'MAIN_MAX_DECIMALS_TOT');
+
 		if ($marginInfos['pa_products'] > 0) {
 			$marginInfos['margin_rate_products'] = 100 * $marginInfos['margin_on_products'] / $marginInfos['pa_products'];
 		}
@@ -187,7 +196,7 @@ class FormMargin
 		//if ($marginInfos['pv_total'] < 0)
 		//	$marginInfos['total_margin'] = -1 * (abs($marginInfos['pv_total']) - $marginInfos['pa_total']);
 		//else
-			$marginInfos['total_margin'] = $marginInfos['pv_total'] - $marginInfos['pa_total'];
+		$marginInfos['total_margin'] = $marginInfos['pv_total'] - $marginInfos['pa_total'];
 		if ($marginInfos['pa_total'] > 0) {
 			$marginInfos['total_margin_rate'] = 100 * $marginInfos['total_margin'] / $marginInfos['pa_total'];
 		}


### PR DESCRIPTION
In case of margin computing for an object with down payment on it (line type 9 not a project or service and negative amount). I had a problem off quasi division by zero due to a rounding error.
  
<img width="1685" height="465" alt="image" src="https://github.com/user-attachments/assets/4fc4af7f-7a97-4b74-af09-2f7e4d3f6e0c" />

I fixed that in rounding pa and pv before testing if it was strictly superior to zero. 