### PR TITLE
FIX: Missing Product ref in Bom stats

### DIFF
--- a/htdocs/product/stats/bom.php
+++ b/htdocs/product/stats/bom.php
@@ -230,7 +230,7 @@ if ($id > 0 || !empty($ref)) {
 					$bomtmp->ref = $objp->ref;
 					$product = new Product($db);
 					if (!empty($objp->fk_product)) {
-						if (!array_key_exists($product->id, $product_cache)) {
+						if (!array_key_exists($objp->fk_product, $product_cache)) {
 							$resultFetch = $product->fetch($objp->fk_product);
 							if ($resultFetch < 0) {
 								setEventMessages($product->error, $product->errors, 'errors');


### PR DESCRIPTION
Wrong verification made to load product in product cache. 

Leading to a bad display of product in list if not in cached product

Before
<img width="1532" height="907" alt="image" src="https://github.com/user-attachments/assets/55ad6c33-d12e-4af1-b730-f174d2f7d55a" />
After
<img width="1527" height="848" alt="2025-12-05_17-26" src="https://github.com/user-attachments/assets/11c80fec-92b1-4599-ab09-769adcc832f6" />
