### PR TITLE
FIX : WebPortal dialog for objects

### DIFF
--- a/htdocs/public/webportal/css/dialog.css
+++ b/htdocs/public/webportal/css/dialog.css
@@ -1,5 +1,5 @@
 /* Dialog container */
-.dialog-full-screen article {
+:is(.dialog-full-screen,.dialog-popup) article {
 	width: 80vw;
 	max-width: 95vw;
 	height: 90vh;
@@ -16,18 +16,36 @@
 	align-content: normal;
 }
 
-.dialog-full-screen article:has(.dialog-header) {
+
+:is(.dialog-full-screen,.dialog-popup)  article:has(.dialog-header) {
 	padding: 0;
 }
 
 
-.dialog-full-screen article .dialog-body {
+:is(.dialog-full-screen,.dialog-popup) article .dialog-body {
 	display: block;
 	flex-grow: 2;
 	flex-shrink: 1;
 	flex-basis: auto;
 	align-self: auto;
 	order: 0;
+	max-width: 100%;
+	overflow: auto;
+}
+
+
+object.object-preview {
+	width: 100%;
+	height: calc(100% - 8px);
+	object-fit:scale-down;
+}
+
+object.object-preview.--show-original-size {
+	max-width: none;
+	max-height: none;
+	width: auto;
+	height: auto;
+	object-fit: unset;
 }
 
 @media (min-width: 576px) {

--- a/htdocs/public/webportal/tpl/footer.tpl.php
+++ b/htdocs/public/webportal/tpl/footer.tpl.php
@@ -108,7 +108,8 @@ if (empty($conf->browser->layout) || $conf->browser->layout != 'phone') { ?>
 		jQuery(document).ready(function () {
 			jQuery(".documentpreview").click(function () {
 				console.log("We click on preview for element with href=" + $(this).attr('href') + " mime=" + $(this).attr('mime'));
-				document_preview($(this).attr('href'), $(this).attr('mime'), '<?php print dol_escape_js($langs->transnoentities("Preview")) ?>');
+				const modalTitle = $(this).data('modal-title') || $(this).attr('title') || '<?php print dol_escape_js($langs->transnoentities("Preview")) ?>';
+				document_preview($(this).attr('href'), $(this).attr('mime'), modalTitle);
 				return false;
 			});
 		});
@@ -146,7 +147,7 @@ if (empty($conf->browser->layout) || $conf->browser->layout != 'phone') { ?>
 						<h2 class="dialog-header-title">${title}</h2>
 					</div>
 					<div class="dialog-header-action-container" >
-						<button class="dialog-header-btn dialog-close-btn btn-low-emphasis close"></button>
+						<button data-role="close-dialog" class="dialog-header-btn dialog-close-btn btn-low-emphasis close"></button>
 					</div>
 				</div>
 				<div class="dialog-body">
@@ -231,28 +232,40 @@ if (empty($conf->browser->layout) || $conf->browser->layout != 'phone') { ?>
 			}
 
 			function show_preview(mode) {
-				// TODO : rebuild dialog tpl show modal_card
-				let newElem = '<a href="#close" aria-label="Close" class="close" data-target="modalforpopup" onClick="toggleModal(event)"></a><object name="objectpreview" data="' +
-					file + '" type="' + type + '" width="' + object_width + '" height="' + object_height + '" param="noparam"></object>';
+
+				let moreButtons = '';
 				if (mode == 'image' && showOriginalSizeButton) {
-					newElem += '<footer>';
-					newElem += '<a href="#cancel" role="button" onClick="document_preview_original_size()"><?php print dol_escape_js($langs->trans("OriginalSize"), 1) ?></a>';
-					newElem += '<a href="#close" role="button" class="secondary" data-target="modalforpopup" onClick="toggleModal(event)"><?php print dol_escape_js($langs->trans("CloseWindow"), 1) ?></a>';
-					newElem += '</footer>';
+					// TODO remove PHP in js...
+					moreButtons += `
+					<button  class="dialog-header-btn btn-low-emphasis" onClick="document_preview_original_size()" ><?php print dol_escape_js($langs->trans("OriginalSize"), 1) ?></button>
+					`;
 				}
 
-				$('#modalforpopup article').css('width', width).css('height', height).html(newElem);
-				if (showOriginalSizeButton) {
-					jQuery("#modalforpopup article > object").css({
-						"max-height": "100%",
-						"width": "auto",
-						"margin-left": "auto",
-						"margin-right": "auto",
-						"display": "block"
-					});
-				}
+				let newElem = `
+					<div class="dialog-header">
+						<div class="dialog-header-title-container" >
+							<h2 class="dialog-header-title">${title}</h2>
+						</div>
+						<div class="dialog-header-action-container" >
+							<button data-role="close-dialog" class="dialog-header-btn dialog-close-btn btn-low-emphasis close"></button>
+							${moreButtons}
+						</div>
+					</div>
+					<div class="dialog-body">
+						<object class="object-preview" name="objectpreview" data="${file}" type="${type}"  width="${object_width}" height="${object_height}" param="noparam" ></object>
+					</div>
+				`;
+
+				$('#modalforpopup article').html(newElem);
 
 				let modal = document.getElementById('modalforpopup');
+
+				// Add close button handler
+				const closeBtn = modal.querySelector('.dialog-close-btn');
+				if (closeBtn) {
+					closeBtn.addEventListener('click', () => closeModal(modal));
+				}
+
 				openModal(modal);
 			}
 		}
@@ -264,7 +277,7 @@ if (empty($conf->browser->layout) || $conf->browser->layout != 'phone') { ?>
 		 */
 		function document_preview_original_size() {
 			console.log("document_preview_original_size A click on original size");
-			jQuery("#modalforpopup article > object").css({ "max-height": "none" });
+			jQuery("#modalforpopup object.object-preview").toggleClass('--show-original-size');
 		}
 	</script>
 


### PR DESCRIPTION
See #36543 

# FIX WebPortal dialog for objects :

- Fix position of dialog
- Fix inset iframe size
- fix link usage instead of btn for close button tab
- remove dialog footer for image because actualy display fail (it's hidden and scrolling needed),  but move btn in dialog header 

# WITH FIX
<img width="1915" height="961" alt="image" src="https://github.com/user-attachments/assets/d14423dd-4843-4974-80ee-602c773bcd44" />
<img width="1914" height="957" alt="image" src="https://github.com/user-attachments/assets/4a232c4f-8e4a-4030-a0ce-8475f4f2ccea" />

# WITHOUT FIX
<img width="1004" height="908" alt="image" src="https://github.com/user-attachments/assets/ebbcc2d7-af46-4052-918c-7d107084e329" />
<img width="1006" height="906" alt="image" src="https://github.com/user-attachments/assets/4f10d811-b342-484f-a964-599b2ef74092" />
<img width="883" height="916" alt="image" src="https://github.com/user-attachments/assets/3511639f-9af2-4394-b035-d8499e8f7669" />
