### PR TITLE
FIX Link member to third party - no check, no feedback 26864

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1004,15 +1004,26 @@ class Adherent extends CommonObject
 						$lthirdparty->default_lang = $this->default_lang;
 
 						$result = $lthirdparty->update($this->fk_soc, $user, 0, 1, 1, 'update'); // Use sync to 0 to avoid cyclic updates
-
 						if ($result < 0) {
-							$this->error = $lthirdparty->error;
+							if ($lthirdparty->error) {
+								$this->error = $lthirdparty->error;
+								dol_syslog(get_class($this)."::update::error=".$this->error, LOG_ERR);
+							} else {
+								$this->error = join(',', $lthirdparty->errors);
+								dol_syslog(get_class($this)."::update::errors=".$this->error, LOG_ERR);
+							}
 							$this->errors = $lthirdparty->errors;
-							dol_syslog(get_class($this)."::update ".$this->error, LOG_ERR);
+							dol_syslog(get_class($this)."::update::lthirdparty->errors=".join(',', $this->errors), LOG_ERR);
 							$error++;
 						}
 					} elseif ($result < 0) {
-						$this->error = $lthirdparty->error;
+						if ($lthirdparty->error) {
+							$this->error = $lthirdparty->error;
+							dol_syslog(get_class($this)."::update::error=".$this->error, LOG_ERR);
+						} else {
+							$this->error = join(',', $this->errors);
+							dol_syslog(get_class($this)."::update::errors=".$this->error, LOG_ERR);
+						}
 						$error++;
 					}
 				}
@@ -1335,10 +1346,11 @@ class Adherent extends CommonObject
 	/**
 	 *    Set link to a third party
 	 *
-	 *    @param     int	$thirdpartyid		Id of user to link to
+	 *    @param     int		$thirdpartyid	Id of thirdparty to link to
+	 *    @param     string		$societe		Name of thirdparty to link to
 	 *    @return    int						1=OK, -1=KO
 	 */
-	public function setThirdPartyId($thirdpartyid)
+	public function setThirdPartyId($thirdpartyid, $societe = '')
 	{
 		global $conf, $langs;
 
@@ -1346,18 +1358,24 @@ class Adherent extends CommonObject
 
 		// Remove link to third party onto any other members
 		if ($thirdpartyid > 0) {
-			$sql = "UPDATE ".MAIN_DB_PREFIX."adherent SET fk_soc = null";
+			$sql = "UPDATE ".MAIN_DB_PREFIX."adherent";
+			$sql .= " SET fk_soc = null, societe = null";
 			$sql .= " WHERE fk_soc = ".((int) $thirdpartyid);
 			$sql .= " AND entity = ".$conf->entity;
-			dol_syslog(get_class($this)."::setThirdPartyId", LOG_DEBUG);
+			dol_syslog(get_class($this)."::setThirdPartyId=".$thirdpartyid." Remove link to third party onto any other members", LOG_DEBUG);
 			$resql = $this->db->query($sql);
 		}
 
 		// Add link to third party for current member
 		$sql = "UPDATE ".MAIN_DB_PREFIX."adherent SET fk_soc = ".($thirdpartyid > 0 ? $thirdpartyid : 'null');
+		if ($thirdpartyid == 0) {
+			$sql .= ", societe = null";
+		} else {
+			$sql .= ", societe = .($societe != '' ? $societe : 'null')";
+		}
 		$sql .= " WHERE rowid = ".((int) $this->id);
 
-		dol_syslog(get_class($this)."::setThirdPartyId", LOG_DEBUG);
+		dol_syslog(get_class($this)."::setThirdPartyId=".$thirdpartyid, LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$this->db->commit();

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1004,6 +1004,7 @@ class Adherent extends CommonObject
 						$lthirdparty->default_lang = $this->default_lang;
 
 						$result = $lthirdparty->update($this->fk_soc, $user, 0, 1, 1, 'update'); // Use sync to 0 to avoid cyclic updates
+
 						if ($result < 0) {
 							if ($lthirdparty->error) {
 								$this->error = $lthirdparty->error;
@@ -1371,7 +1372,11 @@ class Adherent extends CommonObject
 		if ($thirdpartyid == 0) {
 			$sql .= ", societe = null";
 		} else {
-			$sql .= ", societe = .($societe != '' ? $societe : 'null')";
+			if (empty($societe)) {
+				$sql .= ", societe = null";
+			} else {
+				$sql .= ", societe = ".$this->db->escape($societe);
+			}
 		}
 		$sql .= " WHERE rowid = ".((int) $this->id);
 

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -364,7 +364,7 @@ class Members extends DolibarrApi
 						throw new RestException(500, 'id='.$value.' setThirdPartyIdResult='.$value.' failed with error='.$member->error);
 					}
 				} else {
-					throw new RestException(400, 'Socid has to be 0 (remove link to thirdparty) or larger than 0, and you specificied socid='.$value);
+					throw new RestException(400, 'Socid has to be 0 (remove link to thirdparty) or larger than 0, and you specified socid='.$value);
 				}
 			}
 			// Process the status separately because it must be updated using

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -321,12 +321,51 @@ class Members extends DolibarrApi
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('member', $member->id)) {
-			throw new RestException(401, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+			throw new RestException(401, 'Access to member='.$member->id.' not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
+		$newcompanyname = null;
 		foreach ($request_data as $field => $value) {
 			if ($field == 'id') {
 				continue;
+			}
+			if ($field == 'societe') {
+				throw new RestException(400, "Deprecated field societe, use company");
+			}
+			if ($field == 'company') {
+				$newcompanyname = (string) $value;
+			}
+			if ($field == 'socid') {
+				if ($value == 0) {
+					$setThirdPartyIdResult = $member->setThirdPartyId(0);
+					if (!$setThirdPartyIdResult) {
+						throw new RestException(500, 'id=0 setThirdPartyIdResult='.$value.' failed with error='.$member->error);
+					}
+					$member->societe = '';
+					$member->company = '';
+				} elseif ($value > 0) {
+					$oldsocid = (int) $member->socid;
+					if ($oldsocid > 1 and $oldsocid != $value) {
+						throw new RestException(400, 'Not allowed to change old socid='.$oldsocid.' directly, first reset with socid=0, then change to new socid='.$value);
+					}
+					$newthirdparty = new Societe($this->db);
+					$newresult = $newthirdparty->fetch($value);
+					if (!$newresult) {
+						throw new RestException(404, 'Thirdparty='.$value.' not found');
+					}
+					if (!DolibarrApi::_checkAccessToResource('societe', $value)) {
+						throw new RestException(401, 'Access to socid='.$value.' not allowed for login '.DolibarrApiAccess::$user->login);
+					}
+					if (!$newcompanyname) {
+						$newcompanyname = $newthirdparty->name;
+					}
+					$setThirdPartyIdResult = $member->setThirdPartyId($value, $newcompanyname);
+					if (!$setThirdPartyIdResult) {
+						throw new RestException(500, 'id='.$value.' setThirdPartyIdResult='.$value.' failed with error='.$member->error);
+					}
+				} else {
+					throw new RestException(400, 'Socid has to be 0 (remove link to thirdparty) or larger than 0, and you specificied socid='.$value);
+				}
 			}
 			// Process the status separately because it must be updated using
 			// the validate(), resiliate() and exclude() methods of the class Adherent.
@@ -356,6 +395,11 @@ class Members extends DolibarrApi
 				}
 				$member->$field = $value;
 			}
+		}
+
+		if ($newcompanyname) {
+			// set to either the value specified in json or to the company name found using the socid
+			$member->company = $newcompanyname;
 		}
 
 		// If there is no error, update() returns the number of affected rows


### PR DESCRIPTION
# FIX Link member to third party - no check, no feedback 26864 - BREAKING CHANGE
This PR is a partial fix of bug 26864, it only handles the API. The bug was that one could silently overwrite an existing link between memberA and a thirdpartyA by specifying a new link to thirdpartyB. This PR introduces bans direct thirdparty links when there is an existing link and instead reports back that the user has to use a 2 step process by first setting the link to 0, aka remove the link, and then introduce the new link. 

# Breaking Change
You can no longer just update socid using the API, you have to use a 2 step process by first setting it to 0, and then setting it to the new value