### PR TITLE
FIX Accountancy - No limit on chart of account to define category on account

### DIFF
--- a/htdocs/accountancy/class/accountancycategory.class.php
+++ b/htdocs/accountancy/class/accountancycategory.class.php
@@ -443,9 +443,8 @@ class AccountancyCategory // extends CommonObject
 
 		$sql = "SELECT t.rowid, t.account_number, t.label";
 		$sql .= " FROM ".$this->db->prefix()."accounting_account as t";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."accounting_system as asy ON t.fk_pcg_version = asy.pcg_version AND t.entity = ".((int) $conf->entity);
-		$sql .= " WHERE asy.rowid = ".((int) $pcgver);
-		$sql .= " AND t.fk_accounting_category = ".((int) $id);
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."accounting_system as asy ON t.fk_pcg_version = asy.pcg_version AND asy.rowid = ".((int) $pcgver);
+		$sql .= " WHERE t.fk_accounting_category = ".((int) $id);
 		$sql .= " AND t.entity = ".$conf->entity;
 
 		$this->lines_display = array();

--- a/htdocs/accountancy/class/accountancycategory.class.php
+++ b/htdocs/accountancy/class/accountancycategory.class.php
@@ -1,8 +1,8 @@
 <?php
-/* Copyright (C) 2016		Jamal Elbaz			<jamelbaz@gmail.pro>
- * Copyright (C) 2016-2017	Alexandre Spangaro	<aspangaro@open-dsi.fr>
- * Copyright (C) 2018-2024	Frédéric France     <frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2016		Jamal Elbaz				<jamelbaz@gmail.pro>
+ * Copyright (C) 2016-2025	Alexandre Spangaro		<alexandre@inovea-conseil.com>
+ * Copyright (C) 2018-2024	Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -438,9 +438,14 @@ class AccountancyCategory // extends CommonObject
 	public function display($id)
 	{
 		global $conf;
+
+		$pcgver = getDolGlobalInt('CHARTOFACCOUNTS');
+
 		$sql = "SELECT t.rowid, t.account_number, t.label";
 		$sql .= " FROM ".$this->db->prefix()."accounting_account as t";
-		$sql .= " WHERE t.fk_accounting_category = ".((int) $id);
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."accounting_system as asy ON t.fk_pcg_version = asy.pcg_version AND t.entity = ".((int) $conf->entity);
+		$sql .= " WHERE asy.rowid = ".((int) $pcgver);
+		$sql .= " AND t.fk_accounting_category = ".((int) $id);
 		$sql .= " AND t.entity = ".$conf->entity;
 
 		$this->lines_display = array();


### PR DESCRIPTION
I have two accounts define in category account in accountancy

<img width="1193" height="62" alt="Capture d’écran du 2025-12-09 06-39-26" src="https://github.com/user-attachments/assets/00e15d2c-0847-4dec-9d98-f24b6f949abb" />

I enter to see the list and the result is 12 accounts:

<img width="1555" height="846" alt="Capture d’écran du 2025-12-09 06-38-35" src="https://github.com/user-attachments/assets/e7cb54f3-2467-43c5-b11f-c03b8925e7c3" />

in my database:
<img width="1230" height="594" alt="Capture d’écran du 2025-12-09 06-38-54" src="https://github.com/user-attachments/assets/ce965a57-c856-4862-8697-54dd06b35b86" />

Need to limit the list of category display only on the chart of account defined 
