### PR TITLE
#FIX #35136 

### DIFF
--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -649,36 +649,36 @@ if ($action == 'create') {
 			$reshook = $hookmanager->executeHooks('printFieldPreListTitle', $parameters); // Note that $action and $object may have been modified by hook
 			print $hookmanager->resPrint;
 
-			print_liste_field_titre("Products", "", "p.ref", "&amp;id=".$id, "", "", $sortfield, $sortorder);
-			print_liste_field_titre("Label", "", "p.label", "&amp;id=".$id, "", "", $sortfield, $sortorder);
-			print_liste_field_titre("NumberOfUnit", "", "ps.reel", "&amp;id=".$id, "", '', $sortfield, $sortorder, 'right ');
+			print_liste_field_titre("Products", "", "p.ref", "", "&id=".$id, "", $sortfield, $sortorder);
+			print_liste_field_titre("Label", "", "p.label", "", "&id=".$id, "", $sortfield, $sortorder);
+			print_liste_field_titre("NumberOfUnit", "", "ps.reel", "", "&id=".$id, '', $sortfield, $sortorder, 'right ');
 			$totalarray['nbfield'] += 3;
 			$totalarray['pos'][$totalarray['nbfield']] = 'totalunit';
 			$totalarray['type'][$totalarray['nbfield']] = 'stock';
 
 			if (getDolGlobalString('PRODUCT_USE_UNITS')) {
-				print_liste_field_titre("Unit", "", "p.fk_unit", "&amp;id=".$id, "", 'align="left"', $sortfield, $sortorder);
+				print_liste_field_titre("Unit", "", "p.fk_unit", "", "&id=".$id, 'align="left"', $sortfield, $sortorder);
 				$totalarray['nbfield']++;
 				$totalarray['pos'][$totalarray['nbfield']] = 'units';
 				$totalarray['type'][$totalarray['nbfield']] = 'string';
 			}
 			$usercancreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_supplier_prices') : $user->hasRight('product', 'read');
 			if ($usercancreadsupplierprice) {
-				print_liste_field_titre($form->textwithpicto($langs->trans("AverageUnitPricePMPShort"), $langs->trans("AverageUnitPricePMPDesc")), "", "p.pmp", "&amp;id=".$id, "", '', $sortfield, $sortorder, 'right ');
+				print_liste_field_titre($form->textwithpicto($langs->trans("AverageUnitPricePMPShort"), $langs->trans("AverageUnitPricePMPDesc")), "", "p.pmp", "", "&id=".$id, '', $sortfield, $sortorder, 'right ');
 				$totalarray['nbfield']++;
 
-				print_liste_field_titre("EstimatedStockValueShort", "", "svalue", "&amp;id=".$id, "", '', $sortfield, $sortorder, 'right ');
+				print_liste_field_titre("EstimatedStockValueShort", "", "svalue", "", "&id=".$id, '', $sortfield, $sortorder, 'right ');
 				$totalarray['nbfield']++;
 				$totalarray['pos'][$totalarray['nbfield']] = 'totalvalue';
 				$totalarray['type'][$totalarray['nbfield']] = '';
 			}
 
 			if (!getDolGlobalString('PRODUIT_MULTIPRICES')) {
-				print_liste_field_titre("SellPriceMin", "", "p.price", "&amp;id=".$id, "", '', $sortfield, $sortorder, 'right ');
+				print_liste_field_titre("SellPriceMin", "", "p.price", "", "&id=".$id, '', $sortfield, $sortorder, 'right ');
 				$totalarray['nbfield']++;
 			}
 			if (!getDolGlobalString('PRODUIT_MULTIPRICES')) {
-				print_liste_field_titre("EstimatedStockValueSellShort", "", "", "&amp;id=".$id, "", '', $sortfield, $sortorder, 'right ');
+				print_liste_field_titre("EstimatedStockValueSellShort", "", "", "", "&id=".$id, '', $sortfield, $sortorder, 'right ');
 				$totalarray['nbfield']++;
 				$totalarray['pos'][$totalarray['nbfield']] = 'totalvaluesell';
 				$totalarray['type'][$totalarray['nbfield']] = '';


### PR DESCRIPTION
# FIX #35136

# Description:

This PR Fixes sorting links in /product/stock/card.php by correcting print_liste_field_titre arguments (passing warehouse ID to the 5th argument instead of the 4th) and replacing &amp; with & to prevent double-encoding.

# The issue

https://github.com/Dolibarr/dolibarr/issues/35136

When viewing the stock list of a specific warehouse (e.g., ?id=1) and clicking on a column header (Ref, Label, Unit, etc.) to sort the table, the user is redirected to a malformed URL. The warehouse ID was being treated as a pagination offset (begin) rather than a URL parameter, causing the context of the current warehouse to be lost (e.g., resulting in begin=%26amp%3Bid%3D1).

# The fix

 I corrected the function calls to print_liste_field_titre():
- Moved the id parameter from the 4th argument ($begin) to the correct 5th argument ($moreparam).
- Changed the parameter string from &amp;id= to &id= to ensure correct URL parameter parsing by PHP.


