### PR TITLE
fix a php fatal error in case of multicompany and no cache dir

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -59,6 +59,18 @@ class DolibarrApi
 
 		$this->db = $db;
 		$production_mode = (empty($conf->global->API_PRODUCTION_MODE) ? false : true);
+
+		if ($production_mode) {
+			// Create the directory Defaults::$cacheDirectory if it does not exists. If dir does not exists, using production_mode generates an error 500.
+			include_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+			if (!dol_is_dir(Defaults::$cacheDirectory)) {
+				dol_mkdir(Defaults::$cacheDirectory, DOL_DATA_ROOT);
+			}
+			if (getDolGlobalString('MAIN_API_DEBUG')) {
+				dol_syslog("Debug API construct::cacheDirectory=".Defaults::$cacheDirectory, LOG_DEBUG, 0, '_api');
+			}
+		}
+
 		$this->r = new Restler($production_mode, $refreshCache);
 
 		$urlwithouturlroot = preg_replace('/'.preg_quote(DOL_URL_ROOT, '/').'$/i', '', trim($dolibarr_main_url_root));

--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -149,6 +149,11 @@ $reg = array();
 preg_match('/index\.php\/([^\/]+)(.*)$/', $url, $reg);
 // .../index.php/categories?sortfield=t.rowid&sortorder=ASC
 
+//check if cache dir exists to prevent such errors
+//PHP Fatal error:  Uncaught Exception: The cache directory documents/22/api/temp should exist with write permission
+if (isModEnabled('multicompany') && !is_dir(DOL_DATA_ROOT . '/' . $conf->entity . '/api/temp')) {
+	dol_mkdir($conf->entity . '/api/temp', DOL_DATA_ROOT);
+}
 
 // When in production mode, a file api/temp/routes.php is created with the API available of current call.
 // But, if we set $refreshcache to false, so it may have only one API in the routes.php file if we make a call for one API without

--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -149,12 +149,6 @@ $reg = array();
 preg_match('/index\.php\/([^\/]+)(.*)$/', $url, $reg);
 // .../index.php/categories?sortfield=t.rowid&sortorder=ASC
 
-//check if cache dir exists to prevent such errors
-//PHP Fatal error:  Uncaught Exception: The cache directory documents/22/api/temp should exist with write permission
-if (isModEnabled('multicompany') && !is_dir(DOL_DATA_ROOT . '/' . $conf->entity . '/api/temp')) {
-	dol_mkdir($conf->entity . '/api/temp', DOL_DATA_ROOT);
-}
-
 // When in production mode, a file api/temp/routes.php is created with the API available of current call.
 // But, if we set $refreshcache to false, so it may have only one API in the routes.php file if we make a call for one API without
 // using the explorer. And when we make another call for another API, the API is not into the api/temp/routes.php and a 404 is returned.


### PR DESCRIPTION
There is a race condition on dolibarr + multicompany setup:

- create new entity via api requests
- create new user into that entity will stop with a fatal error code 500

Example:

```
[Wed Dec 10 17:20:37.518140 2025] [php:error] PHP Fatal error:  Uncaught Exception: The cache directory `/xxxx/documents/18/api/temp` should exist with write permission. in /xxxx/htdocs/includes/restler/framework/Luracast/Restler/HumanReadableCache.php:123\nStack trace:\n#0 /xxxx/htdocs/includes/restler/framework/Luracast/Restler/HumanReadableCache.php(70): Luracast\\Restler\\HumanReadableCache->throwException()\n#1 /xxxx/htdocs/includes/restler/framework/Luracast/Restler/Restler.php(1639): Luracast\\Restler\\HumanReadableCache->set()\n#2 [internal function]: Luracast\\Restler\\Restler->__destruct()\n#3 {main}\n  thrown in /xxxx/htdocs/includes/restler/framework/Luracast/Restler/HumanReadableCache.php on line 123
```
