### PR TITLE
FIX Accountancy - Verify fiscal year on last hour to enable the integration of asset entries

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -2735,9 +2735,12 @@ class BookKeeping extends CommonObject
 
 				$list = array();
 				while ($obj = $this->db->fetch_object($resql)) {
+					$date_start = $this->db->jdate($obj->date_start);
+					$date_end_base = $this->db->jdate($obj->date_end);
+					$date_end = dol_get_last_hour($date_end_base);
 					$list[] = array(
-						'date_start' => $this->db->jdate($obj->date_start),
-						'date_end' => $this->db->jdate($obj->date_end),
+						'date_start' => $date_start,
+						'date_end' => $date_end,
 					);
 				}
 				$conf->cache['active_fiscal_period_cached'] = $list;
@@ -2758,9 +2761,13 @@ class BookKeeping extends CommonObject
 
 				$list = array();
 				while ($obj = $this->db->fetch_object($resql)) {
+					$date_start = $this->db->jdate($obj->date_start);
+					$date_end_base = $this->db->jdate($obj->date_end);
+					$date_end = dol_get_last_hour($date_end_base);
+
 					$list[] = array(
-						'date_start' => $this->db->jdate($obj->date_start),
-						'date_end' => $this->db->jdate($obj->date_end),
+						'date_start' => $date_start,
+						'date_end' => $date_end,
 					);
 				}
 				$conf->cache['closed_fiscal_period_cached'] = $list;


### PR DESCRIPTION
The integration of fixed asset entries uses hours 23-59-59, not just a date, and when you search for a timestamp to see if the entry can be integrated into the current fiscal year, it responds no because 2025-12-31 00-00-00 is less than 2025-12-31 23-59-59.

Use function dol_get_last_hour() to resolve the problem.

In example, my fiscal year define on 2025-03-01 & 2025-12-31

<img width="1526" height="880" alt="Capture d’écran du 2025-12-11 05-10-33" src="https://github.com/user-attachments/assets/5396a376-962d-40a7-bc9e-71c068190c5a" />

With this fix, it's ok

---------------------------------------------
Extract from my logs added to identify the problem:

Before
<img width="984" height="517" alt="image" src="https://github.com/user-attachments/assets/c7d5a465-ac94-472d-8562-60ccc480dcd6" />

With function added:
<img width="994" height="235" alt="image" src="https://github.com/user-attachments/assets/3be6cb12-8150-48bb-9e9d-7aeb0e238e07" />


