### PR TITLE
Fix #36576 no datec when importing supplier prices from csv/xlsx

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -329,3 +329,5 @@ ALTER TABLE llx_blockedlog ADD COLUMN debuginfo mediumtext;
 ALTER TABLE llx_webhook_history ADD COLUMN trigger_code text NOT NULL;
 ALTER TABLE llx_webhook_history ADD COLUMN error_message text;
 ALTER TABLE llx_webhook_history MODIFY COLUMN url varchar(255);
+
+ALTER TABLE llx_product_fournisseur_price alter column datec set default (current_timestamp());


### PR DESCRIPTION
Fix #36576 no datec when importing supplier prices from csv/xlsx

I found a bug when importing supplier prices for a product using a CSV file: the datec field is never set, so the corresponding column remains empty in the interface.