### PR TITLE
FIX #36624 SQL syntax error when adding line to intervention

### DIFF
--- a/htdocs/fichinter/class/fichinterligne.class.php
+++ b/htdocs/fichinter/class/fichinterligne.class.php
@@ -208,7 +208,7 @@ class FichinterLigne extends CommonObjectLine
 		$sql .= " '".$this->db->idate($this->date)."',";
 		$sql .= " ".((int) $this->duration).",";
 		$sql .= ' '.((int) $rangToUse).",";
-		$sql .= " ".((int) $this->product_type);
+		$sql .= " ".((int) $this->product_type).",";
 		$sql .= " ".((int) $this->special_code);
 		$sql .= ')';
 


### PR DESCRIPTION
# FIX #36624

**Description:**

Fixed the SQL syntax error reported in issue #36624 where adding lines in intervention was impossible.

**Changes:**

- Corrected the file htdocs/fichinter/class/fichinterligne.class.php on the line 211