### PR TITLE
FIX document API third party document POST

### DIFF
--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -949,7 +949,7 @@ class Documents extends DolibarrApi
 			// Test on permissions
 			//if ($modulepart != 'ecm') {	// Here $modulepart is always != 'ecm'
 			if ($modulepart == 'societe' || $modulepart == 'company' || $modulepart == 'thirdparty') {
-				$relativefile = $tmpreldir.dol_sanitizeFileName($object->id);
+				$relativefile = $tmpreldir.dol_sanitizeFileName((string) $object->id);
 			} else {
 				$relativefile = $tmpreldir.dol_sanitizeFileName($object->ref);
 			}

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -892,7 +892,7 @@ class Documents extends DolibarrApi
 				require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 				$object = new Contact($this->db);
 				$fetchbyid = true;
-			} elseif ($modulepart == 'societe' || $modulepart == 'company' || $modulepart == 'thirdparty') {
+			} elseif ($modulepart == 'societe' || $modulepart == 'company') {
 				$modulepart = 'societe';
 				require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 				$object = new Societe($this->db);
@@ -948,7 +948,7 @@ class Documents extends DolibarrApi
 
 			// Test on permissions
 			//if ($modulepart != 'ecm') {	// Here $modulepart is always != 'ecm'
-			if ($modulepart == 'societe' || $modulepart == 'company' || $modulepart == 'thirdparty') {
+			if ($modulepart == 'societe' || $modulepart == 'company') {
 				$relativefile = $tmpreldir.dol_sanitizeFileName((string) $object->id);
 			} else {
 				$relativefile = $tmpreldir.dol_sanitizeFileName($object->ref);

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -768,7 +768,7 @@ class Documents extends DolibarrApi
 	 *
 	 * @param   string  $filename           	Name of file to create ('FA1705-0123.txt')
 	 * @param   string  $modulepart         	Name of module or area concerned by file upload ('product', 'service', 'invoice', 'proposal', 'project', 'project_task', 'supplier_invoice', 'expensereport', 'member', ...)
-	 * @param   string  $ref                	Reference of object (This will define subdir automatically and store submitted file into it)
+	 * @param   string  $ref                	Reference of object (This will define subdir automatically and store submitted file into it). For third party use object ID not name.
 	 * @param   string  $subdir       			Subdirectory (Only if $ref is not provided)
 	 * @param   string  $filecontent        	File content (string with file content. An empty file will be created if this parameter is not provided)
 	 * @param   string  $fileencoding       	File encoding (''=no encoding, 'base64'=Base 64)

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -948,7 +948,7 @@ class Documents extends DolibarrApi
 
 			// Test on permissions
 			//if ($modulepart != 'ecm') {	// Here $modulepart is always != 'ecm'
-			if ($modulepart == 'societe' || $modulepart == 'company') {
+			if ($modulepart == 'societe') {
 				$relativefile = $tmpreldir.dol_sanitizeFileName((string) $object->id);
 			} else {
 				$relativefile = $tmpreldir.dol_sanitizeFileName($object->ref);

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -892,7 +892,7 @@ class Documents extends DolibarrApi
 				require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 				$object = new Contact($this->db);
 				$fetchbyid = true;
-			} elseif ($modulepart == 'societe' || $modulepart == 'company') {
+			} elseif ($modulepart == 'societe' || $modulepart == 'company' || $modulepart == 'thirdparty') {
 				$modulepart = 'societe';
 				require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
 				$object = new Societe($this->db);
@@ -948,7 +948,11 @@ class Documents extends DolibarrApi
 
 			// Test on permissions
 			//if ($modulepart != 'ecm') {	// Here $modulepart is always != 'ecm'
-			$relativefile = $tmpreldir.dol_sanitizeFileName($object->ref);
+			if ($modulepart == 'societe' || $modulepart == 'company' || $modulepart == 'thirdparty') {
+				$relativefile = $tmpreldir.dol_sanitizeFileName($object->id);
+			} else {
+				$relativefile = $tmpreldir.dol_sanitizeFileName($object->ref);
+			}
 			$tmp = dol_check_secure_access_document($modulepart, $relativefile, $entity, DolibarrApiAccess::$user, $ref, 'write');
 			$upload_dir = $tmp['original_file']; // No dirname here, tmp['original_file'] is already the dir because dol_check_secure_access_document was called with param original_file that is only the dir
 			/*} else {


### PR DESCRIPTION
# FIX document API third party document POST
When uploading a document to third party using third party ID in `ref` request payload parameter, file gets stored in `documents/societe/NAME_OF_THIRDPARTY`

File should get stored in `documents/societe/ID_OF_THIRDPARTY`

In case of upload to third party, ref == name and might not be unique.

This PR adds a check on modulepart to determine if should use `$object->ref` or `$object->id` to determine path of document storage.

For info, it is also possible to use third party ID in payload parameter `subdir` instead of `ref` but this uploads document in a different way with a lot less metadata.
