### PR TITLE
FIX: Search all for supplier proposals via object reference

### DIFF
--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -242,6 +242,11 @@ class SupplierProposal extends CommonObject
 	 */
 	public $multicurrency_total_ttc;
 
+	public $fields = array(
+		'ref' => array('type' => 'varchar(255)', 'label' => 'Ref', 'enabled' => 1, 'visible' => 1, 'showoncombobox' => 1, 'position' => 25, 'searchall' => 1),
+		'note_public' => array('type' => 'html', 'label' => 'NotePublic', 'enabled' => 1, 'visible' => 0, 'position' => 750, 'searchall' => 1),
+	);
+
 	/**
 	 * Draft status
 	 */


### PR DESCRIPTION
# FIX Search all for supplier proposals via object reference

In commit https://github.com/Dolibarr/dolibarr/commit/6c8ae0b2a6b10bcf03c6a4b557c29f673dd73f63 the behavior of searching all functionality for supplier proposals via the list.php was changed a bit. It was provided that the supplier_proposal.class.php defines the array of $fields with the flag if a search all is allowed in this field. This short fix adds only the two fields to the list to make the function again working. Without this you cannot search after the reference via the search all functionality.