### PR TITLE
FIX: SQL error for LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5373,7 +5373,7 @@ class Facture extends CommonInvoice
 
 		if (getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED') > 0) {
 			$sql .= " ORDER BY CASE WHEN f.rowid = ".((int) GETPOST('fac_avoir'))." THEN 0 ELSE 1 END, f.ref";
-			$sql .= $this->db->order('DESC');
+			$sql .= " DESC";
 			$sql .= $this->db->plimit(getDolGlobalInt('LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED'));
 		} else {
 			$sql .= " ORDER BY f.ref";


### PR DESCRIPTION
FIX: SQL error for LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED
wrong usage of db->order function, fixed to prevent sql error if LIST_OF_QUALIFIED_INVOICES_LIMIT_DEFINED is used

