### PR TITLE
Fix: Need to check strict on default value on create action

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -177,7 +177,7 @@ if ($action == 'add' && !empty($permissiontoadd)) {
 		//var_dump($key.' '.$value.' '.$object->fields[$key]['type'].' '.$object->fields[$key]['notnull']);
 
 		$object->$key = $value;
-		if (!empty($val['notnull']) && $val['notnull'] > 0 && $object->$key == '' && isset($val['default']) && $val['default'] == '(PROV)') {
+		if (!empty($val['notnull']) && $val['notnull'] > 0 && $object->$key == '' && isset($val['default']) && $val['default'] === '(PROV)') {
 			$object->$key = '(PROV)';
 		}
 		if ($key == 'pass_crypted') {


### PR DESCRIPTION
In php7.4 we need to check strict because with default value 0 we have true on bool check instead of false in php8.0 >
