### PR TITLE
FIX - Add mapping for 'produit' to 'product' in isModEnabled function

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -385,6 +385,7 @@ define(
 		'propale' => 'propal', // Has old directory
 		'socpeople' => 'contact', // Has old directory
 		'fournisseur' => 'supplier',  // Has old directory
+		'produit' => 'product',	// Prevented boxes to display
 
 		'actioncomm' => 'agenda',  // NO module directory (public dir agenda)
 		'product_price' => 'productprice', // NO directory


### PR DESCRIPTION
This allows 'old' product related widget boxes to show up.

FIX - Convert old name 'produit' to 'product'

Some widget box code still contain the 'produit' word and would not show up in widget list nor main page.

ex.: `box_produit_alerte_stock.php`