### PR TITLE
Fix missing css rules for special inputs in WebPortal

### DIFF
--- a/htdocs/core/class/fields/pricecyfield.class.php
+++ b/htdocs/core/class/fields/pricecyfield.class.php
@@ -94,7 +94,7 @@ class PricecyField extends CommonField
 		$out = self::$form->inputType('text', $htmlName, (string) $value, $htmlName, $moreCss, $moreAttrib . $autoFocus);
 		$out .= self::$form->selectCurrency($currency, $htmlName . 'currency_id');
 
-		return $out;
+		return '<span class="form-select-price-currency-container">'.$out.'</span>';
 	}
 
 	/**

--- a/htdocs/public/webportal/css/form-input-special.css
+++ b/htdocs/public/webportal/css/form-input-special.css
@@ -1,4 +1,8 @@
 
+:root{
+	--form-input-margin-bottom : calc(var(--form-element-spacing-vertical)*3);
+}
+
 /**
  * STARS INPUT
  */
@@ -24,7 +28,7 @@
 	height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2) !important;
 }
 .select2.select2-container{
-	margin-bottom: calc(var(--form-element-spacing-vertical)*3);
+	margin-bottom: var(--form-input-margin-bottom);
 }
 .select2-selection--single .select2-selection__rendered, .select2-selection__arrow{
 	line-height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2) !important;
@@ -64,7 +68,7 @@
  * DATE
  */
 
-[class*="fieldname_options_"] input {
+[class*="fieldname_options_"] > input {
 	width: auto;
 	max-width: none;
 	box-sizing: border-box; /* pour que padding/border ne débordent pas */
@@ -76,12 +80,7 @@
 	gap: 0.25rem;
 }
 
-[class*="fieldname_options_"] span {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	line-height: 1;
-}
+
 
 [class*="fieldname_options_"] .dpInvisibleButtons{
 	display: inline-block;
@@ -98,5 +97,21 @@
 }
 
 .nowraponall:has(input:not([type=checkbox], [type=radio]), select, textarea){
-	margin-bottom: calc(var(--form-element-spacing-vertical)*3);
+	margin-bottom: var(--form-input-margin-bottom);
+}
+
+
+/**
+ * Form currency
+ */
+.form-select-price-currency-container {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
+	gap: 0.25rem;
+	margin-bottom: var(--form-input-margin-bottom);;
+}
+.form-select-price-currency-container > input {
+	text-align: right;
 }

--- a/htdocs/public/webportal/css/form-input-special.css
+++ b/htdocs/public/webportal/css/form-input-special.css
@@ -1,0 +1,80 @@
+
+/**
+ * STARS INPUT
+ */
+.star-selection {
+	font-size: 1rem;
+	cursor: pointer;
+	display: flex;
+	white-space: nowrap;
+}
+.star {
+	color: #ccc;
+	transition: color 0.4s;
+}
+.star:hover, .star.active {
+	color: var(--butactionbg);
+}
+
+/**
+ * SELECT 2
+ */
+
+.select2-container, .select2-container .selection, .select2-selection.select2-selection--single{
+	height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2) !important;
+}
+.select2.select2-container{
+	margin-bottom: calc(var(--form-element-spacing-vertical)*3);
+}
+.select2-selection__rendered, .select2-selection__arrow{
+	line-height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2) !important;
+	height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2) !important;
+}
+
+.select2-search__field[type="search"] {
+	margin-bottom: 3px;
+}
+.select2-search.select2-search--dropdown{
+	border-bottom : 1px solid rgba(0,0,0,0.1);
+}
+
+/**
+ * DATE
+ */
+
+[class*="fieldname_options_"] input {
+	width: auto;
+	max-width: none;
+	box-sizing: border-box; /* pour que padding/border ne débordent pas */
+}
+
+[class*="fieldname_options_"] .nowraponall {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+[class*="fieldname_options_"] span {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
+}
+
+[class*="fieldname_options_"] .dpInvisibleButtons{
+	display: inline-block;
+	width: auto;
+	vertical-align: baseline;
+}
+
+/**
+* Inlines forms
+ */
+
+.nowraponall :is(input:not([type=checkbox], [type=radio]), select, textarea){
+	margin-bottom: 0;
+}
+
+.nowraponall:has(input:not([type=checkbox], [type=radio]), select, textarea){
+	margin-bottom: calc(var(--form-element-spacing-vertical)*3);
+}

--- a/htdocs/public/webportal/css/form-input-special.css
+++ b/htdocs/public/webportal/css/form-input-special.css
@@ -110,7 +110,7 @@
 	justify-content: center;
 	line-height: 1;
 	gap: 0.25rem;
-	margin-bottom: var(--form-input-margin-bottom);;
+	margin-bottom: var(--form-input-margin-bottom);
 }
 .form-select-price-currency-container > input {
 	text-align: right;

--- a/htdocs/public/webportal/css/form-input-special.css
+++ b/htdocs/public/webportal/css/form-input-special.css
@@ -26,9 +26,14 @@
 .select2.select2-container{
 	margin-bottom: calc(var(--form-element-spacing-vertical)*3);
 }
-.select2-selection__rendered, .select2-selection__arrow{
+.select2-selection--single .select2-selection__rendered, .select2-selection__arrow{
 	line-height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2) !important;
 	height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 2 + var(--border-width) * 2) !important;
+}
+
+.select2-selection--multiple .select2-selection__rendered{
+	line-height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) + var(--border-width) * 2) !important;
+	height: calc(1rem * var(--line-height) + var(--form-element-spacing-vertical) * 3 + var(--border-width) * 2 ) !important;
 }
 
 .select2-search__field[type="search"] {
@@ -36,6 +41,23 @@
 }
 .select2-search.select2-search--dropdown{
 	border-bottom : 1px solid rgba(0,0,0,0.1);
+}
+
+.select2-container--default.select2-container--focus .select2-selection--multiple {
+	border :var(--border-width) solid var(--border-color) !important; /* fix select 2 to be compatible pico css */
+}
+
+.select2-container--default.select2-container--focus .select2-selection--multiple{
+	--border-color: var(--primary);
+}
+
+.select2-container .select2-selection--multiple .select2-selection__rendered {
+	display: block !important; /* fix select 2 to be compatible pico css */
+	overflow: auto;
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__choice{
+	border: 0px solid #aaa !important; /* fix select 2 to be compatible pico css */
 }
 
 /**

--- a/htdocs/public/webportal/css/style.css.php
+++ b/htdocs/public/webportal/css/style.css.php
@@ -102,6 +102,7 @@ if (empty($dolibarr_nocache)) {
 @import "card.css";
 @import "dialog.css";
 @import "btn.css";
+@import "form-input-special.css";
 /**
 This file can overwrite default pico css
  */

--- a/htdocs/webportal/class/html.formwebportal.class.php
+++ b/htdocs/webportal/class/html.formwebportal.class.php
@@ -1670,4 +1670,19 @@ class FormWebPortal extends Form
 
 		return $html;
 	}
+
+	/**
+	 *  Retourne la liste des devises, dans la langue de l'utilisateur
+	 *
+	 * @param 	string 	$selected 		Preselected currency code
+	 * @param 	string 	$htmlname 		Name of HTML select list
+	 * @param 	int	 	$mode 			0 = Add currency symbol into label, 1 = Add 3 letter iso code, 2 = Add both symbol and code
+	 * @param 	string 	$useempty 		'1'=Allow empty value
+	 * @return  string					HTML component
+	 */
+	public function selectCurrency($selected = '', $htmlname = 'currency_id', $mode = 0, $useempty = '')
+	{
+
+		return '<span class="form-select-currency-container">'.parent::selectCurrency($selected, $htmlname, $mode, $useempty).'</span>';
+	}
 }


### PR DESCRIPTION
# How to reproduce 
In module adherents add all extrafields types and go to webportal  adherents edit page

# Fix
- Fix missing input stars css
- Fix Select 2 css
- Fix Date Css
- Fix inline forms Css

# Before :
<img width="1630" height="942" alt="image" src="https://github.com/user-attachments/assets/e49787a7-017d-472f-8f19-d136ca545073" />


# The fix 
<img width="1899" height="951" alt="image" src="https://github.com/user-attachments/assets/5e653af8-1d37-4849-92ef-6d3bafd8d6b0" />
