### PR TITLE
Fix : tags were not available if product module is disabled

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -82,6 +82,7 @@ class Categorie extends CommonObject
 	 */
 	public $MAP_ID = array(
 		'product'				=> 0,
+		'service'				=> 0,
 		'supplier'				=> 1,
 		'customer'				=> 2,
 		'member'				=> 3,
@@ -159,6 +160,7 @@ class Categorie extends CommonObject
 	 */
 	public $MAP_OBJ_CLASS = array(
 		'product'				=> 'Product',
+		'service'				=> 'Product',
 		'customer'				=> 'Societe',
 		'supplier'				=> 'Fournisseur',
 		'member'				=> 'Adherent',
@@ -186,6 +188,7 @@ class Categorie extends CommonObject
 	 */
 	public static $MAP_TYPE_TITLE_AREA = array(
 		'product'				=> 'Products',
+		'service'				=> 'Services',
 		'customer'				=> 'ProspectsOrCustomers',
 		'supplier'				=> 'Suppliers',
 		'member'				=> 'Members',


### PR DESCRIPTION
If only the service module is active, we weren't able to use the tags.