### PR TITLE
NEW: UIUX|Uiux Drag & drop ordering on project referrers

### DIFF
--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -390,6 +390,22 @@ CREATE TABLE llx_expensereport_det_extrafields
 	import_key                varchar(14)
 ) ENGINE=innodb;
 
+-- Add table to store user-defined ordering of project referrers lists (propal, orders, invoices, ...).
+CREATE TABLE llx_projet_elementorder
+(
+  rowid					integer AUTO_INCREMENT PRIMARY KEY,
+  entity				integer DEFAULT 1 NOT NULL,		-- multi company id
+  fk_projet				integer NOT NULL,
+  elementtype			varchar(64) NOT NULL,
+  fk_element			integer NOT NULL,
+  rang					integer DEFAULT 0,
+  tms					timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=innodb;
+
+ALTER TABLE llx_projet_elementorder ADD UNIQUE INDEX uk_projet_elementorder (entity, fk_projet, elementtype, fk_element);
+ALTER TABLE llx_projet_elementorder ADD INDEX idx_projet_elementorder_rank (entity, fk_projet, elementtype, rang);
+ALTER TABLE llx_projet_elementorder ADD CONSTRAINT fk_projet_elementorder_fk_projet FOREIGN KEY (fk_projet) REFERENCES llx_projet (rowid);
+
 
 ALTER TABLE llx_blockedlog ADD INDEX idx_ref_object (ref_object);
 ALTER TABLE llx_blockedlog ADD CONSTRAINT fk_linktoref FOREIGN KEY (linktoref) REFERENCES llx_blockedlog(ref_object);

--- a/htdocs/install/mysql/tables/llx_projet_elementorder.key.sql
+++ b/htdocs/install/mysql/tables/llx_projet_elementorder.key.sql
@@ -1,0 +1,24 @@
+-- ============================================================================
+-- Copyright (C) 2025
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ============================================================================
+
+ALTER TABLE llx_projet_elementorder ADD UNIQUE INDEX uk_projet_elementorder (entity, fk_projet, elementtype, fk_element);
+
+ALTER TABLE llx_projet_elementorder ADD INDEX idx_projet_elementorder_rank (entity, fk_projet, elementtype, rang);
+
+ALTER TABLE llx_projet_elementorder ADD CONSTRAINT fk_projet_elementorder_fk_projet FOREIGN KEY (fk_projet) REFERENCES llx_projet (rowid);
+

--- a/htdocs/install/mysql/tables/llx_projet_elementorder.key.sql
+++ b/htdocs/install/mysql/tables/llx_projet_elementorder.key.sql
@@ -1,5 +1,5 @@
 -- ============================================================================
--- Copyright (C) 2025
+-- Copyright (C) 2025 Braito <braito4@hotmail.com>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -21,4 +21,3 @@ ALTER TABLE llx_projet_elementorder ADD UNIQUE INDEX uk_projet_elementorder (ent
 ALTER TABLE llx_projet_elementorder ADD INDEX idx_projet_elementorder_rank (entity, fk_projet, elementtype, rang);
 
 ALTER TABLE llx_projet_elementorder ADD CONSTRAINT fk_projet_elementorder_fk_projet FOREIGN KEY (fk_projet) REFERENCES llx_projet (rowid);
-

--- a/htdocs/install/mysql/tables/llx_projet_elementorder.sql
+++ b/htdocs/install/mysql/tables/llx_projet_elementorder.sql
@@ -1,0 +1,29 @@
+-- ===========================================================================
+-- Copyright (C) 2025
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ===========================================================================
+
+create table llx_projet_elementorder
+(
+  rowid					integer AUTO_INCREMENT PRIMARY KEY,
+  entity				integer DEFAULT 1 NOT NULL,		-- multi company id
+  fk_projet				integer NOT NULL,
+  elementtype			varchar(64) NOT NULL,
+  fk_element			integer NOT NULL,
+  rang					integer DEFAULT 0,
+  tms					timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+)ENGINE=innodb;
+

--- a/htdocs/install/mysql/tables/llx_projet_elementorder.sql
+++ b/htdocs/install/mysql/tables/llx_projet_elementorder.sql
@@ -1,5 +1,5 @@
 -- ===========================================================================
--- Copyright (C) 2025
+-- Copyright (C) 2025 Braito <braito4@hotmail.com>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -26,4 +26,3 @@ create table llx_projet_elementorder
   rang					integer DEFAULT 0,
   tms					timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 )ENGINE=innodb;
-

--- a/htdocs/projet/ajax/reorderreferrers.php
+++ b/htdocs/projet/ajax/reorderreferrers.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (C) 2025
+/* Copyright (C) 2025 Braito <braito4@hotmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@
  */
 
 if (!defined('NOTOKENRENEWAL')) {
-	define('NOTOKENRENEWAL', '1'); // Disable token renewal
+	define('NOTOKENRENEWAL', 1); // Disables token renewal
 }
 if (!defined('NOREQUIREMENU')) {
 	define('NOREQUIREMENU', '1');
@@ -44,14 +44,15 @@ if (!defined('CSRFCHECK_WITH_TOKEN')) {
 
 require '../../main.inc.php';
 
-$projectid = GETPOSTINT('projectid', 3);
-$elementtype = GETPOST('elementtype', 'aZ09', 3);
-$roworder = GETPOST('roworder', 'alpha', 3);
+$projectid = GETPOSTINT('projectid');
+$elementtype = GETPOST('elementtype', 'aZ09');
+$roworder = GETPOST('roworder', 'alphanohtml');
 
-top_httphead();
+top_httphead('application/json');
 
 if (empty($projectid) || empty($elementtype)) {
 	http_response_code(400);
+	print json_encode(array('result' => 'error', 'message' => 'Missing projectid/elementtype'));
 	exit;
 }
 
@@ -64,7 +65,7 @@ if (!$user->hasRight('projet', 'creer')) {
 $infotable = $db->DDLInfoTable(MAIN_DB_PREFIX.'projet_elementorder');
 if (empty($infotable)) {
 	http_response_code(409);
-	print 'Missing table '.MAIN_DB_PREFIX.'projet_elementorder';
+	print json_encode(array('result' => 'error', 'message' => 'Missing table '.MAIN_DB_PREFIX.'projet_elementorder'));
 	exit;
 }
 
@@ -92,6 +93,7 @@ $allowed = array(
 
 if (empty($allowed[$elementtype])) {
 	http_response_code(403);
+	print json_encode(array('result' => 'error', 'message' => 'Unsupported elementtype'));
 	exit;
 }
 
@@ -109,6 +111,7 @@ foreach (explode(',', (string) $roworder) as $value) {
 $ids = array_values($ids);
 
 if (empty($ids)) {
+	print json_encode(array('result' => 'ok'));
 	exit;
 }
 
@@ -120,11 +123,12 @@ $tablename = MAIN_DB_PREFIX.$elementtype;
 $sql = "SELECT ".$idfield." as rowid";
 $sql .= " FROM ".$tablename;
 $sql .= " WHERE ".$projectfield." = ".((int) $projectid);
-$sql .= " AND ".$idfield." IN (".$db->sanitize(implode(',', $ids)).")";
+$sql .= " AND ".$idfield." IN (".implode(',', $ids).")";
 
 $resql = $db->query($sql);
 if (!$resql) {
 	http_response_code(500);
+	print json_encode(array('result' => 'error', 'message' => 'Database error'));
 	exit;
 }
 
@@ -134,6 +138,7 @@ while ($obj = $db->fetch_object($resql)) {
 }
 
 if (empty($validids)) {
+	print json_encode(array('result' => 'ok'));
 	exit;
 }
 
@@ -153,6 +158,7 @@ foreach ($ids as $id) {
 	if (!$res) {
 		$db->rollback();
 		http_response_code(500);
+		print json_encode(array('result' => 'error', 'message' => 'Database error'));
 		exit;
 	}
 	$rank++;
@@ -160,3 +166,4 @@ foreach ($ids as $id) {
 
 $db->commit();
 
+print json_encode(array('result' => 'ok'));

--- a/htdocs/projet/ajax/reorderreferrers.php
+++ b/htdocs/projet/ajax/reorderreferrers.php
@@ -1,0 +1,162 @@
+<?php
+/* Copyright (C) 2025
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file        htdocs/projet/ajax/reorderreferrers.php
+ * \brief       Save user-defined ordering of project referrers list (propal, invoices, supplier orders, ...).
+ */
+
+if (!defined('NOTOKENRENEWAL')) {
+	define('NOTOKENRENEWAL', '1'); // Disable token renewal
+}
+if (!defined('NOREQUIREMENU')) {
+	define('NOREQUIREMENU', '1');
+}
+if (!defined('NOREQUIREHTML')) {
+	define('NOREQUIREHTML', '1');
+}
+if (!defined('NOREQUIREAJAX')) {
+	define('NOREQUIREAJAX', '1');
+}
+if (!defined('NOREQUIRESOC')) {
+	define('NOREQUIRESOC', '1');
+}
+if (!defined('NOREQUIRETRAN')) {
+	define('NOREQUIRETRAN', '1');
+}
+if (!defined('CSRFCHECK_WITH_TOKEN')) {
+	define('CSRFCHECK_WITH_TOKEN', '1'); // Token is required even in GET mode
+}
+
+require '../../main.inc.php';
+
+$projectid = GETPOSTINT('projectid', 3);
+$elementtype = GETPOST('elementtype', 'aZ09', 3);
+$roworder = GETPOST('roworder', 'alpha', 3);
+
+top_httphead();
+
+if (empty($projectid) || empty($elementtype)) {
+	http_response_code(400);
+	exit;
+}
+
+// Security: we change the display ordering for a project, so require write access on projects.
+if (!$user->hasRight('projet', 'creer')) {
+	httponly_accessforbidden('Not allowed');
+}
+
+// Ensure table exists (feature may be deployed before DB update).
+$infotable = $db->DDLInfoTable(MAIN_DB_PREFIX.'projet_elementorder');
+if (empty($infotable)) {
+	http_response_code(409);
+	print 'Missing table '.MAIN_DB_PREFIX.'projet_elementorder';
+	exit;
+}
+
+$allowed = array(
+	'propal' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'commande' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'facture' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'facture_rec' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'supplier_proposal' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'commande_fournisseur' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'facture_fourn' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'facture_fourn_rec' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'contrat' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'fichinter' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'expedition' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'loan' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'don' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'chargesociales' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'salary' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'payment_various' => array('projectfield' => 'fk_projet', 'idfield' => 'rowid'),
+	'entrepot' => array('projectfield' => 'fk_project', 'idfield' => 'rowid'),
+	'mrp_mo' => array('projectfield' => 'fk_project', 'idfield' => 'rowid'),
+	'stocktransfer_stocktransfer' => array('projectfield' => 'fk_project', 'idfield' => 'rowid'),
+);
+
+if (empty($allowed[$elementtype])) {
+	http_response_code(403);
+	exit;
+}
+
+$ids = array();
+foreach (explode(',', (string) $roworder) as $value) {
+	$value = trim($value);
+	if ($value === '') {
+		continue;
+	}
+	$intvalue = (int) $value;
+	if ($intvalue > 0) {
+		$ids[$intvalue] = $intvalue;
+	}
+}
+$ids = array_values($ids);
+
+if (empty($ids)) {
+	exit;
+}
+
+$projectfield = $allowed[$elementtype]['projectfield'];
+$idfield = $allowed[$elementtype]['idfield'];
+$tablename = MAIN_DB_PREFIX.$elementtype;
+
+// Keep only ids that are still linked to the project.
+$sql = "SELECT ".$idfield." as rowid";
+$sql .= " FROM ".$tablename;
+$sql .= " WHERE ".$projectfield." = ".((int) $projectid);
+$sql .= " AND ".$idfield." IN (".$db->sanitize(implode(',', $ids)).")";
+
+$resql = $db->query($sql);
+if (!$resql) {
+	http_response_code(500);
+	exit;
+}
+
+$validids = array();
+while ($obj = $db->fetch_object($resql)) {
+	$validids[(int) $obj->rowid] = (int) $obj->rowid;
+}
+
+if (empty($validids)) {
+	exit;
+}
+
+$db->begin();
+
+$rank = 1;
+foreach ($ids as $id) {
+	if (empty($validids[$id])) {
+		continue;
+	}
+
+	$sql = "INSERT INTO ".MAIN_DB_PREFIX."projet_elementorder(entity, fk_projet, elementtype, fk_element, rang)";
+	$sql .= " VALUES (".((int) $conf->entity).", ".((int) $projectid).", '".$db->escape($elementtype)."', ".((int) $id).", ".((int) $rank).")";
+	$sql .= " ON DUPLICATE KEY UPDATE rang = ".((int) $rank);
+
+	$res = $db->query($sql);
+	if (!$res) {
+		$db->rollback();
+		http_response_code(500);
+		exit;
+	}
+	$rank++;
+}
+
+$db->commit();
+

--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -888,7 +888,9 @@ class Project extends CommonObject
 		} elseif ($type == 'expensereport') {
 			$sql = "SELECT ed.rowid FROM ".MAIN_DB_PREFIX."expensereport as e, ".MAIN_DB_PREFIX."expensereport_det as ed WHERE e.rowid = ed.fk_expensereport AND e.entity IN (".getEntity('expensereport').") AND ed.fk_projet IN (".$this->db->sanitize((string) $ids).")";
 		} elseif ($type == 'project_task') {
-			$sql = "SELECT DISTINCT pt.rowid FROM ".MAIN_DB_PREFIX."projet_task as pt WHERE pt.fk_projet IN (".$this->db->sanitize((string) $ids).")";
+			// DISTINCT is not required here (rowid is unique) and may break ORDER BY on some MySQL setups.
+			$sql = "SELECT pt.rowid FROM ".MAIN_DB_PREFIX."projet_task as pt WHERE pt.fk_projet IN (".$this->db->sanitize((string) $ids).")";
+			$sql .= " ORDER BY pt.rang ASC, pt.rowid ASC";
 		} elseif ($type == 'element_time') {	// Case we want to duplicate line foreach user
 			$sql = "SELECT DISTINCT pt.rowid, ptt.fk_user FROM ".MAIN_DB_PREFIX."projet_task as pt, ".MAIN_DB_PREFIX."element_time as ptt WHERE pt.rowid = ptt.fk_element AND ptt.elementtype = 'task' AND pt.fk_projet IN (".$this->db->sanitize((string) $ids).")";
 		} elseif ($type == 'stocktransfer_stocktransfer') {
@@ -1050,6 +1052,21 @@ class Project extends CommonObject
 		$ret = $this->deleteTasks($user);
 		if ($ret < 0) {
 			$error++;
+		}
+
+		// Delete user-defined ordering of referrers (if table exists)
+		if (!$error) {
+			$infotable = $this->db->DDLInfoTable(MAIN_DB_PREFIX.'projet_elementorder');
+			if (!empty($infotable)) {
+				$sql = "DELETE FROM ".MAIN_DB_PREFIX."projet_elementorder";
+				$sql .= " WHERE entity = ".((int) $conf->entity);
+				$sql .= " AND fk_projet = ".((int) $this->id);
+				$resql = $this->db->query($sql);
+				if (!$resql) {
+					$this->errors[] = $this->db->lasterror();
+					$error++;
+				}
+			}
 		}
 
 
@@ -2071,6 +2088,30 @@ class Project extends CommonObject
 			$this->error = $this->db->lasterror();
 			return -1;
 		} else {
+			// Store a default ordering entry for project referrers list (if feature/table is available).
+			$infotable = $this->db->DDLInfoTable(MAIN_DB_PREFIX.'projet_elementorder');
+			if (!empty($infotable)) {
+				global $conf;
+
+				$sqlmax = "SELECT MAX(rang) as maxrank";
+				$sqlmax .= " FROM ".MAIN_DB_PREFIX."projet_elementorder";
+				$sqlmax .= " WHERE entity = ".((int) $conf->entity);
+				$sqlmax .= " AND fk_projet = ".((int) $this->id);
+				$sqlmax .= " AND elementtype = '".$this->db->escape($tableName)."'";
+
+				$maxrank = 0;
+				$resmax = $this->db->query($sqlmax);
+				if ($resmax) {
+					$objmax = $this->db->fetch_object($resmax);
+					$maxrank = (int) (!empty($objmax->maxrank) ? $objmax->maxrank : 0);
+				}
+
+				$sqlins = "INSERT INTO ".MAIN_DB_PREFIX."projet_elementorder(entity, fk_projet, elementtype, fk_element, rang)";
+				$sqlins .= " VALUES (".((int) $conf->entity).", ".((int) $this->id).", '".$this->db->escape($tableName)."', ".((int) $elementSelectId).", ".((int) ($maxrank + 1)).")";
+				$sqlins .= " ON DUPLICATE KEY UPDATE rang = rang";
+				$this->db->query($sqlins); // Best-effort (do not fail link action if ordering is not available)
+			}
+
 			return 1;
 		}
 	}
@@ -2104,6 +2145,18 @@ class Project extends CommonObject
 			$this->error = $this->db->lasterror();
 			return -1;
 		} else {
+			// Cleanup ordering entry (if feature/table is available).
+			$infotable = $this->db->DDLInfoTable(MAIN_DB_PREFIX.'projet_elementorder');
+			if (!empty($infotable)) {
+				global $conf;
+				$sqldel = "DELETE FROM ".MAIN_DB_PREFIX."projet_elementorder";
+				$sqldel .= " WHERE entity = ".((int) $conf->entity);
+				$sqldel .= " AND fk_projet = ".((int) $this->id);
+				$sqldel .= " AND elementtype = '".$this->db->escape($tableName)."'";
+				$sqldel .= " AND fk_element = ".((int) $elementSelectId);
+				$this->db->query($sqldel); // Best-effort
+			}
+
 			return 1;
 		}
 	}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -215,6 +215,143 @@ if (GETPOST('attribute', 'aZ09') && isset($extrafields->attributes[$object->tabl
 	$permissiontoeditextra = dol_eval($extrafields->attributes[$object->table_element]['perms'][GETPOST('attribute', 'aZ09')]);
 }
 
+/**
+ * Return true if table llx_projet_elementorder exists.
+ *
+ * @return boolean
+ */
+function isProjectElementOrderAvailable()
+{
+	global $db;
+
+	static $cached = null;
+	if ($cached === null) {
+		$cached = !empty($db->DDLInfoTable(MAIN_DB_PREFIX.'projet_elementorder'));
+	}
+
+	return (bool) $cached;
+}
+
+/**
+ * Return true if at least one ordering row exists for a project and element type.
+ *
+ * @param int    $entity
+ * @param int    $projectid
+ * @param string $elementtype
+ * @return boolean
+ */
+function hasProjectElementOrder($entity, $projectid, $elementtype)
+{
+	global $db;
+
+	static $cache = array();
+	$cachekey = ((int) $entity).'|'.((int) $projectid).'|'.$elementtype;
+	if (array_key_exists($cachekey, $cache)) {
+		return $cache[$cachekey];
+	}
+
+	$sql = "SELECT 1";
+	$sql .= " FROM ".MAIN_DB_PREFIX."projet_elementorder";
+	$sql .= " WHERE entity = ".((int) $entity);
+	$sql .= " AND fk_projet = ".((int) $projectid);
+	$sql .= " AND elementtype = '".$db->escape($elementtype)."'";
+	$sql .= $db->plimit(1);
+
+	$resql = $db->query($sql);
+	$cache[$cachekey] = ($resql && $db->num_rows($resql) > 0);
+
+	return $cache[$cachekey];
+}
+
+/**
+ * Sort an element array according to user-defined ordering table for a project.
+ *
+ * @param int                 $entity
+ * @param int                 $projectid
+ * @param string              $elementtype
+ * @param array<int,string>   $elementarray
+ * @return array<int,string>
+ */
+function sortElementArrayByProjectOrder($entity, $projectid, $elementtype, $elementarray)
+{
+	global $db;
+
+	if (!is_array($elementarray) || count($elementarray) < 2) {
+		return $elementarray;
+	}
+
+	$sql = "SELECT fk_element, rang";
+	$sql .= " FROM ".MAIN_DB_PREFIX."projet_elementorder";
+	$sql .= " WHERE entity = ".((int) $entity);
+	$sql .= " AND fk_projet = ".((int) $projectid);
+	$sql .= " AND elementtype = '".$db->escape($elementtype)."'";
+	$sql .= " ORDER BY rang ASC";
+
+	$resql = $db->query($sql);
+	if (!$resql) {
+		return $elementarray;
+	}
+
+	$rankbyid = array();
+	while ($obj = $db->fetch_object($resql)) {
+		$rankbyid[(int) $obj->fk_element] = (int) $obj->rang;
+	}
+
+	if (empty($rankbyid)) {
+		return $elementarray;
+	}
+
+	$originalindex = array();
+	foreach ($elementarray as $idx => $value) {
+		$originalindex[(string) $value] = $idx;
+	}
+
+	usort($elementarray, function ($a, $b) use ($rankbyid, $originalindex) {
+		$ida = (int) explode('_', (string) $a)[0];
+		$idb = (int) explode('_', (string) $b)[0];
+
+		$hasa = array_key_exists($ida, $rankbyid);
+		$hasb = array_key_exists($idb, $rankbyid);
+
+		if ($hasa && $hasb) {
+			$cmp = $rankbyid[$ida] <=> $rankbyid[$idb];
+			if ($cmp !== 0) {
+				return $cmp;
+			}
+		} elseif ($hasa) {
+			return -1;
+		} elseif ($hasb) {
+			return 1;
+		}
+
+		return ($originalindex[(string) $a] ?? 0) <=> ($originalindex[(string) $b] ?? 0);
+	});
+
+	return $elementarray;
+}
+
+$projectElementOrderSupported = array_flip(array(
+	'propal',
+	'commande',
+	'facture',
+	'facture_rec',
+	'supplier_proposal',
+	'commande_fournisseur',
+	'facture_fourn',
+	'facture_fourn_rec',
+	'contrat',
+	'fichinter',
+	'expedition',
+	'loan',
+	'don',
+	'chargesociales',
+	'salary',
+	'payment_various',
+	'entrepot',
+	'mrp_mo',
+	'stocktransfer_stocktransfer',
+));
+
 /*
  * Actions
  */
@@ -1171,28 +1308,6 @@ print '<br>';
 
 $total_time = 0;
 
-$projectElementOrderSupported = array_flip(array(
-	'propal',
-	'commande',
-	'facture',
-	'facture_rec',
-	'supplier_proposal',
-	'commande_fournisseur',
-	'facture_fourn',
-	'facture_fourn_rec',
-	'contrat',
-	'fichinter',
-	'expedition',
-	'loan',
-	'don',
-	'chargesociales',
-	'salary',
-	'payment_various',
-	'entrepot',
-	'mrp_mo',
-	'stocktransfer_stocktransfer',
-));
-
 // Detail
 foreach ($listofreferent as $key => $value) {
 	$parameters = array(
@@ -1244,6 +1359,10 @@ foreach ($listofreferent as $key => $value) {
 
 		$elementarray = $object->get_element_list($key, $tablename, $datefieldname, $dates, $datee, !empty($project_field) ? $project_field : 'fk_projet');
 
+		// Apply user-defined ordering for this project (if available).
+		if (isset($projectElementOrderSupported[$tablename]) && isProjectElementOrderAvailable() && $tablename !== 'projet_task' && is_array($elementarray) && count($elementarray) > 1) {
+			$elementarray = sortElementArrayByProjectOrder($conf->entity, $object->id, $tablename, $elementarray);
+		}
 
 		if (!getDolGlobalString('PROJECT_LINK_ON_OVERWIEW_DISABLED') && $idtofilterthirdparty && !in_array($tablename, $exclude_select_element)) {
 			$selectList = $formproject->select_element($tablename, $idtofilterthirdparty, 'minwidth300 minwidth75imp', -2, empty($project_field) ? 'fk_projet' : $project_field, $langs->trans("SelectElement"));
@@ -1515,7 +1634,7 @@ foreach ($listofreferent as $key => $value) {
 
 				// Move handle
 				if ($enablednd) {
-					print '<td class="linecolmove tdlineupdown center"><img src="'.DOL_URL_ROOT.'/theme/'.$conf->theme.'/img/grip.png" alt="" style="opacity:0.7;"></td>';
+					print '<td class="linecolmove tdlineupdown center"></td>';
 				}
 
 				// Remove link
@@ -1898,7 +2017,7 @@ foreach ($listofreferent as $key => $value) {
 				}
 
 				if (canApplySubtotalOn($tablename)) {
-					$breakline = '<tr class="liste_total liste_sub_total nodrop">';
+					$breakline = '<tr class="liste_total liste_sub_total nodrag nodrop">';
 					$breakline .= '<td colspan="'.($enablednd ? 3 : 2).'">';
 					$breakline .= '</td>';
 					$breakline .= '<td>';
@@ -1931,7 +2050,7 @@ foreach ($listofreferent as $key => $value) {
 				if ($enablednd) {
 					$colspan++;
 				}
-				$footerrow .= '<tr class="liste_total nodrop"><td colspan="'.$colspan.'">'.$langs->trans("Number").': '.$i.'</td>';
+				$footerrow .= '<tr class="liste_total nodrag nodrop"><td colspan="'.$colspan.'">'.$langs->trans("Number").': '.$i.'</td>';
 				if (in_array($tablename, array('projet_task'))) {
 					$footerrow .= '<td class="center">'.convertSecondToTime((int) $total_time, 'allhourmin').'</td>';
 					$footerrow .= '<td></td>';
@@ -2005,6 +2124,67 @@ foreach ($listofreferent as $key => $value) {
 		}
 		print "</table>";
 		print '</div>';
+
+		if ($enablednd) {
+			$forcereloadpage = getDolGlobalInt('MAIN_FORCE_RELOAD_PAGE');
+			$urlpost = '';
+			if ($dndmode === 'taskrang') {
+				$urlpost = DOL_URL_ROOT.'/core/ajax/row.php';
+			} elseif ($dndmode === 'projectelementorder') {
+				$urlpost = DOL_URL_ROOT.'/projet/ajax/reorderreferrers.php';
+			}
+
+			print "\n".'<script>';
+			print "\n".'$(document).ready(function(){';
+			print "\n".'	var forcereloadpage = "'.((int) $forcereloadpage).'";';
+			print "\n".'	var tagidfortablednd = "'.dol_escape_js($dndtableid).'";';
+			print "\n".'	console.log("Prepare tableDnD for #"+tagidfortablednd);';
+			print "\n".'	$("#"+tagidfortablednd+" .tdlineupdown")';
+			print "\n".'		.css("background-image", "url('.dol_escape_js(DOL_URL_ROOT.'/theme/'.$conf->theme.'/img/grip.png').')")';
+			print "\n".'		.css("background-repeat", "no-repeat")';
+			print "\n".'		.css("background-position", "center center")';
+			print "\n".'		.hover(function(){ $(this).addClass("showDragHandle"); }, function(){ $(this).removeClass("showDragHandle"); });';
+			print "\n".'	$("#"+tagidfortablednd).tableDnD({';
+			print "\n".'		onDrop: function(table, row) {';
+			print "\n".'			var page_y = jQuery(document).scrollTop();';
+			print "\n".'			$("#"+tagidfortablednd+" tr[data-element=extrafield]").attr("id", "");';
+			print "\n".'			$("#"+tagidfortablednd+" tr[data-ignoreidfordnd=1]").attr("id", "");';
+			print "\n".'			var roworder = cleanSerialize(decodeURI($("#"+tagidfortablednd).tableDnDSerialize()));';
+			print "\n".'			var token = "'.dol_escape_js(currentToken()).'";';
+
+			if ($dndmode === 'taskrang') {
+				print "\n".'			$.post("'.dol_escape_js($urlpost).'", {';
+				print "\n".'				roworder: roworder,';
+				print "\n".'				table_element_line: "projet_task",';
+				print "\n".'				fk_element: "fk_projet",';
+				print "\n".'				element_id: "'.((int) $object->id).'",';
+				print "\n".'				filepath: "",';
+				print "\n".'				token: token';
+				print "\n".'			}, function() {';
+			} else {
+				print "\n".'			$.post("'.dol_escape_js($urlpost).'", {';
+				print "\n".'				projectid: "'.((int) $object->id).'",';
+				print "\n".'				elementtype: "'.dol_escape_js($tablename).'",';
+				print "\n".'				roworder: roworder,';
+				print "\n".'				token: token';
+				print "\n".'			}, function() {';
+			}
+
+			print "\n".'				if (forcereloadpage == 1) {';
+			$redirectURL = $_SERVER['PHP_SELF'].'?'.$_SERVER['QUERY_STRING'];
+			$redirectURL = preg_replace('/(&|\\?)action=[^&#]*/', '', $redirectURL);
+			$redirectURL = preg_replace('/(&|\\?)page_y=[^&#]*/', '', $redirectURL);
+			print "\n".'					location.href = "'.dol_escape_js($redirectURL).'&page_y="+page_y;';
+			print "\n".'				}';
+			print "\n".'			});';
+			print "\n".'		},';
+			print "\n".'		onDragClass: "dragClass",';
+			print "\n".'		dragHandle: "td.tdlineupdown"';
+			print "\n".'	});';
+			print "\n".'});';
+			print "\n".'</script>'."\n";
+		}
+
 		print "<br>\n";
 	}
 }

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1397,49 +1397,55 @@ foreach ($listofreferent as $key => $value) {
 		}
 
 		if (is_array($elementarray) && count($elementarray) > 0 && $key == "order_supplier") {
-			$addform .= '<div class="inline-block valignmiddle"><a id="btnShow" class="buttonxxx marginleftonly" href="#" onClick="return false;">
-						 <span id="textBtnShow" class="valignmiddle text-plus-circle hideonsmartphone">'.$langs->trans("CanceledShown").'</span><span id="minus-circle" class="fa fa-eye valignmiddle paddingleft"></span>
+			$addform .= '<div class="inline-block valignmiddle"><a id="btnShow" class="buttonxxx marginleftonly" href="#" onClick="return false;" data-canceledarehidden="1">
+						 <span id="textBtnShow" class="valignmiddle text-plus-circle hideonsmartphone">'.$langs->trans("CanceledHidden").'</span><span id="minus-circle" class="fa fa-eye-slash valignmiddle paddingleft"></span>
 						 </a>
 						 <script>
-						 $("#btnShow").on("click", function () {
-							console.log("We click to show or hide the canceled lines");
-							var attr = $(this).attr("data-canceledarehidden");
-							if (typeof attr !== "undefined" && attr !== false) {
-								console.log("Show canceled");
-								$(".tr_canceled").show();
-								$("#textBtnShow").text("'.dol_escape_js($langs->transnoentitiesnoconv("CanceledShown")).'");
-								$("#btnShow").removeAttr("data-canceledarehidden");
-								$("#minus-circle").removeClass("fa-eye-slash").addClass("fa-eye");
-							} else {
-								console.log("Hide canceled");
-								$(".tr_canceled").hide();
-								$("#textBtnShow").text("'.dol_escape_js($langs->transnoentitiesnoconv("CanceledHidden")).'");
-								$("#btnShow").attr("data-canceledarehidden", 1);
-								$("#minus-circle").removeClass("fa-eye").addClass("fa-eye-slash");
-							}
+						 $(document).ready(function () {
+							$(".tr_canceled").hide();
+							$("#btnShow").on("click", function () {
+								console.log("We click to show or hide the canceled lines");
+								var attr = $(this).attr("data-canceledarehidden");
+								if (typeof attr !== "undefined" && attr !== false) {
+									console.log("Show canceled");
+									$(".tr_canceled").show();
+									$("#textBtnShow").text("'.dol_escape_js($langs->transnoentitiesnoconv("CanceledShown")).'");
+									$("#btnShow").removeAttr("data-canceledarehidden");
+									$("#minus-circle").removeClass("fa-eye-slash").addClass("fa-eye");
+								} else {
+									console.log("Hide canceled");
+									$(".tr_canceled").hide();
+									$("#textBtnShow").text("'.dol_escape_js($langs->transnoentitiesnoconv("CanceledHidden")).'");
+									$("#btnShow").attr("data-canceledarehidden", 1);
+									$("#minus-circle").removeClass("fa-eye").addClass("fa-eye-slash");
+								}
+							});
 						 });
 						 </script></div>';
 
-			$addform .= '<div class="inline-block valignmiddle"><a id="btnShowPaid" class="buttonxxx marginleftonly" href="#" onClick="return false;">
-						 <span id="textBtnShowPaid" class="valignmiddle text-plus-circle hideonsmartphone">'.$langs->trans("PaidShown").'</span><span id="minus-circle-paid" class="fa fa-eye valignmiddle paddingleft"></span>
+			$addform .= '<div class="inline-block valignmiddle"><a id="btnShowPaid" class="buttonxxx marginleftonly" href="#" onClick="return false;" data-paidarehidden="1">
+						 <span id="textBtnShowPaid" class="valignmiddle text-plus-circle hideonsmartphone">'.$langs->trans("PaidHidden").'</span><span id="minus-circle-paid" class="fa fa-eye-slash valignmiddle paddingleft"></span>
 						 </a>
 						 <script>
-						 $("#btnShowPaid").on("click", function () {
-							console.log("We click to show or hide the paid lines");
-							var attr = $(this).attr("data-paidarehidden");
-							if (typeof attr !== "undefined" && attr !== false) {
-								console.log("Show paid");
-								$(".tr_paid").show();
-								$("#textBtnShowPaid").text("'.dol_escape_js($langs->transnoentitiesnoconv("PaidShown")).'");
-								$("#btnShowPaid").removeAttr("data-paidarehidden");
-								$("#minus-circle-paid").removeClass("fa-eye-slash").addClass("fa-eye");
-							} else {
-								console.log("Hide paid");
-								$(".tr_paid").hide();
-								$("#textBtnShowPaid").text("'.dol_escape_js($langs->transnoentitiesnoconv("PaidHidden")).'");
-								$("#btnShowPaid").attr("data-paidarehidden", 1);
-								$("#minus-circle-paid").removeClass("fa-eye").addClass("fa-eye-slash");
-							}
+						 $(document).ready(function () {
+							$(".tr_paid").hide();
+							$("#btnShowPaid").on("click", function () {
+								console.log("We click to show or hide the paid lines");
+								var attr = $(this).attr("data-paidarehidden");
+								if (typeof attr !== "undefined" && attr !== false) {
+									console.log("Show paid");
+									$(".tr_paid").show();
+									$("#textBtnShowPaid").text("'.dol_escape_js($langs->transnoentitiesnoconv("PaidShown")).'");
+									$("#btnShowPaid").removeAttr("data-paidarehidden");
+									$("#minus-circle-paid").removeClass("fa-eye-slash").addClass("fa-eye");
+								} else {
+									console.log("Hide paid");
+									$(".tr_paid").hide();
+									$("#textBtnShowPaid").text("'.dol_escape_js($langs->transnoentitiesnoconv("PaidHidden")).'");
+									$("#btnShowPaid").attr("data-paidarehidden", 1);
+									$("#minus-circle-paid").removeClass("fa-eye").addClass("fa-eye-slash");
+								}
+							});
 						 });
 						 </script></div>';
 		}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -942,6 +942,11 @@ foreach ($listofreferent as $key => $value) {
 
 		$elementarray = $object->get_element_list($key, $tablename, $datefieldname, $dates, $datee, !empty($project_field) ? $project_field : 'fk_projet');
 
+		// Apply user-defined ordering for this project (if available and compatible with current list).
+		if (isset($projectElementOrderSupported[$tablename]) && isProjectElementOrderAvailable() && $tablename !== 'projet_task' && is_array($elementarray) && count($elementarray) > 1) {
+			$elementarray = sortElementArrayByProjectOrder($conf->entity, $object->id, $tablename, $elementarray);
+		}
+
 		if (is_array($elementarray) && count($elementarray) > 0) {
 			$total_ht = 0;
 			$total_ttc = 0;
@@ -1166,6 +1171,28 @@ print '<br>';
 
 $total_time = 0;
 
+$projectElementOrderSupported = array_flip(array(
+	'propal',
+	'commande',
+	'facture',
+	'facture_rec',
+	'supplier_proposal',
+	'commande_fournisseur',
+	'facture_fourn',
+	'facture_fourn_rec',
+	'contrat',
+	'fichinter',
+	'expedition',
+	'loan',
+	'don',
+	'chargesociales',
+	'salary',
+	'payment_various',
+	'entrepot',
+	'mrp_mo',
+	'stocktransfer_stocktransfer',
+));
+
 // Detail
 foreach ($listofreferent as $key => $value) {
 	$parameters = array(
@@ -1301,11 +1328,40 @@ foreach ($listofreferent as $key => $value) {
 		print '<a id="table_'.$tablename.'"></a>';
 		print load_fiche_titre($langs->trans($title), $addform, '');
 
+		$enablednd = false;
+		$dndtableid = '';
+		$dndmode = '';
+		if (is_array($elementarray) && count($elementarray) > 1 && $user->hasRight('projet', 'creer') && $conf->browser->layout != 'phone') {
+			if ($tablename === 'projet_task' && $key === 'project_task') {
+				$enablednd = true;
+				$dndmode = 'taskrang';
+				$dndtableid = 'tablelines_'.$tablename.'_'.$key;
+			} elseif (isset($projectElementOrderSupported[$tablename]) && isProjectElementOrderAvailable() && $tablename !== 'projet_task') {
+				$dndidsupported = true;
+				foreach ($elementarray as $tmpid) {
+					if (strpos((string) $tmpid, '_') !== false) {
+						$dndidsupported = false;
+						break;
+					}
+				}
+				if ($dndidsupported) {
+					$enablednd = true;
+					$dndmode = 'projectelementorder';
+					$dndtableid = 'tableelements_'.$tablename.'_'.$key;
+				}
+			}
+		}
+
 		print "\n".'<!-- Table for tablename = '.$tablename.' -->'."\n";
 		print '<div class="div-table-responsive">';
-		print '<table class="noborder centpercent">';
+		print '<table class="noborder centpercent"'.($enablednd ? ' id="'.$dndtableid.'"' : '').'>';
 
-		print '<tr class="liste_titre">';
+		print '<thead>';
+		print '<tr class="liste_titre nodrop">';
+		// Move column (drag and drop)
+		if ($enablednd) {
+			print '<td style="width: 24px"></td>';
+		}
 		// Remove link column
 		print '<td style="width: 24px"></td>';
 		// Ref
@@ -1378,16 +1434,19 @@ foreach ($listofreferent as $key => $value) {
 		}
 		// Status
 		if (in_array($tablename, array('projet_task'))) {
-			print '<td class="right" width="200">'.$langs->trans("ProgressDeclared").'</td>';
+		print '<td class="right" width="200">'.$langs->trans("ProgressDeclared").'</td>';
 		} else {
 			print '<td class="right" width="200">'.$langs->trans("Status").'</td>';
 		}
 		print '</tr>';
+		print '</thead>';
+		print '<tbody>';
 
 		if (is_array($elementarray) && count($elementarray) > 0) {
 			$total_ht = 0;
 			$total_ttc = 0;
 			$i = 0;
+			$footerrow = '';
 
 			$total_ht_by_third = 0;
 			$total_ttc_by_third = 0;
@@ -1397,7 +1456,9 @@ foreach ($listofreferent as $key => $value) {
 
 			if (canApplySubtotalOn($tablename)) {
 				// Sort
-				$elementarray = sortElementsByClientName($elementarray);
+				if (!(isset($projectElementOrderSupported[$tablename]) && isProjectElementOrderAvailable() && hasProjectElementOrder($conf->entity, $object->id, $tablename))) {
+					$elementarray = sortElementsByClientName($elementarray);
+				}
 			}
 
 			$num = count($elementarray);
@@ -1446,11 +1507,16 @@ foreach ($listofreferent as $key => $value) {
 				}
 
 				if ($key == "order_supplier" && ($element->status == 6 || $element->status == 7)) {
-					print '<tr class="oddeven tr_canceled">';
+					print '<tr class="oddeven'.($enablednd ? ' drag' : '').' tr_canceled"'.($enablednd ? ' id="row-'.$idofelement.'"' : '').'>';
 				} else {
-					print '<tr class="oddeven" >';
+					print '<tr class="oddeven'.($enablednd ? ' drag' : '').'"'.($enablednd ? ' id="row-'.$idofelement.'"' : '').'>';
 				}
 
+
+				// Move handle
+				if ($enablednd) {
+					print '<td class="linecolmove tdlineupdown center"><img src="'.DOL_URL_ROOT.'/theme/'.$conf->theme.'/img/grip.png" alt="" style="opacity:0.7;"></td>';
+				}
 
 				// Remove link
 				print '<td style="width: 24px">';
@@ -1832,8 +1898,8 @@ foreach ($listofreferent as $key => $value) {
 				}
 
 				if (canApplySubtotalOn($tablename)) {
-					$breakline = '<tr class="liste_total liste_sub_total">';
-					$breakline .= '<td colspan="2">';
+					$breakline = '<tr class="liste_total liste_sub_total nodrop">';
+					$breakline .= '<td colspan="'.($enablednd ? 3 : 2).'">';
 					$breakline .= '</td>';
 					$breakline .= '<td>';
 					$breakline .= '</td>';
@@ -1862,59 +1928,80 @@ foreach ($listofreferent as $key => $value) {
 				if (in_array($tablename, array('projet_task'))) {
 					$colspan = 2;
 				}
-
-				print '<tr class="liste_total"><td colspan="'.$colspan.'">'.$langs->trans("Number").': '.$i.'</td>';
+				if ($enablednd) {
+					$colspan++;
+				}
+				$footerrow .= '<tr class="liste_total nodrop"><td colspan="'.$colspan.'">'.$langs->trans("Number").': '.$i.'</td>';
 				if (in_array($tablename, array('projet_task'))) {
-					print '<td class="center">';
-					print convertSecondToTime((int) $total_time, 'allhourmin');
-					print '</td>';
-					print '<td>';
-					print '</td>';
+					$footerrow .= '<td class="center">'.convertSecondToTime((int) $total_time, 'allhourmin').'</td>';
+					$footerrow .= '<td></td>';
 				}
 				//if (empty($value['disableamount']) && ! in_array($tablename, array('projet_task'))) print '<td class="right" width="100">'.$langs->trans("TotalHT").' : '.price($total_ht).'</td>';
 				//elseif (empty($value['disableamount']) && in_array($tablename, array('projet_task'))) print '<td class="right" width="100">'.$langs->trans("Total").' : '.price($total_ht).'</td>';
 				// If fichinter add the total_duration
 				if ($tablename == 'fichinter') {
-					print '<td class="left">'.convertSecondToTime($total_duration, 'all', $conf->global->MAIN_DURATION_OF_WORKDAY).'</td>';
+					$footerrow .= '<td class="left">'.convertSecondToTime($total_duration, 'all', $conf->global->MAIN_DURATION_OF_WORKDAY).'</td>';
 				}
-				print '<td class="right">';
+				$footerrow .= '<td class="right">';
 				if (empty($value['disableamount'])) {
 					if ($key == 'loan') {
-						print $langs->trans("Total").' '.$langs->trans("LoanCapital").' : '.price($total_ttc);
+						$footerrow .= $langs->trans("Total").' '.$langs->trans("LoanCapital").' : '.price($total_ttc);
 					} elseif ($tablename != 'projet_task' || isModEnabled('salaries')) {
-						print ''.$langs->trans("TotalHT").' : '.price($total_ht);
+						$footerrow .= ''.$langs->trans("TotalHT").' : '.price($total_ht);
 					}
 				}
-				print '</td>';
+				$footerrow .= '</td>';
 				//if (empty($value['disableamount']) && ! in_array($tablename, array('projet_task'))) print '<td class="right" width="100">'.$langs->trans("TotalTTC").' : '.price($total_ttc).'</td>';
 				//elseif (empty($value['disableamount']) && in_array($tablename, array('projet_task'))) print '<td class="right" width="100"></td>';
-				print '<td class="right">';
+				$footerrow .= '<td class="right">';
 				if (empty($value['disableamount'])) {
 					if ($key == 'loan') {
-						print $langs->trans("Total").' '.$langs->trans("RemainderToPay").' : '.price($total_ttc);
+						$footerrow .= $langs->trans("Total").' '.$langs->trans("RemainderToPay").' : '.price($total_ttc);
 					} elseif ($tablename != 'projet_task' || isModEnabled('salaries')) {
-						print $langs->trans("TotalTTC").' : '.price($total_ttc);
+						$footerrow .= $langs->trans("TotalTTC").' : '.price($total_ttc);
 					}
 				}
-				print '</td>';
-				print '<td>&nbsp;</td>';
+				$footerrow .= '</td>';
+				$footerrow .= '<td>&nbsp;</td>';
 				// Because of the added Type and Description columns to Expense Reports
 				if ($tablename == 'expensereport_det') {
-					print '<td>&nbsp;</td>';
-					print '<td>&nbsp;</td>';
+					$footerrow .= '<td>&nbsp;</td>';
+					$footerrow .= '<td>&nbsp;</td>';
 				}
-				print '</tr>';
+				$footerrow .= '</tr>';
 			}
 		} else {
 			if (!is_array($elementarray)) {	// error
-				print '<tr><td>'.$elementarray.'</td></tr>';
+				$colspan = 7;
+				if ($tablename == 'fichinter') {
+					$colspan++;
+				}
+				if ($tablename == 'expensereport_det') {
+					$colspan += 2;
+				}
+				if ($enablednd) {
+					$colspan++;
+				}
+				print '<tr><td colspan="'.$colspan.'">'.$elementarray.'</td></tr>';
 			} else {
 				$colspan = 7;
 				if ($tablename == 'fichinter') {
 					$colspan++;
 				}
+				if ($tablename == 'expensereport_det') {
+					$colspan += 2;
+				}
+				if ($enablednd) {
+					$colspan++;
+				}
 				print '<tr><td colspan="'.$colspan.'"><span class="opacitymedium">'.$langs->trans("None").'</td></tr>';
 			}
+		}
+		print '</tbody>';
+		if (!empty($footerrow)) {
+			print '<tfoot>';
+			print $footerrow;
+			print '</tfoot>';
 		}
 		print "</table>";
 		print '</div>';


### PR DESCRIPTION
his PR adds drag & drop reordering on the Project “Linked elements” overview (proposals, orders, invoices, supplier documents, shipments, etc.) and on project tasks (where supported).

Introduces a new table llx_projet_elementorder to persist a per-project ordering of linked elements.
Adds an Ajax endpoint htdocs/projet/ajax/reorderreferrers.php to save the new order securely (token required).
Updates the project overview page (htdocs/projet/element.php) to:
enable tableDnD when the user has project write rights and not on phone layout,
apply the saved order when displaying linked elements,
prevent subtotal/footer/header rows from being draggable.
Adds the DB migration for the new table in htdocs/install/mysql/migration/22.0.0-23.0.0.sql.