### PR TITLE
FIX: Workflow for classify order as closed when shipping is validated or closed

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -468,7 +468,7 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 					$diff_array = array_diff_assoc($qtyordred, $qtyshipped);
 					if (count($diff_array) == 0) {
 						//No diff => mean everything is shipped
-						$ret = $order->cloture($user);
+						$ret = $order->setStatut(Commande::STATUS_CLOSED, $object->origin_id, $object->origin_type, 'ORDER_CLOSE'); // setStatus needed as closure function checks for permissions
 						if ($ret < 0) {
 							$this->setErrorsFromObject($order);
 							return $ret;


### PR DESCRIPTION
# FIX: Workflow for classify order as closed when shipping is validated or closed
With V21 this was changed the closure of the customer order was changed from setStatut to cloture. As cloture checks the permissions and setStatut nocht, this blocks the automatic workflow for cases where the user doesnt have the permission - but as this is an automatic workflow the permission of the user is not needed in my opinion.
