### PR TITLE
QUAL intervention API merged duplicate routes/methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -213,6 +213,7 @@ The following changes may create regressions for some external modules, but were
 * $conf use into "computed formulae" of etrafields is now deprecated (not yet forbidden). You can replace use of $conf->currency by the new method getCurrency() and $conf->global->xxx by getDolGlobalString('xxx').
 * $user->rights->module->perms is also deprecated. You can use $user->hasRight() instead.
 * The API endpoint /proposals/{id}/contact/{contactid}/{type}/{source} is now {id}/contact/{contactid}/{type} to match same behaviour than order and invoices.
+* The API endpoint /interventions/{id}/reopen hase been removed in favor of /interventions/{id}/settodraft
 
 
 ***** ChangeLog for 22.0.3 compared to 22.0.2 *****

--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -475,43 +475,6 @@ class Interventions extends DolibarrApi
 	}
 
 	/**
-	 * Reopen an intervention
-	 *
-	 * @since	22.0.0	Initial implementation
-	 *
-	 * @param	int		$id		Intervention ID
-	 *
-	 * @url		POST	{id}/reopen
-	 *
-	 * @return	Object
-	 *
-	 * @throws	RestException
-	 */
-	public function reopen($id)
-	{
-		if (!DolibarrApiAccess::$user->hasRight('ficheinter', 'creer')) {
-			throw new RestException(403, "Insufficiant rights");
-		}
-		$result = $this->fichinter->fetch($id);
-		if (!$result) {
-			throw new RestException(404, 'Intervention not found');
-		}
-
-		if (!DolibarrApi::_checkAccessToResource('fichinter', $this->fichinter->id)) {
-			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
-		}
-		$result = $this->fichinter->setDraft(DolibarrApiAccess::$user);
-		if ($result == 0) {
-			throw new RestException(304, 'Error nothing done. May be object is already set as draft');
-		}
-		if ($result < 0) {
-			throw new RestException(500, 'Error when closing Intervention: '.$this->fichinter->error);
-		}
-		$this->fichinter->fetchObjectLinked();
-		return $this->_cleanObjectDatas($this->fichinter);
-	}
-
-	/**
 	 * Validate an intervention
 	 *
 	 * If you get a bad value for param notrigger check, provide this in body
@@ -651,27 +614,29 @@ class Interventions extends DolibarrApi
 	}
 
 	/**
-	 * Sets an interventional as draft
+	 * Sets an intervention as draft
 	 *
-	 * @param   int $id             interventional ID
+	 * @since	23.0.0	Initial implementation
+	 *
+	 * @param	int		$id			ID of intervention
 	 *
 	 * @return	Object				Object with cleaned properties
 	 *
-	 * @url POST    {id}/settodraft
+	 * @url		POST	{id}/settodraft
 	 *
 	 * @throws RestException 304
-	 * @throws RestException 401
+	 * @throws RestException 403
 	 * @throws RestException 404
 	 * @throws RestException 500 System error
 	 */
 	public function settodraft($id)
 	{
 		if (!DolibarrApiAccess::$user->hasRight('ficheinter', 'creer')) {
-			throw new RestException(403);
+			throw new RestException(403, "Insufficiant rights");
 		}
 		$result = $this->fichinter->fetch($id);
 		if (!$result) {
-			throw new RestException(404, 'Interventional not found');
+			throw new RestException(404, 'Intervention not found');
 		}
 
 		if (!DolibarrApi::_checkAccessToResource('ficheinter', $this->fichinter->id)) {
@@ -680,17 +645,13 @@ class Interventions extends DolibarrApi
 
 		$result = $this->fichinter->setDraft(DolibarrApiAccess::$user);
 		if ($result == 0) {
-			throw new RestException(304, 'Nothing done.');
+			throw new RestException(304, 'Nothing done. . May be object is already set as draft.');
 		}
 		if ($result < 0) {
-			throw new RestException(500, 'Error : '.$this->fichinter->error);
+			throw new RestException(500, 'Error when closing intervention: '.$this->fichinter->error);
 		}
 
-		$result = $this->fichinter->fetch($id);
-		if (!$result) {
-			throw new RestException(404, 'Interventional not found');
-		}
-
+		$this->fichinter->fetchObjectLinked();
 		return $this->_cleanObjectDatas($this->fichinter);
 	}
 


### PR DESCRIPTION
# QUAL intervention API merged duplicate routes/methods
`interventions/{id}/reopen` route added with v22
`interventions/{id}/settodraft` route added with v23

Both use intervention class `setDraft` method

In order to align with other API objects preferred to keep `interventions/{id}/settodraft`

Added warning in changelog
