### PR TITLE
NEW Add condition to exclude unpaid invoices from profit

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -968,7 +968,7 @@ foreach ($listofreferent as $key => $value) {
 					if (getDolGlobalString('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS') && $element->type == Facture::TYPE_DEPOSIT) {
 						$qualifiedfortotal = false; // If hidden option to use deposits as payment (deprecated, not recommended to use this), deposits are not included
 					}
-					if (getDolGlobalString('PROJECT_ONLY_PAYED_INVOICE_ON_PROFIT') && $element->type != Facture::STATUS_CLOSED) {
+					if (getDolGlobalString('PROJECT_ONLY_PAYED_INVOICE_ON_PROFIT') && $element->status != Facture::STATUS_CLOSED) {
 						$qualifiedfortotal = false; // Only paid invoices qualify
 					}
 				}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -968,6 +968,9 @@ foreach ($listofreferent as $key => $value) {
 					if (getDolGlobalString('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS') && $element->type == Facture::TYPE_DEPOSIT) {
 						$qualifiedfortotal = false; // If hidden option to use deposits as payment (deprecated, not recommended to use this), deposits are not included
 					}
+					if (getDolGlobalString('PROJECT_ONLY_PAYED_INVOICE_ON_PROFIT') && $element->type != Facture::STATUS_CLOSED) {
+						$qualifiedfortotal = false; // Only paid invoices qualify
+					}
 				}
 				if ($key == 'propal') {
 					if ($element->status != Propal::STATUS_SIGNED && $element->status != Propal::STATUS_BILLED) {


### PR DESCRIPTION
Only qualify paid invoices to profit calculation

FIX #36692 Project profit includes
The project profit can be calculated including only paid invoices with the contant PROJECT_ONLY_PAYED_INVOICE_ON_PROFIT


