### PR TITLE
Fix - Error when producing dissassembly MO

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -391,7 +391,7 @@ if (empty($reshook)) {
 							$moline->batch = GETPOST('batchtoproduce-'.$line->id.'-'.$i);
 							$moline->role = 'produced';
 							$moline->fk_mrp_production = $line->id;
-							$moline->fk_stock_movement = $idstockmove == 0 ? null : $idstockmove;
+							$moline->fk_stock_movement = (($idstockmove == 0) ? null : $idstockmove);
 							$moline->fk_user_creat = $user->id;
 
 							$resultmoline = $moline->create($user);

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -391,7 +391,7 @@ if (empty($reshook)) {
 							$moline->batch = GETPOST('batchtoproduce-'.$line->id.'-'.$i);
 							$moline->role = 'produced';
 							$moline->fk_mrp_production = $line->id;
-							$moline->fk_stock_movement = $idstockmove;
+							$moline->fk_stock_movement = $idstockmove == 0 ? null : $idstockmove;
 							$moline->fk_user_creat = $user->id;
 
 							$resultmoline = $moline->create($user);


### PR DESCRIPTION
NEW:  Fixes producing a disassembly MO

Trying to product a disassembly MO causes the produced SQL insert statement to fail on a database constraint related to fk_stock_movement, the consume statement was successful. The consume statement was checking for a '0' and setting the value to 'null' but the produce line was not doing this check. Adding this check to fk_stock_movement fixes the error and generates the database entries
