### PR TITLE
FIX: global search, list view new search is not working

### DIFF
--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -67,12 +67,6 @@
 @phan-var-force string $sendto
 ';
 
-if (!empty($sall) || !empty($search_all)) {
-	$search_all = empty($sall) ? $search_all : $sall;
-
-	print '<input type="hidden" name="search_all" value="'.$search_all.'">';
-}
-
 if ($massaction == 'predeletedraft') {
 	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("ConfirmMassDraftDeletion"), $langs->trans("ConfirmMassDeletionQuestion", count($toselect)), "delete", null, '', 0, 200, 500, 1);
 }


### PR DESCRIPTION
FIX: global search, list view new search is not working
If you enter something in the global search with an input for example for products where no results are shown, you are in some kind of deadlock. You can enter new search values in the list view, but in the background search_all is added as hidden parameter which prevents the new search.
