### PR TITLE
fix: Fatal in WebHook Triggers ($this->errors is null in array merge)

### DIFF
--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -54,6 +54,7 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 		$this->description = "Webhook triggers.";
 		$this->version = self::VERSIONS['dev'];
 		$this->picto = 'webhook';
+		$this->errors = [];
 	}
 
 	/**


### PR DESCRIPTION

(! )  Fatal error: Uncaught TypeError: array_merge(): Argument #1 must be of  type array, null given in  /var/www/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php  on line 89
