### PR TITLE
FIX #36246 Clarify decimal precision validation error message in ../htdocs/admin/limits.php

### DIFF
--- a/htdocs/admin/limits.php
+++ b/htdocs/admin/limits.php
@@ -107,7 +107,7 @@ if ($action == 'update' && !$cancel) {
 	if (! $error && ((float) $valmainmaxdecimalsshown < $valmainmaxdecimalsunit || (float) $valmainmaxdecimalsshown < $valmainmaxdecimalstot)) {
 		$langs->load("errors");
 		$error++;
-		setEventMessages($langs->trans("ErrorValueForTooLow", dol_trunc(dol_string_nohtmltag($langs->transnoentitiesnoconv("MAIN_MAX_DECIMALS_SHOWN")), 40)), null, 'errors');
+		setEventMessages($langs->trans("ErrorMaxDecimalsShownTooLowComparedToUnitOrTotal", $valmainmaxdecimalsshown, $valmainmaxdecimalsunit, $valmainmaxdecimalstot), null, 'errors');
 		$action = 'edit';
 	}
 

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -373,6 +373,7 @@ ErrorBlockLogNeedAmountsValue=The unalterbale log object needs amounts values to
 ErrorBlockLogNeedElement=The unalterbale log object needs element type to be set
 ErrorBlockLogNeedObject=The unalterbale log object needs object to be set
 ErrorBadParameterWhenCallingCreateOfBlockedLog=Bad parameter when calling create of blocked log
+ErrorMaxDecimalsShownTooLowComparedToUnitOrTotal=Value for 'Max. decimals for prices shown on screen' (%s) must be equal to or greater than both 'Max. decimals for unit prices' (%s) and 'Max. decimals for total prices' (%s). This is required to prevent rounding inconsistencies on documents.
 
 # Warnings
 WarningParamUploadMaxFileSizeHigherThanPostMaxSize=Your PHP parameter upload_max_filesize (%s) is higher than PHP parameter post_max_size (%s). This is not a consistent setup.


### PR DESCRIPTION

# FIX #36246

**Description**

This PR improves the user experience on the Limits/Precision setup page (/admin/limits.php) by replacing a generic validation error with a clear, descriptive, and translatable message.

Currently, when a user sets a value for "Max. decimals for prices shown on screen" that is lower than the precision for unit or total prices, the system returns a generic error: ErrorValueForTooLow. This message does not explain the underlying configuration requirement, leading users to believe it is a bug. The underlying validation rule is, however, crucial for preventing rounding inconsistencies on generated documents.

This change clarifies the requirement to the user, improving usability and reducing confusion.