### PR TITLE
FIX|Fix reassort page colspan and category/tag text color when filtering

### DIFF
--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -412,7 +412,7 @@ if ($resql) {
 		print "<div id='ways'>";
 		$c = new Categorie($db);
 		$c->fetch($search_categ);
-		$ways = $c->print_all_ways(' &gt; ', 'product/reassort.php');
+		$ways = $c->print_all_ways(' &gt; ', 'product/reassort.php', 1);
 		print " &gt; ".$ways[0]."<br>\n";
 		print "</div><br>";
 	}
@@ -442,6 +442,7 @@ if ($resql) {
 	$warehouses_list = $formProduct->cache_warehouses;
 	$nb_warehouse = count($warehouses_list);
 	$colspan_warehouse = 1;
+	$colspan = 0;
 	if (getDolGlobalString('STOCK_DETAIL_ON_WAREHOUSE')) {
 		$colspan_warehouse = $nb_warehouse > 1 ? $nb_warehouse + 1 : 1;
 	}
@@ -457,40 +458,56 @@ if ($resql) {
 		$searchpicto = $form->showFilterAndCheckAddButtons(0);
 		print $searchpicto;
 		print '</td>';
+		$colspan++;
 	}
 	print '<td class="liste_titre">';
 	print '<input class="flat" type="text" name="sref" size="6" value="'.$sref.'">';
 	print '</td>';
+	$colspan++;
 	print '<td class="liste_titre">';
 	print '<input class="flat" type="text" name="snom" size="8" value="'.$snom.'">';
 	print '</td>';
+	$colspan++;
 	// Duration
 	if (isModEnabled("service") && $type == 1) {
 		print '<td class="liste_titre">';
 		print '&nbsp;';
 		print '</td>';
+		$colspan++;
 	}
 	// Stock limit
 	print '<td class="liste_titre">&nbsp;</td>';
+	$colspan++;
 	print '<td class="liste_titre right">&nbsp;</td>';
+	$colspan++;
 	// Physical stock
 	print '<td class="liste_titre right">';
 	print '<input class="flat" type="text" size="5" name="search_stock_physique" value="'.dol_escape_htmltag($search_stock_physique).'">';
 	print '</td>';
+	$colspan++;
 	if ($virtualdiffersfromphysical) {
 		print '<td class="liste_titre">&nbsp;</td>';
+		$colspan++;
 	}
 	$parameters = array();
 	$reshook = $hookmanager->executeHooks('printFieldListOption', $parameters); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
 	print '<td class="liste_titre">&nbsp;</td>';
+	$colspan++;
 	print '<td class="liste_titre" colspan="'.$colspan_warehouse.'">&nbsp;</td>';
+	$colspan++;
 	print '<td class="liste_titre"></td>';
+	$colspan++;
 	if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
 		print '<td class="liste_titre maxwidthsearch">';
 		$searchpicto = $form->showFilterAndCheckAddButtons(0);
 		print $searchpicto;
 		print '</td>';
+		$colspan++;
+	}
+	if (getDolGlobalString('PRODUCT_USE_UNITS')) {
+		print '<td class="liste_titre"></td>';
+		$colspan++;
 	}
 	print '</tr>';
 
@@ -638,7 +655,7 @@ if ($resql) {
 		$i++;
 	}
 	if ($num == 0) {
-		print '<tr><td colspan="">'.$langs->trans("None").'</td></tr>';
+		print '<tr><td colspan="'.$colspan.'"><span class="opacitymedium">'.$langs->trans("NoRecordFound").'</span></td></tr>';
 	}
 
 	print "</table>";


### PR DESCRIPTION
# FIX|Fix reassort page colspan and category/tag text color when filtering
When searching by category or tag on the reassort page, two issues occurred:

- If the search returned no rows, the table `colspan` was incorrect, causing layout issues
- Category and tag labels were forced to white text, making them unreadable depending on the theme background

This fix corrects the colspan calculation when no result rows are displayed
and removes the forced white text color for category/tag labels, allowing
theme CSS to handle colors properly and ensure readability.