### PR TITLE
# FIX - Asking Holidays When Negative Balance

### DIFF
--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -775,9 +775,9 @@ class Holiday extends CommonObject
 
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
 
-			$days = num_open_day($this->date_debut, $this->date_fin);
-			if ((($balance - $days) < 0) && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
+			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -899,10 +899,9 @@ class Holiday extends CommonObject
 
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
 
-			$days = num_public_holiday($this->date_debut, $this->date_fin);
-
-			if ((($balance - $days) < 0) && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
+			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -1029,8 +1028,9 @@ class Holiday extends CommonObject
 
 		if ($checkBalance > 0 && $this->status != self::STATUS_DRAFT) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
 
-			if ($balance < 0) {
+			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}


### PR DESCRIPTION
# FIX - Asking Holidays When Negative Balance

This PR is a discussion.

I'm coming back to this [PR #36661](https://github.com/Dolibarr/dolibarr/pull/36661) because something's not right.
This fix does not work.

We should not use num_public_holiday() to validate leave balance, because it only returns the number of non-working days (public holidays and possibly weekends depending on configuration). It does not represent the actual number of leave days consumed by the request.

To correctly enforce “balance – requested_days < 0”, we must use num_open_day():

-computes the working days consumed over the period,
-excludes weekends and public holidays,
-supports half-day adjustments,
-returns the proper value to compare against the user’s leave balance.

Using num_public_holiday() ends up comparing the balance against “N holidays” instead of “N leave days”, leading to incorrect acceptance/rejection of leave requests.


I also renamed a variable to make it clearer and add this code to the update.
