### PR TITLE
FIX : Reception::reOpen() misleading status display /missing error message when rollback 

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2406,7 +2406,7 @@ class ExpenseReport extends CommonObject
 		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element;
 		$sql .= " WHERE entity = ".((int) $conf->entity); // not shared, only for the current entity
 		$sql .= " AND fk_user_author = ".((int) $user->id);
-		$sql .= " AND NOT (date_fin < '".$this->db->idate($startDate)."' OR date_debut > '".$this->db->idate($endDate)."')";
+		$sql .= " AND (date_fin >= '".$this->db->idate($startDate)."' AND date_debut <= '".$this->db->idate($endDate)."')";
 
 		$row = $this->db->getRow($sql);
 		

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2393,52 +2393,30 @@ class ExpenseReport extends CommonObject
 	/**
 	 * periodExists
 	 *
-	 * @param   User       $fuser          User
-	 * @param   integer    $date_debut     Start date
-	 * @param   integer    $date_fin       End date
+	 * @param   User       $user          User
+	 * @param   integer    $startDate     Start date timestamp
+	 * @param   integer    $endDate       End date timestamp
 	 * @return  int                        Return integer <0 if KO, >0 if OK
 	 */
-	public function periodExists($fuser, $date_debut, $date_fin)
+	public function periodExists(User $user, $startDate, $endDate)
 	{
 		global $conf;
 
 		$sql = "SELECT rowid, date_debut, date_fin";
 		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element;
 		$sql .= " WHERE entity = ".((int) $conf->entity); // not shared, only for the current entity
-		$sql .= " AND fk_user_author = ".((int) $fuser->id);
+		$sql .= " AND fk_user_author = ".((int) $user->id);
+		$sql .= " AND NOT (date_fin < '{$this->db->idate($startDate)}' OR date_debut > '{$this->db->idate($endDate)}')";
 
-		dol_syslog(get_class($this)."::periodExists sql=".$sql);
-		$result = $this->db->query($sql);
-		if ($result) {
-			$num_rows = $this->db->num_rows($result);
-			$i = 0;
-
-			if ($num_rows > 0) {
-				$date_d_form = $date_debut;
-				$date_f_form = $date_fin;
-
-				while ($i < $num_rows) {
-					$objp = $this->db->fetch_object($result);
-
-					$date_d_req = $this->db->jdate($objp->date_debut); // 3
-					$date_f_req = $this->db->jdate($objp->date_fin); // 4
-
-					if (!($date_f_form < $date_d_req || $date_d_form > $date_f_req)) {
-						return $objp->rowid;
-					}
-
-					$i++;
-				}
-
-				return 0;
-			} else {
-				return 0;
-			}
-		} else {
+		dol_syslog(__CLASS__."::". __METHOD__." sql=".$sql);
+		$row = $this->db->getRow($sql);
+		if ($row === false) {
 			$this->error = $this->db->lasterror();
-			dol_syslog(get_class($this)."::periodExists  Error ".$this->error, LOG_ERR);
+			dol_syslog(__CLASS__."::". __METHOD__."  Error ".$this->error, LOG_ERR);
 			return -1;
 		}
+
+		return $row->rowid ?? 0;
 	}
 
 

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2393,19 +2393,19 @@ class ExpenseReport extends CommonObject
 	/**
 	 * periodExists
 	 *
-	 * @param   User       $user          User
+	 * @param   User       $fuser          User
 	 * @param   integer    $startDate     Start date timestamp
 	 * @param   integer    $endDate       End date timestamp
 	 * @return  int                        Return integer <0 if KO, >0 if OK
 	 */
-	public function periodExists(User $user, $startDate, $endDate)
+	public function periodExists(User $fuser, $startDate, $endDate)
 	{
 		global $conf;
 
 		$sql = "SELECT rowid, date_debut, date_fin";
 		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element;
 		$sql .= " WHERE entity = ".((int) $conf->entity); // not shared, only for the current entity
-		$sql .= " AND fk_user_author = ".((int) $user->id);
+		$sql .= " AND fk_user_author = ".((int) $fuser->id);
 		$sql .= " AND (date_fin >= '".$this->db->idate($startDate)."' AND date_debut <= '".$this->db->idate($endDate)."')";
 
 		$row = $this->db->getRow($sql);

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2409,7 +2409,7 @@ class ExpenseReport extends CommonObject
 		$sql .= " AND (date_fin >= '".$this->db->idate($startDate)."' AND date_debut <= '".$this->db->idate($endDate)."')";
 
 		$row = $this->db->getRow($sql);
-		
+
 		if ($row === false) {
 			$this->error = $this->db->lasterror();
 			dol_syslog(__CLASS__."::". __METHOD__."  Error ".$this->error, LOG_ERR);

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2406,10 +2406,10 @@ class ExpenseReport extends CommonObject
 		$sql .= " FROM ".MAIN_DB_PREFIX.$this->table_element;
 		$sql .= " WHERE entity = ".((int) $conf->entity); // not shared, only for the current entity
 		$sql .= " AND fk_user_author = ".((int) $user->id);
-		$sql .= " AND NOT (date_fin < '{$this->db->idate($startDate)}' OR date_debut > '{$this->db->idate($endDate)}')";
+		$sql .= " AND NOT (date_fin < '".$this->db->idate($startDate)."' OR date_debut > '".$this->db->idate($endDate)."')";
 
-		dol_syslog(__CLASS__."::". __METHOD__." sql=".$sql);
 		$row = $this->db->getRow($sql);
+		
 		if ($row === false) {
 			$this->error = $this->db->lasterror();
 			dol_syslog(__CLASS__."::". __METHOD__."  Error ".$this->error, LOG_ERR);


### PR DESCRIPTION
# Instructions
How to reproduce : 
- Set stock increase on reception close
- Create a reception containing a product with batch enabled. Set a DLC / DLUO.
- Validate and close the reception (stock movements are created)
- Go to the corresponding productlot_card, and change a date (e.g DLUO)
- Reopen the reception => reverting movement stock will fail because of the date inconsistency. No error message, and status is "Validated" on the card... (but not in db because of the rollback)
- Since the status is actually wrong on the card, the user have access to the Set to draft action. Then he can valid and close again, causing movement stocks to be recreated, screwing available quantities.  