### PR TITLE
FIX - Supplier Proposal line option

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1311,7 +1311,7 @@ if (empty($reshook)) {
 							$num = count($lines);
 
 							for ($i = 0; $i < $num; $i++) {
-								if (empty($lines[$i]->subprice) || $lines[$i]->qty <= 0 || !in_array($lines[$i]->id, $selectedLines)) {
+								if (empty($lines[$i]->subprice) || $lines[$i]->qty < 0 || !in_array($lines[$i]->id, $selectedLines)) {
 									continue;
 								}
 


### PR DESCRIPTION
# FIX - Supplier Proposal line option
If I have a supplier proposal line with an option (qty = 0) and I create an order from my card, with this check the option lines are "continue" and are not included in my order.

