### PR TITLE
FIX: Prevent default payment term/type from auto-filling list filters

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4850,7 +4850,7 @@ class Form
 		$this->load_cache_conditions_paiements();
 
 		// Set default value if not already set by caller
-		if (empty($selected) && getDolGlobalString('MAIN_DEFAULT_PAYMENT_TERM_ID')) {
+		if (empty($selected) && strpos($htmlname, 'search_') !== 0 && getDolGlobalString('MAIN_DEFAULT_PAYMENT_TERM_ID')) {
 			dol_syslog(__METHOD__ . "Using deprecated option MAIN_DEFAULT_PAYMENT_TERM_ID", LOG_NOTICE);
 			$selected = getDolGlobalString('MAIN_DEFAULT_PAYMENT_TERM_ID');
 		}
@@ -4995,7 +4995,7 @@ class Form
 		$this->load_cache_types_paiements();
 
 		// Set default value if not already set by caller
-		if (empty($selected) && getDolGlobalString('MAIN_DEFAULT_PAYMENT_TYPE_ID')) {
+		if (empty($selected) && strpos($htmlname, 'search_') !== 0 && getDolGlobalString('MAIN_DEFAULT_PAYMENT_TYPE_ID')) {
 			dol_syslog(__METHOD__ . "Using deprecated option MAIN_DEFAULT_PAYMENT_TYPE_ID", LOG_NOTICE);
 			$selected = getDolGlobalString('MAIN_DEFAULT_PAYMENT_TYPE_ID');
 		}


### PR DESCRIPTION
# FIX|Fix default payment constants auto-filling list filters

When `MAIN_DEFAULT_PAYMENT_TERM_ID` or `MAIN_DEFAULT_PAYMENT_TYPE_ID` are set, they incorrectly pre-fill filter fields in list pages (invoices, proposals, etc.) instead of only pre-filling creation/edit forms.

This fix detects filter context by checking if the HTML field name starts with `search_` prefix. When in filter context, default payment constants are not applied.

**Changes:**
- Modified `htdocs/core/class/html.form.class.php`:
  - `getSelectConditionsPaiements()`: Skip `MAIN_DEFAULT_PAYMENT_TERM_ID` for filter fields
  - `select_types_paiements()`: Skip `MAIN_DEFAULT_PAYMENT_TYPE_ID` for filter fields