### PR TITLE
FIX finished regex in product import

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -656,7 +656,6 @@ class modProduct extends DolibarrModules
 			'p.fk_product_type'=>'^[0|1]$',
 			'p.datec'=>'^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$',
 			'p.recuperableonly' => '^[0|1]$',
-			'p.finished' => '^[0|1]$'
 		);
 		// field order as per structure of table llx_product
 		$import_sample = array(


### PR DESCRIPTION
FIX finished regex in product import

**To reproduce**
When you add a product nature in dictionary :
<img width="1689" height="390" alt="image" src="https://github.com/user-attachments/assets/326502ef-f3d0-477b-bdf7-03949e6aef45" />

Then you  want to import a product using this new product nature with code is 2.
You got an error : 
<img width="1663" height="755" alt="image" src="https://github.com/user-attachments/assets/8de0a23b-78b3-4284-a7c5-c322ec8523fb" />

**The fix**
Here I removed the regex to check the code of product nature (was also removed in develop branch).

**_Notice_**
Otherwise we can also keep a regex like : "^[0-9]+$"

