### PR TITLE
FIX|Fix linked object table list text overflow

### DIFF
--- a/htdocs/asset/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/asset/tpl/linkedobjectblock.tpl.php
@@ -66,7 +66,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	}
 	echo '</td>';
 	echo '<td class="linkedcol-name tdoverflowmax150" >'.$objectlink->getNomUrl(1).'</td>';
-	echo '<td class="linkedcol-ref" align="center">'.$objectlink->label.'</td>';
+	echo '<td class="linkedcol-ref tdoverflowmax150" align="center">'.$objectlink->label.'</td>';
 	echo '<td class="linkedcol-date" align="center">'.dol_print_date($objectlink->date_start, 'day').'</td>';
 	echo '<td class="linkedcol-amount right">';
 	if ($user->hasRight('asset', 'read')) {

--- a/htdocs/bom/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/bom/tpl/linkedobjectblock.tpl.php
@@ -58,7 +58,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	echo '</td>';
 	echo '<td class="linkedcol-name tdoverflowmax150" >'.$objectlink->getNomUrl(1).'</td>';
 
-	echo '<td class="linkedcol-ref">';
+	echo '<td class="linkedcol-ref tdoverflowmax150">';
 	$result = $product_static->fetch($objectlink->fk_product);
 	if ($result < 0) {
 		setEventMessage($product_static->error, 'errors');

--- a/htdocs/comm/propal/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/comm/propal/tpl/linkedobjectblock.tpl.php
@@ -62,7 +62,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	}
 	print '</td>';
 	print '<td class="linkedcol-name tdoverflowmax150">'.$objectlink->getNomUrl(1).'</td>';
-	print '<td class="linkedcol-ref" >'.$objectlink->ref_client.'</td>';
+	print '<td class="linkedcol-ref tdoverflowmax150" >'.$objectlink->ref_client.'</td>';
 	print '<td class="linkedcol-date center">'.dol_print_date($objectlink->date, 'day').'</td>';
 	print '<td class="linkedcol-amount right">';
 	if ($user->hasRight('propal', 'lire')) {

--- a/htdocs/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/commande/tpl/linkedobjectblock.tpl.php
@@ -55,7 +55,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	}
 	echo '</td>';
 	echo '<td class="linkedcol-name tdoverflowmax150" >'.$objectlink->getNomUrl(1).'</td>';
-	echo '<td class="linkedcol-ref">'.$objectlink->ref_client.'</td>';
+	echo '<td class="linkedcol-ref tdoverflowmax150">'.$objectlink->ref_client.'</td>';
 	echo '<td class="linkedcol-date center">'.dol_print_date($objectlink->date, 'day').'</td>';
 	echo '<td class="linkedcol-amount right">';
 	if ($user->hasRight('commande', 'lire')) {

--- a/htdocs/delivery/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/delivery/tpl/linkedobjectblock.tpl.php
@@ -58,7 +58,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	}
 	echo '</td>';
 	echo '<td class="linkedcol-name tdoverflowmax150" >'.$objectlink->getNomUrl(1).'</td>';
-	echo '<td class="linkedcol-ref">'.$objectlink->ref.'</td>';
+	echo '<td class="linkedcol-ref tdoverflowmax150">'.$objectlink->ref.'</td>';
 	echo '<td class="linkedcol-date center">'.dol_print_date($objectlink->date_delivery, 'day').'</td>';
 	echo '<td class="linkedcol-amount right">';
 	if ($user->hasRight('delivery', 'read')) {

--- a/htdocs/don/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/don/tpl/linkedobjectblock.tpl.php
@@ -43,7 +43,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	print '<tr class="'.$trclass.'">';
 	print '<td>'.$langs->trans("Donation").'</td>';
 	print '<td>'.$objectlink->getNomUrl(1).'</td>';
-	print '<td class="center">'.$objectlink->ref_client.'</td>';
+	print '<td class="center linkedcol-ref tdoverflowmax150">'.$objectlink->ref_client.'</td>';
 	print '<td class="center">'.dol_print_date($objectlink->date, 'day').'</td>';
 	print '<td class="right">';
 	$total += $objectlink->total_ht;

--- a/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
@@ -52,7 +52,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	<tr class="<?php echo $trclass; ?>">
 		<td><?php echo $langs->trans("SupplierOrder"); ?></td>
 		<td><?php print $objectlink->getNomUrl(1); ?></td>
-		<td class="left"><?php echo $objectlink->ref_supplier; ?></td>
+		<td class="left linkedcol-ref tdoverflowmax150"><?php echo $objectlink->ref_supplier; ?></td>
 		<td class="center"><?php echo dol_print_date($objectlink->date, 'day'); ?></td>
 		<td class="right"><?php
 		if ($user->hasRight("fournisseur", "commande", "lire")) {

--- a/htdocs/fourn/facture/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/fourn/facture/tpl/linkedobjectblock.tpl.php
@@ -54,7 +54,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	<tr class="<?php echo $trclass; ?>">
 		<td><?php echo $langs->trans("SupplierInvoice"); ?></td>
 		<td><a href="<?php echo DOL_URL_ROOT.'/fourn/facture/card.php?facid='.$objectlink->id ?>"><?php echo img_object($langs->trans("ShowBill"), "bill").' '.$objectlink->ref; ?></a></td>
-		<td class="left"><?php echo $objectlink->ref_supplier; ?></td>
+		<td class="left linkedcol-ref tdoverflowmax150"><?php echo $objectlink->ref_supplier; ?></td>
 		<td class="center"><?php echo dol_print_date($objectlink->date, 'day'); ?></td>
 		<td class="right"><?php
 		if ($user->hasRight('fournisseur', 'facture', 'lire')) {

--- a/htdocs/mrp/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/mrp/tpl/linkedobjectblock.tpl.php
@@ -111,7 +111,7 @@ if ($object->element == 'mo') {
 		print '</td>';
 
 		print '<td class="linkedcol-name tdoverflowmax150">'.$objectlink->getNomUrl(1).'</td>';
-		print '<td class="linkedcol-ref" >'.$objectlink->ref_client.'</td>';
+		print '<td class="linkedcol-ref tdoverflowmax150" >'.$objectlink->ref_client.'</td>';
 		print '<td class="linkedcol-date center">'.dol_print_date($objectlink->date_start_planned, 'day').'</td>';
 		print '<td class="linkedcol-amount right">-</td>';
 		print '<td class="linkedcol-statut right">'.$objectlink->getLibStatut(3).'</td>';

--- a/htdocs/reception/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/reception/tpl/linkedobjectblock.tpl.php
@@ -60,7 +60,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 		} ?>
 		</td>
 		<td class="linkedcol-name tdoverflowmax150"><?php echo $objectlink->getNomUrl(1); ?></td>
-		<td class="linkedcol-ref tdoverflowmax100" title="<?php echo dol_escape_htmltag($objectlink->ref_supplier); ?>"><?php echo dol_escape_htmltag($objectlink->ref_supplier); ?></td>
+		<td class="linkedcol-ref tdoverflowmax150" title="<?php echo dol_escape_htmltag($objectlink->ref_supplier); ?>"><?php echo dol_escape_htmltag($objectlink->ref_supplier); ?></td>
 		<td class="linkedcol-date"><?php echo dol_print_date($objectlink->date_delivery, 'day'); ?></td>
 		<td class="linkedcol-amount right"><?php
 		if ($user->hasRight('reception', 'lire')) {

--- a/htdocs/ticket/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/ticket/tpl/linkedobjectblock.tpl.php
@@ -55,7 +55,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 		} ?>
 		</td>
 		<td class="linkedcol-name tdoverflowmax150"><?php echo $objectlink->getNomUrl(1); ?></td>
-		<td class="linkedcol-ref center"><?php echo $objectlink->ref_client; ?></td>
+		<td class="linkedcol-ref tdoverflowmax150 center"><?php echo $objectlink->ref_client; ?></td>
 		<td class="linkedcol-date center"><?php echo dol_print_date($objectlink->datec, 'day'); ?></td>
 		<?php
 		//$objectlink->socid = $objectlink->fk_soc;


### PR DESCRIPTION
# FIX|Fix linked object table list reference column overflow

In linked object list tables, reference columns could grow excessively when displaying long values, causing table layout issues and horizontal overflow.

This fix limits the maximum width of reference table cells to 150px, ensuring large reference values do not break the layout while keeping the rest of the table readable.

Changes:

- Set a max-width of 150px on reference `<td>` elements in linked object table lists
- Prevented excessive column expansion caused by long reference values
- Improved table layout stability without affecting other columns