### PR TITLE
feat(core): allow negative quantities on invoice and order lines

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1055,7 +1055,9 @@ if (empty($reshook)) {
 			}
 		}
 
-		if (!$error && ($qty >= 0) && (!empty($line_desc) || (!empty($idprod) && $idprod > 0))) {
+		$commande_qty_requirement = !empty(getDolGlobalString('COMMANDE_ENABLE_NEGATIVE_QTY')) ? ($qty >= 0 || $qty <= 0) : $qty >= 0;
+
+		if (!$error && $commande_qty_requirement && (!empty($line_desc) || (!empty($idprod) && $idprod > 0))) {
 			// Clean parameters
 			$date_start = dol_mktime(GETPOSTINT('date_start' . $predef . 'hour'), GETPOSTINT('date_start' . $predef . 'min'), GETPOSTINT('date_start' . $predef . 'sec'), GETPOSTINT('date_start' . $predef . 'month'), GETPOSTINT('date_start' . $predef . 'day'), GETPOSTINT('date_start' . $predef . 'year'));
 			$date_end = dol_mktime(GETPOSTINT('date_end' . $predef . 'hour'), GETPOSTINT('date_end' . $predef . 'min'), GETPOSTINT('date_end' . $predef . 'sec'), GETPOSTINT('date_end' . $predef . 'month'), GETPOSTINT('date_end' . $predef . 'day'), GETPOSTINT('date_end' . $predef . 'year'));
@@ -1673,7 +1675,9 @@ if (empty($reshook)) {
 			}
 		}
 
-		if ($qty < 0) {
+		$commande_qty_requirement = !empty(getDolGlobalString('COMMANDE_ENABLE_NEGATIVE_QTY')) ? ($qty >= 0 || $qty <= 0) : $qty >= 0;
+
+		if (!$commande_qty_requirement) {
 			setEventMessages($langs->trans('FieldCannotBeNegative', $langs->transnoentitiesnoconv('Qty')), null, 'errors');
 			$error++;
 			$action = 'editline';

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2548,7 +2548,10 @@ if (empty($reshook)) {
 			setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Qty')), null, 'errors');
 			$error++;
 		}
-		if ($qty < 0) {
+
+		$facture_qty_requirement = !empty(getDolGlobalString('FACTURE_ENABLE_NEGATIVE_QTY')) ? ($qty >= 0 || $qty <= 0) : $qty >= 0;
+
+		if (!$facture_qty_requirement) {
 			$langs->load("errors");
 			setEventMessages($langs->trans('ErrorQtyForCustomerInvoiceCantBeNegative'), null, 'errors');
 			$error++;
@@ -2569,7 +2572,7 @@ if (empty($reshook)) {
 		}
 
 		$price_base_type = null;
-		if (!$error && ($qty >= 0) && (!empty($line_desc) || (!empty($idprod) && $idprod > 0))) {
+		if (!$error && $facture_qty_requirement && (!empty($line_desc) || (!empty($idprod) && $idprod > 0))) {
 			$ret = $object->fetch($id);
 			if ($ret < 0) {
 				dol_print_error($db, $object->error);
@@ -3174,7 +3177,10 @@ if (empty($reshook)) {
 				$error++;
 			}
 		}
-		if ($qty < 0) {
+
+		$facture_qty_requirement = !empty(getDolGlobalString('FACTURE_ENABLE_NEGATIVE_QTY')) ? ($qty >= 0 || $qty <= 0) : $qty >= 0;
+
+		if (!$facture_qty_requirement) {
 			$langs->load("errors");
 			setEventMessages($langs->trans('ErrorQtyForCustomerInvoiceCantBeNegative'), null, 'errors');
 			$error++;


### PR DESCRIPTION
# NEW|New Allow negative quantities on invoice and order lines

This PR adds core support for negative quantities on invoice and order
document lines.

The feature is disabled by default and can be enabled by setting the
following constants:
- COMMANDE_ENABLE_NEGATIVE_QTY = 1
- FACTURE_ENABLE_NEGATIVE_QTY = 1

Allowing negative quantities enables additional business use cases such as:
- adjustments and corrections directly on documents
- discounts represented as document lines
- financial compensations without using credit notes