### PR TITLE
Fix : Set empty td at the correct position when product use unit

### DIFF
--- a/htdocs/product/reassort.php
+++ b/htdocs/product/reassort.php
@@ -489,6 +489,10 @@ if ($resql) {
 		print '<td class="liste_titre">&nbsp;</td>';
 		$colspan++;
 	}
+	if (getDolGlobalString('PRODUCT_USE_UNITS')) {
+		print '<td class="liste_titre"></td>';
+		$colspan++;
+	}
 	$parameters = array();
 	$reshook = $hookmanager->executeHooks('printFieldListOption', $parameters); // Note that $action and $object may have been modified by hook
 	print $hookmanager->resPrint;
@@ -503,10 +507,6 @@ if ($resql) {
 		$searchpicto = $form->showFilterAndCheckAddButtons(0);
 		print $searchpicto;
 		print '</td>';
-		$colspan++;
-	}
-	if (getDolGlobalString('PRODUCT_USE_UNITS')) {
-		print '<td class="liste_titre"></td>';
 		$colspan++;
 	}
 	print '</tr>';


### PR DESCRIPTION
# FIX|Fix Set empty td at the correct position when product uses unit

When a product is configured to use a unit, the generated table layout was misaligned because an empty `<td>` was not inserted at the correct position.

This fix ensures that an empty `<td>` is added at the proper index when the product uses a unit, preserving column alignment and preventing layout issues in the rendered document.

The change only impacts the table rendering logic and does not modify any business rules or data processing.
