### PR TITLE
FIX Accountancy - On annual closing, propose the last exercise not closing

### DIFF
--- a/htdocs/accountancy/closure/index.php
+++ b/htdocs/accountancy/closure/index.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2019-2023  Open-DSI    	    		<support@open-dsi.fr>
  * Copyright (C) 2024		Frédéric France				<frederic.france@free.fr>
- * Copyright (C) 2025		Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2025-2026	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2025		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -93,11 +93,14 @@ if (is_array($fiscal_periods)) {
 			if (!isset($next_active_fiscal_period) && empty($fiscal_period['status'])) {
 				$next_active_fiscal_period = $fiscal_period;
 			}
-		} else {								// If we did not found the current fiscal period
-			if ($fiscal_period_id == $fiscal_period['id'] || (empty($fiscal_period_id) && $fiscal_period['date_start'] <= $now && $now <= $fiscal_period['date_end'])) {
+		} else {                        // If we did not found the current fiscal period
+			// Only select by ID, not by date range for closure page
+			if (!empty($fiscal_period_id) && $fiscal_period_id == $fiscal_period['id']) {
 				$current_fiscal_period = $fiscal_period;
 			} else {
-				$last_fiscal_period = $fiscal_period;	// $last_fiscal_period is in fact $previous_fiscal_period
+				if (empty($current_fiscal_period)) {
+					$last_fiscal_period = $fiscal_period;  // $last_fiscal_period is in fact $previous_fiscal_period
+				}
 			}
 		}
 	}

--- a/htdocs/accountancy/closure/index.php
+++ b/htdocs/accountancy/closure/index.php
@@ -98,9 +98,7 @@ if (is_array($fiscal_periods)) {
 			if (!empty($fiscal_period_id) && $fiscal_period_id == $fiscal_period['id']) {
 				$current_fiscal_period = $fiscal_period;
 			} else {
-				if (empty($current_fiscal_period)) {
-					$last_fiscal_period = $fiscal_period;  // $last_fiscal_period is in fact $previous_fiscal_period
-				}
+				$last_fiscal_period = $fiscal_period;	// $last_fiscal_period is in fact $previous_fiscal_period
 			}
 		}
 	}


### PR DESCRIPTION
Refer to this post on french forum: https://www.dolibarr.fr/forum/t/cloture-dexercice-annulable/50497

Problem: Automatic selection of the wrong fiscal year

Symptom: When accessing the “Closing” page, Dolibarr selects the 2026 fiscal year (current according to the current date) by default instead of the 2025 fiscal year (first fiscal year open for closing).

<img width="1547" height="265" alt="image" src="https://github.com/user-attachments/assets/0ab8003b-9f8d-43ab-af12-290136f4ef3b" />

Technical cause: The selection code uses the current date ($now) to determine which fiscal year to display.
​
Since the current date (January 5, 2026) falls within the range of the 2026-2027 fiscal year, it is automatically selected, even if there is a previous open fiscal year that should be closed first.

UX impact: The user arrives at the wrong fiscal year and risks closing an empty or future fiscal year instead of the fiscal year currently being finalized.