### PR TITLE
FIX Accountancy - Not being able to reopen a closed fiscal year by simply editing its information

### DIFF
--- a/htdocs/accountancy/admin/fiscalyear_card.php
+++ b/htdocs/accountancy/admin/fiscalyear_card.php
@@ -1,7 +1,7 @@
 <?php
-/* Copyright (C) 2014-2024  Alexandre Spangaro  <aspangaro@easya.solutions>
- * Copyright (C) 2018-2024  Frédéric France     <frederic.france@free.fr>
- * Copyright (C) 2025		MDW					<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2014-2026	Alexandre Spangaro		<alexandre@inovea-conseil.com>
+ * Copyright (C) 2018-2024	Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -211,7 +211,9 @@ if ($action == 'create') {
 	print '<table class="border centpercent tableforfieldcreate">'."\n";
 
 	// Label
-	print '<tr><td class="titlefieldcreate fieldrequired">'.$langs->trans("Label").'</td><td><input name="label" size="32" value="'.GETPOST('label', 'alpha').'"></td></tr>';
+	print '<tr><td class="titlefieldcreate fieldrequired">'.$langs->trans("Label").'</td><td>';
+	print '<input name="label" size="32" value="'.GETPOST('label', 'alpha').'">';
+	print '</td></tr>';
 
 	// Date start
 	print '<tr><td class="fieldrequired">'.$langs->trans("DateStart").'</td><td>';
@@ -257,6 +259,7 @@ if (($id || $ref) && $action == 'edit') {
 	print '<form method="POST" name="update" action="'.$_SERVER["PHP_SELF"].'">'."\n";
 	print '<input type="hidden" name="token" value="'.newToken().'">';
 	print '<input type="hidden" name="action" value="update">';
+	print '<input type="hidden" name="status" value="' . $object->status . '">';
 	print '<input type="hidden" name="id" value="'.$object->id.'">';
 	if ($backtopage) {
 		print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';


### PR DESCRIPTION
Refer to this post on french forum: https://www.dolibarr.fr/forum/t/cloture-dexercice-annulable/50497

## Bug Report: Fiscal Year Status Reset to Open When Editing

### Description
When editing a closed fiscal year through the card interface, the fiscal year status is automatically reset from "Closed" (status = 1) to "Open" (status = 0), even without modifying any fields.

### Root Cause
In `/htdocs/accountancy/admin/fiscalyear_card.php`, the edit form displays the fiscal year status as read-only using `$object->getLibStatut(4)` but **does not include a form input field** for the status value.

When the form is submitted (action = 'update'), the code executes:
```php
$object->status = GETPOSTINT('status');
```

Since no `status` field exists in the form, `GETPOSTINT('status')` returns **0** (default value), automatically reopening any closed fiscal year.

### Impact
- **Data integrity issue**: Closed fiscal years can be accidentally reopened without user intention
- **Bypasses security controls**: The `ACCOUNTING_CAN_REOPEN_CLOSED_PERIOD` configuration is completely bypassed
- **Silent corruption**: No warning is displayed to the user that the fiscal year will be reopened
- **Audit trail concern**: Closed accounting periods should remain immutable without explicit action

### Steps to Reproduce
1. Create and close a fiscal year (status = 1)
2. Navigate to the fiscal year card page
3. Click "Modify" button
4. Change any field (label, dates, etc.) or change nothing
5. Click "Save"
6. **Result**: Fiscal year status is reset to "Open" (status = 0)