### PR TITLE
FIX: inventory qty is not saved if page > 1

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -89,6 +89,10 @@ if (!$sortorder) {
 	$sortorder = "ASC";
 }
 
+// Sort by warehouse/product or product/warehouse
+$sortfield .= ',' . ($sortfield == 'e.ref' ? 'p.ref' : 'e.ref');
+$sortorder .= ',' . $sortorder;
+
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
@@ -291,8 +295,10 @@ if (empty($reshook)) {
 		$sql = 'SELECT id.rowid, id.datec as date_creation, id.tms as date_modification, id.fk_inventory, id.fk_warehouse,';
 		$sql .= ' id.fk_product, id.batch, id.qty_stock, id.qty_view, id.qty_regulated';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'inventorydet as id';
+		$sql .= ' LEFT JOIN ' . $db->prefix() . 'product as p ON id.fk_product = p.rowid';
+		$sql .= ' LEFT JOIN ' . $db->prefix() . 'entrepot as e ON id.fk_warehouse = e.rowid';
 		$sql .= ' WHERE id.fk_inventory = '.((int) $object->id);
-		$sql .= $db->order('id.rowid', 'ASC');
+		$sql .= $db->order($sortfield, $sortorder);
 		$sql .= $db->plimit($limit, $offset);
 
 		$db->begin();
@@ -1036,10 +1042,6 @@ if ($object->status == $object::STATUS_DRAFT || $object->status == $object::STAT
 	print '</td>';
 	print '</tr>';
 }
-
-// Sort by warehouse/product or product/warehouse
-$sortfield .= ',' . ($sortfield == 'e.ref' ? 'p.ref' : 'e.ref');
-$sortorder .= ',' . $sortorder;
 
 // Request to show lines of inventory (prefilled after start/validate step)
 $sql = 'SELECT id.rowid, id.datec as date_creation, id.tms as date_modification, id.fk_inventory, id.fk_warehouse,';

--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -89,9 +89,9 @@ if (!$sortorder) {
 	$sortorder = "ASC";
 }
 
-// Sort by warehouse/product or product/warehouse
-$sortfield .= ',' . ($sortfield == 'e.ref' ? 'p.ref' : 'e.ref');
-$sortorder .= ',' . $sortorder;
+// Sort by warehouse/product or product/warehouse, then by batch.
+$sortfield .= ',' . ($sortfield == 'e.ref' ? 'p.ref' : 'e.ref') . ',id.batch,id.rowid';
+$sortorder .= ',' . $sortorder.",ASC,ASC";
 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);


### PR DESCRIPTION
# FIX: On a long inventory, the quantities were not saved on page > 1

To reproduce :
- create an inventory with > 10 products
- validate inventory
- set pagination to 10
- navigate to page 2
- modify qty for a line, then click "Save"
- navigate to page 1
- navigate to page 2 : your quantity has not been saved !

Observed from branch 21.0 to develop.

This is due to the fact that the SQL request to fetch lines to update (l.291) and the one to fetch the lines to display (l.1045) have the same LIMIT params, but not the same ORDER params. 