### PR TITLE
Fix missing line number when bom card in sub bom mode

### DIFF
--- a/htdocs/bom/tpl/objectline_view.tpl.php
+++ b/htdocs/bom/tpl/objectline_view.tpl.php
@@ -290,6 +290,7 @@ $sql .= ' WHERE fk_bom ='. (int) $tmpbom->id;
 $resql = $object->db->query($sql);
 
 if ($resql) {
+	$j = 0; // sub bom line number
 	// Loop on all the sub-BOM lines if they exist
 	while ($obj = $object->db->fetch_object($resql)) {
 		$sub_bom_product = new Product($object->db);
@@ -308,6 +309,12 @@ if ($resql) {
 			print '<tr style="display:none" class="sub_bom_lines" parentid="'.$line->id.'">';
 		} else {
 			print '<tr class="sub_bom_lines" parentid="'.$line->id.'">';
+		}
+
+		// Line nb
+		if (getDolGlobalString('MAIN_VIEW_LINE_NUMBER')) {
+			print '<td class="linecolnum center">'.($i + 1).'.'.($j + 1).'</td>';
+			$coldisplay++;
 		}
 
 		// Product OR BOM
@@ -392,6 +399,8 @@ if ($resql) {
 		print '<td></td>';
 		print '<td></td>';
 		print '<td></td>';
+		print '</tr>';
+		$j++;
 	}
 }
 


### PR DESCRIPTION
Before:
<img width="718" height="390" alt="2026-01-05 - 15_12_45 - BOM2101-0002" src="https://github.com/user-attachments/assets/7ea920f5-e891-4d85-989f-8bca319f59f5" />

After:
<img width="703" height="364" alt="2026-01-05 - 15_13_09 - BOM2101-0002" src="https://github.com/user-attachments/assets/1dc9e80b-1d14-4d2d-b378-ffeca40c5ed6" />
