### PR TITLE
FIX: Correct due date calculation for payment term 45J FDM on 15th

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -1159,7 +1159,7 @@ abstract class CommonInvoice extends CommonObject
 
 			$diff = $date_piece - $date_lim_current;
 
-			if ($diff < 0) {
+			if ($diff <= 0) {
 				$datelim = $date_lim_current;
 			} else {
 				$datelim = $date_lim_next;


### PR DESCRIPTION
# FIX|Fix Due date calculation for payment term 45 J FDM le 15

When using the payment term **"45 J FDM le 15"**, the due date is incorrectly calculated when the invoice date falls on the **last day of the month**.

<img width="1540" height="36" alt="image" src="https://github.com/user-attachments/assets/b191c4f4-03cf-4b08-8838-277f947e3d04" />

### Expected behavior
- Invoice date: 2025-03-31  
- Payment term: 45 J FDM le 15 
- Due date: **2025-05-15**

### Actual behavior
- Invoice date: 2025-03-31  
- Payment term: 45 J FDM le 15  
- Due date: **2025-06-15**

An extra month is incorrectly added in this specific case.

### Root cause
The current due date calculation logic does not correctly handle end-of-month invoice dates when applying the **FDM (end of month)** rule combined with a fixed day (15th).  
This results in advancing the due date by one additional month.

### Fix
- Correct the calculation logic to properly handle invoice dates at the end of the month.
- Ensure that the **45 J FDM le 15** payment term always resolves to the correct month.
- Preserve existing behavior for all other payment terms.

### Tests
- Invoice date: 2025-03-30 → Due date: 2025-05-15
- Invoice date: 2025-03-31 → Due date: 2025-05-15