### PR TITLE
NEW: propagate thirdparty ef to propal

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -2590,6 +2590,9 @@ if ($action == 'create') {
 		}
 
 		// Other attributes
+		if (getDolGlobalInt('THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_PROPAL') && $socid > 0) {
+			$thirdpartytopropagateextrafieldsfrom = $soc;
+		}
 		include DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_add.tpl.php';
 
 		// Lines from source


### PR DESCRIPTION
# NEW: propagate thirdparty extrafields to propal (hidden const THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_PROPAL)

THIRDPARTY_PROPAGATE_EXTRAFIELDS_TO_XXX would work for many object, but not for propal. This PR adds this behavior.
This PR follows previous PR https://github.com/Dolibarr/dolibarr/pull/24943.