### PR TITLE
NEW : allow to save stocks as 0 on a stock movement.

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -656,7 +656,7 @@ class MouvementStock extends CommonObject
 				}
 			}
 
-			if (empty($donotcleanemptylines)) {
+			if (empty($donotcleanemptylines) && !getDolGlobalInt('STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES')) {
 				// If stock is now 0, we can remove entry into llx_product_stock, but only if there is no child lines into llx_product_batch (detail of batch, because we can imagine
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sql = "DELETE FROM ".$this->db->prefix()."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".$this->db->prefix()."product_batch as pb)";

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1052,8 +1052,10 @@ if (!$variants || getDolGlobalString('VARIANT_ALLOW_STOCK_MOVEMENT_ON_VARIANT_PA
 	$sql .= " FROM ".MAIN_DB_PREFIX."entrepot as e,";
 	$sql .= " ".MAIN_DB_PREFIX."product_stock as ps";
 	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON p.rowid = ps.fk_product";
-	$sql .= " WHERE ps.reel != 0";
-	$sql .= " AND ps.fk_entrepot = e.rowid";
+	$sql .= " WHERE ps.fk_entrepot = e.rowid";
+	if (!getDolGlobalInt('STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES')) {
+		$sql .= " AND ps.reel != 0";
+	}
 	$sql .= " AND e.entity IN (".getEntity('stock').")";
 	$sql .= " AND ps.fk_product = ".((int) $object->id);
 	$sql .= " ORDER BY e.ref";


### PR DESCRIPTION
# NEW hidden const STOCK_MOVEMENT_FORCE_DO_NOT_CLEAN_EMPTY_LINES

When this const is set, if a stock movement puts the stock value to zero, the line will not be erased from DB, but will be saved as "0 in stock".

The use case are : 
- one of our customer has multiple entities, but uses same stocks. They want to know that they have 5 products P on warehouse W on entity 1, and 0 product P on same warehouse W on entity 2
- more generally, one may have "reserved" warehouses for products, and want to see that there is 0 of product P on warehouse W.

(this is a restart for PR https://github.com/Dolibarr/dolibarr/pull/33526)

## screenshots 

There is 0 of stock in warehouse 'A-Concarneau' after a stock movement.

before : No mention of the warehouse

![Capture d’écran_2024-02-28_09-47-48](https://private-user-images.githubusercontent.com/28301879/308484240-d4dcf953-1e41-403e-86dc-819aa44d5094.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Njc4NjI1ODQsIm5iZiI6MTc2Nzg2MjI4NCwicGF0aCI6Ii8yODMwMTg3OS8zMDg0ODQyNDAtZDRkY2Y5NTMtMWU0MS00MDNlLTg2ZGMtODE5YWE0NGQ1MDk0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAxMDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMTA4VDA4NTEyNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWI3NTRiODE3MDAzMDlhMjk2YTJmZTgyZmQ4N2NjM2E2YTE5YTRmZWNkZWNkOWIxMDZiYzMzMDgwMWUzOTFiMmEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.gY-bZau8DhN_SRxCOxO2TSJ28xNRbZ0sZlRc3j0E4o8) 

![Capture d’écran_2024-02-28_09-50-55](https://private-user-images.githubusercontent.com/28301879/308484267-76e11c75-242a-45f4-9ee0-dd02097817f4.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Njc4NjI1ODQsIm5iZiI6MTc2Nzg2MjI4NCwicGF0aCI6Ii8yODMwMTg3OS8zMDg0ODQyNjctNzZlMTFjNzUtMjQyYS00NWY0LTllZTAtZGQwMjA5NzgxN2Y0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAxMDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMTA4VDA4NTEyNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWMzYzJlMjVkOGZhZTU4OTkyYmZhNTY3ZmUxYjA4ZDcxYWMwNDM0ZGUwZTc0Zjg1MWU0Y2VlNTRjMWUyYThjYjQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.4572RBrMmeHoQ0kIx14DDVNY4rSFF3U4nZY6vI8hkFs)

after : we see stock 0 in warehouse

![Capture d’écran_2024-02-28_09-52-13](https://private-user-images.githubusercontent.com/28301879/308485365-bcb56e25-2ada-4f1c-9b9c-b90d986a29dc.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Njc4NjI1ODQsIm5iZiI6MTc2Nzg2MjI4NCwicGF0aCI6Ii8yODMwMTg3OS8zMDg0ODUzNjUtYmNiNTZlMjUtMmFkYS00ZjFjLTliOWMtYjkwZDk4NmEyOWRjLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAxMDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMTA4VDA4NTEyNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTFlZTI1ZWI1ZGYyMzQzNjQ4OGNjZjdhMTBjOTkxNjJiNzYyMGRlOWI1MzI2YjIwZjg1NTBjZmVkMGVlNjhmMzEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.K4bMY01fBmwglVl9n5LUsFfHdWy9laoPGi1mSil9K70) 


![Capture d’écran_2024-02-28_09-52-37](https://private-user-images.githubusercontent.com/28301879/308485376-05139e36-241f-4fb4-81e8-4415a8be68ca.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Njc4NjI1ODQsIm5iZiI6MTc2Nzg2MjI4NCwicGF0aCI6Ii8yODMwMTg3OS8zMDg0ODUzNzYtMDUxMzllMzYtMjQxZi00ZmI0LTgxZTgtNDQxNWE4YmU2OGNhLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAxMDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMTA4VDA4NTEyNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWM0ZGY0YTQ2ZDY2ODRlZjIwOTM0MjBiMDM1NzEwNGNkYzk0YTQ4Zjk3MGQ0NjhmMzU4YWVlZDQyMTFiNTI2Y2UmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.m6Jbv9fX2pkKODWYviIW1fJEhFkgLOatfqR4PR8J95I)


