### PR TITLE
NEW : chose which payment request to include in bank transfer

### DIFF
--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -1076,17 +1076,20 @@ class BonPrelevement extends CommonObject
 	 *  @param  int  	$executiondate		Date to execute the transfer
 	 *  @param	int	    $notrigger			Disable triggers
 	 *  @param	string	$type				'direct-debit' or 'bank-transfer'
-	 *  @param	int		$did				ID of an existing payment request. If $did is defined, we use the existing payment request.
+	 * 	@param	array<int>|int	$dids	ID(s) of existing payment request(s).
+	 * 									- If $dids is 0, we use all existing requests.
+	 * 									- If $dids is an int > 0, we use the existing payment request.
+	 * 									- If $dids is an array, the created BonsPrelevement will include these payment requests.
 	 *  @param	int		$fk_bank_account	Bank account ID the receipt is generated for. Will use the ID into the setup of module Direct Debit or Credit Transfer if 0.
 	 *  @param	string	$sourcetype			'invoice' or 'salary'
 	 *	@return	int							Return integer <0 if KO, No of invoice included into file if OK
 	 */
-	public function create($banque = '', $agence = '', $mode = 'real', $format = 'ALL', $executiondate = 0, $notrigger = 0, $type = 'direct-debit', $did = 0, $fk_bank_account = 0, $sourcetype = 'invoice')
+	public function create($banque = '', $agence = '', $mode = 'real', $format = 'ALL', $executiondate = 0, $notrigger = 0, $type = 'direct-debit', $dids = 0, $fk_bank_account = 0, $sourcetype = 'invoice')
 	{
 		// phpcs:enable
 		global $conf, $langs, $user;
 
-		dol_syslog(__METHOD__ . " Bank=".$banque." Office=".$agence." mode=".$mode." format=".$format." type=".$type." did=".$did." fk_bank_account=".$fk_bank_account." sourcetype=".$sourcetype, LOG_DEBUG);
+		dol_syslog(__METHOD__ . " Bank=".$banque." Office=".$agence." mode=".$mode." format=".$format." type=".$type." dids=".$dids." fk_bank_account=".$fk_bank_account." sourcetype=".$sourcetype, LOG_DEBUG);
 
 		require_once DOL_DOCUMENT_ROOT . "/compta/facture/class/facture.class.php";
 		require_once DOL_DOCUMENT_ROOT . "/societe/class/societe.class.php";
@@ -1099,9 +1102,17 @@ class BonPrelevement extends CommonObject
 			}
 		}
 
+		if (!is_int($dids) && !is_array($dids)) {
+			$this->error = 'ErrorBadParametersForDirectDebitFileCreateDids';
+			return -1;
+		}
+
 		// Clean params
 		if (empty($fk_bank_account)) {
 			$fk_bank_account = ($type == 'bank-transfer' ? getDolGlobalInt('PAYMENTBYBANKTRANSFER_ID_BANKACCOUNT') : getDolGlobalInt('PRELEVEMENT_ID_BANKACCOUNT'));
+		}
+		if (is_int($dids)) {
+			$dids = array($dids);
 		}
 
 		$error = 0;
@@ -1121,10 +1132,10 @@ class BonPrelevement extends CommonObject
 		$thirdpartyBANId = 0;
 
 		// Check if there is an iban associated to the bank transfer request or if we take the default
-		if ($did > 0) {
+		if ($dids !== [0] && !empty($dids)) {
 			$sql = "SELECT pd.fk_societe_rib";
 			$sql .= " FROM " . $this->db->prefix() . "prelevement_demande as pd";
-			$sql .= " WHERE pd.rowid = ".((int) $did);
+			$sql .= " WHERE pd.rowid IN (".$this->db->sanitize(implode(',', $dids)).")";
 
 			$resql = $this->db->query($sql);
 
@@ -1161,7 +1172,7 @@ class BonPrelevement extends CommonObject
 		$factures_prev = array();
 		$factures_prev_id = array();
 
-		dol_syslog(__METHOD__ . " Read invoices for did=" . ((int) $did), LOG_DEBUG);
+		dol_syslog(__METHOD__ . " Read invoices for dids=" . implode(', ', $dids), LOG_DEBUG);
 
 		$sql = "SELECT f.rowid, pd.rowid as pfdrowid";
 		$sql .= ", f.".$this->db->sanitize($socOrUser);		// fk_soc or fk_user
@@ -1210,8 +1221,8 @@ class BonPrelevement extends CommonObject
 		}
 		$sql .= " AND pd.traite = 0";
 		$sql .= " AND pd.ext_payment_id IS NULL";
-		if ($did > 0) {
-			$sql .= " AND pd.rowid = " . ((int) $did);
+		if ($dids !== [0] && !empty($dids)) {
+			$sql .= " AND pd.rowid IN (".$this->db->sanitize(implode(',', $dids)).")";
 		}
 
 		$resql = $this->db->query($sql);

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -220,8 +220,7 @@ $bprev = new BonPrelevement($db);
 
 $arrayofselected = is_array($toselect) ? $toselect : array();
 // List of mass actions available
-$arrayofmassactions = array(
-);
+$arrayofmassactions = array();
 if (GETPOSTINT('nomassaction') || in_array($massaction, array('presend', 'predelete'))) {
 	$arrayofmassactions = array();
 }
@@ -298,7 +297,7 @@ print dol_get_fiche_end();
 
 print '<div class="tabsAction">'."\n";
 
-print '<form action="'.$_SERVER['PHP_SELF'].'" method="POST">';
+print '<form id="createBankTransfer" action="'.$_SERVER['PHP_SELF'].'" method="POST">';
 print '<input type="hidden" name="action" value="create">';
 print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="type" value="'.$type.'">';
@@ -388,6 +387,20 @@ if ($nb) {
 }
 
 print "</form>\n";
+
+// Send selected lines to build the transfer file
+print '<script>
+	$().ready(() => {
+		let form_create_transfer = $("#createBankTransfer");
+		let form_list = $("#searchFormList");
+		form_create_transfer.submit(() => {
+			let selected_lines = Array.from(document.querySelectorAll("input.checkforselect:checked"))
+			selected_lines.map(line => {
+				form_create_transfer.append(line);
+			})
+		})
+	})
+</script>';
 
 print "</div>\n";
 
@@ -519,7 +532,7 @@ if ($resql) {
 	print '<tr class="liste_titre">';
 	// Action column
 	if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-		if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
+		if ($num) {
 			print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
 		}
 	}
@@ -551,9 +564,7 @@ if ($resql) {
 	print '<td class="right">'.$langs->trans("PendingSince").'</td>';
 	// Action column
 	if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-		if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-			print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
-		}
+		print '<td align="center">'.$form->showCheckAddButtons('checkforselect', 1).'</td>';
 	}
 	print '</tr>';
 
@@ -588,15 +599,13 @@ if ($resql) {
 
 			// Action column
 			if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-				if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-					print '<td class="nowrap center">';
-					$selected = 0;
-					if (in_array($obj->request_row_id, $arrayofselected)) {
-						$selected = 1;
-					}
-					print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
-					print '</td>';
+				print '<td class="nowrap center">';
+				$selected = 0;
+				if (in_array($obj->request_row_id, $arrayofselected)) {
+					$selected = 1;
 				}
+				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
+				print '</td>';
 			}
 
 			// Ref invoice
@@ -682,15 +691,13 @@ if ($resql) {
 			print '</td>';
 			// Action column
 			if (!getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
-				if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
-					print '<td class="nowrap center">';
-					$selected = 0;
-					if (in_array($obj->request_row_id, $arrayofselected)) {
-						$selected = 1;
-					}
-					print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
-					print '</td>';
+				print '<td class="nowrap center">';
+				$selected = 0;
+				if (in_array($obj->request_row_id, $arrayofselected)) {
+					$selected = 1;
 				}
+				print '<input id="cb'.$obj->request_row_id.'" class="flat checkforselect" type="checkbox" name="toselect[]" value="'.$obj->request_row_id.'"'.($selected ? ' checked="checked"' : '').'>';
+				print '</td>';
 			}
 			print '</tr>';
 			$i++;

--- a/htdocs/compta/prelevement/create.php
+++ b/htdocs/compta/prelevement/create.php
@@ -133,13 +133,18 @@ if (empty($reshook)) {
 			$action = '';
 			$error++;
 		}
-
+		if (empty($toselect)) {
+			$errormessage = $langs->trans('ErrorBankTransferNoPaymentRequestSelected');
+			setEventMessages($errormessage, null, 'errors');
+			$action = '';
+			$error++;
+		}
 
 		$bprev = new BonPrelevement($db);
 
 		if (!$error) {
 			// getDolGlobalString('PRELEVEMENT_CODE_BANQUE') and getDolGlobalString('PRELEVEMENT_CODE_GUICHET') should be empty (we don't use them anymore)
-			$result = $bprev->create(getDolGlobalString('PRELEVEMENT_CODE_BANQUE'), getDolGlobalString('PRELEVEMENT_CODE_GUICHET'), $mode, $format, $executiondate, 0, $type, 0, 0, $sourcetype);
+			$result = $bprev->create(getDolGlobalString('PRELEVEMENT_CODE_BANQUE'), getDolGlobalString('PRELEVEMENT_CODE_GUICHET'), $mode, $format, $executiondate, 0, $type, $toselect, 0, $sourcetype);
 			if ($result < 0) {
 				$mesg = '';
 

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -464,3 +464,5 @@ OperNotDefined=Payment method not defined
 EmptyMessageNotAllowedError=Empty message is not allowed
 SomeShipmentExists=Error, there is some shipment linked to the order. Deletion refused.
 WarningEvaluationEmptyValidate=Can't validate evaluation, levels on skills not defined
+ErrorBadParametersForDirectDebitFileCreate=Can't create bank transfer file: expected format parameter is not provided.
+ErrorBadParametersForDirectDebitFileCreateDids=Can't create bank transfer file: IDs of existing payment requests are not provided.

--- a/htdocs/langs/en_US/withdrawals.lang
+++ b/htdocs/langs/en_US/withdrawals.lang
@@ -172,3 +172,4 @@ SalaryWaitingWithdraw=Salaries waiting for payment by credit transfer
 RefSalary=Salary
 NoSalaryInvoiceToWithdraw=No salary waiting for a '%s'. Go on tab '%s' on salary card to make a request.
 SalaryInvoiceWaitingWithdraw=Salaries waiting for payment by credit transfer
+ErrorBankTransferNoPaymentRequestSelected=No payment request selected.


### PR DESCRIPTION
# NEW Select payment requests to use when creating a bank transfer

On page compta/prelevement/create.php, users can create bank transfers for all the payment requests (or salaries):
![filtres_virement_bancaire_avant](https://github.com/user-attachments/assets/c7e347db-056a-4b6a-a175-c9fc0f794bcf)

This PR allows users to select which payment request (or salaries) they want to include in the SEPA mandate:
![filtres_virement_bancaire_apres](https://github.com/user-attachments/assets/1656e315-b10d-40df-9513-bdaadd233ac5)

This is a restart of https://github.com/Dolibarr/dolibarr/pull/33878.

