### PR TITLE
Fix : PR #36804 includes a regression that blocks navigation between …

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -89,10 +89,6 @@ if (!$sortorder) {
 	$sortorder = "ASC";
 }
 
-// Sort by warehouse/product or product/warehouse, then by batch.
-$sortfield .= ',' . ($sortfield == 'e.ref' ? 'p.ref' : 'e.ref') . ',id.batch,id.rowid';
-$sortorder .= ',' . $sortorder.",ASC,ASC";
-
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
@@ -126,6 +122,9 @@ if ($limit > 0 && $limit != $conf->liste_limit) {
 	$paramwithsearch .= '&limit='.((int) $limit);
 }
 
+// Sort by warehouse/product or product/warehouse
+$sortfield .= ',' . ($sortfield == 'e.ref' ? 'p.ref' : 'e.ref') . ',id.batch,id.rowid';
+$sortorder .= ',' . $sortorder.",ASC,ASC";
 
 if (!getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
 	$permissiontoadd = $user->hasRight('stock', 'creer');


### PR DESCRIPTION
# Fix: PR #36804 includes a bug that blocks navigation between pages of the inventory

Due to the fact that `$sortfield` was expanded before building `$paramwithsearch` .

