### PR TITLE
FIX: getCombination response is way too big (even db object is serialized)

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -718,8 +718,12 @@ class ProductCombination
 			$attrval = new ProductAttributeValue($this->db);
 			// fetch only the used values of this attribute
 			foreach ($attrval->fetchAllByProductAttribute($attr->id, true) as $val) {
-				'@phan-var-force ProductAttributeValue $val';
-				$tmp->values[] = $val;
+				$tmpValue = new stdClass();
+				$tmpValue->id = $val->id;
+				$tmpValue->fk_product_attribute = $val->fk_product_attribute;
+				$tmpValue->ref = $val->ref;
+				$tmpValue->value = $val->value;
+				$tmp->values[] = $tmpValue;
 			}
 
 			$variants[] = $tmp;


### PR DESCRIPTION
getCombination.php is called to get product variants attributes combinations.
But each values returns a full serialized ProductAttributeValue class instance.
Changed this to a single stdClass with a few ProductAttributeValue properties. 

**Before (with dolibarr demo db) :**
**Response was 27.6 ko** 
<img width="670" height="634" alt="image" src="https://github.com/user-attachments/assets/4a551669-3687-42ff-81f3-dc9d360e0d0b" />

**After :**
**Response is 0.8 ko** 
<img width="512" height="215" alt="image" src="https://github.com/user-attachments/assets/475c19eb-2ef3-463f-a147-53572e4706f3" />

