### PR TITLE
FIX warning accountancy export from external module

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -181,7 +181,7 @@ class AccountancyExport
 		);
 
 		global $hookmanager;
-		$code = $formatcode[$type];
+		$code = $formatcode[$type] ?? '';
 		$parameters = array('type' => $type);
 		$reshook = $hookmanager->executeHooks('getFormatCode', $parameters, $code);
 


### PR DESCRIPTION
FIX warning accountancy export from external module
- type of "formatcode" can be undefined when you use hooks to add a specific accountancy export model

