### PR TITLE
FIX Accountancy - Add validation for overlapping fiscal year dates

### DIFF
--- a/htdocs/accountancy/admin/fiscalyear_card.php
+++ b/htdocs/accountancy/admin/fiscalyear_card.php
@@ -128,16 +128,19 @@ if ($action == 'confirm_delete' && $confirm == "yes" && $permissiontoadd) {
 			$db->begin();
 
 			$id = $object->create($user);
-
 			if ($id > 0) {
 				$db->commit();
-
-				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
-				exit();
+				header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
+				exit;
 			} else {
 				$db->rollback();
 
-				setEventMessages($object->error, $object->errors, 'errors');
+				// Handle overlap error
+				if ($id == -5 && !empty($object->errors[0])) {
+					setEventMessages($langs->trans($object->error, $object->errors[0]), null, 'errors');
+				} else {
+					setEventMessages($object->error, $object->errors, 'errors');
+				}
 				$action = 'create';
 			}
 		} else {
@@ -145,7 +148,7 @@ if ($action == 'confirm_delete' && $confirm == "yes" && $permissiontoadd) {
 		}
 	} else {
 		header("Location: ./fiscalyear.php");
-		exit();
+		exit;
 	}
 } elseif ($action == 'update' && $permissiontoadd) {
 	// Update record
@@ -158,16 +161,20 @@ if ($action == 'confirm_delete' && $confirm == "yes" && $permissiontoadd) {
 		$object->status = GETPOSTINT('status');
 
 		$result = $object->update($user);
-
 		if ($result > 0) {
-			header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
-			exit();
+			header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
+			exit;
 		} else {
-			setEventMessages($object->error, $object->errors, 'errors');
+			// Handle overlap error
+			if ($result == -5 && !empty($object->errors[0])) {
+				setEventMessages($langs->trans($object->error, $object->errors[0]), null, 'errors');
+			} else {
+				setEventMessages($object->error, $object->errors, 'errors');
+			}
 		}
 	} else {
-		header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
-		exit();
+		header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
+		exit;
 	}
 } elseif ($action == 'reopen' && $permissiontoadd && getDolGlobalString('ACCOUNTING_CAN_REOPEN_CLOSED_PERIOD')) {
 	$result = $object->fetch($id);

--- a/htdocs/core/class/fiscalyear.class.php
+++ b/htdocs/core/class/fiscalyear.class.php
@@ -285,51 +285,32 @@ class Fiscalyear extends CommonObject
 		// Get entity value
 		$entity = (!empty($this->entity) ? $this->entity : $conf->entity);
 
-		// Query to get all fiscal years for the current entity
-		$sql = "SELECT rowid, label, date_start, date_end";
-		$sql .= " FROM ".$this->db->prefix()."accounting_fiscalyear";
-		$sql .= " WHERE entity = ".((int) $entity);
+		// Query to checks if any existing fiscal year overlaps with the current date range
+		$sql = "SELECT label";
+		$sql .= " FROM " . $this->db->prefix() . "accounting_fiscalyear";
+		$sql .= " WHERE entity = " . ((int)$entity);
+		$sql .= " AND date_start <= '" . $this->db->idate($this->date_end) . "'";
+		$sql .= " AND date_end >= '" . $this->db->idate($this->date_start) . "'";
 
 		// Exclude current fiscal year when updating
 		if (!empty($this->id)) {
-			$sql .= " AND rowid != ".((int) $this->id);
+			$sql .= " AND rowid != " . ((int)$this->id);
 		}
 
-		dol_syslog(get_class($this)."::checkOverlap", LOG_DEBUG);
+		dol_syslog(get_class($this) . "::checkOverlap", LOG_DEBUG);
 
 		$result = $this->db->query($sql);
 		if ($result) {
-			// Loop through all existing fiscal years
-			while ($obj = $this->db->fetch_object($result)) {
-				$existing_start = $this->db->jdate($obj->date_start);
-				$existing_end = $this->db->jdate($obj->date_end);
-
-				// Check for overlapping dates
-				// Case 1: New fiscal year start date falls within an existing fiscal year
-				if ($this->date_start >= $existing_start && $this->date_start <= $existing_end) {
-					$this->error = 'ErrorFiscalYearOverlapWithFiscalYear';
-					$this->errors[] = $obj->label;
-					return -1;
-				}
-
-				// Case 2: New fiscal year end date falls within an existing fiscal year
-				if ($this->date_end >= $existing_start && $this->date_end <= $existing_end) {
-					$this->error = 'ErrorFiscalYearOverlapWithFiscalYear';
-					$this->errors[] = $obj->label;
-					return -2;
-				}
-
-				// Case 3: New fiscal year completely encompasses an existing fiscal year
-				if ($this->date_start <= $existing_start && $this->date_end >= $existing_end) {
-					$this->error = 'ErrorFiscalYearOverlapWithFiscalYear';
-					$this->errors[] = $obj->label;
-					return -3;
-				}
+			if ($this->db->num_rows($result) > 0) {
+				$obj = $this->db->fetch_object($result);
+				$this->error = 'ErrorFiscalYearOverlapWithFiscalYear';
+				$this->errors[] = $obj->label;
+				return -1;
 			}
 			return 1; // No overlap found
 		} else {
 			$this->error = $this->db->lasterror();
-			return -4;
+			return -2;
 		}
 	}
 

--- a/htdocs/core/class/fiscalyear.class.php
+++ b/htdocs/core/class/fiscalyear.class.php
@@ -288,13 +288,13 @@ class Fiscalyear extends CommonObject
 		// Query to checks if any existing fiscal year overlaps with the current date range
 		$sql = "SELECT label";
 		$sql .= " FROM " . $this->db->prefix() . "accounting_fiscalyear";
-		$sql .= " WHERE entity = " . ((int)$entity);
+		$sql .= " WHERE entity = " . ((int) $entity);
 		$sql .= " AND date_start <= '" . $this->db->idate($this->date_end) . "'";
 		$sql .= " AND date_end >= '" . $this->db->idate($this->date_start) . "'";
 
 		// Exclude current fiscal year when updating
 		if (!empty($this->id)) {
-			$sql .= " AND rowid != " . ((int)$this->id);
+			$sql .= " AND rowid != " . ((int) $this->id);
 		}
 
 		dol_syslog(get_class($this) . "::checkOverlap", LOG_DEBUG);

--- a/htdocs/core/class/fiscalyear.class.php
+++ b/htdocs/core/class/fiscalyear.class.php
@@ -1,8 +1,8 @@
 <?php
-/* Copyright (C) 2014-2025	Alexandre Spangaro			<alexandre@inovea-conseil.com>
- * Copyright (C) 2020       OScss-Shop          <support@oscss-shop.fr>
- * Copyright (C) 2023-2024  Frédéric France     <frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2014-2026	Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2020		OScss-Shop					<support@oscss-shop.fr>
+ * Copyright (C) 2023-2024	Frédéric France				<frederic.france@free.fr>
+ * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -135,6 +135,12 @@ class Fiscalyear extends CommonObject
 
 		$now = dol_now();
 
+		// Check for date overlaps with existing fiscal years
+		$checkresult = $this->checkOverlap();
+		if ($checkresult < 0) {
+			return -5; // Overlap error detected
+		}
+
 		$this->db->begin();
 
 		$sql = "INSERT INTO ".$this->db->prefix()."accounting_fiscalyear (";
@@ -159,16 +165,8 @@ class Fiscalyear extends CommonObject
 		$result = $this->db->query($sql);
 		if ($result) {
 			$this->id = $this->db->last_insert_id($this->db->prefix()."accounting_fiscalyear");
-
-			$result = $this->update($user);
-			if ($result > 0) {
-				$this->db->commit();
-				return $this->id;
-			} else {
-				$this->error = $this->db->lasterror();
-				$this->db->rollback();
-				return $result;
-			}
+			$this->db->commit();
+			return $this->id;
 		} else {
 			$this->error = $this->db->lasterror()." sql=".$sql;
 			$this->db->rollback();
@@ -188,6 +186,12 @@ class Fiscalyear extends CommonObject
 		if (empty($this->date_start) && empty($this->date_end)) {
 			$this->error = 'ErrorBadParameter';
 			return -1;
+		}
+
+		// Check for date overlaps with existing fiscal years
+		$checkresult = $this->checkOverlap();
+		if ($checkresult < 0) {
+			return -5; // Overlap error detected
 		}
 
 		$this->db->begin();
@@ -266,6 +270,66 @@ class Fiscalyear extends CommonObject
 			$this->error = $this->db->lasterror();
 			$this->db->rollback();
 			return -1;
+		}
+	}
+
+	/**
+	 * Check if fiscal year dates overlap with existing fiscal years
+	 *
+	 * @return int Return integer <0 if overlap detected, >0 if OK
+	 */
+	public function checkOverlap()
+	{
+		global $conf;
+
+		// Get entity value
+		$entity = (!empty($this->entity) ? $this->entity : $conf->entity);
+
+		// Query to get all fiscal years for the current entity
+		$sql = "SELECT rowid, label, date_start, date_end";
+		$sql .= " FROM ".$this->db->prefix()."accounting_fiscalyear";
+		$sql .= " WHERE entity = ".((int) $entity);
+
+		// Exclude current fiscal year when updating
+		if (!empty($this->id)) {
+			$sql .= " AND rowid != ".((int) $this->id);
+		}
+
+		dol_syslog(get_class($this)."::checkOverlap", LOG_DEBUG);
+
+		$result = $this->db->query($sql);
+		if ($result) {
+			// Loop through all existing fiscal years
+			while ($obj = $this->db->fetch_object($result)) {
+				$existing_start = $this->db->jdate($obj->date_start);
+				$existing_end = $this->db->jdate($obj->date_end);
+
+				// Check for overlapping dates
+				// Case 1: New fiscal year start date falls within an existing fiscal year
+				if ($this->date_start >= $existing_start && $this->date_start <= $existing_end) {
+					$this->error = 'ErrorFiscalYearOverlapWithFiscalYear';
+					$this->errors[] = $obj->label;
+					return -1;
+				}
+
+				// Case 2: New fiscal year end date falls within an existing fiscal year
+				if ($this->date_end >= $existing_start && $this->date_end <= $existing_end) {
+					$this->error = 'ErrorFiscalYearOverlapWithFiscalYear';
+					$this->errors[] = $obj->label;
+					return -2;
+				}
+
+				// Case 3: New fiscal year completely encompasses an existing fiscal year
+				if ($this->date_start <= $existing_start && $this->date_end >= $existing_end) {
+					$this->error = 'ErrorFiscalYearOverlapWithFiscalYear';
+					$this->errors[] = $obj->label;
+					return -3;
+				}
+			}
+			return 1; // No overlap found
+		} else {
+			$this->error = $this->db->lasterror();
+			return -4;
 		}
 	}
 

--- a/htdocs/langs/en_US/compta.lang
+++ b/htdocs/langs/en_US/compta.lang
@@ -290,6 +290,7 @@ FiscalYearOpened=Fiscal year opened
 FiscalYearClosed=Fiscal year closed
 FiscalYearOpenedShort=Opened
 FiscalYearClosedShort=Closed
+ErrorFiscalYearOverlapWithFiscalYear=Fiscal year dates overlap with fiscal year: %s
 ListSocialContributionAssociatedProject=List of social contributions associated with the project
 DeleteFromCat=Remove from accounting group
 AccountingAffectation=Accounting assignment


### PR DESCRIPTION
Discuss on FR forum : https://www.dolibarr.fr/forum/t/cloture-dexercice-annulable/50497/7?u=aspangaro-inovea

## Description

This PR fixes a security issue where users could circumvent closed fiscal year restrictions by modifying the dates of another fiscal year to overlap with a closed period or not.

<img width="1543" height="486" alt="Capture d’écran du 2026-01-09 09-50-37" src="https://github.com/user-attachments/assets/b47f9f57-5a84-4584-b13e-19d54f55bf5e" />

**Problem:**
- When a fiscal year (e.g., 2024) was closed, users could modify the start date of the next fiscal year (e.g., 2025) to overlap with the closed period or not (starting from 01/01/2024 instead of 01/01/2025)
- This allowed unauthorized modifications of accounting entries in closed periods

**Solution:**
- Added a `checkOverlap()` method in the `Fiscalyear` class to validate that fiscal year dates do not overlap with existing fiscal years
- The validation is performed during both creation and update operations
- Proper error messages with fiscal year label are returned when overlaps are detected


