### PR TITLE
FIX cascading extrafields on line items being greyed out and unselectable

### DIFF
--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -1194,6 +1194,10 @@ function showOptions(child_list, parent_list) {
 function setListDependencies() {
 	console.log("setListDependencies");
 	jQuery("select option[parent]").parent().each(function() {
+		// Skip selects inside line item extrafield areas (handled by setListDependencies_extra)
+		if ($(this).closest('[id^="extrafield_lines_area"]').length > 0) {
+			return;
+		}
 		var child_list = $(this).attr("name");
 		var parent = $(this).find("option[parent]:first").attr("parent");
 		var infos = parent.split(":");


### PR DESCRIPTION
Fixes editing line items with parent-child 'Select from table' extrafields, when changing the parent field causes child options to become greyed out.

FIX skip selects inside extrafield_lines_area containers in setListDependencies() as they are handled by setListDependencies_extra().