### PR TITLE
FIX concatenation of labels in extrafields

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1622,6 +1622,7 @@ class ExtraFields
 								if (is_array($fields_label) && count($fields_label) > 1) {
 									$notrans = true;
 									foreach ($fields_label as $field_toshow) {
+										$field_toshow = preg_replace('/^.*\./', '', $field_toshow);
 										$labeltoshow .= $obj->$field_toshow.' ';
 									}
 								} else {
@@ -2216,6 +2217,7 @@ class ExtraFields
 					if (is_array($fields_label) && count($fields_label) > 1) {
 						foreach ($fields_label as $field_toshow) {
 							$translabel = '';
+							$field_toshow = preg_replace('/^.*\./', '', $field_toshow);
 							if (!empty($obj->$field_toshow)) {
 								$translabel = $outputlangs->trans($obj->$field_toshow);
 


### PR DESCRIPTION
# FIX concatenation of labels in extrafields

Follows discussion in PR #36835

IF:
- The extrafield is of type "Select from list"
- AND it would use a join as table
- AND the label would be a concatenation of fields from both tables THEN, the EF value could not be displayed (showOutputField os showInputField).

example of syntax that would trigger this error : 
```
commande c INNER JOIN llx_societe s ON s.rowid = c.fk_soc:s.nom|c.ref:c.rowid::
```

output : 

![Peek 15-01-2026 10-39](https://github.com/user-attachments/assets/e8b9378e-a95c-4a06-94e0-b503e987377f)

This commit fixes this.

