### PR TITLE
Fix: Add SEARCH_LIMIT_AJAX constant support to select_produits_list()

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3323,6 +3323,7 @@ class Form
 			$sql .= $this->db->order("p.ref");
 		}
 
+		$limit = getDolGlobalInt('SEARCH_LIMIT_AJAX') ?: $limit;
 		$sql .= $this->db->plimit($limit, 0);
 
 		// Build output string


### PR DESCRIPTION
# FIX|Fix Performance issue with select_produits_list() on large product databases

## Problem
Loading all products with `select_produits_list()` causes severe performance degradation (30+ seconds page load) on systems with 100K+ products, making multiselect product fields unusable.

## Solution
Add support for `SEARCH_LIMIT_AJAX` global constant to limit initial product loading.
- Add `$limit = getDolGlobalInt('SEARCH_LIMIT_AJAX') ?: $limit;` in `select_produits_list()`
- Backward compatible: Falls back to original `$limit` if constant not set
- Administrators can set `SEARCH_LIMIT_AJAX=50` in Setup > Other

## Impact
- Makes product selection usable on large databases
- No breaking changes

## Testing
Tested with 1M+ products in multiselect forms