### PR TITLE
Fix duplicate button for delivery receipt creation on shipment object

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -3072,12 +3072,6 @@ if ($action == 'create') {
 				}
 			}
 
-			// This is just to generate a delivery receipt
-			//var_dump($object->linkedObjectsIds['delivery']);
-			if (getDolGlobalInt('MAIN_SUBMODULE_DELIVERY') && ($object->status == Expedition::STATUS_VALIDATED || $object->status == Expedition::STATUS_CLOSED) && $user->hasRight('expedition', 'delivery', 'creer') && empty($object->linkedObjectsIds['delivery'])) {
-				print dolGetButtonAction('', $langs->trans('CreateDeliveryOrder'), 'default', $_SERVER["PHP_SELF"].'?action=create_delivery&token='.newToken().'&id='.$object->id, '');
-			}
-
 			// Set Billed and Closed
 			if ($object->status == Expedition::STATUS_VALIDATED) {
 				if ($user->hasRight('expedition', 'creer') && $object->status > 0) {


### PR DESCRIPTION
Remove a duplicate button for delivery receipt creation on shipment object.

Before fix:
<img width="2151" height="63" alt="image" src="https://github.com/user-attachments/assets/f2e9fc41-64a9-4860-a705-b8f363f4cc44" />


After fix:
<img width="2151" height="63" alt="image" src="https://github.com/user-attachments/assets/8ead8c99-5b09-437e-9e5b-d7fba42535b3" />
