### PR TITLE
FIX missmatch of permission check of button and action of cancel delivery note (expedition)

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -648,7 +648,7 @@ if (empty($reshook)) {
 				}
 			}
 		}
-	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $user->hasRight('expedition', 'supprimer')) {
+	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $user->hasRight('expedition', 'creer')) {
 		$also_update_stock = (GETPOST('alsoUpdateStock', 'alpha') ? 1 : 0);
 		$result = $object->cancel($user, 0, (bool) $also_update_stock);
 		if ($result > 0) {


### PR DESCRIPTION
# FIX missmatch of permission check of button and action of cancel delivery note (expedition)

In expedition/card.php there is the action "confirm_cancel" which checks for the right supprimer of expedition. The corresponding UI Button checks for creer of expedition. This means some people can see the button, but nothing happens when clicking on it (also no error message).
