### PR TITLE
NEW: Display thirdparty name with ref in supplier orders linked objects

### DIFF
--- a/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/fourn/commande/tpl/linkedobjectblock.tpl.php
@@ -54,6 +54,8 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	/** @var CommandeFournisseur $objectlink */
 	'@phan-var-force CommandeFournisseur $objectlink';
 	$ilink++;
+	$objectlink->fetch_thirdparty();
+	$refSupplierWithThirdparty = $objectlink->ref_supplier ? dolPrintHTML($objectlink->ref_supplier) . '<br>' . $objectlink->thirdparty->getNomUrl(1) : $objectlink->thirdparty->getNomUrl(1);
 
 	$trclass = 'oddeven';
 	if ($ilink == count($linkedObjectBlock) && empty($noMoreLinkedObjectBlockAfter) && count($linkedObjectBlock) <= 1) {
@@ -62,7 +64,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	<tr class="<?php echo $trclass; ?>">
 		<td class="tdoverflowmax125" title="<?php echo dolPrintHTMLForAttribute($langs->trans("SupplierOrder")); ?>"><?php echo dolPrintHTML($langs->trans("SupplierOrder")); ?></td>
 		<td><?php print $objectlink->getNomUrl(1); ?></td>
-		<td class="left linkedcol-ref tdoverflowmax125" title="<?php echo dolPrintHTMLForAttributeUrl($objectlink->ref_supplier); ?>"><?php echo dolPrintHTML($objectlink->ref_supplier); ?></td>
+		<td class="left linkedcol-ref tdoverflowmax125" title="<?php echo dolPrintHTMLForAttributeUrl($objectlink->ref_supplier); ?>"><?php echo $refSupplierWithThirdparty ?></td>
 		<td class="center"><?php echo dol_print_date($objectlink->date, 'day'); ?></td>
 		<td class="right"><?php
 		if ($user->hasRight("fournisseur", "commande", "lire")) {


### PR DESCRIPTION
# NEW|New Display thirdparty name with ref in supplier orders linked objects

## Description
This PR adds thirdparty display in the linked objects table for supplier orders by concatenating the thirdparty name with the reference.

## Changes
- Fetch thirdparty object for each linked supplier order
- Display thirdparty name as clickable link alongside ref_supplier in the ref column
- Show only thirdparty link when ref_supplier is empty
- Improves supplier order identification with thirdparty context

## Benefits
- Better object identification by showing which thirdparty the supplier order belongs to
- No UI/design changes (uses existing ref column)
- Maintains table layout and responsiveness
- No additional column needed

## Testing
- Tested with supplier orders in linked objects table
- Verified thirdparty link works correctly
- Checked display with and without ref_supplier value