### PR TITLE
FIX #36589 extrafields UI for product attribute values. Now all parts of the form is displayed

### DIFF
--- a/htdocs/blockedlog/admin/blockedlog_archives.php
+++ b/htdocs/blockedlog/admin/blockedlog_archives.php
@@ -47,6 +47,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array('admin', 'banks', 'bills', 'blockedlog', 'other'));
+global $withtab;
 
 // Get Parameters
 $action = GETPOST('action', 'aZ09');
@@ -142,8 +143,17 @@ $upload_dir = getMultidirOutput($block_static, 'blockedlog').'/archives';
 dol_mkdir($upload_dir);
 
 $fh = null;
+$totalhtamountforaction = [];
+$totalvatamountforaction = [];
+$totalamountforaction = [];
 
+// Variables used during export / analysis (init for static analysis safety)
+$concatenateddata = '';
+$nbLinesModifiedBeforeExport = 0;
+$nbLinesModifiedInExportButKo = 0;
 
+$totalhtamount = 0.0;
+$totalvatamount = 0.0;
 /*
  * Actions
  */
@@ -324,7 +334,7 @@ if ($action == 'export' && $user->hasRight('blockedlog', 'read')) {		// read is 
 				$block_static->module_source = $obj->module_source;
 				$block_static->pos_source = $obj->pos_source;
 
-				$block_static->amounts_taxexcl = is_null($obj->amounts_taxexcl) ? null : (float) $obj->amounts_taxexcl;	// Database store value with 8 digits, we cut ending 0 them with (flow)
+				$block_static->amounts_taxexcl = (float) $obj->amounts_taxexcl;	// Database store value with 8 digits, we cut ending 0 them with (flow)
 				$block_static->amounts = (float) $obj->amounts;															// Database store value with 8 digits, we cut ending 0 them with (flow)
 
 				$block_static->fk_object = $obj->fk_object;							// Not in signature
@@ -383,7 +393,11 @@ if ($action == 'export' && $user->hasRight('blockedlog', 'read')) {		// read is 
 					$statusofrecordnote = $langs->trans("PreviousFingerprint").': '.$previoushash.($statusofrecordnote ? ' - '.$statusofrecordnote : '');
 				}
 
-				//$concatenateddata = $block_static->buildKeyForSignature();
+				$concatenateddata = $block_static->buildKeyForSignature();
+
+				$previoushashexport = '';
+				// Note: The signature on export line is not used. It has been replaced with a global signature on all file.
+				$signatureexport = dol_hash($previoushashexport.$concatenateddata, 'sha256');
 
 				// Define $totalhtamount, $totalvatamount, $totalamount for $block->action event / $block->module_source
 				$total_ht = $total_vat = $total_ttc = 0;
@@ -531,7 +545,7 @@ if ($action == 'export' && $user->hasRight('blockedlog', 'read')) {		// read is 
 		// We do not use $totalamountalllines because it is only for the period, but we want lifetime amount since the first record to now.
 		$totalamountlifetime = array('BILL_VALIDATE' => 0, 'PAYMENT_CUSTOMER_CREATE' => 0, 'PAYMENT_CUSTOMER_DELETE' => 0);
 		$totalhtamountlifetime = array('BILL_VALIDATE' => 0, 'PAYMENT_CUSTOMER_CREATE' => 0, 'PAYMENT_CUSTOMER_DELETE' => 0);
-		$foundoldformat = 0;
+		$foundoldformat = $foundoldformat ?? false;
 		$firstrecorddate = 0;
 		global $foundoldformat, $firstrecorddate;
 		include DOL_DOCUMENT_ROOT.'/blockedlog/admin/lifetimeamount.inc.php';
@@ -814,9 +828,17 @@ if ($action == 'check' || $action == 'checkconfirmed') {
 
 
 	if ($action == 'checkconfirmed') {
-		$totalhtamountforaction = $totalvatamountforaction = $totalamountforaction = array(
+		$totalamount = array(
 			'BILL_VALIDATE' => 0,
-			'PAYMENT_CUSTOMER' => 0		// PAYMENT_CUSTOMER_CREATE + PAYMENT_CUSTOMER_DELETE
+			'PAYMENT_CUSTOMER_CREATE' => 0
+		);
+		$totalhtamount = array(
+			'BILL_VALIDATE' => 0,
+			'PAYMENT_CUSTOMER_CREATE' => 0
+		);
+		$totalvatamount = array(
+			'BILL_VALIDATE' => 0,
+			'PAYMENT_CUSTOMER_CREATE' => 0
 		);
 		$reg = array();
 		$refinvoicefound = array();
@@ -830,12 +852,18 @@ if ($action == 'check' || $action == 'checkconfirmed') {
 		$nbLinesModifiedInExportButKo = 0;
 		$nbLinesModifiedBeforeExport = 0;
 
-		$amounthtlifetime = array();
-		$amountvatlifetime = array();
-		$amountttclifetime = array();
-		$amounthtlifetime['BILL_VALIDATE'] = $amounthtlifetime['PAYMENT_CUSTOMER'] = null;
-		$amountvatlifetime['BILL_VALIDATE'] = $amountvatlifetime['PAYMENT_CUSTOMER'] = null;
-		$amountttclifetime['BILL_VALIDATE'] = $amountttclifetime['PAYMENT_CUSTOMER'] = null;
+		$amounthtlifetime = array(
+			'BILL_VALIDATE' => 0,
+			'PAYMENT_CUSTOMER' => 0
+		);
+		$amountvatlifetime = array(
+			'BILL_VALIDATE' => 0,
+			'PAYMENT_CUSTOMER' => 0
+		);
+		$amountttclifetime = array(
+			'BILL_VALIDATE' => 0,
+			'PAYMENT_CUSTOMER' => 0
+		);
 
 		$handle = fopen($fullpath, "r");
 		if ($handle) {
@@ -869,7 +897,7 @@ if ($action == 'check' || $action == 'checkconfirmed') {
 					$block_static->action = $lineactioncode = (string) $line[3];
 					$block_static->module_source = (string) $line[4];
 					$block_static->pos_source = '';
-					$block_static->amounts_taxexcl = $lineamountht = ($line[5] === '' ? null : (float) $line[5]);
+					$block_static->amounts_taxexcl = $lineamountht = (float) $line[5];
 					$block_static->amounts = $lineamountttc = (float) $line[6];
 					$block_static->ref_object = $lineref = (string) $line[7];
 					$block_static->date_object = (int) $line[8];
@@ -966,43 +994,12 @@ if ($action == 'check' || $action == 'checkconfirmed') {
 							$lineactioncode = 'PAYMENT_CUSTOMER';
 						}
 
-						$totalhtamountforaction[$lineactioncode] += $lineamountht;
-						$totalvatamountforaction[$lineactioncode] += ($lineamountttc - $lineamountht);
-						$totalamountforaction[$lineactioncode] += $lineamountttc;
+						$totalhtamountforaction[$lineactioncode] = ($totalhtamountforaction[$lineactioncode] ?? 0) + $lineamountht;
+						$totalvatamountforaction[$lineactioncode] = ($totalvatamountforaction[$lineactioncode] ?? 0) + ($lineamountttc - $lineamountht);
+						$totalamountforaction[$lineactioncode] = ($totalamountforaction[$lineactioncode] ?? 0) + $lineamountttc;
 					}
 					if ($lineactioncode == 'BILL_VALIDATE') {
 						$refinvoicefound[$lineref] = 1;
-					}
-				}
-
-				// Test if line is a summary line
-				if (preg_match('/^SUMMARY /', (string) $line[0])) {
-					// We are on a line for summary information
-					$lineanalyzed = 1;
-					/*
-					if (preg_match('/^SUMMARY TURNOVER BILLED/', (string) $line[0])) {
-						// Do nothing, we recalculate amount from previous lines
-					}
-					if (preg_match('/^SUMMARY TURNOVER PAID/', (string) $line[0])) {
-						// Do nothing, we recalculate amount from previous lines
-					}
-					*/
-					if (preg_match('/^SUMMARY LIFETIME BILLED/', (string) $line[0])) {
-						// We load data from line
-						$amountstring = (string) $line[0];
-						if (preg_match('/^SUMMARY LIFETIME BILLED[^\d]*\s:\s([\d\.]+)\s[^\d]+\s([\d\.]+)\s[^\d]+\s([\d\.]+)\s[^\d]+/', $amountstring, $reg)) {
-							$amounthtlifetime['BILL_VALIDATE'] = (float) $reg[1];
-							$amountvatlifetime['BILL_VALIDATE'] = (float) $reg[2];
-							$amountttclifetime['BILL_VALIDATE'] = (float) $reg[3];
-						}
-					}
-					if (preg_match('/^SUMMARY LIFETIME PAID/', (string) $line[0])) {
-						$amountstring = (string) $line[0];
-						if (preg_match('/^SUMMARY LIFETIME PAID[^\d]*\s:\s([\d\.]+)/', $amountstring, $reg)) {
-							$amounthtlifetime['PAYMENT_CUSTOMER'] = (float) $reg[1];
-							$amountvatlifetime['PAYMENT_CUSTOMER'] = 0.0;
-							$amountttclifetime['PAYMENT_CUSTOMER'] = (float) $reg[1];
-						}
 					}
 				}
 
@@ -1100,9 +1097,9 @@ if ($action == 'check' || $action == 'checkconfirmed') {
 
 		$arraykeys = array('BILL_VALIDATE', 'PAYMENT_CUSTOMER');
 		foreach ($arraykeys as $key) {
-			$totalhttoshow = $totalhtamountforaction[$key];
-			$totalvattoshow = $totalvatamountforaction[$key];
-			$totaltoshow = $totalamountforaction[$key];
+			$totalhttoshow = (float) $totalhtamountforaction[$key];
+			$totalvattoshow = (float) $totalvatamountforaction[$key];
+			$totaltoshow = (float) $totalamountforaction[$key];
 
 			print '<b>'.dolPrintHTML($langs->trans("TotalForAction").' '.$langs->trans('log'.$key)).'</b>';
 			if ($key == 'BILL_VALIDATE') {
@@ -1134,12 +1131,9 @@ if ($action == 'check' || $action == 'checkconfirmed') {
 		// Now print the value for lifetime amounts.
 		$arraykeys = array('BILL_VALIDATE', 'PAYMENT_CUSTOMER');
 		foreach ($arraykeys as $key) {
-			if (is_null($amounthtlifetime[$key])) {		// If not entry found, we discard
-				continue;
-			}
-			$totalhttoshow = $amounthtlifetime[$key];
-			$totalvattoshow = $amountvatlifetime[$key];
-			$totaltoshow = $amountttclifetime[$key];
+			$totalhttoshow = (float) ($amounthtlifetime[$key]);
+			$totalvattoshow = (float) ($amountvatlifetime[$key]);
+			$totaltoshow = (float) ($amountttclifetime[$key]);
 
 			print '<b>'.dolPrintHTML($langs->trans("LifetimeAmountShort").' '.$langs->trans('log'.$key)).'</b>';
 			if ($key == 'BILL_VALIDATE') {

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -957,16 +957,13 @@ abstract class CommonInvoice extends CommonObject
 			}
 
 			$parameters = array();
-			$reshook = $hookmanager->executeHooks('isErasable', $parameters, $this, $action);
-			if (!empty($hookmanager->resArray['result'])) {
-				$this->error = $hookmanager->resArray['error'];
-				if (!empty($hookmanager->resArray['errors'])) {
-					$this->errors = array_merge($this->errors, $hookmanager->resArray['errors']);
+			$reshook = $hookmanager->executeHooks('isEditable', $parameters, $this, $action);
+			if ($reshook < 0) {
+				$this->error = $hookmanager->error;
+				if (!empty($hookmanager->errors)) {
+					$this->errors = array_merge($this->errors, $hookmanager->errors);
 				}
-				if (!in_array($this->error, $this->errors)) {
-					$this->errors[] = $this->error;
-				}
-				return $hookmanager->resArray['result'];
+				return (int) $reshook;
 			}
 		}
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -81,7 +81,14 @@ class Form
 	// Cache arrays
 	/** @var array<int,array{id:int,code:string,label:string,type:int,entity:int,active:int}> */
 	public $cache_types_paiements = array();
-	/** @var array<int,array{code:string,label:string,deposit_percent:string,entity:int}> */
+	/**
+	 * @var array<string,array{
+	 *   code:string,
+	 *   label:string,
+	 *   deposit_percent?:string,
+	 *   entity?:int
+	 * }>
+	 */
 	public $cache_conditions_paiements = array();
 	/** @var array<int,array{rowid:int,code:string,label:string,active:int}> */
 	public $cache_transport_mode = array();

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -82,12 +82,7 @@ class Form
 	/** @var array<int,array{id:int,code:string,label:string,type:int,entity:int,active:int}> */
 	public $cache_types_paiements = array();
 	/**
-	 * @var array<string,array{
-	 *   code:string,
-	 *   label:string,
-	 *   deposit_percent?:string,
-	 *   entity?:int
-	 * }>
+	 * @var array<int|string, array{code:string,label:string,deposit_percent?:string,entity?:int}>
 	 */
 	public $cache_conditions_paiements = array();
 	/** @var array<int,array{rowid:int,code:string,label:string,active:int}> */

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1953,6 +1953,7 @@ function show_actions_done($conf, $langs, $db, $filterobj, $objcon = null, $nopr
 	}
 
 	$sql = '';
+	$canedit = 0;
 
 	if (isModEnabled('agenda')) {
 		// Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1501,6 +1501,9 @@ class Societe extends CommonObject
 		$this->vat_reverse_charge = empty($this->vat_reverse_charge) ? 0 : 1;
 		$this->euid = trim((string) $this->euid);
 
+		$this->tva_assuj			= (is_numeric($this->tva_assuj)) ? (int) trim((string) $this->tva_assuj) : 0;
+		$this->tva_intra			= trim((string) $this->tva_intra);
+		$this->vat_reverse_charge	= empty($this->vat_reverse_charge) ? 0 : 1;
 		if (empty($this->status)) {
 			$this->status = 0;
 		}

--- a/htdocs/variants/admin/product_attribute_extrafields.php
+++ b/htdocs/variants/admin/product_attribute_extrafields.php
@@ -17,9 +17,9 @@
  */
 
 /**
- *      \file       htdocs/variants/admin/product_attribute_value_extrafields.php
+ *      \file       htdocs/variants/admin/product_attribute_extrafields.php
  *		\ingroup    variants
- *		\brief      Page to setup extra fields of product_attribute_value
+ *		\brief      Page to setup extra fields of product_attribute
  */
 
 // Load Dolibarr environment
@@ -28,11 +28,11 @@ require_once DOL_DOCUMENT_ROOT.'/variants/lib/variants.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 
 /**
- * @var Conf $conf
- * @var DoliDB $db
+ * @var Conf       $conf
+ * @var DoliDB     $db
  * @var HookManager $hookmanager
  * @var Translate $langs
- * @var User $user
+ * @var User      $user
  */
 
 if (!$user->admin) {
@@ -41,7 +41,6 @@ if (!$user->admin) {
 
 // Load translation files required by the page
 $langs->loadLangs(array('admin', 'other', 'product'));
-
 
 $extrafields = new ExtraFields($db);
 $form = new Form($db);
@@ -55,25 +54,23 @@ foreach ($tmptype2label as $key => $val) {
 
 $action = GETPOST('action', 'aZ09');
 $attrname = GETPOST('attrname', 'alpha');
-$elementtype = 'product_attribute'; //Must be the $table_element of the class that manage extrafield
-
+$elementtype = 'product_attribute'; // Must be the $table_element of the extrafield owner
 
 /*
  * Actions
  */
-
 require DOL_DOCUMENT_ROOT.'/core/actions_extrafields.inc.php';
-
-
 
 /*
  * View
  */
-
-$title =  $langs->trans("ProductAttributeExtrafieldsSetup");
+$title = $langs->trans("ProductAttributeExtrafieldsSetup");
 llxHeader('', $title);
 
-$linkback = '<a href="'.dolBuildUrl(DOL_URL_ROOT.'/admin/modules.php', ['restore_lastsearch_values' => 1]).'">'.img_picto($langs->trans("BackToModuleList"), 'back', 'class="pictofixedwidth"').'<span class="hideonsmartphone">'.$langs->trans("BackToModuleList").'</span></a>';
+$linkback = '<a href="' . dolBuildUrl(DOL_URL_ROOT.'/admin/modules.php', ['restore_lastsearch_values' => 1]) . '">' .
+	img_picto($langs->trans("BackToModuleList"), 'back', 'class="pictofixedwidth"') .
+	'<span class="hideonsmartphone">'.$langs->trans("BackToModuleList").'</span></a>';
+
 print load_fiche_titre($title, $linkback, 'title_setup');
 
 $head = adminProductAttributePrepareHead();
@@ -84,13 +81,22 @@ require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_view.tpl.php';
 
 print dol_get_fiche_end();
 
-
 // Creation of an optional field
 if ($action == 'create') {
 	print '<br><div id="newattrib"></div>';
 	print load_fiche_titre($langs->trans('NewAttribute'));
 
+	// Temporary override for template
+	$textobject = $elementtype;
+
+	// Map attributes so template logic remains consistent
+	if (!empty($extrafields->attributes[$textobject])) {
+		$extrafields->attributes['product'] = $extrafields->attributes[$textobject];
+	}
+
+	$elementtype = 'product';
 	require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_add.tpl.php';
+	$elementtype = $textobject;
 }
 
 // Edition of an optional field
@@ -98,7 +104,17 @@ if ($action == 'edit' && !empty($attrname)) {
 	print "<br>";
 	print load_fiche_titre($langs->trans("FieldEdition", $attrname));
 
+	// Temporary override for template
+	$textobject = $elementtype;
+
+	// Map attributes so template can read existing values
+	if (!empty($extrafields->attributes[$textobject])) {
+		$extrafields->attributes['product'] = $extrafields->attributes[$textobject];
+	}
+
+	$elementtype = 'product';
 	require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
+	$elementtype = $textobject;
 }
 
 // End of page

--- a/htdocs/variants/admin/product_attribute_value_extrafields.php
+++ b/htdocs/variants/admin/product_attribute_value_extrafields.php
@@ -17,7 +17,7 @@
  */
 
 /**
- *      \file       htdocs/variants/admin/product_attribute_extrafields.php
+ *      \file       htdocs/variants/admin/product_attribute_value_extrafields.php
  *		\ingroup    variants
  *		\brief      Page to setup extra fields of product_attribute_value
  */
@@ -28,11 +28,11 @@ require_once DOL_DOCUMENT_ROOT.'/variants/lib/variants.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 
 /**
- * @var Conf $conf
- * @var DoliDB $db
+ * @var Conf       $conf
+ * @var DoliDB     $db
  * @var HookManager $hookmanager
  * @var Translate $langs
- * @var User $user
+ * @var User      $user
  */
 
 if (!$user->admin) {
@@ -54,25 +54,23 @@ foreach ($tmptype2label as $key => $val) {
 
 $action = GETPOST('action', 'aZ09');
 $attrname = GETPOST('attrname', 'alpha');
-$elementtype = 'product_attribute_value'; //Must be the $table_element of the class that manage extrafield
-
+$elementtype = 'product_attribute_value'; // Must be the $table_element of the extrafield owner
 
 /*
  * Actions
  */
-
 require DOL_DOCUMENT_ROOT.'/core/actions_extrafields.inc.php';
-
-
 
 /*
  * View
  */
-
 $title = $langs->trans("ProductAttributeValueExtrafieldsSetup");
 llxHeader('', $title);
 
-$linkback = '<a href="'.dolBuildUrl(DOL_URL_ROOT.'/admin/modules.php', ['restore_lastsearch_values' => 1]).'">'.img_picto($langs->trans("BackToModuleList"), 'back', 'class="pictofixedwidth"').'<span class="hideonsmartphone">'.$langs->trans("BackToModuleList").'</span></a>';
+$linkback = '<a href="' . dolBuildUrl(DOL_URL_ROOT.'/admin/modules.php', ['restore_lastsearch_values' => 1]) . '">' .
+	img_picto($langs->trans("BackToModuleList"), 'back', 'class="pictofixedwidth"') .
+	'<span class="hideonsmartphone">'.$langs->trans("BackToModuleList").'</span></a>';
+
 print load_fiche_titre($title, $linkback, 'title_setup');
 
 $head = adminProductAttributePrepareHead();
@@ -83,13 +81,21 @@ require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_view.tpl.php';
 
 print dol_get_fiche_end();
 
-
 // Creation of an optional field
 if ($action == 'create') {
 	print '<br><div id="newattrib"></div>';
 	print load_fiche_titre($langs->trans('NewAttribute'));
 
+	// Temporary override for template
+	$textobject = $elementtype;
+
+	if (!empty($extrafields->attributes[$textobject])) {
+		$extrafields->attributes['product'] = $extrafields->attributes[$textobject];
+	}
+
+	$elementtype = 'product';
 	require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_add.tpl.php';
+	$elementtype = $textobject;
 }
 
 // Edition of an optional field
@@ -97,7 +103,16 @@ if ($action == 'edit' && !empty($attrname)) {
 	print "<br>";
 	print load_fiche_titre($langs->trans("FieldEdition", $attrname));
 
+	// Temporary override for template
+	$textobject = $elementtype;
+
+	if (!empty($extrafields->attributes[$textobject])) {
+		$extrafields->attributes['product'] = $extrafields->attributes[$textobject];
+	}
+
+	$elementtype = 'product';
 	require DOL_DOCUMENT_ROOT.'/core/tpl/admin_extrafields_edit.tpl.php';
+	$elementtype = $textobject;
 }
 
 // End of page


### PR DESCRIPTION
## **Related ssue:** #36589

The extrafields interface is designed to work with core elements such as products. Product attribute values reuse the same extrafields mechanism, but their specific element type is not directly handled by the standard templates, which prevented the forms from being displayed completely.

This improvement makes product attribute extrafields fully usable by reusing the existing product extrafields templates at render time. The element type is temporarily mapped to product only for display purposes and then restored, ensuring a seamless UI experience without altering how data is stored or managed.