### PR TITLE
FIX: Massaction Create Bills from expedition

### DIFF
--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -299,7 +299,7 @@ if (empty($reshook)) {
 			}
 
 			if ($objecttmp->id > 0) {
-				$res = $objecttmp->add_object_linked($objecttmp->origin, $id_sending);
+				$res = $objecttmp->add_object_linked($objecttmp->origin_type, $id_sending);
 
 				if ($res == 0) {
 					$errors[] = $expd->ref.' : '.$langs->trans($objecttmp->errors[0]);


### PR DESCRIPTION
In the shipment list, massaction invoice creation was not working. Invoices were created successfully, but they were never linked to the shipment due to the value `$objecttmp->origin = null` instead of `$objecttmp->origin_type = “shipment”` given to the add_object_linked function as $origin argument.