### PR TITLE
FIX Contract - Wrong button to edit contract odt path

### DIFF
--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -145,7 +145,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 		$texte .= getDolGlobalString('CONTRACT_ADDON_PDF_ODT_PATH');
 		$texte .= '</textarea>';
 		$texte .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$texte .= '<input type="submit" class="button reposition smallpaddingimp" value="'.dol_escape_htmltag($langs->trans("Upload")).'" name="upload">';
+		$texte .= '<input type="submit" class="button reposition smallpaddingimp" name="modify" value="'.dol_escape_htmltag($langs->trans("Modify")).'">';
 		$texte .= '<br></div></div>';
 
 		// Scan directories
@@ -153,7 +153,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 		if (getDolGlobalString('CONTRACT_ADDON_PDF_ODT_PATH')) {
 			$texte .= $langs->trans("NumberOfModelFilesFound").': <b>';
 			//$texte.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$texte .= count($listoffiles);
+			$texte .= $nbofiles;
 			//$texte.=$nbofiles?'</a>':'';
 			$texte .= '</b>';
 		}


### PR DESCRIPTION
Wrong button in contract admin to manage odt path. Problem to register path for odt.

<img width="1116" height="239" alt="Capture d’écran du 2026-01-23 08-42-12" src="https://github.com/user-attachments/assets/66be0745-f8a6-441b-a8b4-1efe65d82ecb" />
