### PR TITLE
Fix/ai OpenAI gpt5 responses

### DIFF
--- a/htdocs/ai/class/ai.class.php
+++ b/htdocs/ai/class/ai.class.php
@@ -54,6 +54,13 @@ class Ai
 	 */
 	private $apiEndpoint;
 
+	/**
+	 * Avoid writing repeated quota alerts during the same request.
+	 *
+	 * @var bool
+	 */
+	private static $quotaAlertRaised = false;
+
 	const AI_DEFAULT_PROMPT_FOR_EMAIL = 'You are an email editor. Return all HTML content inside a section tag. Do not add explanation.';
 	const AI_DEFAULT_PROMPT_FOR_WEBPAGE = 'You are a website editor. Return all HTML content inside a section tag. Do not add explanation.';
 	const AI_DEFAULT_PROMPT_FOR_TEXT_TRANSLATION = 'You are a translator, answer with one and only one translation with no comment and explanation.';
@@ -61,6 +68,109 @@ class Ai
 	const AI_DEFAULT_PROMPT_FOR_TEXT_REPHRASER = 'You are a writer, give only one answer with no comment and explanation and give the answer in the same language than the original text to rephrase.';
 	const AI_DEFAULT_PROMPT_FOR_EXTRAFIELD_FILLER = 'Give only one answer with no comment and explanation, I want the text to be ready to copy and paste.';
 	const AI_DEFAULT_PROMPT_FOR_DOC_PARSING = 'You are an assistant to anayze documents. Return your answer with a JSON string and only a JSON string, do not add any other comment.';
+
+	/**
+	 * Detect AI quota / billing hard-limit errors to trigger a persistent warning in Dolibarr.
+	 *
+	 * @param int $httpCode
+	 * @param mixed $decodedResponse
+	 * @param string $errorMessage
+	 * @return bool
+	 */
+	private function isQuotaExhaustedError($httpCode, $decodedResponse, $errorMessage)
+	{
+		$httpCode = (int) $httpCode;
+		$errorMessage = strtolower(trim((string) $errorMessage));
+
+		$payload = '';
+		if (is_array($decodedResponse)) {
+			$tmp = json_encode($decodedResponse);
+			if ($tmp !== false) $payload = strtolower($tmp);
+		} elseif (is_string($decodedResponse)) {
+			$payload = strtolower($decodedResponse);
+		}
+
+		$hay = trim($errorMessage.' '.$payload);
+		if ($hay === '') return false;
+
+		// OpenAI: error.code/type = "insufficient_quota" or similar.
+		if (strpos($hay, 'insufficient_quota') !== false) return true;
+		if (strpos($hay, 'billing_hard_limit_reached') !== false) return true;
+		if (strpos($hay, 'hard_limit') !== false && strpos($hay, 'billing') !== false) return true;
+
+		// Generic quota wording.
+		if (strpos($hay, 'quota') !== false && (strpos($hay, 'exceed') !== false || strpos($hay, 'exceeded') !== false)) return true;
+		if (strpos($hay, 'quota') !== false && strpos($hay, 'billing') !== false) return true;
+
+		// HTTP hints (429 can also be rate-limit; we only treat it as quota when "quota" is present).
+		if (in_array($httpCode, array(402, 403, 429), true) && strpos($hay, 'quota') !== false) return true;
+
+		return false;
+	}
+
+	/**
+	 * Persist a quota exhausted warning into global constants so admins see it in the UI.
+	 *
+	 * @param int $httpCode
+	 * @param string $function
+	 * @param string $errorMessage
+	 * @param mixed $decodedResponse
+	 * @return void
+	 */
+	private function recordQuotaExhaustedWarning($httpCode, $function, $errorMessage, $decodedResponse = null)
+	{
+		global $conf;
+
+		if (self::$quotaAlertRaised) return;
+		self::$quotaAlertRaised = true;
+
+		if (empty($conf) || empty($conf->entity) || !is_object($this->db)) return;
+
+		$httpCode = (int) $httpCode;
+		$function = trim((string) $function);
+		$errorMessage = trim((string) $errorMessage);
+
+		if ($errorMessage === '') {
+			$errorMessage = 'AI quota exhausted';
+		}
+
+		// Avoid writing the same alert too often.
+		$now = dol_now('gmt');
+		$prevAt = (int) getDolGlobalString('AI_LAST_QUOTA_EXHAUSTED_AT', '0');
+		$prevMsg = (string) getDolGlobalString('AI_LAST_QUOTA_EXHAUSTED_MSG', '');
+
+		$shortMsg = dol_trunc($errorMessage, 255);
+
+		// Suspend further AI calls for some time (to avoid burning retry attempts in background jobs).
+		// Can be tuned with AI_QUOTA_SUSPEND_SECONDS (0 disables suspension).
+		$suspendSeconds = (int) getDolGlobalInt('AI_QUOTA_SUSPEND_SECONDS', 3600);
+		if ($suspendSeconds < 0) $suspendSeconds = 0;
+		if ($suspendSeconds > 0) {
+			$suspendUntil = $now + $suspendSeconds;
+			$prevSuspendUntil = (int) getDolGlobalString('AI_QUOTA_SUSPEND_UNTIL', '0');
+			if ($prevSuspendUntil < $suspendUntil) {
+				dolibarr_set_const($this->db, 'AI_QUOTA_SUSPEND_UNTIL', (string) $suspendUntil, 'chaine', 0, '', $conf->entity);
+			}
+		}
+
+		if ($prevAt > 0 && ($now - $prevAt) < 600 && $prevMsg === $shortMsg) {
+			return;
+		}
+
+		dolibarr_set_const($this->db, 'AI_LAST_QUOTA_EXHAUSTED_AT', (string) $now, 'chaine', 0, '', $conf->entity);
+		dolibarr_set_const($this->db, 'AI_LAST_QUOTA_EXHAUSTED_MSG', $shortMsg, 'chaine', 0, '', $conf->entity);
+		dolibarr_set_const($this->db, 'AI_LAST_QUOTA_EXHAUSTED_SERVICE', (string) $this->apiService, 'chaine', 0, '', $conf->entity);
+		dolibarr_set_const($this->db, 'AI_LAST_QUOTA_EXHAUSTED_HTTP', (string) $httpCode, 'chaine', 0, '', $conf->entity);
+		if ($function !== '') {
+			dolibarr_set_const($this->db, 'AI_LAST_QUOTA_EXHAUSTED_FUNCTION', $function, 'chaine', 0, '', $conf->entity);
+		}
+		if (is_array($decodedResponse)) {
+			$tmp = json_encode($decodedResponse);
+			if ($tmp !== false && $tmp !== '') {
+				dolibarr_set_const($this->db, 'AI_LAST_QUOTA_EXHAUSTED_RAW', dol_trunc($tmp, 2048), 'chaine', 0, '', $conf->entity);
+			}
+		}
+	}
 
 
 	/**
@@ -108,6 +218,19 @@ class Ai
 		// TODO Can store the need for a key into array returned by getListOfAIServices()
 		if (empty($this->apiKey) && in_array($this->apiService, array('chatgpt', 'groq', 'mistral'))) {
 			return array('error' => true, 'message' => 'API key is not defined for the AI enabled service ('.$this->apiService.')');
+		}
+
+		// Fast-fail when AI calls are suspended due to a recent "insufficient quota" error.
+		$suspendUntil = (int) getDolGlobalString('AI_QUOTA_SUSPEND_UNTIL', '0');
+		if ($suspendUntil > 0 && $suspendUntil > dol_now('gmt')) {
+			return array(
+				'error' => true,
+				'message' => 'AI quota suspended until '.$suspendUntil,
+				'code' => 429,
+				'format' => $format,
+				'service' => $this->apiService,
+				'function' => $function
+			);
 		}
 
 		// $this->apiEndpoint is already set here only if it was previously forced.
@@ -168,6 +291,26 @@ class Ai
 			}
 		}
 
+		// OpenAI GPT-5 models use the Responses API (Chat Completions may return "invalid model ID").
+		$useResponsesApi = false;
+		if (
+			!is_array($instructions)
+			&& $this->apiService === 'chatgpt'
+			&& is_string($model)
+			&& preg_match('/^gpt-5/i', $model)
+		) {
+			// Only for text-like functions.
+			if (!in_array($function, array('imagegeneration', 'audiogeneration', 'transcription', 'translation', 'file', 'assistant', 'thread'), true)) {
+				$useResponsesApi = true;
+				if (!empty($this->apiEndpoint) && strpos($this->apiEndpoint, 'chat/completions') !== false) {
+					$tmpEndpoint = preg_replace('~/chat/completions~', '/responses', $this->apiEndpoint, 1);
+					if (!empty($tmpEndpoint)) {
+						$this->apiEndpoint = $tmpEndpoint;
+					}
+				}
+			}
+		}
+
 		dol_syslog("Call API for apiKey=".substr($this->apiKey, 0, 5).'***********, apiEndpoint='.$this->apiEndpoint.", model=".$model);
 
 		$response = null;
@@ -219,8 +362,8 @@ class Ai
 			if (is_array($instructions)) {
 				$arrayforpayload = $instructions;
 				$fullInstructions = '';
-			} else {
-				$fullInstructions = $instructions.($postPrompt ? (preg_match('/[\.\!\?]$/', $instructions) ? '' : '.').' '.$postPrompt : '');
+				} else {
+					$fullInstructions = $instructions.($postPrompt ? (preg_match('/[\.\!\?]$/', $instructions) ? '' : '.').' '.$postPrompt : '');
 
 				// Set payload string
 				/*{
@@ -246,20 +389,37 @@ class Ai
 					"top_p": 0.95
 				}*/
 
-				$arrayforpayload = array(
-					'messages' => array(array('role' => 'user', 'content' => $fullInstructions)),
-					'model' => $model,
-				);
+					// Add a system message (Chat Completions) / instructions (Responses API)
+					$addDateTimeContext = false;
+					if ($addDateTimeContext) {		// @phpstan-ignore-line
+						$prePrompt = ($prePrompt ? $prePrompt.(preg_match('/[\.\!\?]$/', $prePrompt) ? '' : '.').' ' : '').'Today we are '.dol_print_date(dol_now(), 'dayhourtext');
+					}
 
-				// Add a system message
-				$addDateTimeContext = false;
-				if ($addDateTimeContext) {		// @phpstan-ignore-line
-					$prePrompt = ($prePrompt ? $prePrompt.(preg_match('/[\.\!\?]$/', $prePrompt) ? '' : '.').' ' : '').'Today we are '.dol_print_date(dol_now(), 'dayhourtext');
+					if ($useResponsesApi) {
+						$arrayforpayload = array(
+							'model' => $model,
+							'input' => array(
+								array(
+									'role' => 'user',
+									'content' => array(
+										array('type' => 'input_text', 'text' => $fullInstructions),
+									),
+								),
+							),
+						);
+						if ($prePrompt) {
+							$arrayforpayload['instructions'] = $prePrompt;
+						}
+					} else {
+						$arrayforpayload = array(
+							'messages' => array(array('role' => 'user', 'content' => $fullInstructions)),
+							'model' => $model,
+						);
+						if ($prePrompt) {
+							$arrayforpayload['messages'][] = array('role' => 'system', 'content' => $prePrompt);
+						}
+					}
 				}
-				if ($prePrompt) {
-					$arrayforpayload['messages'][] = array('role' => 'system', 'content' => $prePrompt);
-				}
-			}
 
 			/*
 			$arrayforpayload['temperature'] = 0.7;
@@ -317,17 +477,27 @@ class Ai
 			if (empty($response['http_code'])) {
 				throw new Exception('API request failed. No http received');
 			}
-			if (!empty($response['http_code']) && $response['http_code'] != 200) {
-				if (in_array($response['http_code'], array(400, 401, 403, 429)) && !empty($response['content'])) {
-					$tmp = json_decode($response['content'], true);
-					if (!empty($tmp['message'])) {
-						return array(
-							'error' => true,
-							'message' => $tmp['message'],
-							'code' => (empty($response['http_code']) ? 0 : $response['http_code']),
-							'curl_error_no' => (empty($response['curl_error_no']) ? 0 : $response['curl_error_no']),
-							'format' => $format,
-							'service' => $this->apiService,
+				if (!empty($response['http_code']) && $response['http_code'] != 200) {
+					if (in_array($response['http_code'], array(400, 401, 403, 429)) && !empty($response['content'])) {
+						$tmp = json_decode($response['content'], true);
+						$tmpMsg = '';
+						if (!empty($tmp['message'])) {
+							$tmpMsg = (string) $tmp['message'];
+						} elseif (!empty($tmp['error']['message'])) {
+							$tmpMsg = (string) $tmp['error']['message'];
+						}
+
+						if ($tmpMsg !== '') {
+							if ($this->isQuotaExhaustedError((int) $response['http_code'], $tmp, $tmpMsg)) {
+								$this->recordQuotaExhaustedWarning((int) $response['http_code'], (string) $function, $tmpMsg, $tmp);
+							}
+							return array(
+								'error' => true,
+								'message' => $tmpMsg,
+								'code' => (empty($response['http_code']) ? 0 : $response['http_code']),
+								'curl_error_no' => (empty($response['curl_error_no']) ? 0 : $response['curl_error_no']),
+								'format' => $format,
+								'service' => $this->apiService,
 							'function' => $function
 						);
 					}
@@ -351,20 +521,63 @@ class Ai
 			}
 
 
-			// Decode JSON response
-			$decodedResponse = json_decode($response['content'], true);
+				// Decode JSON response
+				$decodedResponse = json_decode($response['content'], true);
 
-			// Extraction content
-			if (!empty($decodedResponse['error'])) {
-				if (is_scalar($decodedResponse['error'])) {
-					$generatedContent = $decodedResponse['error'];
-				} else {
-					$generatedContent = var_export($decodedResponse['error'], true);
+				// Clear quota suspension after a successful request.
+				if (!empty($decodedResponse) && is_array($decodedResponse)) {
+					global $conf;
+					if (!empty($conf) && !empty($conf->entity) && is_object($this->db)) {
+						if ((int) getDolGlobalString('AI_QUOTA_SUSPEND_UNTIL', '0') > 0) {
+							dolibarr_del_const($this->db, 'AI_QUOTA_SUSPEND_UNTIL', $conf->entity);
+						}
+					}
 				}
-			} else {
-				$generatedContent = $decodedResponse['choices'][0]['message']['content'];
-			}
-			dol_syslog("ai->generatedContent returned: ".dol_trunc($generatedContent, 50));
+
+				// Extraction content
+				$generatedContent = '';
+				if ($useResponsesApi) {
+					if (!empty($decodedResponse['output_text']) && is_string($decodedResponse['output_text'])) {
+						$generatedContent = (string) $decodedResponse['output_text'];
+					} elseif (!empty($decodedResponse['output']) && is_array($decodedResponse['output'])) {
+						$texts = array();
+						foreach ($decodedResponse['output'] as $outItem) {
+							if (!is_array($outItem)) continue;
+							if (!empty($outItem['content']) && is_array($outItem['content'])) {
+								foreach ($outItem['content'] as $cont) {
+									if (!is_array($cont)) continue;
+									if (!empty($cont['text']) && is_string($cont['text'])) {
+										$texts[] = $cont['text'];
+									} elseif (!empty($cont['output_text']) && is_string($cont['output_text'])) {
+										$texts[] = $cont['output_text'];
+									}
+								}
+							} elseif (!empty($outItem['text']) && is_string($outItem['text'])) {
+								$texts[] = $outItem['text'];
+							}
+						}
+						$generatedContent = trim(implode("\n", $texts));
+					}
+
+					if ($generatedContent === '' && !empty($decodedResponse['error'])) {
+						if (is_scalar($decodedResponse['error'])) {
+							$generatedContent = (string) $decodedResponse['error'];
+						} else {
+							$generatedContent = var_export($decodedResponse['error'], true);
+						}
+					}
+				} else {
+					if (!empty($decodedResponse['error'])) {
+						if (is_scalar($decodedResponse['error'])) {
+							$generatedContent = $decodedResponse['error'];
+						} else {
+							$generatedContent = var_export($decodedResponse['error'], true);
+						}
+					} else {
+						$generatedContent = $decodedResponse['choices'][0]['message']['content'];
+					}
+				}
+				dol_syslog("ai->generatedContent returned: ".dol_trunc($generatedContent, 50));
 
 			// If content is not HTML, we convert it into HTML
 			if ($format == 'html') {
@@ -381,25 +594,30 @@ class Ai
 			}
 
 			return $generatedContent;
-		} catch (Exception $e) {
-			$errormessage = $e->getMessage();
-			$errormessagelog = $e->getMessage();
-			if (!empty($response['content'])) {
-				$decodedResponse = json_decode($response['content'], true);
-				$errormessagelog .= ' - '.$response['content'];
+			} catch (Exception $e) {
+				$errormessage = $e->getMessage();
+				$errormessagelog = $e->getMessage();
+				$decodedResponse = null;
+				if (!empty($response['content'])) {
+					$decodedResponse = json_decode($response['content'], true);
+					$errormessagelog .= ' - '.$response['content'];
 
 				if (!empty($decodedResponse['error']['message'])) {
 					// With OpenAI, error is into an object error into the content
 					$errormessage .= ' - '.$decodedResponse['error']['message'];
 				} else {
 					$errormessage .= ' - '.$response['content'];
+					}
 				}
-			}
 
-			if (getDolGlobalString("AI_DEBUG")) {
-				if (@is_writable($dolibarr_main_data_root)) {	// Avoid fatal error on fopen with open_basedir
-					$outputfile = $dolibarr_main_data_root."/dolibarr_ai.log";
-					$fp = fopen($outputfile, "a");
+				if ($this->isQuotaExhaustedError((empty($response['http_code']) ? 0 : (int) $response['http_code']), $decodedResponse, $errormessage)) {
+					$this->recordQuotaExhaustedWarning((empty($response['http_code']) ? 0 : (int) $response['http_code']), (string) $function, $errormessage, $decodedResponse);
+				}
+
+				if (getDolGlobalString("AI_DEBUG")) {
+					if (@is_writable($dolibarr_main_data_root)) {	// Avoid fatal error on fopen with open_basedir
+						$outputfile = $dolibarr_main_data_root."/dolibarr_ai.log";
+						$fp = fopen($outputfile, "a");
 
 					if ($fp) {
 						fwrite($fp, "Error: ".$errormessagelog."\n");

--- a/htdocs/ai/class/ai.class.php
+++ b/htdocs/ai/class/ai.class.php
@@ -362,8 +362,8 @@ class Ai
 			if (is_array($instructions)) {
 				$arrayforpayload = $instructions;
 				$fullInstructions = '';
-				} else {
-					$fullInstructions = $instructions.($postPrompt ? (preg_match('/[\.\!\?]$/', $instructions) ? '' : '.').' '.$postPrompt : '');
+			} else {
+				$fullInstructions = $instructions.($postPrompt ? (preg_match('/[\.\!\?]$/', $instructions) ? '' : '.').' '.$postPrompt : '');
 
 				// Set payload string
 				/*{
@@ -389,37 +389,37 @@ class Ai
 					"top_p": 0.95
 				}*/
 
-					// Add a system message (Chat Completions) / instructions (Responses API)
-					$addDateTimeContext = false;
-					if ($addDateTimeContext) {		// @phpstan-ignore-line
-						$prePrompt = ($prePrompt ? $prePrompt.(preg_match('/[\.\!\?]$/', $prePrompt) ? '' : '.').' ' : '').'Today we are '.dol_print_date(dol_now(), 'dayhourtext');
-					}
+				// Add a system message (Chat Completions) / instructions (Responses API)
+				$addDateTimeContext = false;
+				if ($addDateTimeContext) {		// @phpstan-ignore-line
+					$prePrompt = ($prePrompt ? $prePrompt.(preg_match('/[\.\!\?]$/', $prePrompt) ? '' : '.').' ' : '').'Today we are '.dol_print_date(dol_now(), 'dayhourtext');
+				}
 
-					if ($useResponsesApi) {
-						$arrayforpayload = array(
-							'model' => $model,
-							'input' => array(
-								array(
-									'role' => 'user',
-									'content' => array(
-										array('type' => 'input_text', 'text' => $fullInstructions),
-									),
+				if ($useResponsesApi) {
+					$arrayforpayload = array(
+						'model' => $model,
+						'input' => array(
+							array(
+								'role' => 'user',
+								'content' => array(
+									array('type' => 'input_text', 'text' => $fullInstructions),
 								),
 							),
-						);
-						if ($prePrompt) {
-							$arrayforpayload['instructions'] = $prePrompt;
-						}
-					} else {
-						$arrayforpayload = array(
-							'messages' => array(array('role' => 'user', 'content' => $fullInstructions)),
-							'model' => $model,
-						);
-						if ($prePrompt) {
-							$arrayforpayload['messages'][] = array('role' => 'system', 'content' => $prePrompt);
-						}
+						),
+					);
+					if ($prePrompt) {
+						$arrayforpayload['instructions'] = $prePrompt;
+					}
+				} else {
+					$arrayforpayload = array(
+						'messages' => array(array('role' => 'user', 'content' => $fullInstructions)),
+						'model' => $model,
+					);
+					if ($prePrompt) {
+						$arrayforpayload['messages'][] = array('role' => 'system', 'content' => $prePrompt);
 					}
 				}
+			}
 
 			/*
 			$arrayforpayload['temperature'] = 0.7;
@@ -477,27 +477,27 @@ class Ai
 			if (empty($response['http_code'])) {
 				throw new Exception('API request failed. No http received');
 			}
-				if (!empty($response['http_code']) && $response['http_code'] != 200) {
-					if (in_array($response['http_code'], array(400, 401, 403, 429)) && !empty($response['content'])) {
-						$tmp = json_decode($response['content'], true);
-						$tmpMsg = '';
-						if (!empty($tmp['message'])) {
-							$tmpMsg = (string) $tmp['message'];
-						} elseif (!empty($tmp['error']['message'])) {
-							$tmpMsg = (string) $tmp['error']['message'];
-						}
+			if (!empty($response['http_code']) && $response['http_code'] != 200) {
+				if (in_array($response['http_code'], array(400, 401, 403, 429)) && !empty($response['content'])) {
+					$tmp = json_decode($response['content'], true);
+					$tmpMsg = '';
+					if (!empty($tmp['message'])) {
+						$tmpMsg = (string) $tmp['message'];
+					} elseif (!empty($tmp['error']['message'])) {
+						$tmpMsg = (string) $tmp['error']['message'];
+					}
 
-						if ($tmpMsg !== '') {
-							if ($this->isQuotaExhaustedError((int) $response['http_code'], $tmp, $tmpMsg)) {
-								$this->recordQuotaExhaustedWarning((int) $response['http_code'], (string) $function, $tmpMsg, $tmp);
-							}
-							return array(
-								'error' => true,
-								'message' => $tmpMsg,
-								'code' => (empty($response['http_code']) ? 0 : $response['http_code']),
-								'curl_error_no' => (empty($response['curl_error_no']) ? 0 : $response['curl_error_no']),
-								'format' => $format,
-								'service' => $this->apiService,
+					if ($tmpMsg !== '') {
+						if ($this->isQuotaExhaustedError((int) $response['http_code'], $tmp, $tmpMsg)) {
+							$this->recordQuotaExhaustedWarning((int) $response['http_code'], (string) $function, $tmpMsg, $tmp);
+						}
+						return array(
+							'error' => true,
+							'message' => $tmpMsg,
+							'code' => (empty($response['http_code']) ? 0 : $response['http_code']),
+							'curl_error_no' => (empty($response['curl_error_no']) ? 0 : $response['curl_error_no']),
+							'format' => $format,
+							'service' => $this->apiService,
 							'function' => $function
 						);
 					}
@@ -520,64 +520,63 @@ class Ai
 				}
 			}
 
+			// Decode JSON response
+			$decodedResponse = json_decode($response['content'], true);
 
-				// Decode JSON response
-				$decodedResponse = json_decode($response['content'], true);
-
-				// Clear quota suspension after a successful request.
-				if (!empty($decodedResponse) && is_array($decodedResponse)) {
-					global $conf;
-					if (!empty($conf) && !empty($conf->entity) && is_object($this->db)) {
-						if ((int) getDolGlobalString('AI_QUOTA_SUSPEND_UNTIL', '0') > 0) {
-							dolibarr_del_const($this->db, 'AI_QUOTA_SUSPEND_UNTIL', $conf->entity);
-						}
+			// Clear quota suspension after a successful request.
+			if (!empty($decodedResponse) && is_array($decodedResponse)) {
+				global $conf;
+				if (!empty($conf) && !empty($conf->entity) && is_object($this->db)) {
+					if ((int) getDolGlobalString('AI_QUOTA_SUSPEND_UNTIL', '0') > 0) {
+						dolibarr_del_const($this->db, 'AI_QUOTA_SUSPEND_UNTIL', $conf->entity);
 					}
 				}
+			}
 
-				// Extraction content
-				$generatedContent = '';
-				if ($useResponsesApi) {
-					if (!empty($decodedResponse['output_text']) && is_string($decodedResponse['output_text'])) {
-						$generatedContent = (string) $decodedResponse['output_text'];
-					} elseif (!empty($decodedResponse['output']) && is_array($decodedResponse['output'])) {
-						$texts = array();
-						foreach ($decodedResponse['output'] as $outItem) {
-							if (!is_array($outItem)) continue;
-							if (!empty($outItem['content']) && is_array($outItem['content'])) {
-								foreach ($outItem['content'] as $cont) {
-									if (!is_array($cont)) continue;
-									if (!empty($cont['text']) && is_string($cont['text'])) {
-										$texts[] = $cont['text'];
-									} elseif (!empty($cont['output_text']) && is_string($cont['output_text'])) {
-										$texts[] = $cont['output_text'];
-									}
+			// Extraction content
+			$generatedContent = '';
+			if ($useResponsesApi) {
+				if (!empty($decodedResponse['output_text']) && is_string($decodedResponse['output_text'])) {
+					$generatedContent = (string) $decodedResponse['output_text'];
+				} elseif (!empty($decodedResponse['output']) && is_array($decodedResponse['output'])) {
+					$texts = array();
+					foreach ($decodedResponse['output'] as $outItem) {
+						if (!is_array($outItem)) continue;
+						if (!empty($outItem['content']) && is_array($outItem['content'])) {
+							foreach ($outItem['content'] as $cont) {
+								if (!is_array($cont)) continue;
+								if (!empty($cont['text']) && is_string($cont['text'])) {
+									$texts[] = $cont['text'];
+								} elseif (!empty($cont['output_text']) && is_string($cont['output_text'])) {
+									$texts[] = $cont['output_text'];
 								}
-							} elseif (!empty($outItem['text']) && is_string($outItem['text'])) {
-								$texts[] = $outItem['text'];
 							}
+						} elseif (!empty($outItem['text']) && is_string($outItem['text'])) {
+							$texts[] = $outItem['text'];
 						}
-						$generatedContent = trim(implode("\n", $texts));
 					}
+					$generatedContent = trim(implode("\n", $texts));
+				}
 
-					if ($generatedContent === '' && !empty($decodedResponse['error'])) {
-						if (is_scalar($decodedResponse['error'])) {
-							$generatedContent = (string) $decodedResponse['error'];
-						} else {
-							$generatedContent = var_export($decodedResponse['error'], true);
-						}
+				if ($generatedContent === '' && !empty($decodedResponse['error'])) {
+					if (is_scalar($decodedResponse['error'])) {
+						$generatedContent = (string) $decodedResponse['error'];
+					} else {
+						$generatedContent = var_export($decodedResponse['error'], true);
+					}
+				}
+			} else {
+				if (!empty($decodedResponse['error'])) {
+					if (is_scalar($decodedResponse['error'])) {
+						$generatedContent = $decodedResponse['error'];
+					} else {
+						$generatedContent = var_export($decodedResponse['error'], true);
 					}
 				} else {
-					if (!empty($decodedResponse['error'])) {
-						if (is_scalar($decodedResponse['error'])) {
-							$generatedContent = $decodedResponse['error'];
-						} else {
-							$generatedContent = var_export($decodedResponse['error'], true);
-						}
-					} else {
-						$generatedContent = $decodedResponse['choices'][0]['message']['content'];
-					}
+					$generatedContent = $decodedResponse['choices'][0]['message']['content'];
 				}
-				dol_syslog("ai->generatedContent returned: ".dol_trunc($generatedContent, 50));
+			}
+			dol_syslog("ai->generatedContent returned: ".dol_trunc($generatedContent, 50));
 
 			// If content is not HTML, we convert it into HTML
 			if ($format == 'html') {
@@ -594,30 +593,30 @@ class Ai
 			}
 
 			return $generatedContent;
-			} catch (Exception $e) {
-				$errormessage = $e->getMessage();
-				$errormessagelog = $e->getMessage();
-				$decodedResponse = null;
-				if (!empty($response['content'])) {
-					$decodedResponse = json_decode($response['content'], true);
-					$errormessagelog .= ' - '.$response['content'];
+		} catch (Exception $e) {
+			$errormessage = $e->getMessage();
+			$errormessagelog = $e->getMessage();
+			$decodedResponse = null;
+			if (!empty($response['content'])) {
+				$decodedResponse = json_decode($response['content'], true);
+				$errormessagelog .= ' - '.$response['content'];
 
 				if (!empty($decodedResponse['error']['message'])) {
 					// With OpenAI, error is into an object error into the content
 					$errormessage .= ' - '.$decodedResponse['error']['message'];
 				} else {
 					$errormessage .= ' - '.$response['content'];
-					}
 				}
+			}
 
-				if ($this->isQuotaExhaustedError((empty($response['http_code']) ? 0 : (int) $response['http_code']), $decodedResponse, $errormessage)) {
-					$this->recordQuotaExhaustedWarning((empty($response['http_code']) ? 0 : (int) $response['http_code']), (string) $function, $errormessage, $decodedResponse);
-				}
+			if ($this->isQuotaExhaustedError((empty($response['http_code']) ? 0 : (int) $response['http_code']), $decodedResponse, $errormessage)) {
+				$this->recordQuotaExhaustedWarning((empty($response['http_code']) ? 0 : (int) $response['http_code']), (string) $function, $errormessage, $decodedResponse);
+			}
 
-				if (getDolGlobalString("AI_DEBUG")) {
-					if (@is_writable($dolibarr_main_data_root)) {	// Avoid fatal error on fopen with open_basedir
-						$outputfile = $dolibarr_main_data_root."/dolibarr_ai.log";
-						$fp = fopen($outputfile, "a");
+			if (getDolGlobalString("AI_DEBUG")) {
+				if (@is_writable($dolibarr_main_data_root)) {	// Avoid fatal error on fopen with open_basedir
+					$outputfile = $dolibarr_main_data_root."/dolibarr_ai.log";
+					$fp = fopen($outputfile, "a");
 
 					if ($fp) {
 						fwrite($fp, "Error: ".$errormessagelog."\n");


### PR DESCRIPTION
Add automatic support for OpenAI gpt-5* models in the AI module by switching to the Responses API when required, and improve handling of “insufficient quota” / billing hard-limit errors.

Changes
When AI_API_SERVICE=chatgpt and the selected model matches gpt-5*, the request is sent to /v1/responses (Chat Completions may return “invalid model ID” for GPT‑5).
Build the proper Responses payload (input + optional instructions) and keep the existing Chat Completions payload for other models.
Parse Responses outputs (output_text and output[].content[].text) while preserving the existing choices[0].message.content parsing for Chat Completions.
Detect quota/billing hard-limit errors (e.g. insufficient_quota) and store a persistent warning in global constants (AI_LAST_QUOTA_EXHAUSTED_*). Optionally suspend further AI calls for a cooldown period using AI_QUOTA_SUSPEND_UNTIL (default 1h, configurable with AI_QUOTA_SUSPEND_SECONDS, 0 disables).
Follow-up commit: whitespace/indentation cleanup only (no functional change intended).