### PR TITLE
NEW Add EUID number

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -103,4 +103,6 @@ ALTER TABLE llx_facture_fourn ADD COLUMN dispute_status	integer DEFAULT 0;
 
 ALTER TABLE llx_facture_rec ADD COLUMN fk_email_template integer DEFAULT NULL;
 
+ALTER TABLE llx_societe ADD COLUMN euid varchar (64);
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_societe.sql
+++ b/htdocs/install/mysql/tables/llx_societe.sql
@@ -1,11 +1,11 @@
 -- ========================================================================
--- Copyright (C) 2000-2004 Rodolphe Quiedeville <rodolphe@quiedeville.org>
--- Copyright (C) 2004-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
--- Copyright (C) 2005-2010 Regis Houssin        <regis.houssin@inodbox.com>
--- Copyright (C) 2010      Juanjo Menent        <dolibarr@2byte.es>
--- Copyright (C) 2014      Teddy Andreotti      <125155@supinfo.com>
--- Copyright (C) 2015      Marcos García        <marcosgdf@gmail.com>
--- Copyright (C) 2023      Alexandre Spangaro   <aspangaro@open-dsi.fr>
+-- Copyright (C) 2000-2004	Rodolphe Quiedeville	<rodolphe@quiedeville.org>
+-- Copyright (C) 2004-2017	Laurent Destailleur		<eldy@users.sourceforge.net>
+-- Copyright (C) 2005-2010	Regis Houssin			<regis.houssin@inodbox.com>
+-- Copyright (C) 2010		Juanjo Menent			<dolibarr@2byte.es>
+-- Copyright (C) 2014		Teddy Andreotti			<125155@supinfo.com>
+-- Copyright (C) 2015		Marcos García			<marcosgdf@gmail.com>
+-- Copyright (C) 2023-2026	Alexandre Spangaro		<alexandre@inovea-conseil.com>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -76,12 +76,13 @@ create table llx_societe
   idprof4                  varchar(128),                         		-- IDProf4: depends on country (example: nu for france, ...)
   idprof5                  varchar(128),                         		-- IDProf5: depends on country (example: nu for france, ...)
   idprof6                  varchar(128),                         		-- IDProf6: depends on country (example: nu for france, ...
-  tva_intra                varchar(20),                         		-- vat numero
+  tva_intra                varchar(20),                         		-- vat number
+  euid                     varchar(64),                         		-- EUID number (European Unique Identifier)
   capital                  double(24,8)   DEFAULT NULL,        			-- capital of company
   fk_stcomm                integer        DEFAULT 0 NOT NULL,      		-- commercial status
   note_private             text,                                		--
   note_public              text,                                        --
-  model_pdf				   varchar(255),								-- the last tempate used to generate a document
+  model_pdf				   varchar(255),								-- the last template used to generate a document
   last_main_doc			   varchar(255),								-- relative filepath+filename of the last main generated document
   prefix_comm              varchar(5),                          		-- prefix commercial (deprecated)
   client                   tinyint        DEFAULT 0,            		-- client 0/1/2


### PR DESCRIPTION
SQL Part

----------------------------------------------------
### Addition of support for the European Unique Identifier (EUID)

**_Context_**

Since December 1, 2025, all French Kbis extracts include a new mandatory entry: the EUID (European Unique Identifier), a unique European identifier for companies.

This identifier does not replace the SIREN or RCS numbers, but is added to company identification information to enhance transparency and combat document fraud within the European Union.

**_European scope_**

The EUID is a standardized identifier at the European level (Directive 2012/17/EU and Implementing Regulation EU 2021/1042) that applies to all companies registered in a commercial register of an EU member state.

It cannot therefore be stored in an idprof field specific to France, as it is a European standard applicable to all EU countries.

**_Structure of the EUID_**

The identifier follows a harmonized structure:

Country code (e.g., “FR”)
Register code (e.g., “RCSxxxx” for a French registry)
National identifier (the SIREN number in France)

French format: FR-RCSXXXX-SIREN

**_Analysis of European identifier lengths_**

National company identifiers vary significantly from country to country:

- France: SIREN = 9 digits
- Germany: Handelsregisternummer = up to ~15 characters
- Italy: Codice Fiscale = 11 digits
- Spain: NIF/CIF = 9 characters
- Netherlands: KVK = 8 digits
- Belgium: Company Number = 10 digits
- Poland: REGON = 10 digits
- 

The full EUID COUNTRY-REGISTER-IDENTIFIER format can be up to 35-40 characters long in the longest cases (particularly for Germany).

**_Proposed implementation_**

It would be necessary to:

- Add a new dedicated euid field in the third-party table (llx_societe)
- Provide for the display of this field in the company file
- Allow manual entry and/or import of this data
- Add this field to exports and APIs
- Document the expected format according to European countries

**_Benefits_**

- Compliance with European regulations in force since December 2025
- Facilitation of the identification of European companies
- Enhanced security and verification of business partners
- Preparation of Dolibarr for cross-border use in Europe

**_References_**

[GerantDeSARL.com article dated December 19, 2025](https://www.gerantdesarl.com/actualite/kbis-une-nouvelle-mention-obligatoire-pour-securiser-l-identification-des-entreprises)

Directive 2012/17/EU of the European Parliament and of the Council of June 13, 2012

Commission Implementing Regulation (EU) 2021/1042 of June 18, 2021


----------------------------------------------------
### Ajout du support de l'identifiant européen EUID (European Unique Identifier)

**_Contexte_**

Depuis le 1er décembre 2025, tous les extraits Kbis français comportent une nouvelle mention obligatoire : l'EUID (European Unique Identifier), identifiant unique européen des entreprises.

Cet identifiant ne remplace pas le SIREN ni le numéro RCS, mais vient s'ajouter aux informations d'identification des entreprises pour renforcer la transparence et la lutte contre les fraudes documentaires au sein de l'Union Européenne.

**_Périmètre européen_**

L'EUID est un identifiant normalisé au niveau européen (Directive 2012/17/UE et Règlement d'exécution UE 2021/1042) qui concerne toutes les entreprises immatriculées dans un registre du commerce d'un État membre de l'UE.

Il ne peut donc pas être stocké dans un champ idprof spécifique à la France, car il s'agit d'un standard européen applicable à tous les pays de l'UE.

**_Structure de l'EUID_**

L'identifiant suit une structure harmonisée :

Code pays (exemple : "FR")
Code du registre (exemple : "RCSxxxx" pour un greffe français)
Identifiant national (le numéro SIREN en France)

Format français : FR-RCSXXXX-SIREN

**_Analyse des longueurs des identifiants européens_**

Les identifiants nationaux d'entreprise varient significativement selon les pays :

- France : SIREN = 9 chiffres
- Allemagne : Handelsregisternummer = jusqu'à ~15 caractères
- Italie : Codice Fiscale = 11 chiffres
- Espagne : NIF/CIF = 9 caractères
- Pays-Bas : KVK = 8 chiffres
- Belgique : Numéro d'Entreprise = 10 chiffres
- Pologne : REGON = 10 chiffres

Le format complet EUID PAYS-REGISTRE-IDENTIFIANT peut atteindre 35-40 caractères dans les cas les plus longs (notamment pour l'Allemagne).

**_Proposition d'implémentation_**

Il serait nécessaire de :

- Ajouter un nouveau champ dédié euid dans la table des tiers (llx_societe)
- Prévoir l'affichage de ce champ dans la fiche entreprise
- Permettre la saisie manuelle et/ou l'import de cette donnée
- Ajouter ce champ dans les exports et API
- Documenter le format attendu selon les pays européens

**_Bénéfices_**

- Conformité avec la réglementation européenne en vigueur depuis décembre 2025
- Facilitation de l'identification des entreprises européennes
- Renforcement de la sécurité et de la vérification des partenaires commerciaux
- Préparation de Dolibarr pour une utilisation transfrontalière en Europe

**_Références_**

[Article GerantDeSARL.com du 19 décembre 2025](https://www.gerantdesarl.com/actualite/kbis-une-nouvelle-mention-obligatoire-pour-securiser-l-identification-des-entreprises)

Directive 2012/17/UE du Parlement européen et du Conseil du 13 juin 2012

Règlement d'exécution (UE) 2021/1042 de la Commission du 18 juin 2021