### PR TITLE
FIX Add table alias prefix in selectForFormsList() to prevent SQL ambiguity errors

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -15,7 +15,7 @@
  * Copyright (C) 2012-2016  Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2012       Cedric Salvador         <csalvador@gpcsolutions.fr>
  * Copyright (C) 2012-2015  Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
- * Copyright (C) 2014-2020  Alexandre Spangaro      <aspangaro@open-dsi.fr>
+ * Copyright (C) 2014-2026  Alexandre Spangaro      <alexandre@inovea-conseil.com>
  * Copyright (C) 2018-2022  Ferran Marcet           <fmarcet@2byte.es>
  * Copyright (C) 2018-2021  Frédéric France         <frederic.france@netlogic.fr>
  * Copyright (C) 2018       Nicolas ZABOURI	        <info@inovea-conseil.com>
@@ -8094,6 +8094,26 @@ class Form
 
 			if ($filter) {     // Syntax example "(t.ref:like:'SO-%') and (t.date_creation:<:'20160101')"
 				$errormessage = '';
+
+				// Fix: Add table alias prefix to common field names to avoid SQL ambiguity
+				$common_fields = array('entity', 'status', 'rowid', 'ref', 'label', 'fk_soc', 'date_creation', 'tms', 'nom', 'name');
+
+				foreach ($common_fields as $field) {
+					// Universal Search syntax: (fieldname:operator:value)
+					$filter = preg_replace(
+						'/\((\s*)(' . preg_quote($field, '/') . ')(\s*:[=!<>]+:)/i',
+						'($1t.$2$3',
+						$filter
+					);
+
+					// Standard SQL syntax: fieldname operator value
+					$filter = preg_replace(
+						'/(?<![a-zA-Z0-9_\.])(' . preg_quote($field, '/') . ')(\s*(?:=|!=|<|>|<=|>=|<>|IN|NOT\s+IN|LIKE|NOT\s+LIKE|IS))/i',
+						't.$1$2',
+						$filter
+					);
+				}
+
 				$sql .= forgeSQLFromUniversalSearchCriteria($filter, $errormessage);
 				if ($errormessage) {
 					return 'Error forging a SQL request from an universal criteria: ' . $errormessage;


### PR DESCRIPTION
Bug see from v18 (maybe under) to develop

Problem detected in one of our modules: 

<img width="1010" height="638" alt="Capture d’écran du 2026-01-27 16-41-14" src="https://github.com/user-attachments/assets/2e9e9d30-0a94-4da0-a052-08eae366cee3" />

**_Problem_**
When using Universal Search syntax (e.g., (entity:=:1) AND (status:=:1)) in field definitions, the selectForFormsList() method generates SQL queries without table alias prefixes for common field names. This causes DB_ERROR_1052 "Column 'entity' in WHERE clause is ambiguous" when the query involves JOINs with tables that share the same column names.

Example of problematic filter:

php
```
'fk_soc' => array(
    'type' => 'integer:Societe:societe/class/societe.class.php:1:entity=__SHARED_ENTITIES__ AND status=1',
    // ...
)
```
Generated SQL (broken):

sql
```
SELECT t.rowid, t.nom, t.name_alias FROM llx_societe as t 
WHERE 1=1 AND t.entity IN (1) AND entity = 1 AND status = 1
```
The fields entity and status lose the t. prefix, causing ambiguity when JOINs are present.

**_Solution_**
This PR adds automatic table alias prefix (t.) to common field names that frequently cause ambiguity in SQL queries. The fix handles both:

Universal Search syntax: (entity:=:1) → (t.entity:=:1)

Standard SQL syntax: entity = 1 → t.entity = 1

Common fields covered:
entity, status, rowid, ref, label, fk_soc, date_creation, tms, nom, name

Generated SQL (fixed):

sql
```
SELECT t.rowid, t.nom, t.name_alias FROM llx_societe as t 
WHERE 1=1 AND t.entity IN (1) AND t.entity = 1 AND t.status = 1
```

**_Changes_**

Modified htdocs/core/class/html.form.class.php

Function: selectForFormsList()

Added regex-based field name prefixing before calling forgeSQLFromUniversalSearchCriteria()