### PR TITLE
fix phan

### DIFF
--- a/htdocs/core/modules/movement/doc/pdf_standard_movementstock.modules.php
+++ b/htdocs/core/modules/movement/doc/pdf_standard_movementstock.modules.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2017 		Laurent Destailleur 		<eldy@stocks.sourceforge.net>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024	    Nick Fragoulis
  *
  * This program is free software; you can redistribute it and/or modify
@@ -618,7 +618,7 @@ class pdf_standard_movementstock extends ModelePDFMovement
 
 						// Lot/series
 						$pdf->SetXY($this->posxqty, $curY);
-						$pdf->MultiCell($this->posxup - $this->posxqty - 0.8, 3, $productlot->batch, 0, 'R');
+						$pdf->MultiCell($this->posxup - $this->posxqty - 0.8, 3, (string) $productlot->batch, 0, 'R');
 
 						// Inv. code
 						$pdf->SetXY($this->posxup, $curY);


### PR DESCRIPTION
PhanTypeMismatchArgumentNullable Argument 3 ($txt) is $productlot->batch of type ?string but \TCPDF::MultiCell() takes string defined at htdocs/includes/tecnickcom/tcpdf/tcpdf.php:5871 (expected type to be non-nullable)