### PR TITLE
[FIX] Remove jstz.min.js from JavaScript array

### DIFF
--- a/htdocs/core/modules/openid_connect/callback.php
+++ b/htdocs/core/modules/openid_connect/callback.php
@@ -38,7 +38,6 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/functions.lib.php';
 
 // Javascript code on logon page only to detect user tz, dst_observed, dst_first, dst_second
 $arrayofjs = array(
-	'/includes/jstz/jstz.min.js'.(empty($conf->dol_use_jmobile) ? '' : '?version='.urlencode(DOL_VERSION)),
 	'/core/js/dst.js'.(empty($conf->dol_use_jmobile) ? '' : '?version='.urlencode(DOL_VERSION))
 );
 


### PR DESCRIPTION
# FIX 404 error

jstz.min.js was deleted in https://github.com/Dolibarr/dolibarr/commit/5599ac733b07d990d64e3ff18b30b3dca16d5b86
this PR removes it from callback.php