### PR TITLE
ENH rename llx_societe field euid to idprof7

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -107,6 +107,7 @@ ALTER TABLE llx_facture_rec ADD COLUMN fk_email_template integer DEFAULT NULL;
 ALTER TABLE llx_holiday_users ADD COLUMN import_key varchar(14);
 
 ALTER TABLE llx_societe ADD COLUMN euid varchar (64);
+ALTER TABLE llx_societe CHANGE euid idprof7 varchar (64) AFTER idprof6;
 
 CREATE TABLE llx_ai_request_log
 (

--- a/htdocs/install/mysql/tables/llx_societe.sql
+++ b/htdocs/install/mysql/tables/llx_societe.sql
@@ -76,7 +76,7 @@ create table llx_societe
   idprof4                  varchar(128),                         		-- IDProf4: depends on country (example: Rcs/rm for france, ...)
   idprof5                  varchar(128),                         		-- IDProf5: depends on country (example: EORI, ...)
   idprof6                  varchar(128),                         		-- IDProf6: depends on country (example: Not used for france, ...
-  euid                     varchar(64),                         		-- EUID number (European Unique Identifier)
+  idprof7                  varchar(64),                         		-- IDProf7: depends on country (example: EUID European Unique Identifier)
   tva_intra                varchar(20),                         		-- VAT number (example: FR12345678901 for france, ...)
   capital                  double(24,8)   DEFAULT NULL,        			-- capital of company
   fk_stcomm                integer        DEFAULT 0 NOT NULL,      		-- commercial status


### PR DESCRIPTION
# QUAL Rename llx_societe field euid to idprof7

PR #36997 added a new field `euid` for European companies.
This PR suggests a mors generic approach by naming this field idprof7.

NB - idprof6 might also be used, but I don't know if european companies already have to use idprof6.

@aspangaro 