### PR TITLE
FIX #36843 Update card-rec.php

### DIFF
--- a/htdocs/compta/facture/card-rec.php
+++ b/htdocs/compta/facture/card-rec.php
@@ -688,7 +688,7 @@ if (empty($reshook)) {
 					$desc = $prod->description;
 				}
 
-				$desc = dol_concatdesc($desc, $product_desc);
+				//Fix #36843 $desc = dol_concatdesc($desc, $product_desc);
 
 				// Add custom code and origin country into description
 				if (!getDolGlobalString('MAIN_PRODUCT_DISABLE_CUSTOMCOUNTRYCODE') && (!empty($prod->customcode) || !empty($prod->country_code))) {


### PR DESCRIPTION

#Fix #36843 Item desc appreas twice on Sales Invoice template

The item desc is already added into the line when selecting the Item. No Need to concat it again when clicking the "add" button.


