### PR TITLE
FIX: TakePOS, webapp-hardware-bridge and TakePOS-Connector for modern weighing scales

### DIFF
--- a/htdocs/admin/receiptprinter.php
+++ b/htdocs/admin/receiptprinter.php
@@ -487,7 +487,7 @@ if ($mode == 'template') {
 				print '<input type="hidden" name="templateid" value="'.($printer->listprinterstemplates[$line]['rowid'] ?? '').'">';
 				print '<td><input type="text" class="minwidth200" name="templatename" value="'.($printer->listprinterstemplates[$line]['name'] ?? '').'"></td>';
 				print '<td class="wordbreak">';
-				print '<textarea name="template" wrap="soft" cols="120" rows="12">'.($printer->listprinterstemplates[$line]['template'] ?? '').'</textarea>';
+				print '<textarea name="template" wrap="soft" cols="90" rows="12">'.($printer->listprinterstemplates[$line]['template'] ?? '').'</textarea>';
 				print '</td>';
 				print '<td>';
 				print $form->buttonsSaveCancel("Save", '');
@@ -516,7 +516,7 @@ if ($mode == 'template') {
 		print '<tr>';
 		print '<td><input type="text" class="minwidth200" name="templatename" value="'.($printer->listprinterstemplates[$line]['name'] ?? '').'"></td>';
 		print '<td class="wordbreak">';
-		print '<textarea name="template" wrap="soft" cols="120" rows="12">';
+		print '<textarea name="template" wrap="soft" cols="90" rows="12">';
 		print '</textarea>';
 		print '</td>';
 		print '<td>';

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1518,7 +1518,7 @@ if (getDolGlobalString('TAKEPOS_BAR_RESTAURANT')) {
 
 // Button to print receipt
 if (getDolGlobalString('TAKEPOS_PRINT_METHOD') == "takeposconnector") {		// deprecated method
-	if (getDolGlobalString('TAKEPOS_PRINT_SERVER') && filter_var(getDolGlobalString('TAKEPOS_PRINT_SERVER, FILTER_VALIDATE_URL')) == true) {
+	if (getDolGlobalString('TAKEPOS_PRINT_SERVER') && filter_var(getDolGlobalString('TAKEPOS_PRINT_SERVER'), FILTER_VALIDATE_URL) == true) {
 		$menus[$r++] = array('title' => '<span class="fa fa-receipt paddingrightonly"></span><div class="trunc">'.$langs->trans("PrintTicket").'</div>', 'action' => 'TakeposConnector(placeid);');
 	} else {
 		$menus[$r++] = array('title' => '<span class="fa fa-receipt paddingrightonly"></span><div class="trunc">'.$langs->trans("PrintTicket").'</div>', 'action' => 'TakeposPrinting(placeid);');

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -579,19 +579,30 @@ function ClickProduct(position, qty = 1) {
 		LoadProducts(position, true);
 	}
 	else{
-		console.log($('#prodiv4').data('rowid'));
 		invoiceid = $("#invoiceid").val();
 		idproduct=$('#prodiv'+position).data('rowid');
 		console.log("Click on product at position "+position+" for idproduct "+idproduct+", qty="+qty+" invoiceid="+invoiceid);
 		if (idproduct == "") {
 			return;
 		}
-		// Call page invoice.php to generate the section with product lines
-		$("#poslines").load("invoice.php?action=addline&token=<?php echo newToken(); ?>&place="+place+"&idproduct="+idproduct+"&qty="+qty+"&invoiceid="+invoiceid, function() {
-			<?php if (getDolGlobalString('TAKEPOS_CUSTOMER_DISPLAY')) {
-				echo "CustomerDisplay();";
-			}?>
-		});
+		addInvoiceLine = function(qty) {
+			// Call page invoice.php to generate the section with product lines
+			$("#poslines").load("invoice.php?action=addline&token=<?php echo newToken(); ?>&place="+place+"&idproduct="+idproduct+"&qty="+qty+"&invoiceid="+invoiceid, function() {
+				<?php if (getDolGlobalString('TAKEPOS_CUSTOMER_DISPLAY')) {
+					echo "CustomerDisplay();";
+				}?>
+			});
+		};
+		// appeler WeighingScale() si le produit est un produit pesé
+		<?php if (getDolGlobalString('TAKEPOS_WEIGHING_SCALE')) { ?>
+			if ($('#prodiv'+position).data('unit') == 2) {
+				WeighingScale(addInvoiceLine);
+			} else {
+				addInvoiceLine(qty);
+			}
+		<?php } else { ?>
+			addInvoiceLine(qty);
+		<?php } ?>
 	}
 
 	ClearSearch(false);
@@ -1076,18 +1087,51 @@ function FullScreen() {
 	document.documentElement.requestFullscreen();
 }
 
-function WeighingScale(){
-	console.log("Weighing Scale");
+function WeighingScale(callback) {
+	console.log("Weighing Scale: invoiceid = " + placeid + ", lineid = " + selectedline);
+	<?php if (getDolGlobalString('TAKEPOS_CONNECTOR_TO_WHB_SCALE')) {?>
+		<?php if (getDolGlobalString('WEIGHINGSCALE_PROTOCOL') == "diag06") { ?>
+			// Protocole Dialog-06, il a besoin du prix unitaire, le demander s'il manque
+			var urlProduct;
+			if (idproduct == "" && selectedline > 0) {
+				urlProduct = "<?php echo DOL_URL_ROOT; ?>/api/index.php/takeposconnector/invoices/" + placeid + "/lines/" + selectedline + "/product";
+			} else {
+				urlProduct = "<?php echo DOL_URL_ROOT; ?>/api/index.php/products/" + idproduct;
+			}
+			$.ajax({
+				type: "GET",
+				headers: { "DOLAPIKEY": '<?php echo $user->api_key; ?>' },
+				url: urlProduct,
+			})
+			.done(function(product) {
+				if (callback === undefined) {
+					callback = function(qty) {
+						$("#poslines").load("invoice.php?token=<?php echo newToken(); ?>&action=updateqty&place="+place+"&idline="+selectedline+"&number="+qty);
+					};
+				}
+				if (product.fk_unit == "2") {
+					askForWeight(product.multicurrency_total_ttc, callback);
+				}
+			});
+		<?php } else { ?>
+			// Protocole par défaut de takeposconnector: réception continue du poids/stabilité
+			editnumber = globalWeight;
+			$("#poslines").load("invoice.php?token=<?php echo newToken(); ?>&action=updateqty&place="+place+"&idline="+selectedline+"&number="+editnumber, function() {
+				editnumber="";
+			});
+		<?php } ?>
+	<?php } else { ?> // utilisation du new TakePOS-Connector PHP: envoie "$" à la balance pour avoir le poids
 	$.ajax({
 		type: "POST",
 		data: { token: 'notrequired' },
 		url: '<?php print getDolGlobalString('TAKEPOS_PRINT_SERVER'); ?>/scale/index.php',
 	})
 	.done(function( editnumber ) {
-		$("#poslines").load("invoice.php?token=<?php echo newToken(); ?>&place="+place+"&idline="+selectedline+"&number="+editnumber, function() {
+		$("#poslines").load("invoice.php?token=<?php echo newToken(); ?>&action=updateqty&place="+place+"&idline="+selectedline+"&number="+editnumber, function() {
 				editnumber="";
 			});
 	});
+	<?php } ?>
 }
 
 $( document ).ready(function() {

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1111,7 +1111,9 @@ function WeighingScale(callback) {
 					};
 				}
 				if (product.fk_unit == "2") {
-					askForWeight(product.multiprices_ttc[1], callback);
+					askForWeight(product.multiprices_ttc[1], callback, function (errorMessage) {
+						console.log("Erreur: " + errorMessage);
+					});
 				}
 			});
 		<?php } else { ?>

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1111,7 +1111,7 @@ function WeighingScale(callback) {
 					};
 				}
 				if (product.fk_unit == "2") {
-					askForWeight(product.multicurrency_total_ttc, callback);
+					askForWeight(product.multiprices_ttc[1], callback);
 				}
 			});
 		<?php } else { ?>

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -588,6 +588,7 @@ function ClickProduct(position, qty = 1) {
 		addInvoiceLine = function(qty) {
 			// Call page invoice.php to generate the section with product lines
 			$("#poslines").load("invoice.php?action=addline&token=<?php echo newToken(); ?>&place="+place+"&idproduct="+idproduct+"&qty="+qty+"&invoiceid="+invoiceid, function() {
+				idproduct = "";
 				<?php if (getDolGlobalString('TAKEPOS_CUSTOMER_DISPLAY')) {
 					echo "CustomerDisplay();";
 				}?>

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -1781,11 +1781,16 @@ if (getDolGlobalString('TAKEPOS_CUSTOMER_DISPLAY')) {
 	echo "line1=line1.padEnd(20);";
 	echo "var line2='".$CUSTOMER_DISPLAY_line2."'.substring(0,20);";
 	echo "line2=line2.padEnd(20);";
-	echo "$.ajax({
-		type: 'GET',
-		data: { text: line1+line2 },
-		url: '".getDolGlobalString('TAKEPOS_PRINT_SERVER')."/display/index.php',
-	});";
+	if (getDolGlobalString('TAKEPOS_CONNECTOR_TO_WHB_CUSTOMER_DISPLAY')) {
+		echo 'webSocketCustomerDisplay.send(line1);';
+		echo 'webSocketCustomerDisplay.send(line2);';
+	} else {
+		echo "$.ajax({
+			type: 'GET',
+			data: { text: line1+line2 },
+			url: '".getDolGlobalString('TAKEPOS_PRINT_SERVER')."/display/index.php',
+		});";
+	}
 	echo "}";
 }
 ?>

--- a/htdocs/takepos/pay.php
+++ b/htdocs/takepos/pay.php
@@ -534,11 +534,18 @@ if (getDolGlobalString('TAKEPOS_CUSTOMER_DISPLAY')) {
 	echo "line1=line1.padEnd(20);";
 	echo "var line2='".price($invoice->total_ttc, 1, '', 1, -1, -1)."'.substring(0,20);";
 	echo "line2=line2.padEnd(20);";
-	echo "$.ajax({
-		type: 'GET',
-		data: { text: line1+line2 },
-		url: '".getDolGlobalString('TAKEPOS_PRINT_SERVER')."/display/index.php',
-	});";
+	if (getDolGlobalString('TAKEPOS_CONNECTOR_TO_WHB_CUSTOMER_DISPLAY')) {
+		echo 'webSocketCustomerDisplay.onOpen(function() {';
+		echo '	webSocketCustomerDisplay.send(line1);';
+		echo '	webSocketCustomerDisplay.send(line2);';
+		echo '});';
+	} else {
+		echo "$.ajax({
+			type: 'GET',
+			data: { text: line1+line2 },
+			url: '".getDolGlobalString('TAKEPOS_PRINT_SERVER')."/display/index.php',
+		});";
+	}
 }
 ?>
 </script>


### PR DESCRIPTION
Ça a commencé par un besoin client de pouvoir qui pèse ses produits à la vente. Tout fonctionnait bien avec le Takepos-connector-PHP (de andreubisquerra) mais suite à une modernisation du matériel ça n'a plus fonctionné.

Après enquête c'est le protocole de communication avec la balance qui n'était plus le même. Là où le Takepos-connector-PHP utilise une requête avec le symbole "$" pour demander la poids, la nouvelle balance utilise le protocole Dialog-06 (plus précisément la version 04 du Dialog-06).

Pour pouvoir analyser le problème j'ai modifié le service Webapp-Hardware-Bridge (de imTigger) et le module TakePOS-Connector (de andreubisquerra) et j'ai donc remplacé le Takepos-connector-PHP par le Webapp-Hardware-Bridge. Ca fonctionne mais j'ai eu besoin de modifier TakePOS d'où cette PR.

Cependant je trouve que les modifications, même si ça fonctionne, ne sont pas satisfaisantes. En effet, il y a, d'après ce que j'ai constaté avec Dolibarr, déjà 2 autres protocoles de communication avec les balances et en l'état cela nécessite une bonne connaissance de Dolibarr/TakePOS/WHB/connector/… pour pouvoir tout configurer.

Mon but est de rendre TakePOS utilisable pour le plus grand nombre car je pense que ce serait une vraie valeur ajoutée à Dolibarr et j’ai constaté la difficulté à faire fonctionner les imprimantes thermiques, la balance, l’afficheur client et le tiroir caisse. Il faut en effet jongler avec les configurations des modules TakePOS, receipt printer et takeposconnector et les faire dialoguer avec le matériel en utilisant le WHB, le Takepos-connector-PHP ou même l’ancien connecteur Java.

Associés à cette PR, je mets à disposition le Webapp-Hardware-Bridge et le TakePOS-connector en public sur mon github. **L'essentiel des modifications sont dans le module TakePOS-Connector, certaines auraient leur place directement dans TakePOS**:
[Webapp-hardware-bridge](https://github.com/LePat/webapp-hardware-bridge/tree/1.0-console)
[TakePOS-Connector](https://github.com/LePat/TakePOS-Connector/tree/dev)

Mon souhait est de démarrer une discussion qui nous permettra d’améliorer TakePOS pour une configuration plus facile même pour les utilisateurs et capable de s’adapter aux nouveau matériels. Je suis convaincu que ça aidera à la diffusion de Dolibarr. Je vous invite donc à critiquer mon travail et même un avis venant du côté obscur peut avoir une raison utile.

Pour ces modifications, mon principal objectif était que ça fonctionne bien sûr mais aussi d’avoir un  impact minimum sur les sources de TakePOS (Dolibarr) au cas où il aurait fallu systématiquement refaire des modifications. Il y a conservation de l’esprit de la certification LNE pour les points de vente même si le point de vente est modifié. En effet ces modifications ne perturbent pas le fonctionnement profond de Dolibarr pour la traçabilité des opérations et il est aisé de garantir la légalité de l’usage du protocole Dialog-06 (entre autre) pour un point de vente: ce ne sont que des branchement de tuyaux qui sont proposé et non pas des modifications de ce qui circule dans ces tuyaux.

Lien possible avec les bugs [36309](https://github.com/Dolibarr/dolibarr/issues/36309) et [35685](https://github.com/Dolibarr/dolibarr/issues/35685) car un produit au poids est pesé automatiquement en ayant connaissance de l’unité (fk_unit) 