### PR TITLE
FIX - avoids undefined array key

### DIFF
--- a/htdocs/opensurvey/wizard/create_survey.php
+++ b/htdocs/opensurvey/wizard/create_survey.php
@@ -53,11 +53,11 @@ $mailsonde = GETPOST('mailsonde');
 $creation_sondage_date = GETPOST('creation_sondage_date');
 $creation_sondage_autre = GETPOST('creation_sondage_autre');
 
-// We init some session variable to avoir warning
-$session_var = array('title', 'description', 'mailsonde');
+// We init some session variable to avoid warning
+$session_var = array('title', 'description', 'mailsonde', 'allow_comments', 'allow_spy');
 foreach ($session_var as $var) {
-	if (isset($_SESSION[$var])) {
-		$_SESSION[$var] = null;
+	if (!isset($_SESSION[$var])) {
+		$_SESSION[$var] = '';
 	}
 }
 


### PR DESCRIPTION
# FIX [#36923](https://github.com/Dolibarr/dolibarr/issues/36923) Undefined array key warnings in poll module

## Description
Fixed undefined array key warnings in the Poll module.

## Changes
- Set default empty values for undefined session variables
- Added 'allow_comments' and 'allow_spy' to the list of session variables to initialize
- Fixed typo in comment: "avoir" → "avoid"

@defrance 