### PR TITLE
FIX #37080 - Fix extrafields visibility formulas without computed fields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9347,6 +9347,7 @@ abstract class CommonObject
 	public function showOptionals($extrafields, $mode = 'view', $params = null, $keysuffix = '', $keyprefix = '', $onetrtd = '', $display_type = 'card')
 	{
 		global $db, $conf, $langs, $action, $form, $hookmanager;
+		global $objectoffield;
 
 		if (!is_object($form)) {
 			$form = new Form($db);
@@ -9358,6 +9359,9 @@ abstract class CommonObject
 		if (!is_array($extrafields->attributes[$this->table_element])) {
 			dol_syslog("extrafields->attributes was not loaded with extrafields->fetch_name_optionals_label(table_element);", LOG_WARNING);
 		}
+
+		// Ensure $objectoffield is available for dol_eval visibility formulas.
+		$objectoffield = $this;
 
 		$out = '';
 

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -45,6 +45,10 @@ if (!is_object($form)) {
 	$form = new Form($db);
 }
 
+// Ensure $objectoffield is available for dol_eval visibility formulas.
+global $objectoffield;
+$objectoffield = $object;
+
 ?>
 <!-- BEGIN PHP TEMPLATE core/tpl/extrafields_view.tpl.php to show formObjectOptions + extrafields -->
 <?php


### PR DESCRIPTION
FIX #37080 - Fix extrafields visibility formulas without computed fields

Problem
Extrafields visibility formulas that rely on $objectoffield only evaluate correctly if at least one extrafield has a computed formula. This breaks conditional visibility for fields like conditional_field_a/b in contracts.

Solution
Ensure $objectoffield is initialized before evaluating extrafield visibility/perms so dol_eval has the expected context in all cases.

Changes
Set $objectoffield in CommonObject::showOptionals before visibility evaluation.
Set $objectoffield in [extrafields_view.tpl.php](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/joris/.vscode/extensions/openai.chatgpt-0.4.69-win32-x64/webview/#) for view mode.

@defrance 