### PR TITLE
fix(emailcollector): prevent PHPIMAP body carryover between emails

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -2114,6 +2114,11 @@ class EmailCollector extends CommonObject
 				if (getDolGlobalInt('MAIN_IMAP_USE_PHPIMAP')) {
 					/** @var Webklex\PHPIMAP\Message $imapemail */
 					'@phan-var-force Webklex\PHPIMAP\Message $imapemail';
+					// Reset message body globals to prevent carryover from previous email in loop
+					// Note: $charset is NOT reset as PHPIMAP handles charset internally
+					$htmlmsg = $plainmsg = '';
+					$attachments = array();
+
 					if ($imapemail->hasHTMLBody()) {
 						$htmlmsg = $imapemail->getHTMLBody();
 					}
@@ -2123,7 +2128,7 @@ class EmailCollector extends CommonObject
 					if ($imapemail->hasAttachments()) {
 						$attachments = $imapemail->getAttachments()->all();
 					} else {
-						$attachments = [];
+						$attachments = array();
 					}
 				} else {
 					$getMsg = $this->getmsg($connection, $imapemail); // This set global var $charset, $htmlmsg, $plainmsg, $attachments


### PR DESCRIPTION
Reset global variables $htmlmsg, $plainmsg, and $attachments before processing each email in PHPIMAP mode to prevent email body content from previous email carrying over into the next one.

This issue only affected Microsoft OAuth (PHPIMAP) mode. When an email had no plain-text body but the previous email did, the previous email's plain-text would incorrectly be used for the current email.

The $charset variable is intentionally not reset as PHPIMAP handles charset internally, unlike native IMAP mode.

Also standardized array syntax to use array() consistently per Dolibarr coding conventions.

