### PR TITLE
Ensure that if $object->members is not loaded either we do not send m…

### DIFF
--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -321,7 +321,7 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 
 					$info = $object->_load_ldap_info();
 					if (isset($info['member']) && empty($info['member']) && !getDolGlobalString('LDAP_SEND_EMPTY_MEMBERS_TO_GROUP')) {
-						// Members were not explicitly loaded and LDAP alows us not to send members, so we do not send them
+						// Members were not explicitly loaded and LDAP allows us not to send members, so we do not send them
 						unset($info['member']);
 					}
 					$dn = $object->_load_ldap_dn($info);

--- a/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
+++ b/htdocs/core/triggers/interface_50_modLdap_Ldapsynchro.class.php
@@ -295,6 +295,10 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 		} elseif ($action == 'USERGROUP_MODIFY') {
 			dol_syslog("Trigger '".$this->name."' for action '$action' launched by ".__FILE__.". id=".$object->id);
 			if (getDolGlobalString('LDAP_SYNCHRO_ACTIVE') && getDolGlobalInt('LDAP_SYNCHRO_ACTIVE') === Ldap::SYNCHRO_DOLIBARR_TO_LDAP) {
+				if ($object->member === null && getDolGlobalString('LDAP_SEND_EMPTY_MEMBERS_TO_GROUP')) {
+					// LDAP requires that we always send members so we load them to avoid emptying group
+					$object->members = $object->listUsersForGroup('', 0);
+				}
 				$ldap = new Ldap();
 				$result = $ldap->connectBind();
 
@@ -316,6 +320,10 @@ class InterfaceLdapsynchro extends DolibarrTriggers
 					}
 
 					$info = $object->_load_ldap_info();
+					if (isset($info['member']) && empty($info['member']) && !getDolGlobalString('LDAP_SEND_EMPTY_MEMBERS_TO_GROUP')) {
+						// Members were not explicitly loaded and LDAP alows us not to send members, so we do not send them
+						unset($info['member']);
+					}
 					$dn = $object->_load_ldap_dn($info);
 
 					$result = $ldap->update($dn, $info, $user, $olddn);


### PR DESCRIPTION
# FIX Ensure member field is loaded or do not send it to LDAP


Since Dolibarr 20.x, `member` field of goups is only loaded if explicitly asked.

As a result, the LDAP `USERGROUP_MODIFY` trigger can be called, with `$object->members` being empty, for instance if we change a group permissions. The Ldap query will then empty the group in the LDAP while the users are still in the group in Dolibarr.

This PR handle this case in two ways :

If `LDAP_SEND_EMPTY_MEMBERS_TO_GROUP`, the `member` field is always loaded before ldap sync, else, if the `member` field is empty, it is not sent to the ldap.
