### PR TITLE
FIX: Backport fix on v20 for result page of compta (/compta/resultat/index.php)

### DIFF
--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -678,7 +678,7 @@ if (isModEnabled('salaries') && ($modecompta == 'CREANCES-DETTES' || $modecompta
  * Expense reports
  */
 
-if (!isModEnabled('expensereport') && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES")) {
+if (isModEnabled('expensereport') && ($modecompta == 'CREANCES-DETTES' || $modecompta == "RECETTES-DEPENSES")) {
 	$langs->load('trips');
 
 	if ($modecompta == 'CREANCES-DETTES') {

--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -45,7 +45,7 @@ $date_endyear = GETPOST('date_endyear', 'int');
 
 $nbofyear = 4;
 
-// Change this to test different cases of setup
+// Change this to test different cases of setup.
 //$conf->global->SOCIETE_FISCAL_MONTH_START = 7;
 
 


### PR DESCRIPTION
Backport fix on v20 for result page of compta (/compta/resultat/index.php).
The expense report were not included when the module was activated.
