### PR TITLE
FIX #37118 Add missing require_once for CMailFile and functions2 in advtargetemailing

### DIFF
--- a/htdocs/comm/mailing/advtargetemailing.php
+++ b/htdocs/comm/mailing/advtargetemailing.php
@@ -36,6 +36,8 @@ require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/advtargetemailing.class.php'
 require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/html.formadvtargetemailing.class.php';
 require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
 require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 
 /**
  * @var Conf $conf


### PR DESCRIPTION
Add missing require_once for CMailFile.class.php and functions2.lib.php
  in advtargetemailing.php.

  These are needed for:
  - `CMailFile::getArrayAddress()` (lines 491, 510)
  - `CMailFile::getValidAddress()` (line 535)
  - `isValidMailDomain()` (lines 518, 540)

  Without them, accessing the Advanced Emailing Targeting page causes a
  PHP fatal error.

  Fixes #37118