### PR TITLE
FIX #37118 Add missing require_once for CMailFile and functions2 in advtargetemailing

### DIFF
--- a/htdocs/comm/mailing/advtargetemailing.php
+++ b/htdocs/comm/mailing/advtargetemailing.php
@@ -36,6 +36,8 @@ require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/advtargetemailing.class.php'
 require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/html.formadvtargetemailing.class.php';
 require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
 require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 
 /**
  * @var Conf $conf


### PR DESCRIPTION
## Problem

`htdocs/comm/mailing/advtargetemailing.php` uses `CMailFile::getArrayAddress()`, `CMailFile::getValidAddress()` and `isValidMailDomain()` but does not include the required files, causing PHP Fatal errors when accessing the advanced target emailing page.

## Usage in file

- Line 491: `CMailFile::getArrayAddress($object->email_from)`
- Line 510: `CMailFile::getArrayAddress($object->email_errorsto)`
- Line 518: `isValidMailDomain($email)`
- Line 535: `CMailFile::getValidAddress($object->email_replyto, 2)`
- Line 540: `isValidMailDomain($email)`

## Fix

Added two missing require_once statements after line 38:

```php
require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
```

Fixes #37118