### PR TITLE
FIX #36923 Fix undefined array key warnings in opensurvey create_survey.php

### DIFF
--- a/htdocs/opensurvey/wizard/create_survey.php
+++ b/htdocs/opensurvey/wizard/create_survey.php
@@ -53,11 +53,11 @@ $mailsonde = GETPOST('mailsonde');
 $creation_sondage_date = GETPOST('creation_sondage_date');
 $creation_sondage_autre = GETPOST('creation_sondage_autre');
 
-// We init some session variable to avoir warning
-$session_var = array('title', 'description', 'mailsonde');
+// We init some session variables to avoid PHP 8 "undefined array key" warning
+$session_var = array('title', 'description', 'mailsonde', 'allow_comments', 'allow_spy', 'champdatefin');
 foreach ($session_var as $var) {
-	if (isset($_SESSION[$var])) {
-		$_SESSION[$var] = null;
+	if (!isset($_SESSION[$var])) {
+		$_SESSION[$var] = '';
 	}
 }
 
@@ -151,7 +151,7 @@ print '<table class="border centpercent">'."\n";
 
 print '<tr><td class="titlefieldcreate fieldrequired">'.$langs->trans("PollTitle").'</td>';
 
-print '<td><input type="text" name="title" class="minwidth300" maxlength="80" value="'.$_SESSION["title"].'" autofocus></td>'."\n";
+print '<td><input type="text" name="title" class="minwidth300" maxlength="80" value="'.dol_escape_htmltag($_SESSION["title"]).'" autofocus></td>'."\n";
 if (!$_SESSION["title"] && (GETPOST('creation_sondage_date') || GETPOST('creation_sondage_autre'))) {
 	setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("PollTitle")), null, 'errors');
 }


### PR DESCRIPTION
## Problem

The poll creation page (`opensurvey/wizard/create_survey.php`) throws `undefined array key` warnings on PHP 8.1+ when accessing the form for the first time.

**Error:**
```
Warning: Undefined array key "title" in .../opensurvey/wizard/create_survey.php on line 154
Warning: Undefined array key "description" in .../opensurvey/wizard/create_survey.php on line 161
Warning: Undefined array key "mailsonde" in .../opensurvey/wizard/create_survey.php on line 179
```

## Root Cause

The session initialization logic (lines 56-62) was **inverted**:

```php
// BEFORE (buggy): only sets null when var already exists
foreach ($session_var as $var) {
    if (isset($_SESSION[$var])) {    // ← wrong: should be !isset
        $_SESSION[$var] = null;
    }
}
```

This means on first page load, session variables are never initialized, causing undefined array key warnings when accessed later.

## Fix

```php
// AFTER: properly initialize missing session variables
$session_var = array('title', 'description', 'mailsonde', 'allow_comments', 'allow_spy', 'champdatefin');
foreach ($session_var as $var) {
    if (!isset($_SESSION[$var])) {   // ← fixed: initialize when missing
        $_SESSION[$var] = '';
    }
}
```

**Additional improvements:**
- Added `allow_comments`, `allow_spy`, `champdatefin` to initialization (also accessed without checks)
- Added `dol_escape_htmltag()` for title output (XSS hardening)

## Testing

1. Start with a clean session (clear cookies or use incognito)
2. Navigate to Surveys → New Survey
3. Verify no PHP warnings appear
4. Fill in title, description, submit → verify data flows correctly

Fixes #36923