### PR TITLE
FIX Add missing isset() check for $_GET['file'] in viewimage.php

### DIFF
--- a/htdocs/viewimage.php
+++ b/htdocs/viewimage.php
@@ -62,7 +62,7 @@ if (isset($_GET["modulepart"])) {
 	// Some value of modulepart can be used to get resources that are public so no login are required.
 
 	// For logo of company (by definition, the company logo is public)
-	if ($_GET["modulepart"] == 'mycompany' && preg_match('/^\/?logos\//', $_GET['file'])) {
+	if ($_GET["modulepart"] == 'mycompany' && isset($_GET['file']) && preg_match('/^\/?logos\//', $_GET['file'])) {
 		$needlogin = 0;
 	}
 	// For barcode live generation (barcode are just a graph of a value, so can be public)


### PR DESCRIPTION
## Problem

In `viewimage.php`, line 65 accesses `$_GET['file']` without an `isset()` check, causing an `undefined array key` warning on PHP 8.1+:

```
Warning: Undefined array key "file" in .../viewimage.php on line 65
```

This occurs when `modulepart=mycompany` is set but no `file` parameter is provided.

## Fix

Added `isset($_GET['file'])` check before accessing the value:

```php
// Before
if ($_GET["modulepart"] == 'mycompany' && preg_match('/^\/?logos\//', $_GET['file'])) {

// After
if ($_GET["modulepart"] == 'mycompany' && isset($_GET['file']) && preg_match('/^\/?logos\//', $_GET['file'])) {
```

**Note:** `GETPOST()` is intentionally not used here as it is not available before `main.inc.php` is loaded (see existing code comment on line 60).