### PR TITLE
FIX PHP 8.1 undefined array key warnings in ProductCombination multiprices loop

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -551,22 +551,22 @@ class ProductCombination
 			if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
 				$produit_multiprices_limit = getDolGlobalInt('PRODUIT_MULTIPRICES_LIMIT');
 				for ($i = 1; $i <= $produit_multiprices_limit; $i++) {
-					if ($parent->multiprices[$i] != '' || isset($this->combination_price_levels[$i]->variation_price)) {
+					if ((isset($parent->multiprices[$i]) && $parent->multiprices[$i] != '') || isset($this->combination_price_levels[$i]->variation_price)) {
 						$new_type = empty($parent->multiprices_base_type[$i]) ? 'HT' : $parent->multiprices_base_type[$i];
-						$new_min_price = $parent->multiprices_min[$i];
+						$new_min_price = isset($parent->multiprices_min[$i]) ? $parent->multiprices_min[$i] : 0;
 						$variation_price = (float) (!isset($this->combination_price_levels[$i]->variation_price) ? $this->variation_price : $this->combination_price_levels[$i]->variation_price);
 						$variation_price_percentage = (bool) (!isset($this->combination_price_levels[$i]->variation_price_percentage) ? $this->variation_price_percentage : $this->combination_price_levels[$i]->variation_price_percentage);
 
-						if ($parent->prices_by_qty_list[$i]) {
+						if (!empty($parent->prices_by_qty_list[$i])) {
 							$new_psq = 1;
 						} else {
 							$new_psq = 0;
 						}
 
 						if ($new_type == 'TTC') {
-							$new_price = $parent->multiprices_ttc[$i];
+							$new_price = isset($parent->multiprices_ttc[$i]) ? $parent->multiprices_ttc[$i] : 0;
 						} else {
-							$new_price = $parent->multiprices[$i];
+							$new_price = isset($parent->multiprices[$i]) ? $parent->multiprices[$i] : 0;
 						}
 
 						if ($variation_price_percentage) {


### PR DESCRIPTION
## Problem

When `PRODUIT_MULTIPRICES` is enabled, the `ProductCombination::updateChildPrice()` method iterates through all price levels up to `PRODUIT_MULTIPRICES_LIMIT`. For price levels where the parent product has no prices defined, direct array access to `$parent->multiprices[$i]` and related arrays causes **'undefined array key' warnings** on PHP 8.1+.

**Errors:**
```
Warning: Undefined array key 1 in .../variants/class/ProductCombination.class.php on line 553
Warning: Undefined array key 2 in .../variants/class/ProductCombination.class.php on line 553
```

This triggers when using product variants with multiprices where not all price levels are populated.

## Root Cause

The loop iterates from 1 to `PRODUIT_MULTIPRICES_LIMIT`, but the `multiprices`, `multiprices_min`, `multiprices_ttc`, and `prices_by_qty_list` arrays may not have entries for all levels. Direct access without `isset()` checks causes PHP 8.1+ warnings.

## Fix

- Add `isset()` check before comparing `$parent->multiprices[$i]` in the loop condition
- Use `isset()` ternary for `$parent->multiprices_min[$i]` (default: 0)
- Use `!empty()` for `$parent->prices_by_qty_list[$i]` check (suppresses undefined key)
- Use `isset()` ternary for `$parent->multiprices_ttc[$i]` and second `$parent->multiprices[$i]` (default: 0)

## Testing

1. Enable PRODUIT_MULTIPRICES with a limit > 1
2. Create a parent product with prices only on level 1
3. Create a product variant (combination) for that parent
4. Update the variant price — verify no PHP warnings appear
5. Verify that variant prices are correctly calculated for populated levels