### PR TITLE
FIX Replace direct $_POST access with GETPOST() in origin/originid error recovery

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -820,8 +820,8 @@ if (empty($reshook)) {
 			$db->rollback();
 
 			$action = 'create';
-			$_GET["origin"] = $_POST["origin"];		// Keep GET and POST here ?
-			$_GET["originid"] = $_POST["originid"]; // Keep GET and POST here ?
+			$_GET["origin"] = GETPOST("origin", 'alpha');
+			$_GET["originid"] = GETPOSTINT("originid");
 			if (!empty($errors)) {
 				setEventMessages(null, $errors, 'errors');
 			} else {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2296,8 +2296,8 @@ if (empty($reshook)) {
 		} else {
 			$db->rollback();
 			$action = 'create';
-			$_GET["origin"] = $_POST["origin"];		// Keep GET and POST here ?
-			$_GET["originid"] = $_POST["originid"]; // Keep GET and POST here ?
+			$_GET["origin"] = GETPOST("origin", 'alpha');
+			$_GET["originid"] = GETPOSTINT("originid");
 			setEventMessages($object->error, $object->errors, 'errors');
 		}
 	} elseif ($action == 'addline' && GETPOST('submitforalllines', 'aZ09') && (GETPOST('alldate_start', 'alpha') || GETPOST('alldate_end', 'alpha')) && $usercancreate) {

--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -611,8 +611,8 @@ if (empty($reshook)) {
 			$db->rollback();
 
 			$action = 'create';
-			$_GET["origin"] = $_POST["origin"];
-			$_GET["originid"] = $_POST["originid"];
+			$_GET["origin"] = GETPOST("origin", 'alpha');
+			$_GET["originid"] = GETPOSTINT("originid");
 			if (!empty($errors)) {
 				setEventMessages(null, $errors, 'errors');
 			} else {

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -790,8 +790,8 @@ if (empty($reshook)) {
 		} else {
 			$db->rollback();
 			$action = 'create';
-			$_GET["origin"] = $_POST["origin"];		// Keep this ?
-			$_GET["originid"] = $_POST["originid"];	// Keep this ?
+			$_GET["origin"] = GETPOST("origin", 'alpha');
+			$_GET["originid"] = GETPOSTINT("originid");
 			setEventMessages("Error", null, 'errors');
 			$error++;
 		}

--- a/htdocs/reception/list.php
+++ b/htdocs/reception/list.php
@@ -612,8 +612,8 @@ if (empty($reshook)) {
 			$db->rollback();
 
 			$action = 'create';
-			$_GET["origin"] = $_POST["origin"];		// Keep this ?
-			$_GET["originid"] = $_POST["originid"];	// Keep this ?
+			$_GET["origin"] = GETPOST("origin", 'alpha');
+			$_GET["originid"] = GETPOSTINT("originid");
 			setEventMessages($object->error, $errors, 'errors');
 			$error++;
 		}


### PR DESCRIPTION
## Problem

When a create action fails (e.g., creating a shipment, order, invoice, or reception), several pages roll back the transaction and restore the `origin` and `originid` parameters by directly assigning `$_POST` values to `$_GET`:

```php
$_GET["origin"] = $_POST["origin"];
$_GET["originid"] = $_POST["originid"];
```

This causes **'undefined array key' warnings** on PHP 8.1+ if the POST data is missing or malformed. The existing code even had TODO-style comments questioning this pattern (`// Keep this ?`, `// Keep GET and POST here ?`).

## Fix

Replace raw `$_POST` access with Dolibarr's safe `GETPOST()` wrapper:

```php
$_GET["origin"] = GETPOST("origin", 'alpha');
$_GET["originid"] = GETPOSTINT("originid");
```

`GETPOST()` safely returns an empty string when the parameter is not set, preventing PHP 8.1+ warnings.

## Files Changed

| File | Context |
|------|---------|
| `htdocs/expedition/list.php` | Shipment creation rollback |
| `htdocs/fourn/commande/list.php` | Supplier order creation rollback |
| `htdocs/commande/list.php` | Customer order creation rollback |
| `htdocs/compta/facture/card.php` | Invoice creation rollback |
| `htdocs/reception/list.php` | Reception creation rollback |

## Testing

1. Create a shipment/order/invoice from an origin document
2. Trigger a creation error (e.g., missing required field)
3. Verify the error recovery works correctly (page reloads with origin data)
4. Verify no PHP warnings in logs