### PR TITLE
FIX Invoice - Don't show discount on credit note type

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -1774,7 +1774,8 @@ class pdf_sponge extends ModelePDFFactures
 			}
 		}
 		if ($total_line_remise > 0) {
-			if (!getDolGlobalString('MAIN_HIDE_AMOUNT_DISCOUNT')) {
+			// Show discount except on credit note type invoices
+			if (!getDolGlobalString('MAIN_HIDE_AMOUNT_DISCOUNT') && $object->type != 2) {
 				$pdf->SetFillColor(255, 255, 255);
 				$pdf->SetXY($col1x, $tab2_top + $tab2_hl);
 				$pdf->MultiCell($col2x - $col1x, $tab2_hl, $outputlangs->transnoentities("TotalDiscount").(is_object($outputlangsbis) ? ' / '.$outputlangsbis->transnoentities("TotalDiscount") : ''), 0, 'L', 1);
@@ -1782,8 +1783,8 @@ class pdf_sponge extends ModelePDFFactures
 				$pdf->MultiCell($largcol2, $tab2_hl, price($total_line_remise_print, 0, $outputlangs), 0, 'R', 1);
 				$index++;
 			}
-			// Show total NET before discount
-			if (!getDolGlobalString('MAIN_HIDE_AMOUNT_BEFORE_DISCOUNT')) {
+			// Show total NET before discount except on credit note type invoices
+			if (!getDolGlobalString('MAIN_HIDE_AMOUNT_BEFORE_DISCOUNT') && $object->type != 2) {
 				$pdf->SetFillColor(255, 255, 255);
 				$pdf->SetXY($col1x, $tab2_top);
 				$pdf->MultiCell($col2x - $col1x, $tab2_hl, $outputlangs->transnoentities("TotalHTBeforeDiscount").(is_object($outputlangsbis) ? ' / '.$outputlangsbis->transnoentities("TotalHTBeforeDiscount") : ''), 0, 'L', 1);


### PR DESCRIPTION
When generating a credit memo with the same lines as the original invoice and containing a discount, the credit memo displays inconsistent information in the “Discount” block. I suggest not displaying anything in this case because it doesn't mean anything

Before:

<img width="469" height="143" alt="image" src="https://github.com/user-attachments/assets/244a196a-0f76-473b-8f95-dc7b76bd7770" />

After:

<img width="469" height="143" alt="image" src="https://github.com/user-attachments/assets/f6069cff-8e95-4aae-992f-dce938de5160" />
