### PR TITLE
Fix: Move $arrayforbutaction initialization before addMoreActionsButtons hook in commande/card.php

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -3433,6 +3433,7 @@ if ($action == 'create' && $usercancreate) {
 			print '<div class="tabsAction">';
 
 			$parameters = array();
+			$arrayforbutaction = array();
 			// Note that $action and $object may be modified by hook
 			$reshook = $hookmanager->executeHooks('addMoreActionsButtons', $parameters, $object, $action);
 			if (empty($reshook)) {
@@ -3493,7 +3494,6 @@ if ($action == 'create' && $usercancreate) {
 					print dolGetButtonAction('', $langs->trans('Modify'), 'default', $_SERVER["PHP_SELF"] . '?action=modif&amp;token=' . newToken() . '&amp;id=' . $object->id, '');
 				}
 
-				$arrayforbutaction = array();
 				// Create a purchase order
 
 				if (!getDolGlobalInt('COMMANDE_DISABLE_ADD_PURCHASE_ORDER')) {


### PR DESCRIPTION
**Problem:** 
In commande/card.php, the $arrayforbutaction array is initialized (cleared) after the addMoreActionsButtons hook is executed. This makes it impossible for module developers to add buttons to this array via hooks, forcing them to use less clean methods and use only separate buttons

**Solution:** 
Move the initialization $arrayforbutaction = array(); before the hook call. This allows hooks to populate the array while maintaining core logic.

**Impact:** 
Improves extensibility for third-party modules without breaking existing core functionality.