### PR TITLE
MEMBER_ADDON does not exists, MEMBER_CODEMEMBER_ADDON is the right key

### DIFF
--- a/htdocs/core/modules/modAdherent.class.php
+++ b/htdocs/core/modules/modAdherent.class.php
@@ -363,8 +363,8 @@ class modAdherent extends DolibarrModules
 		$this->import_convertvalue_array[$r] = array(
 			'a.ref'=>array(
 				'rule'=>'getrefifauto',
-				'class'=>(empty($conf->global->MEMBER_ADDON) ? 'mod_member_simple' : $conf->global->MEMBER_ADDON),
-				'path'=>"/core/modules/member/".(empty($conf->global->MEMBER_ADDON) ? 'mod_member_simple' : $conf->global->MEMBER_ADDON).'.php'
+				'class'=>(empty($conf->global->MEMBER_CODEMEMBER_ADDON) ? 'mod_member_simple' : $conf->global->MEMBER_CODEMEMBER_ADDON),
+				'path'=>"/core/modules/member/".(empty($conf->global->MEMBER_CODEMEMBER_ADDON) ? 'mod_member_simple' : $conf->global->MEMBER_CODEMEMBER_ADDON).'.php'
 			),
 			'a.state_id' => array(
 				'rule' => 'fetchidfromcodeid',


### PR DESCRIPTION
There is an old bug, visible when we make an import of adherent file : even if you put "auto" into the column name "Réf adhérent* (a.ref)" the member will get number (id) as ref.

Example: set module with advanced number setup

<img width="2777" height="709" alt="2026-02-08_14-25" src="https://github.com/user-attachments/assets/36022f1a-7cdc-46dd-a94f-38580d68cc0b" />


Make an import : users does not have mem-xxxxx-xxxx reference

<img width="2799" height="847" alt="2026-02-08_14-26" src="https://github.com/user-attachments/assets/59374828-4caf-4f57-9bb2-610a052454fa" />


After the fix

<img width="2774" height="631" alt="2026-02-08_14-43" src="https://github.com/user-attachments/assets/60f3c047-e18a-4724-8976-d40409ec9476" />


That's just because conf->global->MEMBER_ADDON does not exists, the right key is MEMBER_CODEMEMBER_ADDON

