### PR TITLE
Fix/accountancy pdf wrong labels

### DIFF
--- a/htdocs/core/modules/accountancy/doc/pdf_balance.modules.php
+++ b/htdocs/core/modules/accountancy/doc/pdf_balance.modules.php
@@ -317,7 +317,7 @@ class pdf_balance extends ModelePdfAccountancy
 					$curY,
 					$nexY,
 					$default_font_size,
-					$langs->trans('Total') . ' ' . $langs->trans('AccountancyGroup' . $accountGroup),
+					$langs->transnoentitiesnoconv('Total') . ' ' . $langs->transnoentitiesnoconv('AccountancyGroup' . $accountGroup),
 					$tab_top_newpage,
 					$groupDebit,
 					$groupCredit
@@ -503,7 +503,7 @@ class pdf_balance extends ModelePdfAccountancy
 				$curY,
 				$nexY,
 				$default_font_size,
-				$langs->trans('Total') . ' ' . $langs->trans('AccountancyGroup' . $accountingAccount->pcg_type),
+				$langs->transnoentitiesnoconv('Total') . ' ' . $langs->transnoentitiesnoconv('AccountancyGroup' . $accountingAccount->pcg_type),
 				$tab_top_newpage,
 				$groupDebit,
 				$groupCredit

--- a/htdocs/core/modules/accountancy/doc/pdf_balance.modules.php
+++ b/htdocs/core/modules/accountancy/doc/pdf_balance.modules.php
@@ -303,7 +303,7 @@ class pdf_balance extends ModelePdfAccountancy
 		$groupDebit = $groupCredit = $totalDebit = $totalCredit = 0;
 		for ($i = 0; $i < $nblines; $i++) {
 			$accountingAccount = new AccountingAccount($this->db);
-			$accountingAccount->fetch(0, $object->lines[$i]->numero_compte);
+			$accountingAccount->fetch(0, $object->lines[$i]->numero_compte, true);
 
 			// Init the first account group
 			if (empty($accountGroup)) {

--- a/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
+++ b/htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php
@@ -336,7 +336,7 @@ class pdf_ledger extends ModelePdfAccountancy
 			} else {
 				if (empty($account) || $account != $object->lines[$i]->numero_compte) {
 					$accountingAccount = new AccountingAccount($this->db);
-					$accountingAccount->fetch(0, $object->lines[$i]->numero_compte);
+					$accountingAccount->fetch(0, $object->lines[$i]->numero_compte, true);
 
 					// Add the subtotal line
 					if (!empty($account)) {


### PR DESCRIPTION
# FIX #37147 Wrong account labels in PDF balance/ledger exports

This PR fixes two issues in the PDF exports for accountancy balance and ledger:

## Problem 1: Wrong account labels
When multiple chart of accounts have the same account number, the PDF exports (balance and ledger) could retrieve the wrong account label from an inactive or unrelated chart of accounts.

**Example:** Account 6064 was displayed as "CARBURANTS ET LUBRIFIANTS" in the PDF, while the active chart of accounts defines it as "FOURNITURES ADMINISTRATIVES".

## Problem 2: HTML entity encoding in group labels
The balance PDF export was displaying HTML entities (like `&EACUTE;`) instead of properly decoded characters (like `É`) in account group labels.

**Example:** "TOTAL D&EACUTE;PENSES" instead of "TOTAL DÉPENSES".

## Solution

### Fix 1: Limit account fetch to active chart of accounts
Add the third parameter (`limittocurrentchart=true`) to `AccountingAccount::fetch()` to ensure we only retrieve accounts from the currently active chart of accounts configured via `CHARTOFACCOUNTS`.

**Files modified:**
- `htdocs/core/modules/accountancy/doc/pdf_balance.modules.php`
- `htdocs/core/modules/accountancy/doc/pdf_ledger.modules.php`

### Fix 2: Decode HTML entities in group labels
Replace `trans()` with `transnoentitiesnoconv()` to avoid HTML entity encoding when displaying account group labels in the balance PDF.

**Files modified:**
- `htdocs/core/modules/accountancy/doc/pdf_balance.modules.php`

## Testing
- Verify that account labels in PDF exports match the labels displayed in web views
- Verify that account group labels display correctly with proper character encoding (no HTML entities)
- Test with multiple chart of accounts to ensure the correct one is used