### PR TITLE
datamodel for user change password next time

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -137,4 +137,7 @@ ALTER TABLE llx_usergroup ADD COLUMN fk_parent integer DEFAULT NULL AFTER entity
 ALTER TABLE llx_usergroup ADD INDEX idx_usergroup_fk_parent (fk_parent);
 ALTER TABLE llx_usergroup ADD CONSTRAINT fk_usergroup_parent FOREIGN KEY (fk_parent) REFERENCES llx_usergroup (rowid);
 
+-- Force change password next time
+ALTER TABLE llx_user ADD COLUMN force_pass_change TINYINT DEFAULT 0 AFTER pass_temp;
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_user.sql
+++ b/htdocs/install/mysql/tables/llx_user.sql
@@ -41,6 +41,7 @@ create table llx_user
   pass                varchar(128),
   pass_crypted        varchar(128),
   pass_temp           varchar(128),			                  -- temporary password when asked for forget password or 'hashtoallowreset:YYYMMDDHHMMSS' (where date is max date of validity)
+  force_pass_change   tinyint       DEFAULT 0,                -- 1 if user must change password at next login
   api_key             varchar(128),			                  -- key to use REST API by this user
   gender              varchar(10),
   civility            varchar(6),


### PR DESCRIPTION
The target of this new field is to be able to add a "force change password on next login" then admin could set a password for a user or send new password via dolibarr process (email, so unsecure by default). Then we should "force" user to create a new password by himself.

Or after a new big update, or a sort of dataleak or ... 

Solution with massaction will come after that PR if you are agree with such change