### PR TITLE
FIX display dlc dluo in tooltip

### DIFF
--- a/htdocs/product/stock/class/productlot.class.php
+++ b/htdocs/product/stock/class/productlot.class.php
@@ -956,10 +956,10 @@ class Productlot extends CommonObject
 		//$datas['divopen'] = '<div width="100%">';
 		$datas['batch'] = '<br><b>'.$langs->trans('Batch').':</b> '.$this->batch;
 		if ($this->eatby && empty($conf->global->PRODUCT_DISABLE_EATBY)) {
-			$datas['eatby'] = '<br><b>'.$langs->trans('EatByDate').':</b> '.dol_print_date($this->db->jdate($this->eatby), 'day');
+			$datas['eatby'] = '<br><b>'.$langs->trans('EatByDate').':</b> '.dol_print_date($this->eatby, 'day');
 		}
 		if ($this->sellby && empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
-			$datas['sellby'] = '<br><b>'.$langs->trans('SellByDate').':</b> '.dol_print_date($this->db->jdate($this->sellby), 'day');
+			$datas['sellby'] = '<br><b>'.$langs->trans('SellByDate').':</b> '.dol_print_date($this->sellby, 'day');
 		}
 		//$datas['divclose'] = '</div>';
 


### PR DESCRIPTION
# FIX display DLC/DLUO in tooltip of a product lot

When a product with lots uses DLC/DLUO, the dates are not displayed in the tooltip.

Example on product/stock page.

<img width="519" height="307" alt="Capture d’écran_2026-02-09_15-13-44" src="https://github.com/user-attachments/assets/eda77cd3-b042-47e7-bed1-8cec33cee378" />



Seem on DLB18.0. Not on 19.0. 

NB - the bug has been introduced by commit 002b0aa38669ef82a71230496a82b9f6787d2afb with following lines :
```php
// modified: htdocs/product/stock/class/productlot.class.php

@ htdocs/product/stock/class/productlot.class.php:898 @ class Productlot extends CommonObject
        //$datas['divopen'] = '<div width="100%">';
        $datas['batch'] = '<br><b>'.$langs->trans('Batch').':</b> '.$this->batch;
        if ($this->eatby && empty($conf->global->PRODUCT_DISABLE_EATBY)) {
-            $datas['eatby'] = '<br><b>'.$langs->trans('EatByDate').':</b> '.dol_print_date($this->eatby, 'day');
+           $datas['eatby'] = '<br><b>'.$langs->trans('EatByDate').':</b> '.dol_print_date($this->db->jdate($this->eatby), 'day');
        }
        if ($this->sellby && empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
-            $datas['sellby'] = '<br><b>'.$langs->trans('SellByDate').':</b> '.dol_print_date($this->sellby, 'day');
+           $datas['sellby'] = '<br><b>'.$langs->trans('SellByDate').':</b> '.dol_print_date($this->db->jdate($this->sellby), 'day');
        }
        //$datas['divclose'] = '</div>';
```

... But these changes have been reverted between 18.0 and 19.0



