### PR TITLE
New Error handling methods for commonobject fixes #37194

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -11722,4 +11722,29 @@ abstract class CommonObject
 			return true;
 		}
 	}
+
+	/**
+	 * Set the error message for the object without logging it.
+	 *
+	 * @param string $message    the error message
+	 * @return void
+	 */
+	public function setErrorWithoutLog($message)
+	{
+		$this->error = $message;
+		$this->errors[] = $message;
+	}
+
+	/**
+	 * Set the error message for the object and log it.
+	 *
+	 * @param string $message      the error message
+	 * @param int<0,7> $loglevel   the log level
+	 * @return void
+	 */
+	public function setErrorWithLog($message, $loglevel = LOG_ERR)
+	{
+		$this->setErrorWithLog($message);
+		dol_syslog($message, $loglevel);
+	}
 }


### PR DESCRIPTION
# New error handling methods for class commonobject

fixes #37194

Two new methods to simplify error handling, with and without loggins errors.

We do not want to systematically record errors in the logs, as this could lead to sensitive data being leaked (RGPD personnal data, secrets like IBANs...)