### PR TITLE
Qual: Ignore exit code from `grep -v` in phan flow

### DIFF
--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -74,7 +74,7 @@ jobs:
             echo -n "" > "$FILE_CHANGED_LIST"
             for f in $ALL_CHANGED_FILES; do echo "$f" >> "$FILE_CHANGED_LIST"; done
             # Must exclude same files as in phan configuration
-            grep -v -E '^htdocs/(custom/|.*/canvas/.*/tpl/.*.tpl.php|admin/tools/ui/|includes/(nusoap/|restler/|stripe/)|conf/conf.php|modulebuilder/template/|[^h].*/.*)$' "$FILE_CHANGED_LIST"> "$FILE_CHANGED_LIST".tmp
+            grep -v -E '^htdocs/(custom/|.*/canvas/.*/tpl/.*.tpl.php|admin/tools/ui/|includes/(nusoap/|restler/|stripe/)|conf/conf.php)$' "$FILE_CHANGED_LIST"> "$FILE_CHANGED_LIST".tmp || true
             mv "$FILE_CHANGED_LIST".tmp "$FILE_CHANGED_LIST"
             if [ ! -s "$FILE_CHANGED_LIST" ] ; then
                echo "All changed files are excluded for phan"


### PR DESCRIPTION
# Qual: Ignore exit code from `grep -v` in phan flow

`grep -v` returns 1 when the resulting filtered list is empty and would stop the execution. This is fixed with `|| true` to have a final exit code that is 0.

The exclusion list was also corrected.