### PR TITLE
remove id= from redirect : we use current logged user

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1116,7 +1116,7 @@ if (!defined('NOLOGIN')) {
 			}
 		}
 		if (!$isallowed) {
-			header('Location: '.DOL_URL_ROOT.'/user/changepassword.php?id='.$user->id);
+			header('Location: '.DOL_URL_ROOT.'/user/changepassword.php');
 			exit;
 		}
 	}


### PR DESCRIPTION
i'm sorry ... there is a not-needed "?id=xxx" on redirect request because of that page is for self-user update password !