### PR TITLE
Comment out additional case for ORDER_SUPPLIER_SUBMIT

### DIFF
--- a/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
+++ b/htdocs/modulebuilder/template/core/triggers/interface_99_modMyModule_MyModuleTriggers.class.php
@@ -149,6 +149,7 @@ class InterfaceMyModuleTriggers extends DolibarrTriggers
 			//case 'ORDER_SUPPLIER_VALIDATE':
 			//case 'ORDER_SUPPLIER_DELETE':
 			//case 'ORDER_SUPPLIER_APPROVE':
+			//case 'ORDER_SUPPLIER_SUBMIT':
 			//case 'ORDER_SUPPLIER_CLASSIFY_BILLED':		// TODO Replace with ORDER_SUPPLIER_BILLED
 			//case 'ORDER_SUPPLIER_CLASSIFY_UNBILLED':		// TODO Replace with ORDER_SUPPLIER_UNBILLED
 			//case 'ORDER_SUPPLIER_REFUSE':


### PR DESCRIPTION
Trigger ORDER_SUPPLIER_SUBMIT is not présent in module builder
See /fourn/class/fournisseur.commande.class.php line 1562

