### PR TITLE
Fix #37227

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -15707,7 +15707,7 @@ function showValueWithClipboardCPButton($valuetocopy, $showonlyonhover = 1, $tex
  */
 function jsonOrUnserialize($stringtodecode)
 {
-	$result = json_decode($stringtodecode);
+	$result = json_decode($stringtodecode, true);
 	if ($result === null) {
 		$result = unserialize($stringtodecode);	// For backward compatibility. Is no more used in recent versions.
 	}


### PR DESCRIPTION
# Fix #37227

`jsonOrUnserialize` should return an array not an object

array is also expected here https://github.com/Dolibarr/dolibarr/blob/4d319bc2e16ca33e2b1dea387adcc8a0a167bc69/htdocs/core/modules/export/exportcsv.class.php#L278