### PR TITLE
Fix bug for PU TTC on situation invoice card

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5558,11 +5558,12 @@ abstract class CommonObject
 			}
 
 			// Recalculate unit price with tax if not defined
-			if (empty($line->subprice_ttc) && $line->qty) {	// subprice_ttc may be not stored on old version or not defined for lines with no unit price (like a discount)
+			if (empty($this->situation_cycle_ref) && empty($line->subprice_ttc) && $line->qty) {	// subprice_ttc may be not stored on old version or not defined for lines with no unit price (like a discount)
 				// So we calculate an estimated value just to show something on screen
 				$line->subprice_ttc = (float) price2num($line->total_ttc / $line->qty, 'MU');
-				//other method is less accurate
-				// $line->subprice_ttc = (float) price2num((!empty($line->subprice) ? $line->subprice : 0) * (1 + ((!empty($line->tva_tx) ? $line->tva_tx : 0) / 100)), 'MU');
+			} elseif (empty($line->subprice_ttc)) {
+				//other method is less accurate but best for situation invoices 
+				$line->subprice_ttc = (float) price2num((!empty($line->subprice) ? $line->subprice : 0) * (1 + ((!empty($line->tva_tx) ? $line->tva_tx : 0) / 100)), 'MU');
 			}
 			$line->pu_ttc = $line->subprice_ttc;	// deprecated
 

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5558,11 +5558,11 @@ abstract class CommonObject
 			}
 
 			// Recalculate unit price with tax if not defined
-			if (empty($this->situation_cycle_ref) && empty($line->subprice_ttc) && $line->qty) {	// subprice_ttc may be not stored on old version or not defined for lines with no unit price (like a discount)
+			if (empty($this->situation_cycle_ref) && empty($line->subprice_ttc) && $line->qty) { // subprice_ttc may be not stored on old version or not defined for lines with no unit price (like a discount)
 				// So we calculate an estimated value just to show something on screen
 				$line->subprice_ttc = (float) price2num($line->total_ttc / $line->qty, 'MU');
 			} elseif (empty($line->subprice_ttc)) {
-				//other method is less accurate but best for situation invoices 
+				//other method is less accurate but best for situation invoices
 				$line->subprice_ttc = (float) price2num((!empty($line->subprice) ? $line->subprice : 0) * (1 + ((!empty($line->tva_tx) ? $line->tva_tx : 0) / 100)), 'MU');
 			}
 			$line->pu_ttc = $line->subprice_ttc;	// deprecated


### PR DESCRIPTION
On  situation invoice (credit or not) card, there is a display bug in every lines on TTC Unit Price wich is completely false
This bug was introduces in V23 (not present in V22)

<img width="3425" height="1096" alt="image" src="https://github.com/user-attachments/assets/9e79eed8-f480-427b-9ebd-4b248d479882" />
