### PR TITLE
FIX: Clean filenames with double spaces

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1783,7 +1783,8 @@ function dol_sanitizeFileName($str, $newstr = '_', $unaccent = 1, $includequotes
 	$tmp = preg_replace('/\s+\-([^\s])/', ' _$1', $tmp);
 	$tmp = preg_replace('/\s+\-$/', '', $tmp);
 	$tmp = str_replace('..', '', $tmp);
-
+	$tmp = preg_replace('/\s{2,}/', ' ', $tmp);
+	
 	return $tmp;
 }
 
@@ -1815,6 +1816,8 @@ function dol_sanitizePathName($str, $newstr = '_', $unaccent = 1)
 	$tmp = preg_replace('/\s+\-([^\s])/', ' _$1', $tmp);
 	$tmp = preg_replace('/\s+\-$/', '', $tmp);
 	$tmp = str_replace('..', '', $tmp);
+	$tmp = preg_replace('/\s{2,}/', ' ', $tmp);
+	
 	return $tmp;
 }
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1784,7 +1784,7 @@ function dol_sanitizeFileName($str, $newstr = '_', $unaccent = 1, $includequotes
 	$tmp = preg_replace('/\s+\-$/', '', $tmp);
 	$tmp = str_replace('..', '', $tmp);
 	$tmp = preg_replace('/\s{2,}/', ' ', $tmp);
-	
+
 	return $tmp;
 }
 
@@ -1817,7 +1817,7 @@ function dol_sanitizePathName($str, $newstr = '_', $unaccent = 1)
 	$tmp = preg_replace('/\s+\-$/', '', $tmp);
 	$tmp = str_replace('..', '', $tmp);
 	$tmp = preg_replace('/\s{2,}/', ' ', $tmp);
-	
+
 	return $tmp;
 }
 


### PR DESCRIPTION
If a filename contains double spaces (like "a  b"), the file can get uploaded in Dolibarr exactly as it is. I.e. it gets stored under documents/ with double spaces in the name.

When listing the linked files or when trying to download it, the dolibarr functions clear double spaces in the filename. In particular the alpha parameter for GETPOST but also in other places. This results in files being uploaded (e.g. attachments for invoices) that can get listed but remain inaccessible and even cannot get deleted via UI. System shows an error message that the file could not be found.

We either need to fix all these places to accept double spaces or we change a single location, when we sanitize filenames.

This problem exists at least from v20 up to develop.

