### PR TITLE
FIX: linktoref should be able to receive more than 255 chars

### DIFF
--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -318,7 +318,8 @@ INSERT INTO llx_c_forme_juridique (fk_pays, code, libelle, active) VALUES (5, '5
 ALTER TABLE llx_oauth_token ADD COLUMN tokenstring_refresh text NULL AFTER tokenstring;
 ALTER TABLE llx_oauth_token ADD COLUMN expire_at datetime NULL AFTER lastaccess;
 
-ALTER TABLE llx_blockedlog ADD COLUMN linktoref varchar(255);
+ALTER TABLE llx_blockedlog ADD COLUMN linktoref text;
+ALTER TABLE llx_blockedlog MODIFY COLUMN linktoref text;
 ALTER TABLE llx_blockedlog ADD COLUMN linktype varchar(16);
 ALTER TABLE llx_blockedlog ADD COLUMN module_source varchar(32) DEFAULT '' AFTER action;
 ALTER TABLE llx_blockedlog ADD COLUMN amounts_taxexcl double(24,8) DEFAULT NULL AFTER amounts;

--- a/htdocs/install/mysql/tables/llx_blockedlog.sql
+++ b/htdocs/install/mysql/tables/llx_blockedlog.sql
@@ -29,7 +29,7 @@ CREATE TABLE llx_blockedlog
 	ref_object varchar(255),					-- field included into line signature (denormalized data from object_data)
 	date_object	datetime,						-- field included into line signature (denormalized data from object_data)
 	user_fullname varchar(255),					-- field included into line signature. User recording the event.
-	linktoref varchar(255),						-- field included into line signature. Link to another ref_object.
+	linktoref text,								-- field included into line signature. Link to another ref_object.
 	linktype varchar(16),						-- field included into line signature. Link type.
 	object_data	mediumtext,						-- field included into line signature
 	-- the signature of line


### PR DESCRIPTION
# FIX: linktoref should be able to receive more than 255 chars
Fixes a serious regression in blockedlog module : 
- actions logged can refer to multiple objects
- typically, a payment can be related to multiple invoices
- payment creation will fail (with no error visible in Dolibarr) in such case

As the 23.0 branch already exists, I am not sure if the migration sql should ALTER the linktoref field or if it should be on the 23 to 24 migration.