### PR TITLE
Fix export extra-fields of warehouses

### DIFF
--- a/htdocs/core/modules/modStock.class.php
+++ b/htdocs/core/modules/modStock.class.php
@@ -235,8 +235,8 @@ class modStock extends DolibarrModules
 		);
 		$this->export_entities_array[$r] = array();	// We define here only fields that use another icon that the one defined into export_icon
 		$this->export_aggregate_array[$r] = array();	// TODO Not used yet
-		$keyforselect = 'warehouse';
-		$keyforelement = 'warehouse';
+		$keyforselect = 'entrepot';
+		$keyforelement = 'entrepot';
 		$keyforaliasextra = 'extra';
 		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinexport.inc.php';
 


### PR DESCRIPTION
Fix export extra-fields of warehouses

Update the keyforselect and keyforelement from 'warehouse' to 'entrepot' in the modStock in order ton fix the export of extra fields belonging to the warehouses