### PR TITLE
FIX pagination losing filters on contract services list

### DIFF
--- a/htdocs/contrat/services_list.php
+++ b/htdocs/contrat/services_list.php
@@ -494,8 +494,12 @@ if ($search_total_ttc) {
 if ($search_service) {
 	$param .= '&amp;search_service='.urlencode($search_service);
 }
-if ($search_status) {
-	$param .= '&amp;search_status='.urlencode($search_status);
+if ($search_status != '') {
+	if ($filter == 'expired' || $filter == 'notexpired') {
+		$param .= '&amp;search_status='.urlencode($search_status.'&filter='.$filter);
+	} else {
+		$param .= '&amp;search_status='.urlencode($search_status);
+	}
 }
 if ($search_option) {
 	$param .= "&amp;search_option=".urlencode($search_option);


### PR DESCRIPTION
# FIX pagination losing filters on contract services list

On contract services list (htdocs/contract/services_list.php), when pagination is active and you click on a chevron to go to the next / previous page : 
- the filter on the status 'inactive' is lost.
- the filter on status 'active / expired' or 'active / not expired', loses the  '(not) expired' 


Bug seen on 22.0 (maybe before) and develop

