### PR TITLE
fix: filter on shipping list on mass action

### DIFF
--- a/htdocs/expedition/list.php
+++ b/htdocs/expedition/list.php
@@ -557,8 +557,10 @@ if (empty($reshook)) {
 			if ($search_company) {
 				$param .= "&search_company=".urlencode($search_company);
 			}
-			if ($search_shipping_method_id) {
-				$param .= "&amp;search_shipping_method_id=".urlencode($search_shipping_method_id);
+			if ($search_shipping_method_ids) {
+				foreach ($search_shipping_method_ids as $value) {
+					$param .= "&amp;search_shipping_method_ids[]=".urlencode($value);
+				}
 			}
 			if ($search_tracking) {
 				$param .= "&search_tracking=".urlencode($search_tracking);


### PR DESCRIPTION
fix : PHP8  waring 
On mass action the filter aren't correctly set `$search_shipping_method_id` don't exist any more it's `$search_shipping_method_ids`

It has the same as in htdocs/expedition/list.php line 982
https://github.com/Dolibarr/dolibarr/blob/d4ff519b7547443ba1f03d887558150334ba791e/htdocs/expedition/list.php#L982