### PR TITLE
FIX - espadon shipping note overflow

### DIFF
--- a/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
@@ -348,13 +348,14 @@ class pdf_espadon extends ModelePdfExpedition
 				if (!empty($notetoshow) || !empty($object->tracking_number)) {
 					$tab_top -= 2;
 					$tab_topbeforetrackingnumber = $tab_top;
+					$height_trackingnumber = 0;
 
 					// Tracking number
 					if (!empty($object->tracking_number)) {
-						$height_trackingnumber = 4;
+						$tracking_block_start_y = $tab_top;
 
 						$pdf->SetFont('', 'B', $default_font_size - 2);
-						$pdf->writeHTMLCell(60, $height_trackingnumber, $this->posxdesc - 1, $tab_top - 1, $outputlangs->transnoentities("TrackingNumber") . " : " . $object->tracking_number, 0, 1, false, true, 'L');
+						$pdf->writeHTMLCell(60, 4, $this->posxdesc - 1, $tab_top - 1, $outputlangs->transnoentities("TrackingNumber") . " : " . $object->tracking_number, 0, 1, false, true, 'L');
 						$tab_top_alt = $pdf->GetY();
 
 						$object->getUrlTrackingStatus($object->tracking_number);
@@ -373,12 +374,15 @@ class pdf_espadon extends ModelePdfExpedition
 									$label .= $object->tracking_url;
 								}
 
-								$height_trackingnumber += 4;
 								$pdf->SetFont('', 'B', $default_font_size - 2);
-								$pdf->writeHTMLCell(60, $height_trackingnumber, $this->posxdesc - 1, $tab_top_alt, $label, 0, 1, false, true, 'L');
+								$pdf->writeHTMLCell(60, 4, $this->posxdesc - 1, $tab_top_alt, $label, 0, 1, false, true, 'L');
 							}
 						}
 						$tab_top = $pdf->GetY();
+						$height_trackingnumber = $tab_top - $tracking_block_start_y;
+						if ($height_trackingnumber < 4) {
+							$height_trackingnumber = 4;
+						}
 					}
 
 					// Notes


### PR DESCRIPTION
# FIX|Fix #[*espadon shipping note overflow*]

Before: The Espadon shipment PDF calculated a fixed height for the tracking/method block (4–8 units) even when the label and URL wrapped to multiple lines. As a result, the public note frame was drawn too small and the note text
appeared outside the box.

Fix: Measure the real rendered height of the tracking/method block and use that value when computing the note frame. This keeps the public note fully inside its box even when the shipping method label and tracking URL are long and
wrap.
