### PR TITLE
fix: add 'shipping' as valid modulepart in dol_check_secure_access_document

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3465,7 +3465,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 			$accessallowed = 1;
 		}
 		$original_file = $conf->accounting->dir_output.'/'.$original_file;
-	} elseif (($modulepart == 'expedition' || $modulepart == 'shipment') && !empty($conf->expedition->dir_output)) {
+	} elseif (($modulepart == 'expedition' || $modulepart == 'shipment' || $modulepart == 'shipping') && !empty($conf->expedition->dir_output)) {
 		// Wrapping pour les expedition
 		if ($fuser->hasRight('expedition', $lire) || preg_match('/^specimen/i', $original_file)) {
 			$accessallowed = 1;


### PR DESCRIPTION
Fixes #37162

## What
`dol_check_secure_access_document()` rejects `modulepart=shipping`, causing an error when viewing shipment documents. The function already handles `expedition` and `shipment` but not `shipping`, which is the element name used throughout the expedition module.

## How
Added `shipping` alongside `expedition` and `shipment` in the modulepart check on line 3468 of `files.lib.php`.