### PR TITLE
fix: default NULL/empty price_base_type to HT in product fetch

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2381,7 +2381,7 @@ class Product extends CommonObject
 		$pu_ttc = $this->price_ttc;
 		$price_min = $this->price_min;
 		$price_min_ttc = $this->price_min_ttc;
-		$price_base_type = $this->price_base_type;
+		$price_base_type = (empty($this->price_base_type) ? 'HT' : $this->price_base_type);
 
 		// if price by customer / level
 		if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES_AND_MULTIPRICES')) {
@@ -3072,7 +3072,7 @@ class Product extends CommonObject
 				$this->price_ttc = $obj->price_ttc;
 				$this->price_min = $obj->price_min;
 				$this->price_min_ttc = $obj->price_min_ttc;
-				$this->price_base_type = $obj->price_base_type;
+				$this->price_base_type = (empty($obj->price_base_type) ? 'HT' : $obj->price_base_type);
 				$this->cost_price = isset($obj->cost_price) ? (float) $obj->cost_price : null;
 				$this->default_vat_code = $obj->default_vat_code;
 				$this->tva_tx = $obj->tva_tx;


### PR DESCRIPTION
Fixes #37061

## What
Products with NULL or empty `price_base_type` in the database (e.g. from CSV imports that did not set this field) were treated as TTC after v22, because code checking `price_base_type != 'HT'` would match on NULL/empty. In v21 this worked differently and NULL was effectively treated as HT.

## How
Default `price_base_type` to `'HT'` when NULL or empty in `Product::fetch()` and `Product::getSellPrice()`. This matches the existing fallback pattern already used in `compta/facture/card.php`, `takepos/invoice.php`, and other callers of `getSellPrice()`.