### PR TITLE
FIX #37323 Accountancy closure page - Problem with GETPOSTINT cannot read checkbox values properly

### DIFF
--- a/htdocs/accountancy/closure/index.php
+++ b/htdocs/accountancy/closure/index.php
@@ -156,8 +156,8 @@ if (empty($reshook)) {
 			}
 		} elseif ($action == 'confirm_step_2' && $confirm == "yes" && $user->hasRight('accounting', 'fiscalyear', 'write')) {
 			$new_fiscal_period_id = GETPOSTINT('new_fiscal_period_id');
-			$separate_auxiliary_account = GETPOSTINT('separate_auxiliary_account');
-			$generate_bookkeeping_records = GETPOSTINT('generate_bookkeeping_records');
+			$separate_auxiliary_account = (!empty(GETPOST('separate_auxiliary_account', 'none')) ? 1 : 0);
+			$generate_bookkeeping_records = (!empty(GETPOST('generate_bookkeeping_records', 'none')) ? 1 : 0);
 
 			$error = 0;
 			if ($generate_bookkeeping_records) {


### PR DESCRIPTION
Thanks @alain029

In **htdocs/accountancy/closure/index.php** (lines 158–159), the options separate_auxiliary_account and generate_bookkeeping_records are retrieved using GETPOSTINT().

However, HTML checkboxes submit the string value "on" when checked, not an integer. PHP's intval("on") returns 0, which means GETPOSTINT() always returns 0 regardless of whether the checkbox is checked or not.

As a result, the fiscal year closure never generates the opening balance entries ("À-Nouveaux"), even when the user explicitly checks the corresponding options.