### PR TITLE
Fix recruitment API candidature creation validation

### DIFF
--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -375,7 +375,7 @@ class Recruitments extends DolibarrApi
 		}
 
 		// Check mandatory fields
-		$result = $this->_validate($request_data);
+		$result = $this->_validate($request_data, $this->jobposition);
 
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {
@@ -415,16 +415,16 @@ class Recruitments extends DolibarrApi
 		}
 
 		// Check mandatory fields
-		$result = $this->_validate($request_data);
+		$result = $this->_validate($request_data, $this->candidature);
 
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller
-				$this->jobposition->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
+				$this->candidature->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
 			}
 
-			$this->jobposition->$field = $this->_checkValForAPI($field, $value, $this->jobposition);
+			$this->candidature->$field = $this->_checkValForAPI($field, $value, $this->candidature);
 		}
 
 		// Clean data
@@ -686,25 +686,26 @@ class Recruitments extends DolibarrApi
 	 * Validate fields before create or update object
 	 *
 	 * @param	?array<string,mixed>		$data   Array of data to validate
+	 * @param	CommonObject				$object Object to validate against
 	 * @return	array<string,mixed>
 	 *
 	 * @throws	RestException
 	 */
-	private function _validate($data)
+	private function _validate($data, $object)
 	{
 		if ($data === null) {
 			$data = array();
 		}
-		$jobposition = array();
-		foreach ($this->jobposition->fields as $field => $propfield) {
-			if (in_array($field, array('rowid', 'entity', 'date_creation', 'tms', 'fk_user_creat')) || empty($propfield['notnull']) || $propfield['notnull'] != 1) {
-				continue; // Not a mandatory field
+		$result = array();
+		foreach ($object->fields as $field => $propfield) {
+			if (in_array($field, array('rowid', 'entity', 'date_creation', 'tms', 'fk_user_creat', 'ref')) || empty($propfield['notnull']) || $propfield['notnull'] != 1 || !empty($propfield['noteditable']) || isset($propfield['default'])) {
+				continue; // Not a mandatory field or auto-generated field or has default value
 			}
 			if (!isset($data[$field])) {
 				throw new RestException(400, "$field field missing");
 			}
-			$jobposition[$field] = $data[$field];
+			$result[$field] = $data[$field];
 		}
-		return $jobposition;
+		return $result;
 	}
 }


### PR DESCRIPTION
FIX|Fix #37330 Recruitment API candidature creation fails
Fix POST /api/recruitments/candidature which could fail due to validating against the wrong object and assigning request fields to the wrong object.

Changes:

Make _validate() object-agnostic (_validate($data, $object)) and validate against $object->fields.
Skip auto-generated/non-editable/defaulted fields (ref, noteditable, default) when checking mandatory fields.
In postJobPosition(), call _validate($request_data, $this->jobposition).
In postCandidature(), call _validate($request_data, $this->candidature) and assign fields/context to $this->candidature (not $this->jobposition).
Fixes #37330

