### PR TITLE
Fix missing trans no entities for Dolibarr context lang tool

### DIFF
--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-context.mock.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-context.mock.js
@@ -60,6 +60,15 @@ var Dolibarr = {
 			 * @returns {string}
 			 */
 			trans(key, ...args) {},
+
+			/**
+			 * Translate a key using current locale
+			 * Supports placeholders like %s, %d, %f (simple sprintf)
+			 * @param {string} key
+			 * @param  {...any} args
+			 * @returns {string}
+			 */
+			transNoEntities(key, ...args) {},
 		},
 
 		// You can add more standard Dolibarr tools here for IDE autocompletion.

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
@@ -220,6 +220,21 @@ document.addEventListener('Dolibarr:Init', function(e) {
 			return sprintf(text, ...args);
 		}
 
+		/**
+		 * Translate a key using current locale
+		 * Supports placeholders like %s, %d, %f (simple sprintf)
+		 * @param {string} key
+		 * @param  {...any} args
+		 * @returns {string}
+		 */
+		function transNoEntities(key, ...args) {
+			let str = trans(key, ...args);
+			let txt = document.createElement('textarea');
+			txt.innerHTML = str;
+			return txt.value;
+		}
+
+
 		function sprintf(fmt, ...args) {
 			let i = 0;
 			return fmt.replace(/%[%bcdeEfFgGosuxX]/g, (match) => {
@@ -246,6 +261,7 @@ document.addEventListener('Dolibarr:Init', function(e) {
 			clearCache,
 			setLocale,
 			trans,
+			transNoEntities,
 			get currentLocale() { return currentLocale; }
 		};
 	};


### PR DESCRIPTION
# Fix
il some case trans need no html enties encoding so add transnoentitie

