### PR TITLE
FIX "Undefined array key" warnings in import_csv.modules.php on $this->cacheconvert access

### DIFF
--- a/htdocs/core/modules/import/import_csv.modules.php
+++ b/htdocs/core/modules/import/import_csv.modules.php
@@ -1,10 +1,11 @@
 <?php
-/* Copyright (C) 2006-2012	Laurent Destailleur	<eldy@users.sourceforge.net>
- * Copyright (C) 2009-2012	Regis Houssin		<regis.houssin@inodbox.com>
- * Copyright (C) 2012      Christophe Battarel  <christophe.battarel@altairis.fr>
- * Copyright (C) 2012-2016 Juanjo Menent		<jmenent@2byte.es>
+/* Copyright (C) 2006-2012	Laurent Destailleur         <eldy@users.sourceforge.net>
+ * Copyright (C) 2009-2012	Regis Houssin               <regis.houssin@inodbox.com>
+ * Copyright (C) 2012       Christophe Battarel         <christophe.battarel@altairis.fr>
+ * Copyright (C) 2012-2016  Juanjo Menent               <jmenent@2byte.es>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024       MDW                         <mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Alexandre Spangaro          <alexandre@inovea-conseil.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -444,7 +445,7 @@ class ImportCsv extends ModeleImports
 										$file = (empty($objimport->array_import_convertvalue[0][$val]['classfile']) ? $objimport->array_import_convertvalue[0][$val]['file'] : $objimport->array_import_convertvalue[0][$val]['classfile']);
 										$class = $objimport->array_import_convertvalue[0][$val]['class'];
 										$method = $objimport->array_import_convertvalue[0][$val]['method'];
-										if ($this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval] != '') {
+										if (isset($this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval]) && $this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval] != $newval) {
 											$newval = $this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval];
 										} else {
 											$resultload = dol_include_once($file);


### PR DESCRIPTION
### Problem

When importing a CSV file of third parties (societe_1), PHP 8 warnings are triggered at line 447 of import_csv.modules.php:

**text**

> Warning: Undefined array key "/core/class/ccountry.class.php_Ccountry_fetch_"
> Warning: Trying to access array offset on value of type null
> These warnings appear for every record containing an ISO country code (SE, CN, TW, TR, etc.) mapped to s.fk_pays.

### Root Cause

In the import_insert() method, the cache array $this->cacheconvert is accessed without first checking whether the parent key exists:

**php**
```
// Buggy (PHP 8 incompatible)
if ($this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval] != $newval) {
    $newval = $this->cacheconvert[$file.'_'.$class.'_'.$method.'_'][$newval];
} else {
    // ... load object and populate cache
}
```

On PHP 7, accessing an undefined array key returned null silently. On PHP 8, this raises a Warning: Undefined array key, followed by Warning: Trying to access array offset on value of type null. As a result, the country code is never resolved to a rowid, and subsequent fields (such as fk_stcomm) may be left null, causing a DB_ERROR_CONSTRAINT SQL error.

<img width="1515" height="91" alt="image" src="https://github.com/user-attachments/assets/d7d8fecc-57ce-47de-99dd-eafd4cb2f401" />
