### PR TITLE
Fix bad rounding when spliting discounts

### DIFF
--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -84,7 +84,7 @@ if ($action == 'confirm_split' && GETPOST("confirm", "alpha") == 'yes' && $permi
 		$error++;
 		setEventMessages($langs->trans("ErrorFailedToLoadDiscount"), null, 'errors');
 	}
-	if (!$error && price2num((float) $amount_ttc_1 + (float) $amount_ttc_2 ,'MT') != $discount->amount_ttc) {
+	if (!$error && price2num((float) $amount_ttc_1 + (float) $amount_ttc_2, 'MT') != $discount->amount_ttc) {
 		$error++;
 		setEventMessages($langs->trans("TotalOfTwoDiscountMustEqualsOriginal"), null, 'errors');
 	}

--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -84,7 +84,7 @@ if ($action == 'confirm_split' && GETPOST("confirm", "alpha") == 'yes' && $permi
 		$error++;
 		setEventMessages($langs->trans("ErrorFailedToLoadDiscount"), null, 'errors');
 	}
-	if (!$error && price2num((float) $amount_ttc_1 + (float) $amount_ttc_2) != $discount->amount_ttc) {
+	if (!$error && price2num((float) $amount_ttc_1 + (float) $amount_ttc_2 ,'MT') != $discount->amount_ttc) {
 		$error++;
 		setEventMessages($langs->trans("TotalOfTwoDiscountMustEqualsOriginal"), null, 'errors');
 	}


### PR DESCRIPTION
When we test if the two new  amounts are equal to discount amount while discount spliting, a bad rounding make the condition false even if the calculus is good.

Step to reproduce : 

- Create a new discount equal to  17 083 306.81
- Split discount in two values example: 14 824 157.72 and 2 259 149.09
- An error is generated saying that 14 824 157.72 + 2 259 149.09 isn't equal to 17 083 306.81