### PR TITLE
FIX 37359 - pass over thirdpartystatic id to emailcollector hook

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -3809,7 +3809,7 @@ class EmailCollector extends CommonObject
 
 								'actionparam' =>  $operation['actionparam'],
 
-								'thirdpartyid' => $thirdpartyid,
+								'thirdpartyid' => !$thirdpartyid?$thirdpartystatic->id:0,
 								'objectid' => $objectid,
 								'objectemail' => $objectemail,
 

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -3809,7 +3809,7 @@ class EmailCollector extends CommonObject
 
 								'actionparam' =>  $operation['actionparam'],
 
-								'thirdpartyid' => !$thirdpartyid?$thirdpartystatic->id:0,
+								'thirdpartyid' => !$thirdpartyid?$thirdpartystatic->id:$thirdpartyid,
 								'objectid' => $objectid,
 								'objectemail' => $objectemail,
 

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -3809,7 +3809,7 @@ class EmailCollector extends CommonObject
 
 								'actionparam' =>  $operation['actionparam'],
 
-								'thirdpartyid' => !$thirdpartyid?$thirdpartystatic->id:$thirdpartyid,
+								'thirdpartyid' => ($thirdpartyid ? $thirdpartyid : $thirdpartystatic->id),
 								'objectid' => $objectid,
 								'objectemail' => $objectemail,
 


### PR DESCRIPTION
This fixes #37359 by giving a chance to thirdpartystatic object.