### PR TITLE
FIX - Security odt template extension

### DIFF
--- a/htdocs/core/actions_setmoduleoptions.inc.php
+++ b/htdocs/core/actions_setmoduleoptions.inc.php
@@ -171,7 +171,54 @@ if ($action == 'setModuleOptions' && !empty($user->admin)) {
 			}
 		}
 
-		if ($upload_dir) {
+		// Restrict uploads for ODT template setup pages.
+		if (preg_match('/_ADDON_PDF_ODT_PATH$/', $keyforuploaddir) && !empty($_FILES['uploadfile'])) {
+			$allowedext = array('odt', 'ods');
+			$allowedmimes = array(
+				'application/vnd.oasis.opendocument.text',
+				'application/vnd.oasis.opendocument.spreadsheet',
+				'application/zip',
+				'application/x-zip-compressed',
+				'application/octet-stream'
+			);
+			$files = $_FILES['uploadfile'];
+			if (!is_array($files['name'])) {
+				foreach ($files as $key => &$val) {
+					$val = array($val);
+				}
+				unset($val);
+			}
+			foreach ($files['name'] as $idx => $filename) {
+				if (empty($filename)) {
+					continue;
+				}
+
+				$extension = strtolower(pathinfo((string) $filename, PATHINFO_EXTENSION));
+				if (!in_array($extension, $allowedext, true)) {
+					$error++;
+					setEventMessages($langs->trans("ErrorFileNotUploaded").' (Only .odt/.ods templates are allowed)', null, 'errors');
+					dol_syslog(__FILE__." ODT template upload refused on extension filename=".$filename, LOG_WARNING);
+					break;
+				}
+
+				$detectedmime = '';
+				if (!empty($files['tmp_name'][$idx]) && function_exists('finfo_open')) {
+					$finfo = finfo_open(FILEINFO_MIME_TYPE);
+					if ($finfo) {
+						$detectedmime = (string) finfo_file($finfo, $files['tmp_name'][$idx]);
+						finfo_close($finfo);
+					}
+				}
+				if (!empty($detectedmime) && !in_array(strtolower($detectedmime), $allowedmimes, true)) {
+					$error++;
+					setEventMessages($langs->trans("ErrorFileNotUploaded").' (Invalid MIME type for ODT/ODS template)', null, 'errors');
+					dol_syslog(__FILE__." ODT template upload refused on mime filename=".$filename." mime=".$detectedmime, LOG_WARNING);
+					break;
+				}
+			}
+		}
+
+		if ($upload_dir && !$error) {
 			$result = dol_add_file_process($upload_dir, 1, 1, 'uploadfile', '');
 			if ($result <= 0) {
 				$error++;


### PR DESCRIPTION
# FIX - Security odt template extension
UploadNewTemplate flows through core/actions_setmoduleoptions.inc.php.
 It called dol_add_file_process(...) without extension/MIME restrictions for *_ADDON_PDF_ODT_PATH.


  1. Added server-side validation in actions_setmoduleoptions.inc.php, only when keyforuploaddir matches *_ADDON_PDF_ODT_PATH.
  2. Extension allowlist: .odt, .ods.
  3. MIME check (via finfo_file) allowlist:

  - application/vnd.oasis.opendocument.text
  - application/vnd.oasis.opendocument.spreadsheet
  - application/zip
  - application/x-zip-compressed
  - application/octet-stream (compat fallback)


Upload execution is now guarded by !$error, so dol_add_file_process(...) is not called after a failed validation.



