### PR TITLE
fix: use client language for recurring invoice PDF generation

### DIFF
--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -1507,7 +1507,16 @@ class FactureRec extends CommonInvoice
 					if (!$errorforinvoice && $facturerec->generate_pdf) {
 						// We refresh the object in order to have all necessary data (like date_lim_reglement)
 						$facture->fetch($facture->id);
-						$result = $facture->generateDocument($facturerec->model_pdf, $langs);
+						$outputlangs = $langs;
+						if (getDolGlobalInt('MAIN_MULTILANGS')) {
+							$facture->fetch_thirdparty();
+							if (!empty($facture->thirdparty->default_lang)) {
+								$outputlangs = new Translate('', $conf);
+								$outputlangs->setDefaultLang($facture->thirdparty->default_lang);
+								$outputlangs->loadLangs(array('main', 'bills'));
+							}
+						}
+						$result = $facture->generateDocument($facturerec->model_pdf, $outputlangs);
 						if ($result <= 0) {
 							$this->setErrorsFromObject($facture);
 							$error++;


### PR DESCRIPTION
When a recurring invoice has PDF generation enabled, the generated document was always produced in the system language rather than the client's configured language.

The fix adds the same multilang handling that already exists for manual invoice sending: if `MAIN_MULTILANGS` is active and the thirdparty has a `default_lang` set, a proper `Translate` object is initialized with that language before calling `generateDocument`.

Steps to reproduce:
1. Configure a third party with a non-system default language
2. Create a recurring invoice template with PDF generation enabled
3. Run the cron task — the generated PDF uses system language instead of client language

After this fix the cron-generated PDF respects the client's language, same as a manually sent invoice.

Fixes Dolibarr/dolibarr#27022
