### PR TITLE
fix: EmailCollector uses exact folder match instead of first wildcard result

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1779,7 +1779,20 @@ class EmailCollector extends CommonObject
 
 				$f = $client->getFolders(false, $tmpsourcedir);	// Note the search of directory do a search on sourcedir*
 				if ($f) {
-					$folder = $f[0];
+					// getFolders() matches sourcedir* so it may return sub-folders too.
+					// Find the folder whose path exactly matches the configured source directory.
+					$folder = null;
+					foreach ($f as $tmpfolder) {
+						if ($tmpfolder instanceof Webklex\PHPIMAP\Folder) {
+							if ($tmpfolder->path === $tmpsourcedir || $tmpfolder->full_name === $sourcedir) {
+								$folder = $tmpfolder;
+								break;
+							}
+						}
+					}
+					if (is_null($folder)) {
+						$folder = $f[0]; // fallback to first result if no exact match
+					}
 					if ($folder instanceof Webklex\PHPIMAP\Folder) {
 						$Query = $folder->messages()->where($criteria); // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
 					} else {


### PR DESCRIPTION
`Client::getFolders(false, $sourcedir)` uses a wildcard pattern and returns all IMAP folders whose name starts with the given prefix. With a source folder configured as `INBOX`, the call returns both `INBOX` and any sub-folder like `INBOX.Traites`.

The previous code always used `$f[0]` — whichever folder the server returned first — which could be an empty sub-folder, causing the collector to find no messages even though the target mailbox contains matching emails.

The fix iterates the returned list and selects the entry whose `path` or `full_name` matches the configured source directory exactly. If no exact match is found it falls back to `$f[0]` to preserve existing behaviour for setups where the pattern is intentional.

Fixes Dolibarr/dolibarr#37357
