### PR TITLE
Fix #37388 Change GETPOSTINT to GETPOST for form question

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -165,7 +165,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOSTINT($key));
+				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOST($key));
 			}
 		}
 


### PR DESCRIPTION
FIX#37388
Multicurrency payment amounts lose decimal places due to GETPOSTINT() in confirmation step