### PR TITLE
FIX: Prevent invalid SQL entity list in user hierarchy queries (multicompany)

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -3905,6 +3905,32 @@ class User extends CommonObject
 		}
 	}
 
+	/**
+	 * Return a safe entity list for SQL IN(...)
+	 * Avoid invalid SQL like IN (0,) or IN (,)
+	 *
+	 * @param string $element Element name for getEntity()
+	 * @return string CSV of integers, never empty
+	 */
+	private function getEntityListForSql($element)
+	{
+		$list = (string) getEntity($element);
+
+		// Split by comma, keep only numeric ids
+		$parts = preg_split('/\s*,\s*/', $list);
+		$parts = array_values(array_filter($parts, static function ($v) {
+			$v = (string) $v;
+			return ($v !== '' && ctype_digit($v));
+		}));
+
+		// Never return empty list (avoid IN ())
+		if (empty($parts)) {
+			return '0'; // or '-1' if you prefer returning no rows
+		}
+
+		return implode(',', $parts);
+	}
+
 
 	/**
 	 *  Load this->parentof that is array(id_son=>id_parent, ...)
@@ -3915,11 +3941,13 @@ class User extends CommonObject
 	{
 		$this->parentof = array();
 
+		$entityList = $this->getEntityListForSql('user');
+
 		// Load array[child]=parent
 		$sql = "SELECT fk_user as id_parent, rowid as id_son";
 		$sql .= " FROM ".$this->db->prefix()."user";
 		$sql .= " WHERE fk_user <> 0";
-		$sql .= " AND entity IN (".getEntity('user').")";
+		$sql .= " AND entity IN (".$entityList.")";
 
 		dol_syslog(get_class($this)."::loadParentOf", LOG_DEBUG);
 		$resql = $this->db->query($sql);
@@ -3967,10 +3995,11 @@ class User extends CommonObject
 		// Add fields from hooks
 		$parameters = array();
 		$reshook = $hookmanager->executeHooks('printUserListWhere', $parameters); // Note that $action and $object may have been modified by hook
+		$entityList = $this->getEntityListForSql('user');
 		if ($reshook > 0) {
 			$sql .= $hookmanager->resPrint;
 		} else {
-			$sql .= " WHERE u.entity IN (".getEntity('user').")";
+			$sql .= " WHERE u.entity IN (".$entityList.")";
 		}
 		if ($filter) {
 			$sql .= " AND ".$filter;	// already sanitized

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -3912,15 +3912,15 @@ class User extends CommonObject
 	 * @param string $element Element name for getEntity()
 	 * @return string CSV of integers, never empty
 	 */
-	private function getEntityListForSql($element)
+	private function getEntityListForSql(string $element): string
 	{
 		$list = (string) getEntity($element);
 
 		// Split by comma, keep only numeric ids
-		$parts = preg_split('/\s*,\s*/', $list);
-		$parts = array_values(array_filter($parts, static function ($v) {
-			$v = (string) $v;
-			return ($v !== '' && ctype_digit($v));
+		$parts = preg_split('/\s*,\s*/', $list, -1, PREG_SPLIT_NO_EMPTY);
+
+		$parts = array_values(array_filter($parts, static function (string $v): bool {
+			return (ctype_digit($v));
 		}));
 
 		// Never return empty list (avoid IN ())


### PR DESCRIPTION
### Description

This patch fixes an SQL syntax error that occurs when enabling the multicompany module.

In some contexts, `getEntity('user')` may return a malformed list such as: 0, 0,, ,

This leads to invalid SQL like:

entity IN (0,)

which triggers `DB_ERROR_SYNTAX` errors in:

- `User::loadParentOf()`
- `User::get_full_tree()`

### Root cause

The entity list returned by `getEntity()` may contain trailing commas or empty values, resulting in invalid SQL `IN (...)` clauses.

### Fix

The patch ensures that the entity list used in SQL queries is valid and does not generate malformed `IN` conditions.

### Impact

- Prevents SQL syntax errors when enabling multicompany
- No functional change outside this fix
- Backward compatible
