### PR TITLE
UIUX : initNewContent event system (Dolibarr JS context)

### DIFF
--- a/htdocs/admin/tools/ui/class/documentation.class.php
+++ b/htdocs/admin/tools/ui/class/documentation.class.php
@@ -251,7 +251,7 @@ class Documentation
 						'JSDolibarrhooks' => '#titlesection-hooks',
 						'JSDolibarrhooksReadyVsInit' => '#titlesection-event-init-vs-ready',
 						'JSDolibarrAwaitHooks' => '#titlesection-await-hooks',
-						'JSDolibarrhooksAjaxSpecial' => '#titlesection-dom-reloaddomready',
+						'JSDolibarrhooksAjaxSpecial' => '#titlesection-dom-initnewcontent',
 						'ExampleOfCreatingNewContextTool' => '#titlesection-create-tool-example',
 						'SetEventMessageTool' => '#titlesection-tool-seteventmessage',
 						'SetAndUseContextVars' => '#titlesection-contextvars',

--- a/htdocs/admin/tools/ui/class/documentation.class.php
+++ b/htdocs/admin/tools/ui/class/documentation.class.php
@@ -251,6 +251,7 @@ class Documentation
 						'JSDolibarrhooks' => '#titlesection-hooks',
 						'JSDolibarrhooksReadyVsInit' => '#titlesection-event-init-vs-ready',
 						'JSDolibarrAwaitHooks' => '#titlesection-await-hooks',
+						'JSDolibarrhooksAjaxSpecial' => '#titlesection-dom-reloaddomready',
 						'ExampleOfCreatingNewContextTool' => '#titlesection-create-tool-example',
 						'SetEventMessageTool' => '#titlesection-tool-seteventmessage',
 						'SetAndUseContextVars' => '#titlesection-contextvars',

--- a/htdocs/admin/tools/ui/dolibarr-context/index.php
+++ b/htdocs/admin/tools/ui/dolibarr-context/index.php
@@ -40,8 +40,8 @@ $langs->load('uxdocumentation');
 
 //
 $documentation = new Documentation($db);
-$group = 'ExperimentalUx';
-$experimentName = 'UxDolibarrContext';
+$group = 'UxDolibarrContext';
+$experimentName = 'UxDolibarrContextHowItWork';
 
 $js = [
 	'/includes/ace/src/ace.js',
@@ -65,7 +65,7 @@ $documentation->showSidebar(); ?>
 
 	<div class="doc-content-wrapper">
 
-		<h1 class="documentation-title"><?php echo $langs->trans($experimentName); ?> : <?php echo $langs->trans('UxDolibarrContextHowItWork'); ?></h1>
+		<h1 class="documentation-title"><?php echo $langs->trans($group); ?> : <?php echo $langs->trans('UxDolibarrContextHowItWork'); ?></h1>
 
 		<?php $documentation->showSummary(); ?>
 

--- a/htdocs/admin/tools/ui/dolibarr-context/index.php
+++ b/htdocs/admin/tools/ui/dolibarr-context/index.php
@@ -439,6 +439,216 @@ $documentation->showSidebar(); ?>
 
 		</div>
 
+		<div class="documentation-section">
+			<h2 id="titlesection-dom-initnewcontent" class="documentation-title">
+				initNewContent event system
+			</h2>
+
+			<p>
+				The <strong>initNewContent</strong> event is a standardized Dolibarr mechanism
+				to re-initialize UI components on dynamically added content.
+				Use it whenever you inject new DOM elements via AJAX, templates, or other dynamic updates.
+			</p>
+
+			<h3 id="titlesection-usecase-tooltips" class="documentation-title">
+				Use Case example: Dynamic Tooltips
+			</h3>
+
+			<p>
+				In a typical Dolibarr page, tooltips are initialized on page load for all elements
+				that have the class <code>.classfortooltip</code>. This works perfectly for static content.
+			</p>
+
+			<p>
+				However, when a section of the page is dynamically recreated or loaded via AJAX,
+				the new elements with <code>.classfortooltip</code> do not automatically have tooltips,
+				because the initialization script has already run on the initial DOM and is not rerun for the new elements.
+			</p>
+
+			<p>
+				The <strong>initNewContent</strong> mechanism solves this problem by providing a standardized hook
+				to re-initialize all interactive components on newly added DOM elements.
+				Developers can listen to <code>initNewContent</code> and re-run tooltip initialization
+				(or any other dynamic behavior) only on the new elements or their children, ensuring consistency and avoiding duplication.
+			</p>
+
+			<p>
+				This approach guarantees that tooltips, dialogs, and other interactive components
+				remain functional even when content is injected or updated asynchronously.
+			</p>
+
+			<p>
+				In addition to <code>document.ready</code> or <code>$(document).ready()</code>,
+				listen to <strong>initNewContent</strong> to ensure that tooltips, dialogs, or other interactive components
+				are properly initialized on any new DOM fragment added dynamically.
+			</p>
+
+
+			<div class="documentation-example">
+				<p>
+					<button class="button" id="try-no-initNewContent">Test without event</button>
+					<button class="button" id="try-initNewContent">Test with initNewContent event</button>
+				</p>
+				<div id="initNewContent-test-container"></div>
+
+				<style>
+					/* Animation for highlighting new content */
+					@keyframes highlightfortest {
+						from { background-color: #fffa8d; }
+						to { background-color: transparent; }
+					}
+					.highlightfortest {
+						padding: 10px;
+						animation: highlightfortest 1s ease-out;
+					}
+				</style>
+
+				<script nonce="<?php print getNonce() ?>">
+					document.addEventListener('Dolibarr:Ready', function(e) {
+						const container = document.getElementById('initNewContent-test-container');
+
+						document.getElementById('try-no-initNewContent').addEventListener('click', function() {
+							container.innerHTML = `<span class="classfortooltip highlightfortest" title="this is the title">A text with a tooltip but the tooltip isn't load</span>
+								And <span class="classfortooltiponclicktext highlightfortest" title="this is the title">A text with a tooltip to click but the tooltip isn't load</span>`;
+						});
+
+						document.getElementById('try-initNewContent').addEventListener('click', function() {
+							container.innerHTML = `<span class="classfortooltip highlightfortest" title="this is the title">A text with a tooltip and the tooltip is loaded</span>
+								And <span class="classfortooltiponclicktext" title="this is the title">A text with a tooltip to click and the tooltip is loaded</span>`;
+							Dolibarr.initNewContent(container);
+						});
+					});
+				</script>
+			</div>
+
+
+			<h3 id="titlesection-usecase-tooltips" class="documentation-title">
+				How to use it
+			</h3>
+
+			<p>
+				The event handler receives an object with the property <code>targets</code>,
+				which is an array of DOM elements or jQuery collections to initialize. Each element can be:
+			</p>
+
+			<ul>
+				<li>a container with child elements to initialize</li>
+				<li>or a direct element that needs initialization</li>
+			</ul>
+
+			<h4>Example: Trigger initNewContent manually on a container</h4>
+			<div class="documentation-example">
+				<?php
+				$lines = array(
+					'<script nonce="<?php print getNonce() ?>">',
+					'    document.addEventListener(\'Dolibarr:Ready\', function(e) {',
+					'        /* [... code that dynamically reloads part of the DOM ...] */',
+					'',
+					'        /**',
+					'         * true: only include the children of each target element',
+					'         * false: include the target elements themselves',
+					'         */',
+					'        const applyToChildrenOnly = true;',
+					'',
+					'        // Trigger initNewContent manually on a jQuery container',
+					'        Dolibarr.initNewContent($("#myContainer"), applyToChildrenOnly);',
+					'',
+					'        // Trigger initNewContent manually on a vanilla JS element',
+					'        const element = document.getElementById("myContainer");',
+					'        Dolibarr.initNewContent(element, applyToChildrenOnly);',
+					'    });',
+					'</script>',
+				);
+				$documentation->showCode($lines, 'php');
+				?>
+			</div>
+
+			<p>
+				Dolibarr provides a custom event system to properly initialize dynamic content.
+				Always use <strong>initNewContent</strong> when working with AJAX-injected fragments or
+				dynamically created elements instead of relying solely on jQuery document ready.
+			</p>
+
+
+
+			<h4>Example in pure JS style: listening to initNewContent</h4>
+			<div class="documentation-example">
+				<?php
+				$lines = array(
+					'<script nonce="<?php print getNonce() ?>">',
+					'    Dolibarr.on("initNewContent", ({ targets }) => {',
+					'        targets.forEach(root => {',
+					'',
+					'            // Array to store all matching dialog elements',
+					'            const dialogs = [];',
+					'',
+					'            // Include the root element if it matches the selector',
+					'            if (root.matches(".classfortooltiponclicktext")) {',
+					'                dialogs.push(root);',
+					'            }',
+					'',
+					'            // Add all descendants matching the selector',
+					'            dialogs.push(...root.querySelectorAll(".classfortooltiponclicktext"));',
+					'',
+					'            // Initialize each dialog element',
+					'            dialogs.forEach(el => {',
+					'                // Your code to initialize the tooltip/dialog or other stuff',
+					'            });',
+					'        });',
+					'    });',
+					'</script>',
+				);
+				$documentation->showCode($lines, 'php');
+				?>
+			</div>
+
+			<h4>Compact version in pure JS</h4>
+			<div class="documentation-example">
+				<?php
+				$lines = array(
+					'<script nonce="<?php print getNonce() ?>">',
+					'    Dolibarr.on("initNewContent", ({ targets }) => {',
+					'        targets.forEach(root => {',
+					'            const dialogs = [',
+					'                ...(root.matches(".classfortooltiponclicktext") ? [root] : []),',
+					'                ...root.querySelectorAll(".classfortooltiponclicktext")',
+					'            ];',
+					'            dialogs.forEach(el => {',
+					'                // Initialize tooltip/dialog or other stuff here',
+					'            });',
+					'        });',
+					'    });',
+					'</script>',
+				);
+				$documentation->showCode($lines, 'php');
+				?>
+			</div>
+
+			<h4>Example in jQuery style</h4>
+			<div class="documentation-example">
+				<?php
+				$lines = array(
+					'<script nonce="<?php print getNonce() ?>">',
+					'    Dolibarr.on("initNewContent", ({ targets }) => {',
+					'        targets.forEach($root => {',
+					'            const $dialogs = $root',
+					'                .filter(".classfortooltiponclicktext")',
+					'                .add($root.find(".classfortooltiponclicktext"));',
+					'            $dialogs.each(function () {',
+					'                const $el = $(this);',
+					'                // Initialize tooltip/dialog behavior or other stuff here',
+					'            });',
+					'        });',
+					'    });',
+					'</script>',
+				);
+				$documentation->showCode($lines, 'php');
+				?>
+			</div>
+
+		</div>
+
+
 
 		<div class="documentation-section">
 			<h2 id="titlesection-create-tool-example" class="documentation-title">Example of creating a new context tool</h2>

--- a/htdocs/admin/tools/ui/dolibarr-context/index.php
+++ b/htdocs/admin/tools/ui/dolibarr-context/index.php
@@ -137,7 +137,6 @@ $documentation->showSidebar(); ?>
 				When enabled, <code>Dolibarr.log()</code> behaves like <code>console.log()</code>.
 			</p>
 
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script>',
@@ -153,7 +152,6 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php');
 				?>
-			</div>
 
 			<h3>Summary</h3>
 			<ul>
@@ -187,7 +185,6 @@ $documentation->showSidebar(); ?>
 				<code>e.detail</code> and the event name is prefixed by <code>Dolibarr:</code> so for a hook named A event name is <code>Dolibarr:A</code>
 			</p>
 
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script>',
@@ -203,7 +200,7 @@ $documentation->showSidebar(); ?>
 					'</script>',
 				);
 				$documentation->showCode($lines, 'php'); ?>
-			</div>
+
 
 			<h3>Practical usage</h3>
 			<p>
@@ -212,7 +209,6 @@ $documentation->showSidebar(); ?>
 				are valid, but <code>Dolibarr.on()</code> is simpler and more convenient because you get the
 				data directly.
 			</p>
-			<div  class="documentation-example">
 				<?php
 				$lines = array(
 					'<script>',
@@ -246,6 +242,7 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php'); ?>
 
+			<div  class="documentation-example">
 				Open your console <code>F12</code> and click on  <button class="button" id="try-event-yourCustomHookName">try</button>
 				<script nonce="<?php print getNonce() ?>"  >
 					document.addEventListener('Dolibarr:Ready', function(e) {
@@ -309,7 +306,6 @@ $documentation->showSidebar(); ?>
 			</p>
 
 			<h3>Examples of usage</h3>
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script>',
@@ -334,7 +330,7 @@ $documentation->showSidebar(); ?>
 					'</script>',
 				);
 				$documentation->showCode($lines, 'php'); ?>
-			</div>
+
 
 			<p>
 				In summary:
@@ -364,7 +360,6 @@ $documentation->showSidebar(); ?>
 				This means you can <code>await</code> their results in your code, and any asynchronous operations inside a hook (e.g., API calls, timers) will be handled correctly before moving to the next hook.
 			</p>
 
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script nonce="<?php print getNonce() ?>">',
@@ -402,6 +397,7 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php'); ?>
 
+			<div class="documentation-example">
 				Open your console <code>F12</code> and click on  <button class="button" id="try-event-yourCustomAwaitHookName">try</button>
 
 				<script nonce="<?php print getNonce() ?>">
@@ -502,25 +498,49 @@ $documentation->showSidebar(); ?>
 						animation: highlightfortest 1s ease-out;
 					}
 				</style>
-
+				<div id="idfortooltiponclick_doc-event-dialog-test" class="classfortooltiponclicktext" title="The title" style="display: none" >Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce nec elit venenatis, bibendum dui in, tristique dolor. In hac habitasse platea dictumst. Vestibulum consectetur quam non felis fringilla mollis pretium vel nibh. Pellentesque congue risus et laoreet blandit. Aliquam orci ipsum, gravida id leo eget, molestie pulvinar sem. Nulla sed felis et lacus tristique finibus. Cras ornare tincidunt. Aenean hendrerit volutpat efficitur. Integer vestibulum dui eget lectus pulvinar, vel mattis odio facilisis. Etiam convallis scelerisque lobortis. Mauris tristique, quam dignissim sollicitudin sodales, elit ligula venenatis neque, sit amet interdum lacus tellus id tellus. Mauris eu pretium turpis. Proin porta sem eget nisl vulputate vehicula.</div>
 				<script nonce="<?php print getNonce() ?>">
 					document.addEventListener('Dolibarr:Ready', function(e) {
 						const container = document.getElementById('initNewContent-test-container');
 
 						document.getElementById('try-no-initNewContent').addEventListener('click', function() {
 							container.innerHTML = `<span class="classfortooltip highlightfortest" title="this is the title">A text with a tooltip but the tooltip isn't load</span>
-								And <span class="classfortooltiponclicktext highlightfortest" title="this is the title">A text with a tooltip to click but the tooltip isn't load</span>`;
+								and <span class="classfortooltiponclick highlightfortest" dolid="doc-event-dialog-test" style="cursor: pointer;" >A text with a tooltip to click but the tooltip isn't load</span>`;
 						});
 
 						document.getElementById('try-initNewContent').addEventListener('click', function() {
 							container.innerHTML = `<span class="classfortooltip highlightfortest" title="this is the title">A text with a tooltip and the tooltip is loaded</span>
-								And <span class="classfortooltiponclicktext" title="this is the title">A text with a tooltip to click and the tooltip is loaded</span>`;
+								And <span class="classfortooltiponclick highlightfortest" dolid="doc-event-dialog-test"  style="cursor: pointer;" >A text with a tooltip to click and the tooltip is loaded</span>`;
 							Dolibarr.initNewContent(container);
 						});
 					});
 				</script>
-			</div>
 
+
+			</div>
+			<?php
+			$lines = array(
+				'<div id="idfortooltiponclick_doc-event-dialog-test" class="classfortooltiponclicktext" title="The title" >Lorem ipsum .....</div>',
+				'<script nonce="<?php print getNonce() ?>">',
+				'document.addEventListener("Dolibarr:Ready", function(e) {',
+				'    const container = document.getElementById("initNewContent-test-container");',
+				'',
+				'    // Insert content without calling initNewContent',
+				'    document.getElementById("try-no-initNewContent").addEventListener("click", function() {',
+				'        container.innerHTML = `<span class="classfortooltip highlightfortest" title="this is the title">A text with a tooltip but the tooltip isn\'t load</span>',
+				'            and <span class="classfortooltiponclick highlightfortest" dolid="doc-event-dialog-test" style="cursor: pointer;">A text with a tooltip to click but the tooltip isn\'t load</span>`;',
+				'    });',
+				'',
+				'    // Insert content and trigger initNewContent',
+				'    document.getElementById("try-initNewContent").addEventListener("click", function() {',
+				'        container.innerHTML = `<span class="classfortooltip highlightfortest" title="this is the title">A text with a tooltip and the tooltip is loaded</span>',
+				'            and <span class="classfortooltiponclick highlightfortest" dolid="doc-event-dialog-test" style="cursor: pointer;">A text with a tooltip to click and the tooltip is loaded</span>`;',
+				'        Dolibarr.initNewContent(container);',
+				'    });',
+				'});',
+				'</script>',
+			);
+			$documentation->showCode($lines, 'php'); ?>
 
 			<h3 id="titlesection-usecase-tooltips" class="documentation-title">
 				How to use it
@@ -537,8 +557,8 @@ $documentation->showSidebar(); ?>
 			</ul>
 
 			<h4>Example: Trigger initNewContent manually on a container</h4>
-			<div class="documentation-example">
-				<?php
+
+			<?php
 				$lines = array(
 					'<script nonce="<?php print getNonce() ?>">',
 					'    document.addEventListener(\'Dolibarr:Ready\', function(e) {',
@@ -559,9 +579,7 @@ $documentation->showSidebar(); ?>
 					'    });',
 					'</script>',
 				);
-				$documentation->showCode($lines, 'php');
-				?>
-			</div>
+				$documentation->showCode($lines, 'php'); ?>
 
 			<p>
 				Dolibarr provides a custom event system to properly initialize dynamic content.
@@ -572,7 +590,6 @@ $documentation->showSidebar(); ?>
 
 
 			<h4>Example in pure JS style: listening to initNewContent</h4>
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script nonce="<?php print getNonce() ?>">',
@@ -600,10 +617,8 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php');
 				?>
-			</div>
 
 			<h4>Compact version in pure JS</h4>
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script nonce="<?php print getNonce() ?>">',
@@ -622,10 +637,8 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php');
 				?>
-			</div>
 
 			<h4>Example in jQuery style</h4>
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script nonce="<?php print getNonce() ?>">',
@@ -644,7 +657,6 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php');
 				?>
-			</div>
 
 		</div>
 
@@ -660,7 +672,6 @@ $documentation->showSidebar(); ?>
 			<p>See also <code>dolibarr-context.mock.js</code> for defining all standard Dolibarr tools and creating mock implementations to improve code completion and editor support.</p>
 			<p><b>Note :</b> a tool can be a class not only a function</p>
 
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 				'<script>',
@@ -677,14 +688,12 @@ $documentation->showSidebar(); ?>
 				'</script>',
 				);
 				$documentation->showCode($lines, 'php'); ?>
-			</div>
 
 			<h3>Protected Tools</h3>
 			<p>
 				Once a tool is defined on overwrite false, it cannot be replaced. Attempting to redefine it without overwrite will throw an error:
 			</p>
 
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script>',
@@ -696,14 +705,12 @@ $documentation->showSidebar(); ?>
 					'</script>',
 				);
 				$documentation->showCode($lines, 'php'); ?>
-			</div>
 
 			<h3>Reading Tools</h3>
 			<p>
 				You can read the list of available tools using <code>Dolibarr.tools</code>. It returns a frozen copy:
 			</p>
 
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script>',
@@ -712,7 +719,6 @@ $documentation->showSidebar(); ?>
 					'</script>',
 				);
 				$documentation->showCode($lines, 'php'); ?>
-			</div>
 
 		</div>
 
@@ -732,33 +738,33 @@ $documentation->showSidebar(); ?>
 				This means all developers can write features without worrying about frontend compatibility or future library replacements. Enjoy!
 
 			</p>
-
+			<?php
+			$lines = array(
+				'<script nonce="<?php print getNonce() ?>" >',
+				'	document.addEventListener(\'Dolibarr:Ready\', function(e) {',
+				'',
+				'		document.getElementById(\'setEventMessage-success\').addEventListener(\'click\', function(e) {',
+				'			Dolibarr.tools.setEventMessage(\'Success Test\');',
+				'		});',
+				'',
+				'		document.getElementById(\'setEventMessage-error\').addEventListener(\'click\', function(e) {',
+				'			Dolibarr.tools.setEventMessage(\'Error Test\', \'errors\');',
+				'		});',
+				'',
+				'		document.getElementById(\'setEventMessage-error-sticky\').addEventListener(\'click\', function(e) {',
+				'			Dolibarr.tools.setEventMessage(\'Error Test\', \'errors\', true);',
+				'		});',
+				'',
+				'		document.getElementById(\'setEventMessage-warning\').addEventListener(\'click\', function(e) {',
+				'			Dolibarr.tools.setEventMessage(\'Warning Test\', \'warnings\');',
+				'		});',
+				'',
+				'	});',
+				'</script>',
+			);
+			$documentation->showCode($lines, 'php'); ?>
 			<div class="documentation-example">
-				<?php
-				$lines = array(
-					'<script nonce="<?php print getNonce() ?>" >',
-					'	document.addEventListener(\'Dolibarr:Ready\', function(e) {',
-					'',
-					'		document.getElementById(\'setEventMessage-success\').addEventListener(\'click\', function(e) {',
-					'			Dolibarr.tools.setEventMessage(\'Success Test\');',
-					'		});',
-					'',
-					'		document.getElementById(\'setEventMessage-error\').addEventListener(\'click\', function(e) {',
-					'			Dolibarr.tools.setEventMessage(\'Error Test\', \'errors\');',
-					'		});',
-					'',
-					'		document.getElementById(\'setEventMessage-error-sticky\').addEventListener(\'click\', function(e) {',
-					'			Dolibarr.tools.setEventMessage(\'Error Test\', \'errors\', true);',
-					'		});',
-					'',
-					'		document.getElementById(\'setEventMessage-warning\').addEventListener(\'click\', function(e) {',
-					'			Dolibarr.tools.setEventMessage(\'Warning Test\', \'warnings\');',
-					'		});',
-					'',
-					'	});',
-					'</script>',
-				);
-				$documentation->showCode($lines, 'php'); ?>
+
 				<script nonce="<?php print getNonce() ?>"  >
 					document.addEventListener('Dolibarr:Ready', function(e) {
 
@@ -808,7 +814,6 @@ $documentation->showSidebar(); ?>
 			</p>
 
 			<h3>Add  context var (overridable or not)</h3>
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script nonce="<?php print getNonce() ?>" >',
@@ -823,11 +828,9 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php');
 				?>
-			</div>
 
 
 			<h3>Add multiple context vars (overridable or not)</h3>
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<?php',
@@ -854,10 +857,8 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php');
 				?>
-			</div>
 
 			<h3>Get context var</h3>
-			<div class="documentation-example">
 				<?php
 				$lines = array(
 					'<script nonce="<?php print getNonce() ?>" >',
@@ -869,7 +870,6 @@ $documentation->showSidebar(); ?>
 				);
 				$documentation->showCode($lines, 'php');
 				?>
-			</div>
 
 		</div>
 

--- a/htdocs/core/js/lib_foot.js.php
+++ b/htdocs/core/js/lib_foot.js.php
@@ -68,95 +68,71 @@ if (empty($dolibarr_nocache)) {
 	header('Cache-Control: no-cache');
 }
 
-//var_dump($conf);
 
+$jsConst = [
+	'DOL_URL_ROOT' => DOL_URL_ROOT,
+	'classfortooltiponclicktextWidth' => ($conf->browser->layout == 'phone' ? max((empty($_SESSION['dol_screenwidth']) ? 0 : $_SESSION['dol_screenwidth']) - 20, 320) : 700),
+	'dol_no_mouse_hover' => !empty($conf->dol_no_mouse_hover)
+];
+
+
+include __DIR__ . '/lib_initTooltips.js';
+
+?>
 
 // Wrapper to show tooltips (html or onclick popup)
-print "\n/* JS CODE TO ENABLE Tooltips on all object with class classfortooltip */
-jQuery(document).ready(function () {\n";
+/* JS CODE TO ENABLE Tooltips on all object with class classfortooltip */
+jQuery(function() {
 
-if (empty($conf->dol_no_mouse_hover)) {
-	print '
-	/* for standard tooltip */
-	jQuery(".classfortooltip").tooltip({
-		tooltipClass: "mytooltip",
-		show: { collision: "flipfit", effect:"toggle", delay:50, duration: 20 },
-		hide: { delay: 250, duration: 20 },
-		content: function () {
-			console.log("Return title for popup");
-			return $(this).prop("title");		/* To force to get title as is */
-		}
-	});
+	const footerConst = <?php print json_encode($jsConst); ?>;
 
-	var opendelay = 100;
-	var elemtostoretooltiptimer = jQuery("#dialogforpopup");
-	var currenttoken = jQuery("meta[name=anti-csrf-currenttoken]").attr("content");
 
-	/* for ajax tooltip */
-	target = jQuery(".classforajaxtooltip");
-	target.tooltip({
-		tooltipClass: "mytooltip",
-		show: { collision: "flipfit", effect:"toggle", delay: 0, duration: 20 },
-		hide: { delay: 250, duration: 20 }
-	});
+	if(!footerConst.dol_no_mouse_hover) {
+		// --------------------------------
+		// Initial page load
+		// --------------------------------
+		initTooltips(document.body); // initialize all tooltips on page load
+		initAjaxTooltips(document.body, footerConst.DOL_URL_ROOT); // initialize all AJAX tooltips on page load
 
-	target.off("mouseover mouseout");
-	target.on("mouseover", function(event) {
-		console.log("we will create timer for ajax call");
-		event.stopImmediatePropagation();
-		clearTimeout(elemtostoretooltiptimer.data("openTimeoutId"));
 
-		var params = JSON.parse($(this).attr("data-params"));
-		params.token = currenttoken;
-		var elemfortooltip = $(this);
-
-		elemtostoretooltiptimer.data("openTimeoutId", setTimeout(function() {
-			target.tooltip("close");
-			$.ajax({
-				url:"'. DOL_URL_ROOT.'/core/ajax/ajaxtooltip.php",
-				type: "post",
-				async: true,
-				data: params,
-				success: function(response){
-					// Setting content option
-					console.log("ajax success");
-					if (elemfortooltip.is(":hover")) {
-						elemfortooltip.tooltip("option","content",response);
-						elemfortooltip.tooltip("open");
-					}
-				}
+		// --------------------------------
+		// Dynamic reload via Dolibarr hook
+		// --------------------------------
+		if (typeof Dolibarr !== "undefined" && Dolibarr.on) {
+			// Because Dolibarr context isn't in all Dolibarr page and lib_foot.js.php can be loaded everywhere
+			// it useful to check Dolibarr context is loaded before but we are already in a jQuery(function() so event Dolibarr:Ready can't be used here
+			Dolibarr.on('initNewContent', ({targets}) => {
+				targets.forEach(container => {
+					initTooltips(container);
+					initAjaxTooltips(container, footerConst.DOL_URL_ROOT);
+				})
 			});
-		}, opendelay));
-	});
-	target.on("mouseout", function(event) {
-		console.log("mouse out of a .classforajaxtooltip");
-	    event.stopImmediatePropagation();
-	    clearTimeout(elemtostoretooltiptimer.data("openTimeoutId"));
-	    target.tooltip("close");
-	});
-	';
-}
+		};
+	}
 
-print '
-	jQuery(".classfortooltiponclicktext").dialog({
-		/* title: \'No title\', */
-		closeOnEscape: true, classes: { "ui-dialog": "highlight" },
-		maxHeight: window.innerHeight-60, width: '.($conf->browser->layout == 'phone' ? max((empty($_SESSION['dol_screenwidth']) ? 0 : $_SESSION['dol_screenwidth']) - 20, 320) : 700).',
-		modal: true,
-		autoOpen: false
-	}).css("z-index: 5000");
-	jQuery(".classfortooltiponclick").click(function () {
-		console.log("We click on tooltip for element with dolid="+$(this).attr(\'dolid\'));
-		if ($(this).attr(\'dolid\')) {
-			obj=$("#idfortooltiponclick_"+$(this).attr(\'dolid\'));		/* obj is a div component */
-			obj.dialog("open");
-			return false;
-		}
+	// --------------------------------
+	// Initial page load
+	// --------------------------------
+	jQuery(function() {
+		initTooltipDialogs(document.body);
 	});
+
+	// --------------------------------
+	// Dynamic reload via Dolibarr hook
+	// --------------------------------
+
+	if (typeof Dolibarr !== "undefined" && Dolibarr.on) {
+		// Because Dolibarr context isn't in all Dolibarr page and lib_foot.js.php can be loaded everywhere
+		// it useful to check Dolibarr context is loaded before but we are already in a jQuery(function() so event Dolibarr:Ready can't be used here
+		Dolibarr.on('initNewContent', ({ targets }) => {
+			targets.forEach(container => initTooltipDialogs(container, footerConst.classfortooltiponclicktextWidth));
+		});
+	};
+
 });
-';
 
 
+<?php
 // Wrapper to manage dropdown
 if (!defined('JS_JQUERY_DISABLE_DROPDOWN')) {
 	print "\n/* JS CODE TO ENABLE dropdown (hamburger, linkto, ...) */\n";

--- a/htdocs/core/js/lib_initTooltips.js
+++ b/htdocs/core/js/lib_initTooltips.js
@@ -140,7 +140,7 @@ function initTooltipDialogs(root, dialogWidth) {
 			if (!dolid) return false;
 
 			const $dialog = jQuery("#idfortooltiponclick_" + dolid);
-			if ($dialog.length) {
+			if ($dialog.length && $dialog.data("ui-dialog")) {
 				$dialog.dialog("open");
 			}
 

--- a/htdocs/core/js/lib_initTooltips.js
+++ b/htdocs/core/js/lib_initTooltips.js
@@ -1,0 +1,150 @@
+/**
+ * Initialize standard tooltips.
+ *
+ * @param {HTMLElement|jQuery} root
+ */
+function initTooltips(root) {
+	const $root = jQuery(root);
+
+	const $elements = $root
+		.filter(".classfortooltip")
+		.add($root.find(".classfortooltip"));
+
+	$elements.each(function () {
+		const $el = jQuery(this);
+
+		if ($el.data("ui-tooltip")) {
+			$el.tooltip("destroy");
+		}
+
+		$el.tooltip({
+			tooltipClass: "mytooltip",
+			show: { collision: "flipfit", effect: "toggle", delay: 50, duration: 20 },
+			hide: { delay: 250, duration: 20 },
+			content: function () {
+				return $el.prop("title");
+			}
+		});
+	});
+}
+
+/**
+ * Initialize AJAX tooltips.
+ *
+ * @param {HTMLElement|jQuery} root
+ * @param {string} baseUrl
+ */
+function initAjaxTooltips(root, baseUrl) {
+	const $root = jQuery(root);
+
+	const $elements = $root
+		.filter(".classforajaxtooltip")
+		.add($root.find(".classforajaxtooltip"));
+
+	const openDelay = 100;
+	const $storeElem = jQuery("#dialogforpopup");
+	const currentToken = jQuery("meta[name=anti-csrf-currenttoken]").attr("content");
+
+	$elements.each(function () {
+		const $el = jQuery(this);
+
+		if ($el.data("ui-tooltip")) {
+			$el.tooltip("destroy");
+		}
+
+		$el.tooltip({
+			tooltipClass: "mytooltip",
+			show: { collision: "flipfit", effect: "toggle", delay: 0, duration: 20 },
+			hide: { delay: 250, duration: 20 }
+		});
+
+		$el.off("mouseover.ajaxTooltip mouseout.ajaxTooltip");
+
+		$el.on("mouseover.ajaxTooltip", function (event) {
+			event.stopImmediatePropagation();
+			clearTimeout($storeElem.data("openTimeoutId"));
+
+			const params = JSON.parse($el.attr("data-params") || "{}");
+			params.token = currentToken;
+
+			$storeElem.data("openTimeoutId", setTimeout(() => {
+				$elements.tooltip("close");
+
+				jQuery.ajax({
+					url: baseUrl + "/core/ajax/ajaxtooltip.php",
+					type: "post",
+					async: true,
+					data: params,
+					success: function (response) {
+						if ($el.is(":hover")) {
+							$el.tooltip("option", "content", response);
+							$el.tooltip("open");
+						}
+					}
+				});
+			}, openDelay));
+		});
+
+		$el.on("mouseout.ajaxTooltip", function (event) {
+			event.stopImmediatePropagation();
+			clearTimeout($storeElem.data("openTimeoutId"));
+			$elements.tooltip("close");
+		});
+	});
+}
+
+/**
+ * Initialize click-to-open tooltip dialogs.
+ * Works whether root is a container or a direct element.
+ *
+ * @param {HTMLElement|jQuery} root - Element or container to scan.
+ * @param {number} dialogWidth - Width of the dialog.
+ */
+function initTooltipDialogs(root, dialogWidth) {
+	const $root = jQuery(root);
+
+	// Dialog elements (self + descendants)
+	const $dialogs = $root
+		.filter(".classfortooltiponclicktext")
+		.add($root.find(".classfortooltiponclicktext"));
+
+	$dialogs.each(function () {
+		const $dialog = jQuery(this);
+
+		if ($dialog.data("ui-dialog")) {
+			$dialog.dialog("destroy");
+		}
+
+		$dialog.dialog({
+			closeOnEscape: true,
+			classes: { "ui-dialog": "highlight" },
+			maxHeight: window.innerHeight - 60,
+			width: dialogWidth,
+			modal: true,
+			autoOpen: false
+		}).css("z-index", 5000);
+	});
+
+	// Trigger elements (self + descendants)
+	const $triggers = $root
+		.filter(".classfortooltiponclick")
+		.add($root.find(".classfortooltiponclick"));
+
+	$triggers.each(function () {
+		const $trigger = jQuery(this);
+
+		$trigger.off("click.tooltipDialog");
+
+		$trigger.on("click.tooltipDialog", function () {
+			const dolid = jQuery(this).attr("dolid");
+			if (!dolid) return false;
+
+			const $dialog = jQuery("#idfortooltiponclick_" + dolid);
+			if ($dialog.length) {
+				$dialog.dialog("open");
+			}
+
+			return false;
+		});
+	});
+}

--- a/htdocs/langs/en_US/uxdocumentation.lang
+++ b/htdocs/langs/en_US/uxdocumentation.lang
@@ -195,3 +195,5 @@ SetEventMessageTool = Dolibarr Tool : Set event message
 ContextLangToolTest = This text is in english
 LangsLocalChangedTo = Language locale changed to %s. Translations will now use the new locale.
 CacheCleared = Cache cleared
+
+JSDolibarrhooksAjaxSpecial = Dom reloaded Hook

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-context.mock.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-context.mock.js
@@ -148,6 +148,22 @@ var Dolibarr = {
 	executeHook(hookName, data = {}) {},
 
 	/**
+	 * Trigger a standardized Dolibarr DOM reload hook.
+	 * Useful for re-initializing UX components (tooltips, selects, modals, etc.)
+	 * on dynamically injected or updated DOM portions.
+	 *
+	 * @param {HTMLElement|NodeList|Array<HTMLElement>|jQuery|string} targetEl
+	 *   - A single DOM element
+	 *   - A CSS selector string
+	 *   - A NodeList or array of DOM elements
+	 *   - A jQuery object (can contain multiple elements)
+	 * @param {boolean} applyToChildrenOnly
+	 *   - true: include only the children of each target element
+	 *   - false: include the target elements themselves
+	 */
+	initNewContent(targetEl, applyToChildrenOnly = true) {},
+
+	/**
 	 * Registers an event listener.
 	 * @param {string} eventName Event to listen to
 	 * @param {function} callback Listener function

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-context.umd.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-context.umd.js
@@ -260,6 +260,58 @@
 		},
 
 		/**
+		 * Trigger a standardized Dolibarr DOM reload hook.
+		 * Useful for re-initializing UX components (tooltips, selects, modals, etc.)
+		 * on dynamically injected or updated DOM portions.
+		 *
+		 * @param {HTMLElement|NodeList|Array<HTMLElement>|jQuery|string} targetEl
+		 *   - A single DOM element
+		 *   - A CSS selector string
+		 *   - A NodeList or array of DOM elements
+		 *   - A jQuery object (can contain multiple elements)
+		 * @param {boolean} applyToChildrenOnly
+		 *   - true: include only the children of each target element
+		 *   - false: include the target elements themselves
+		 */
+		initNewContent(targetEl, applyToChildrenOnly = true) {
+			let elements = [];
+
+			// Convert jQuery to array of DOM elements
+			if (typeof jQuery !== 'undefined' && targetEl instanceof jQuery) {
+				elements = targetEl.toArray();
+			}
+			// CSS selector
+			else if (typeof targetEl === 'string') {
+				elements = Array.from(document.querySelectorAll(targetEl));
+			}
+			// NodeList or array
+			else if (NodeList.prototype.isPrototypeOf(targetEl) || Array.isArray(targetEl)) {
+				elements = Array.from(targetEl);
+			}
+			// Single HTMLElement
+			else if (targetEl instanceof HTMLElement) {
+				elements = [targetEl];
+			}
+
+			if (elements.length === 0) return;
+
+			// Flatten elements according to applyToChildrenOnly
+			const finalElements = [];
+			elements.forEach(el => {
+				if (applyToChildrenOnly) {
+					finalElements.push(...Array.from(el.children));
+				} else {
+					finalElements.push(el);
+				}
+			});
+
+			if (finalElements.length === 0) return;
+
+			// Trigger standardized hook with an array of elements
+			this.executeHook('initNewContent', { targets: finalElements });
+		},
+
+		/**
 		 * Registers an event listener.
 		 * @param {string} eventName Event to listen to
 		 * @param {function} callback Listener function

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-context.umd.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-context.umd.js
@@ -274,6 +274,59 @@
 		 *   - false: include the target elements themselves
 		 */
 		initNewContent(targetEl, applyToChildrenOnly = true) {
+			let elements = this.normalizeToElements(targetEl);
+			if (elements.length === 0) return;
+
+			// Flatten elements according to applyToChildrenOnly
+			const finalElements = [];
+			elements.forEach(el => {
+				if (applyToChildrenOnly) {
+					finalElements.push(...Array.from(el.children));
+				} else {
+					finalElements.push(el);
+				}
+			});
+
+			if (finalElements.length === 0) return;
+
+			// Trigger standardized hook with an array of elements
+			this.executeHook('initNewContent', {
+				targets: finalElements, // final loaded elements
+				targetEl: targetEl, // the raw element sent in hook
+				applyToChildrenOnly: applyToChildrenOnly
+			});
+		},
+
+		/**
+		 * Normalize a target element input into an array of DOM elements.
+		 *
+		 * This function accepts various types of inputs:
+		 * - jQuery objects
+		 * - CSS selectors (string)
+		 * - NodeLists
+		 * - Arrays of HTMLElements
+		 * - Single HTMLElement
+		 *
+		 * @param {HTMLElement | HTMLElement[] | NodeList | jQuery | string} targetEl - The target element(s) to normalize.
+		 * @returns {HTMLElement[]} An array of DOM elements corresponding to the input.
+		 *
+		 * @example
+		 * // Using a CSS selector
+		 * const elems = Dolibarr.normalizeToElements('.my-class');
+		 *
+		 * @example
+		 * // Using a single HTMLElement
+		 * const elem = Dolibarr.normalizeToElements(document.getElementById('myId'));
+		 *
+		 * @example
+		 * // Using a jQuery object
+		 * const elems = Dolibarr.normalizeToElements($('.my-class'));
+		 *
+		 * @example
+		 * // Using an array of elements
+		 * const elems = Dolibarr.normalizeToElements([elem1, elem2]);
+		 */
+		normalizeToElements(targetEl){
 			let elements = [];
 
 			// Convert jQuery to array of DOM elements
@@ -293,22 +346,7 @@
 				elements = [targetEl];
 			}
 
-			if (elements.length === 0) return;
-
-			// Flatten elements according to applyToChildrenOnly
-			const finalElements = [];
-			elements.forEach(el => {
-				if (applyToChildrenOnly) {
-					finalElements.push(...Array.from(el.children));
-				} else {
-					finalElements.push(el);
-				}
-			});
-
-			if (finalElements.length === 0) return;
-
-			// Trigger standardized hook with an array of elements
-			this.executeHook('initNewContent', { targets: finalElements });
+			return elements;
 		},
 
 		/**


### PR DESCRIPTION
# initNewContent event system
The initNewContent event is a standardized Dolibarr mechanism to re-initialize UI components on dynamically added content. Use it whenever you inject new DOM elements via AJAX, templates, or other dynamic updates.

Use Case example: Dynamic Tooltips
In a typical Dolibarr page, tooltips are initialized on page load for all elements that have the class .classfortooltip. This works perfectly for static content.

However, when a section of the page is dynamically recreated or loaded via AJAX, the new elements with .classfortooltip do not automatically have tooltips, because the initialization script has already run on the initial DOM and is not rerun for the new elements.

The initNewContent mechanism solves this problem by providing a standardized hook to re-initialize all interactive components on newly added DOM elements. Developers can listen to initNewContent and re-run tooltip initialization (or any other dynamic behavior) only on the new elements or their children, ensuring consistency and avoiding duplication.

This approach guarantees that tooltips, dialogs, and other interactive components remain functional even when content is injected or updated asynchronously.

In addition to document.ready or $(document).ready(), listen to initNewContent to ensure that tooltips, dialogs, or other interactive components are properly initialized on any new DOM fragment added dynamically.

## doc + test exemple

<img width="940" height="1921" alt="image" src="https://github.com/user-attachments/assets/0b26ec82-2f83-4b19-bc0f-7c899e328766" />
