### PR TITLE
WIP : Implement page reload detection to clear JS context language cache

### DIFF
--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
@@ -12,7 +12,7 @@ document.addEventListener('Dolibarr:Init', function(e) {
 	 */
 	const langs = function() {
 
-		const ONE_DAY = 86400000;
+		const CACHE_MSTIME = 86400000;
 		let currentLocale = Dolibarr.getContextVar('MAIN_LANG_DEFAULT', 'en_US');
 		let translations = {}; // { en_US: {KEY: TEXT}, fr_FR: {...} }
 		let domainsLoaded = {}; // { en_US: Set(['main','other']), fr_FR: Set([...]) }
@@ -30,6 +30,13 @@ document.addEventListener('Dolibarr:Init', function(e) {
 			const hashedPath = await hashString(path);
 			const dbName = `DolibarrLangs_${hashedPath}`;
 
+			// Check if this is a reload to clear the cache
+			const [nav] = performance.getEntriesByType("navigation");
+			if (nav && nav.type === "reload") {
+				this.clearCache(true);
+			}
+
+			// Open or create the database
 			return new Promise((resolve, reject) => {
 				const request = indexedDB.open(dbName, 1);
 				request.onupgradeneeded = e => {
@@ -128,7 +135,7 @@ document.addEventListener('Dolibarr:Init', function(e) {
 			const now = Date.now();
 			const dolibarrVersion = Dolibarr.getContextVar('DOL_VERSION', 0);
 
-			if (cache && cache.data && (now - cache.timestamp < ONE_DAY) && cache.dolibarrVersion === dolibarrVersion) {
+			if (cache && cache.data && (now - cache.timestamp < CACHE_MSTIME) && cache.dolibarrVersion === dolibarrVersion) {
 				Dolibarr.log('Langs tool : Load lang from cache');
 				return cache.data;
 			}

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
@@ -272,11 +272,22 @@ document.addEventListener('Dolibarr:Init', function(e) {
 		}
 
 
-		// Clear cache automatically on browser reload
+		/**
+		 * Clear cache automatically under specific conditions
+		 * Support for Hard Reload (Shift or Ctrl) and Debug Mode
+		 */
 		(async () => {
-			const navType = performance?.getEntriesByType?.("navigation")?.[0]?.type || performance.navigation.type;
-			if (navType === "reload") {
-				await clearCache(true);
+			const navEntries = performance?.getEntriesByType?.("navigation");
+			const isReload = navEntries?.[0]?.type === "reload" || performance.navigation.type === 1;
+
+			if (isReload) {
+				window.addEventListener('keydown', async (e) => {
+					// Check if user is holding Shift OR Control OR if Dolibarr Debug is enabled
+					if (e.shiftKey || e.ctrlKey) {
+						await clearCache(true);
+						Dolibarr.log('Langs tool: Cache cleared (Reason: Hard Reload or Debug Mode)');
+					}
+				}, { once: true });
 			}
 		})();
 

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
@@ -28,9 +28,7 @@ document.addEventListener('Dolibarr:Init', function(e) {
 		async function openDB(clear = false) {
 
 			// Generate a unique name per instance
-			const path = Dolibarr.getContextVar('DOL_URL_ROOT'); // or a unique Dolibarr identifier if available
-			const hashedPath = await hashString(path);
-			const dbName = `DolibarrLangs_${hashedPath}`;
+			const dbName = await getSafeDbName();
 
 			return new Promise((resolve, reject) => {
 				const request = indexedDB.open(dbName, 1);
@@ -122,6 +120,7 @@ document.addEventListener('Dolibarr:Init', function(e) {
 				await store.clear();
 
 				// Delete database
+				const dbName = await getSafeDbName();
 				const deleteRequest = indexedDB.deleteDatabase(dbName);
 				deleteRequest.onsuccess = () => Dolibarr.log('Dolibarr.tools.langs: database deleted');
 				deleteRequest.onerror = () => console.error('Dolibarr.tools.langs:Failed to delete DB', deleteRequest.error);

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
@@ -121,7 +121,7 @@ document.addEventListener('Dolibarr:Init', function(e) {
 				const store = tx.objectStore('langs');
 				await store.clear();
 
-				// 1. Supprimer la base entière
+				// Delete database
 				const deleteRequest = indexedDB.deleteDatabase(dbName);
 				deleteRequest.onsuccess = () => Dolibarr.log('Dolibarr.tools.langs: database deleted');
 				deleteRequest.onerror = () => console.error('Dolibarr.tools.langs:Failed to delete DB', deleteRequest.error);

--- a/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
+++ b/htdocs/public/includes/dolibarr-js-context/dolibarr-tool.langs.js
@@ -19,31 +19,33 @@ document.addEventListener('Dolibarr:Init', function(e) {
 		if (!domainsLoaded[currentLocale]) domainsLoaded[currentLocale] = new Set();
 		let domainsRequested = new Set();     // Set of domain names that were requested at least once
 
+
+
 		/**
 		 * Open or create IndexedDB for caching translations
 		 * @returns {Promise<IDBDatabase>}
 		 */
-		async function openDB() {
+		async function openDB(clear = false) {
 
 			// Generate a unique name per instance
 			const path = Dolibarr.getContextVar('DOL_URL_ROOT'); // or a unique Dolibarr identifier if available
 			const hashedPath = await hashString(path);
 			const dbName = `DolibarrLangs_${hashedPath}`;
 
-			// Check if this is a reload to clear the cache
-			const [nav] = performance.getEntriesByType("navigation");
-			if (nav && nav.type === "reload") {
-				this.clearCache(true);
-			}
-
-			// Open or create the database
 			return new Promise((resolve, reject) => {
 				const request = indexedDB.open(dbName, 1);
 				request.onupgradeneeded = e => {
 					const db = e.target.result;
 					if (!db.objectStoreNames.contains('langs')) db.createObjectStore('langs');
 				};
-				request.onsuccess = () => resolve(request.result);
+				request.onsuccess = async () => {
+					const db = request.result;
+					if (clear) {
+						const tx = db.transaction('langs', 'readwrite');
+						tx.objectStore('langs').clear();
+					}
+					resolve(db);
+				};
 				request.onerror = () => reject(request.error);
 			});
 		}
@@ -114,10 +116,17 @@ document.addEventListener('Dolibarr:Init', function(e) {
 			}
 
 			try {
-				const db = await openDB();
+				const db = await openDB(true);
 				const tx = db.transaction('langs', 'readwrite');
 				const store = tx.objectStore('langs');
 				await store.clear();
+
+				// 1. Supprimer la base entière
+				const deleteRequest = indexedDB.deleteDatabase(dbName);
+				deleteRequest.onsuccess = () => Dolibarr.log('Dolibarr.tools.langs: database deleted');
+				deleteRequest.onerror = () => console.error('Dolibarr.tools.langs:Failed to delete DB', deleteRequest.error);
+				deleteRequest.onblocked = () => console.warn('Dolibarr.tools.langs: DB deletion blocked, maybe open connections exist');
+
 				Dolibarr.log('Dolibarr.tools.langs: cache cleared');
 			} catch (err) {
 				console.error('Dolibarr.tools.langs: failed to clear cache', err);
@@ -262,6 +271,15 @@ document.addEventListener('Dolibarr:Init', function(e) {
 				}
 			});
 		}
+
+
+		// Clear cache automatically on browser reload
+		(async () => {
+			const navType = performance?.getEntriesByType?.("navigation")?.[0]?.type || performance.navigation.type;
+			if (navType === "reload") {
+				await clearCache(true);
+			}
+		})();
 
 		return {
 			load,


### PR DESCRIPTION
# New
Implement page reload detection to clear JS context language cache

on ```CTRL``` + ```F5``` or  ```MAJ``` + ```F5``` or  ```CTRL``` + ```R```  ONLY