### PR TITLE
Fix: Sales order add line shows 0 when only multicurrency unit price …

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1250,6 +1250,23 @@ if (empty($reshook)) {
 					}
 				}
 
+				// When product is selected: if user entered multicurrency price (UP currency), use it and set pu_ht_devise; derive pu_ht from rate when local price was not filled (fix: add line showed 0 when only currency price filled)
+				// multicurrency_tx = foreign per 1 local => local = foreign / rate (see price.lib.php calcul_price_total)
+				if (GETPOST('multicurrency_price_ht') !== '') {
+					$pu_ht_devise = (float) price2num($price_ht_devise, 'CU');
+					if (!empty($object->multicurrency_tx) && ($pu_ht === '' || $pu_ht === null || (float) $pu_ht == 0)) {
+						$pu_ht = (float) price2num((float) $pu_ht_devise / (float) $object->multicurrency_tx, 'MU');
+						$pu_ttc = (float) price2num((float) $pu_ht * (1 + ($tmpvat / 100)), 'MU');
+					}
+				}
+				if (GETPOST('multicurrency_price_ttc') !== '') {
+					$pu_ttc_devise = (float) price2num($price_ttc_devise, 'CU');
+					if (!empty($object->multicurrency_tx) && ($pu_ttc === '' || $pu_ttc === null || (float) $pu_ttc == 0)) {
+						$pu_ttc = (float) price2num((float) $pu_ttc_devise / (float) $object->multicurrency_tx, 'MU');
+						$pu_ht = (float) price2num((float) $pu_ttc / (1 + ($tmpvat / 100)), 'MU');
+					}
+				}
+
 				$desc = '';
 
 				// Define output language


### PR DESCRIPTION
# FIX|Fix Sales order add line shows 0 when only multicurrency unit price is filled (**this bug exists since many versions**).

When adding a product line to a sales order in multicurrency mode, if the user fills only the "UP currency" (multicurrency unit price) field and not the local unit price, the new line was saved with price 0 and the user had to edit the line again.

**Cause:** In `htdocs/commande/card.php`, when a product is selected (`idprod > 0`), the code only overrode `pu_ht`/`pu_ttc` from the local price fields (`price_ht`/`price_ttc`). The form values for `multicurrency_price_ht`/`multicurrency_price_ttc` were never applied to `pu_ht_devise`, and `pu_ht` was not derived from the currency price using the order rate.

**Fix:** When the user enters `multicurrency_price_ht`, set `pu_ht_devise` and, when local price is empty/zero, derive `pu_ht` from `pu_ht_devise / multicurrency_tx` (same convention as `core/lib/price.lib.php` `calcul_price_total`). Same for `multicurrency_price_ttc` → `pu_ttc_devise` and `pu_ttc`.

**Testing:** Create a sales order with a foreign currency, add a product line by filling only the "UP currency" field and qty, click Add — the new line should show the correct unit price without needing to edit again.
