### PR TITLE
FIX view image for external module in Webportal

### DIFF
--- a/htdocs/webportal/controllers/viewimage.controller.class.php
+++ b/htdocs/webportal/controllers/viewimage.controller.class.php
@@ -217,6 +217,10 @@ class ViewImageController extends Controller
 			$accessallowed = $check_access['accessallowed'];
 			$sqlprotectagainstexternals = $check_access['sqlprotectagainstexternals'];
 			$fullpath_original_file = $check_access['original_file']; // $fullpath_original_file is now a full path name
+		} else {
+			$accessallowed = $parameters['accessallowed'];
+			$sqlprotectagainstexternals = $parameters['sqlprotectagainstexternals'];
+			$fullpath_original_file = $parameters['original_file']; // $fullpath_original_file is now a full path name
 		}
 
 		if (!empty($hashp)) {


### PR DESCRIPTION
FIX view image for external module in Webportal
- for external module when it uses hook view image and return specific rights to allow access on pictures to show (remplace standard code)