### PR TITLE
FIX: read_supplier_price filter for stock complement

### DIFF
--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -165,6 +165,17 @@ if (getDolGlobalString('PRODUCT_DISABLE_EATBY')) {
 	unset($arrayfields['pl.eatby']);
 }
 
+if (!getDolGlobalString('STOCK_SUPPORT_SERVICES')) {
+	$usercanreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_supplier_prices') : $user->hasRight('product', 'lire');
+} elseif (getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
+	$usercanreadsupplierprice = $user->hasRight('product', 'product_advance', 'read_supplier_prices') || $user->hasRight('product', 'service_advance', 'read_supplier_prices');
+} else {
+	$usercanreadsupplierprice = $user->hasRight('product', 'lire') || $user->hasRight('service', 'lire');
+}
+
+if (!$usercanreadsupplierprice) {
+	unset($arrayfields['m.price']);
+}
 
 $tmpwarehouse = new Entrepot($db);
 if ($id > 0 || !empty($ref)) {
@@ -944,9 +955,11 @@ if ($warehouse->id > 0) {
 	print '<table class="border centpercent tableforfield">';
 
 	// Value
-	print '<tr><td class="titlefield">'.$langs->trans("EstimatedStockValueShort").'</td><td>';
-	print price((empty($calcproducts['value']) ? '0' : price2num($calcproducts['value'], 'MT')), 0, $langs, 0, -1, -1, $conf->currency);
-	print "</td></tr>";
+	if ($usercanreadsupplierprice) {
+		print '<tr><td class="titlefield">'.$langs->trans("EstimatedStockValueShort").'</td><td>';
+		print price((empty($calcproducts['value']) ? '0' : price2num($calcproducts['value'], 'MT')), 0, $langs, 0, -1, -1, $conf->currency);
+		print "</td></tr>";
+	}
 
 	// Last movement
 	$sql = "SELECT MAX(m.datem) as datem";
@@ -1629,12 +1642,13 @@ while ($i < $imaxinloop) {
 		}
 		// Price
 		if (!empty($arrayfields['m.price']['checked'])) {
-			$usercancreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_supplier_prices') : $user->hasRight('product', 'lire');
+			// Product and service differentiation, if we have permissions for only one of them
+			$displayprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('product', 'product_advance', 'read_supplier_prices') : $user->hasRight('product', 'lire');
 			if ($productstatic->isService()) {
-				$usercancreadsupplierprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('service', 'service_advance', 'read_supplier_prices') : $user->hasRight('service', 'lire');
+				$displayprice = getDolGlobalString('MAIN_USE_ADVANCED_PERMS') ? $user->hasRight('service', 'service_advance', 'read_supplier_prices') : $user->hasRight('service', 'lire');
 			}
 			print '<td class="right">';
-			if ($obj->price != 0 && $usercancreadsupplierprice) {
+			if ($obj->price != 0 && $displayprice) {
 				print price($obj->price);
 			}
 			print '</td>';

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -892,7 +892,7 @@ if ($warehouse->id > 0) {
 				$morehtmlref .= '<form method="post" action="'.$_SERVER['PHP_SELF'].'?id='.$warehouse->id.'">';
 				$morehtmlref .= '<input type="hidden" name="action" value="classin">';
 				$morehtmlref .= '<input type="hidden" name="token" value="'.newToken().'">';
-				$morehtmlref .= $formproject->select_projects(-1, (string) $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 1, 0, 'maxwidth500');
+				$morehtmlref .= $formproject->select_projects(($socid > 0 ? $socid : -1), (string) $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 1, 0, 'maxwidth500');
 				$morehtmlref .= '<input type="submit" class="button valignmiddle" value="'.$langs->trans("Modify").'">';
 				$morehtmlref .= '</form>';
 			} else {

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -892,7 +892,7 @@ if ($warehouse->id > 0) {
 				$morehtmlref .= '<form method="post" action="'.$_SERVER['PHP_SELF'].'?id='.$warehouse->id.'">';
 				$morehtmlref .= '<input type="hidden" name="action" value="classin">';
 				$morehtmlref .= '<input type="hidden" name="token" value="'.newToken().'">';
-				$morehtmlref .= $formproject->select_projects(($socid > 0 ? $socid : -1), (string) $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 1, 0, 'maxwidth500');
+				$morehtmlref .= $formproject->select_projects(-1, (string) $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 1, 0, 'maxwidth500');
 				$morehtmlref .= '<input type="submit" class="button valignmiddle" value="'.$langs->trans("Modify").'">';
 				$morehtmlref .= '</form>';
 			} else {
@@ -1706,7 +1706,7 @@ print '</div>'."\n";
 print '</form>'."\n";
 
 // Add number of product when there is a filter on period
-if (count($arrayofuniqueproduct) == 1 && !empty($year) && is_numeric($year)) {
+if (count($arrayofuniqueproduct) == 1 && !empty($search_date_startyear) && is_numeric($search_date_startyear)) {
 	print "<br>";
 
 	$productidselected = 0;
@@ -1714,8 +1714,8 @@ if (count($arrayofuniqueproduct) == 1 && !empty($year) && is_numeric($year)) {
 		$productidselected = $key;
 		$productlabelselected = $val;
 	}
-	$datebefore = dol_get_first_day($year ? $year : (int) dol_print_date(time(), "%Y"), $month ? $month : 1, true);
-	$dateafter = dol_get_last_day($year ? $year : (int) dol_print_date(time(), "%Y"), $month ? $month : 12, true);
+	$datebefore = dol_get_first_day($search_date_startyear ? $search_date_startyear : dol_print_date(time(), "%Y"), $search_date_startmonth ? $search_date_startmonth : 1, true);
+	$dateafter = dol_get_last_day($search_date_endyear ? $search_date_endyear : dol_print_date(time(), "%Y"), $search_date_endmonth ? $search_date_endmonth : 12, true);
 	$balancebefore = $object->calculateBalanceForProductBefore($productidselected, $datebefore);
 	$balanceafter = $object->calculateBalanceForProductBefore($productidselected, $dateafter);
 

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1137,7 +1137,7 @@ if ($showstockdetails) {
 			print '<td class="right">'.$stock_real.($stock_real < 0 ? ' '.img_warning() : '').'</td>';
 
 			// PMP
-			print '<td class="right nowraponall">'.(price2num($object->pmp) ? price2num($object->pmp, 'MU') : '').'</td>';
+			print '<td class="right nowraponall">'.($usercancreadsupplierprice ? (price2num($object->pmp) ? price2num($object->pmp, 'MU') : '') : '').'</td>';
 
 			// Value purchase
 			if ($usercancreadsupplierprice) {


### PR DESCRIPTION
# FIX: read_supplier_price filter for stock complement

Removes total PMP for stock card and movement_list in case of insufficient permissions : 
<img width="1614" height="400" alt="image" src="https://github.com/user-attachments/assets/54c6105b-390d-44f7-9965-3395189688ab" />

Removes Price column is stock movement_list in case of insufficient permissions
<img width="1595" height="754" alt="image" src="https://github.com/user-attachments/assets/c5ea801b-a976-4ffe-88cd-379e2bcae4af" />

Removes WAP column content in product stock tab in case of insufficient permissions
<img width="1610" height="224" alt="image" src="https://github.com/user-attachments/assets/9e5c79b8-7a02-4f5c-928f-72717e4b6006" />

complements #37119

Additionally, I removed an unset variable (warehouse do not have $socids) and set two others in order to get values in it, fixing a broken feature (show previous and following stock for product)
<img width="1608" height="521" alt="image" src="https://github.com/user-attachments/assets/cbe2c733-bc1a-4938-98a8-b701f3171f2f" />

