### PR TITLE
FIX : disabled extrafield should not appear on PDF

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1453,8 +1453,12 @@ abstract class CommonDocGenerator
 			foreach ($extrafields->attributes[$object->table_element]['label'] as $key => $label) {
 				// Enable extrafield ?
 				$enabled = 0;
+				if (!empty($extrafields->attributes[$object->table_element]['enabled'][$key])) {
+					$enabled = (int) dol_eval((string) $extrafields->attributes[$object->table_element]['enabled'][$key], 1, 1, '2');
+				}
+
 				$disableOnEmpty = 0;
-				if (!empty($extrafields->attributes[$object->table_element]['printable'][$key])) {
+				if ($enabled && !empty($extrafields->attributes[$object->table_element]['printable'][$key])) {
 					$printable = intval($extrafields->attributes[$object->table_element]['printable'][$key]);
 					if (in_array($printable, $params['printableEnable']) || in_array($printable, $params['printableEnableNotEmpty'])) {
 						$enabled = 1;


### PR DESCRIPTION
If an extrafield is disabled but defined to appear on PDF, it still appears.

Just as in the extrafield_view.tpl.php where the "enabled" option is tested before the "list" option, I added the "enabled" test before the "printable" test in the PDF generation.

Related to https://github.com/Dolibarr/dolibarr-community-modules/issues/93