### PR TITLE
QUAL Replace $_REQUEST superglobals with GETPOST() in projet and compta/tva

### DIFF
--- a/htdocs/compta/tva/clients.php
+++ b/htdocs/compta/tva/clients.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2014		Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2018-2024	Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Juan Pablo Farber		<jfarber55@hotmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -124,10 +125,7 @@ foreach ($listofparams as $param) {
 	}
 }
 
-$special_report = false;
-if (isset($_REQUEST['extra_report']) && $_REQUEST['extra_report'] == 1) {
-	$special_report = true;
-}
+$special_report = (GETPOSTINT('extra_report') == 1);
 
 llxHeader('', $langs->trans("VATReport"), '', '', 0, 0, '', '', $morequerystring);
 

--- a/htdocs/projet/note.php
+++ b/htdocs/projet/note.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2012 Laurent Destailleur  	<eldy@users.sourceforge.net>
  * Copyright (C) 2024 MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024 Frédéric France       <frederic.france@free.fr>
+ * Copyright (C) 2026 Juan Pablo Farber     <jfarber55@hotmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +44,7 @@ $action = GETPOST('action', 'aZ09');
 $id = GETPOSTINT('id');
 $ref = GETPOST('ref', 'alpha');
 
-$mine = (isset($_REQUEST['mode']) && $_REQUEST['mode'] == 'mine') ? 1 : 0;
+$mine = (GETPOST('mode', 'alpha') == 'mine') ? 1 : 0;
 
 $object = new Project($db);
 


### PR DESCRIPTION
# QUAL Replace $_REQUEST superglobals with GETPOST()

Replace direct `$_REQUEST` access with the proper Dolibarr `GETPOST()` function
in two files, following project coding conventions for input sanitization.

- `htdocs/projet/note.php`: replace `$_REQUEST['mode']` with `GETPOST('mode', 'alpha')`
- `htdocs/compta/tva/clients.php`: replace `$_REQUEST['extra_report']` with `GETPOSTINT('extra_report')`
