### PR TITLE
FIX 23.0 webhook trigger and postgres global db killed

### DIFF
--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -92,6 +92,7 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 
 		// Create new instance of db for webhook history save
 		$dbhistory = null;
+		$useglobaldb = true;
 
 		$sendmanualtriggers = (!empty($object->context['sendmanualtriggers']) ? $object->context['sendmanualtriggers'] : "");
 		foreach ($target_url as $key => $tmpobject) {
@@ -148,6 +149,7 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 
 				if (empty($dbhistory)) {
 					$dbhistory = getDoliDBInstance($conf->db->type, $conf->db->host, (string) $conf->db->user, $dolibarr_main_db_pass, $conf->db->name, (int) $conf->db->port);
+					$useglobaldb = false;
 				}
 
 				$dbhistory->begin();
@@ -174,7 +176,7 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 		}
 
 		// Test if dbhistory exist and IS different to main db used. Else postgres will crash because there is no db left for end of pages
-		if ($dbhistory && $dbhistory !== $this->db) {
+		if ($dbhistory && $useglobaldb) {
 			$dbhistory->close();
 		}
 

--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -173,7 +173,8 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 			}
 		}
 
-		if ($dbhistory) {
+		// Test if dbhistory exist and IS different to main db used. Else postgres will crash because there is no db left for end of pages
+		if ($dbhistory && $dbhistory !== $this->db) {
 			$dbhistory->close();
 		}
 


### PR DESCRIPTION
Problem : the postgres db was killed when we use webhook and all pages (called by this webhook conf) were going to fatal after the webhook trigger call.

# Instructions
Conf : Use a postgres db with dolibarr and activ webhook on company update or anything else.

User experience : Try to edit a company and save

Result : Error 500 becasue the db is already closed before the ned of societe page (during the webhook trigger)



