### PR TITLE
FIX show export full documents checkbox on change format in accountancy export

### DIFF
--- a/htdocs/accountancy/bookkeeping/export.php
+++ b/htdocs/accountancy/bookkeeping/export.php
@@ -764,16 +764,36 @@ if ($action == 'export_file') {
 	}
 
 	// add documents in an archive for accountancy export (Quadratus)
-	if (getDolGlobalString('ACCOUNTING_EXPORT_MODELCSV') == AccountancyExport::$EXPORT_TYPE_QUADRATUS) {
-		$form_question['notifiedexportfull'] = array(
-			'name' => 'notifiedexportfull',
-			'type' => 'checkbox',
-			'label' => $langs->trans('NotifiedExportFull'),
-			'value' => 'false',
-		);
-	}
+	$exportTypesWithDocs = array(
+		AccountancyExport::$EXPORT_TYPE_QUADRATUS,
+	);
+	$isExportTypeWithDocs = in_array((int) $formatexportset, $exportTypesWithDocs);
+	$form_question['notifiedexportfull'] = array(
+		'name' => 'notifiedexportfull',
+		'type' => 'checkbox',
+		'label' => $langs->trans('NotifiedExportFull'),
+		'value' => 'false',
+	);
 
 	$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?'.$param, $langs->trans("ExportFilteredList").'...', $langs->trans('ConfirmExportFile'), 'export_fileconfirm', $form_question, '', 1, 420, 600);
+	$formconfirm .= '<script>
+jQuery(document).ready(function() {
+	const exportTypesWithDocs = ['.implode(',', $exportTypesWithDocs).'];
+	const $formatExport = jQuery("#formatexport");
+
+	function toggleExportFull() {
+		const $checkbox = jQuery("#notifiedexportfull");
+		const show = exportTypesWithDocs.indexOf(parseInt($formatExport.val())) !== -1;
+		$checkbox.closest(".tagtr").toggle(show);
+		if (!show) {
+			$checkbox.prop("checked", false); // remove checked if hidden
+		}
+	}
+
+	$formatExport.on("change", toggleExportFull);
+	toggleExportFull();
+});
+</script>';
 }
 
 // Print form confirm

--- a/htdocs/accountancy/bookkeeping/export.php
+++ b/htdocs/accountancy/bookkeeping/export.php
@@ -767,7 +767,6 @@ if ($action == 'export_file') {
 	$exportTypesWithDocs = array(
 		AccountancyExport::$EXPORT_TYPE_QUADRATUS,
 	);
-	$isExportTypeWithDocs = in_array((int) $formatexportset, $exportTypesWithDocs);
 	$form_question['notifiedexportfull'] = array(
 		'name' => 'notifiedexportfull',
 		'type' => 'checkbox',


### PR DESCRIPTION
FIX show export full documents checkbox on change format in accountancy export

**To reproduce**
1. Set the export model in accountancy export setup :
<img width="1674" height="659" alt="image" src="https://github.com/user-attachments/assets/ebbcb164-58a2-4a65-b96d-5d93a5a074f6" />

2. Go to bookeeping export page :
<img width="2318" height="324" alt="image" src="https://github.com/user-attachments/assets/4160e7fc-14be-41fc-9f9a-4fecb4756cfd" />

3. Click on export button

4. Select Quadratus export model 

Here the checkbox to "export with docuemtns" is missing : 
<img width="613" height="420" alt="image" src="https://github.com/user-attachments/assets/8d6c031c-96f3-4ad7-80d9-9120fef8d021" />


**After**
You can check the "export with documents" in this form confirm :   
<img width="611" height="424" alt="image" src="https://github.com/user-attachments/assets/02595ac9-e157-429c-9367-8e41464aead1" />

