### PR TITLE
FIX Order API: delete order returns wrong http response in case order could not be deleted

### DIFF
--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -887,7 +887,7 @@ class Orders extends DolibarrApi
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
-		if (!$this->commande->delete(DolibarrApiAccess::$user)) {
+		if ($this->commande->delete(DolibarrApiAccess::$user) <= 0) {
 			throw new RestException(500, 'Error when deleting order : '.$this->commande->error);
 		}
 


### PR DESCRIPTION
# FIX Order API: delete order returns wrong http response in case order could not be deleted
The commande->delete returns <= 0 if not OK, and above zero if ok. The check if (!$this->commande->delete(..)) handles only the case if the return value is 0 and not also below to return 500 as http response.