### PR TITLE
Remove project label overflow in societe/project.php to allow better readability 

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1042,7 +1042,7 @@ function show_projects($conf, $langs, $db, $object, $backtopage = '', $nocreatel
 						print '</td>';
 
 						// Label
-						print '<td title="' . dol_escape_htmltag($obj->title) . '">' . dol_escape_htmltag($obj->title) . '</td>';
+						print '<td title="' . dol_escape_htmltag($obj->title) . '"><div class="twolinesmax-normallineheight minwidth200onall">' . dol_escape_htmltag($obj->title) . '</div></td>';
 						// Date start
 						print '<td class="center">' . dol_print_date($db->jdate($obj->do), "day") . '</td>';
 						// Date end

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1151,7 +1151,7 @@ function show_projects($conf, $langs, $db, $object, $backtopage = '', $nocreatel
 							print '</td>';
 
 							// Label
-							print '<td title="' . dol_escape_htmltag($obj->title) . '">' . dol_escape_htmltag($obj->title) . '</td>';
+							print '<td title="' . dol_escape_htmltag($obj->title) . '"><div class="twolinesmax-normallineheight minwidth200onall">' . dol_escape_htmltag($obj->title) . '</div></td>';
 							// Date start
 							print '<td class="center">' . dol_print_date($db->jdate($obj->do), "day") . '</td>';
 							// Date end

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -1042,7 +1042,7 @@ function show_projects($conf, $langs, $db, $object, $backtopage = '', $nocreatel
 						print '</td>';
 
 						// Label
-						print '<td class="tdoverflowmax200" title="' . dol_escape_htmltag($obj->title) . '">' . dol_escape_htmltag($obj->title) . '</td>';
+						print '<td title="' . dol_escape_htmltag($obj->title) . '">' . dol_escape_htmltag($obj->title) . '</td>';
 						// Date start
 						print '<td class="center">' . dol_print_date($db->jdate($obj->do), "day") . '</td>';
 						// Date end
@@ -1151,7 +1151,7 @@ function show_projects($conf, $langs, $db, $object, $backtopage = '', $nocreatel
 							print '</td>';
 
 							// Label
-							print '<td class="tdoverflowmax200" title="' . dol_escape_htmltag($obj->title) . '">' . dol_escape_htmltag($obj->title) . '</td>';
+							print '<td title="' . dol_escape_htmltag($obj->title) . '">' . dol_escape_htmltag($obj->title) . '</td>';
 							// Date start
 							print '<td class="center">' . dol_print_date($db->jdate($obj->do), "day") . '</td>';
 							// Date end


### PR DESCRIPTION
**Before**

<img width="811" height="46" alt="image" src="https://github.com/user-attachments/assets/9b67fb8d-f2fa-4407-8019-08d6cf948ac8" />

**After**

<img width="700" height="52" alt="image" src="https://github.com/user-attachments/assets/5010f933-a7f7-4971-875d-822710ef4919" />
