### PR TITLE
FIX delete new added check for invoice ID validation

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -141,9 +141,7 @@ class Invoices extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('facture', 'lire')) {
 			throw new RestException(403);
 		}
-		if ($id == 0) {
-			throw new RestException(400, 'No invoice with id=0 can exist');
-		}
+
 		$result = $this->invoice->fetch($id, $ref, $ref_ext);
 		if (!$result) {
 			throw new RestException(404, 'Invoice not found');


### PR DESCRIPTION
The recent ID validation added to `_fetch` causes `getByRef` to always fail with a 400 error.