### PR TITLE
Fix(accounting): exportWinfic now supports  parameter like other expo…

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1172,7 +1172,12 @@ class AccountancyExport
 
 			$tab['end_line'] = $end_line;
 
-			print implode('|', $tab);
+            $output = implode('|', $tab);
+            if ($exportFile) {
+                fwrite($exportFile, $output);
+            } else {
+                print $output;
+            }
 
 			$index++;
 		}

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1172,12 +1172,12 @@ class AccountancyExport
 
 			$tab['end_line'] = $end_line;
 
-            $output = implode('|', $tab);
-            if ($exportFile) {
-                fwrite($exportFile, $output);
-            } else {
-                print $output;
-            }
+			$output = implode('|', $tab);
+			if ($exportFile) {
+				fwrite($exportFile, $output);
+			} else {
+				print $output;
+			}
 
 			$index++;
 		}


### PR DESCRIPTION
# FIX | Fix exportWinfic missing $exportFile support

exportWinfic was using `print` directly instead of supporting the `$exportFile` parameter like exportEbp and exportAgiris do.