### PR TITLE
Fix automatic barcode generation in product update

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1481,7 +1481,7 @@ class Product extends CommonObject
 			$this->stockable_product = 0;
 		}
 
-		// For automatic creation during create action (not used by Dolibarr GUI, can be used by scripts)
+		// For automatic creation during update action (not used by Dolibarr GUI, can be used by scripts)
 		if ($this->barcode == '-1' || $this->barcode == 'auto') {
 			$this->barcode = $this->get_barcode($this, $this->barcode_type_code);
 		}

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1481,6 +1481,11 @@ class Product extends CommonObject
 			$this->stockable_product = 0;
 		}
 
+		// For automatic creation during create action (not used by Dolibarr GUI, can be used by scripts)
+		if ($this->barcode == '-1' || $this->barcode == 'auto') {
+			$this->barcode = $this->get_barcode($this, $this->barcode_type_code);
+		}
+
 		// Barcode value
 		$this->barcode = (empty($this->barcode) ? '' : trim($this->barcode));
 
@@ -1563,11 +1568,6 @@ class Product extends CommonObject
 						}
 					}
 				}
-			}
-
-			// For automatic creation
-			if ($this->barcode == -1) {
-				$this->barcode = $this->get_barcode($this, $this->barcode_type_code);
 			}
 
 			$sql = "UPDATE ".$this->db->prefix()."product";


### PR DESCRIPTION
In the product update mechanism we only allow automatic barcode generation if the barcode was set to '-1' but in the create we allow '-1' and 'auto'. This PR aims to harmonize the logic between update and creation.

Also the barcode generation has been move before the ``$result = $this->verify();`` method otherwise the product update will fail because '-1' or 'auto' are not valid barcode...

This looks a FIX to me but I submit it against develop branche because it may impact external modules I feel.