### PR TITLE
FIX bad tab underlined in display setup

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -843,7 +843,7 @@ function ihm_prepare_head()
 
 	$head[$h][0] = DOL_URL_ROOT."/admin/tools/ui/index.php";
 	$head[$h][1] = $langs->trans("UxComponentsDoc").' '.img_picto('', 'external-link-square-alt');
-	$head[$h][2] = 'css';
+	$head[$h][2] = 'ux';
 	$h++;
 
 	complete_head_from_modules($conf, $langs, null, $head, $h, 'ihm_admin');


### PR DESCRIPTION
FIX bad tab underlined in display setup
- backport on v22 of commit 361169b

**Before**
<img width="1185" height="547" alt="image" src="https://github.com/user-attachments/assets/e4e54a83-1707-4fa7-9981-5b70a1d9dbe9" />

**After**
<img width="1111" height="526" alt="image" src="https://github.com/user-attachments/assets/c9db5c50-5c48-4d83-ac29-55cb1f5cf3eb" />
