### PR TITLE
Update login form action URL to use DOL_URL_ROOT

### DIFF
--- a/htdocs/core/tpl/login.tpl.php
+++ b/htdocs/core/tpl/login.tpl.php
@@ -245,7 +245,7 @@ if (!getDolGlobalString('ADD_UNSPLASH_LOGIN_BACKGROUND')) {
 <div class="login_vertical_align">
 
 
-<form id="login" name="login" method="post" action="<?php echo $php_self; ?>">
+<form id="login" name="login" method="post" action="<?php echo DOL_URL_ROOT.$php_self; ?>">
 
 <input type="hidden" name="token" value="<?php echo newToken(); ?>" />
 <input type="hidden" name="actionlogin" id="actionlogin" value="login">


### PR DESCRIPTION
# FIX Login when you have specificed a subdir in $dolibarr_main_url_root 

Before this PR v23.0.0 - and probably earlier versions as well - contained this line in the HTML source

```
<form id="login" name="login" method="post" action="/index.php?mainmenu=home">
```

After this PR the value of DOL_URL_ROOT / $dolibarr_main_url_root from conf/conf.php

```
$dolibarr_main_url_root='https://bad.example.com/dolibarr';
```
```
<form id="login" name="login" method="post" action="/dolibarr/index.php?mainmenu=home">
```

and login now works :-)
