### PR TITLE
FIX computed width of bodyforlist in eldy theme

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -2417,6 +2417,7 @@ td.showDragHandle {
 }
 .bodyforlist #id-right {
 	padding-bottom: 4px;
+	width: auto; /* Prevent Chromium from resolving width:100% as 1e6px during max-content calculation */
 }
 .bodyforlist.poslist #id-right {
 	display: block;
@@ -2438,6 +2439,20 @@ td.showDragHandle {
 .classforhorizontalscrolloftabs #id-right {
 	width: calc(100% - <?php echo $leftmenuwidth + 30 ?>px);
 	display: inline-block;
+}
+
+/* Fix horizontal overflow for list pages (bodyforlist).
+ * Body expands to max-content width → html handles the horizontal scroll
+ * → native browser scrollbar at the bottom of the window.
+ * .div-table-responsive must be overflow-x:visible (not auto) so that table content
+ * overflows up to body level. Without this, Chromium computes a circular/broken
+ * max-content because the overflow:auto container is in the chain. */
+.bodyforlist {
+	min-width: max-content;
+}
+.bodyforlist .div-table-responsive,
+.bodyforlist .div-table-responsive-no-min {
+	overflow-x: visible;
 }
 
 /*


### PR DESCRIPTION
FIX computed width of bodyforlist in eldy theme
- the header menu doesn't take full width of page on lists with a lot a columns to show and bottom scrollbar appears

**Before**
<img width="1915" height="893" alt="image" src="https://github.com/user-attachments/assets/29aff158-4d36-4143-ba3a-ff8350d069ba" />

**After**
<img width="1919" height="892" alt="image" src="https://github.com/user-attachments/assets/67105e24-a899-4077-9602-cfeaad571171" />

-> This fix works on Firefox and Chromium Web browsers (Brave)
And it keeps the horizontal srol bar at bottom of window of Web browser
And no fix needed for md theme (not use the same way to show lists) : the horizontal scrollbar is under the table of the list and not at bottom of window of Web browser