### PR TITLE
Fix confirmation email not sent when ticket created via Email Collect

### DIFF
--- a/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
+++ b/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
@@ -221,6 +221,8 @@ class InterfaceTicketEmail extends DolibarrTriggers
 					} elseif (!empty($object->fk_soc)) {
 						$object->fetch_thirdparty();
 						$sendto = $object->thirdparty->email;
+					} elseif (!empty($object->origin_email)) {
+						$sendto = $object->origin_email;
 					}
 
 					if ($sendto) {

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -3471,7 +3471,7 @@ class EmailCollector extends CommonObject
 										$sender_contact = new Contact($this->db);
 										$sender_contact->fetch(0, null, '', $from);
 										if (!empty($sender_contact->id)) {
-											$tickettocreate->context['contactid'] = $sender_contact->id;
+											$tickettocreate->context['contact_id'] = $sender_contact->id;
 										}
 
 										$result = $tickettocreate->create($user);


### PR DESCRIPTION
FIX#37517
- Fix key mismatch: emailcollector.class.php sets context['contactid'] but trigger reads context['contact_id'] — rename key to contact_id
- Add fallback to origin_email in trigger so unknown senders (no contact, no third party) also receive the confirmation email
