### PR TITLE
NEW - Improve API support for external users and ticket documents

### DIFF
--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -1,11 +1,13 @@
 <?php
 
-/* Copyright (C) 2016   Xebax Christy           <xebax@wanadoo.fr>
- * Copyright (C) 2016	Laurent Destailleur		<eldy@users.sourceforge.net>
- * Copyright (C) 2016   Jean-François Ferry     <jfefe@aternatik.fr>
- * Copyright (C) 2023   Romain Neil             <contact@romain-neil.fr>
- * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+/* Copyright (C) 2016   	Xebax Christy           <xebax@wanadoo.fr>
+ * Copyright (C) 2016		Laurent Destailleur		<eldy@users.sourceforge.net>
+ * Copyright (C) 2016   	Jean-François Ferry     <jfefe@aternatik.fr>
+ * Copyright (C) 2023   	Romain Neil             <contact@romain-neil.fr>
+ * Copyright (C) 2024-2025  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2025		William Mead			<william@m34d.com>
+ * Copyright (C) 2025		Charlene Benke			<charlene@patas-monkey.com>
  *
  * This program is free software you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,6 +32,8 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 /**
  * API class for receive files
  *
+ * @since	6.0.0	Initial implementation
+ *
  * @access protected
  * @class Documents {@requires user,external}
  */
@@ -46,10 +50,12 @@ class Documents extends DolibarrApi
 
 
 	/**
-	 * Download a document.
+	 * Download a document
 	 *
 	 * Note that, this API is similar to using the wrapper link "documents.php" to download a file (used for
 	 * internal HTML links of documents into application), but with no need to have a session cookie (the token is used instead).
+	 *
+	 * @since	7.0.0	Initial implementation
 	 *
 	 * @param   string  $modulepart     Name of module or area concerned by file download ('facture', ...)
 	 * @param   string  $original_file  Relative path with filename, relative to modulepart (for example: IN201701-999/IN201701-999.pdf)
@@ -114,11 +120,16 @@ class Documents extends DolibarrApi
 
 
 	/**
-	 * Build a document.
+	 * Build a document
 	 *
 	 * Test sample 1: { "modulepart": "invoice", "original_file": "FA1701-001/FA1701-001.pdf", "doctemplate": "crabe", "langcode": "fr_FR" }.
 	 *
-	 * Supported modules: invoice, order, proposal, contract, shipment
+	 * Supported modules: invoice, order, proposal, contract, supplier invoice, shipment, mrp
+	 *
+	 * @since	7.0.0	Initial implementation, support for invoice, order and proposal documents
+	 * @since	18.0.0	Added support for contract and suppliers invoice documents
+	 * @since	19.0.0	Added support for shipment documents
+	 * @since	20.0.0	Added support for mrp documents
 	 *
 	 * @param   string  $modulepart		Name of module or area concerned by file download ('thirdparty', 'member', 'proposal', 'supplier_proposal', 'order', 'supplier_order', 'invoice', 'supplier_invoice', 'shipment', 'project',  ...)
 	 * @param   string  $original_file  Relative path with filename, relative to modulepart (for example: IN201701-999/IN201701-999.pdf).
@@ -300,15 +311,22 @@ class Documents extends DolibarrApi
 	}
 
 	/**
-	 * Return the list of documents of a dedicated element (from its ID or Ref)
+	 * List documents of an element
 	 *
+	 * Use element ID or Ref.
 	 * Supported modules: thirdparty, user, member, proposal, order, supplier_order, shipment, invoice, supplier_invoice, product, event, expensereport, knowledgemanagement, category, contract
+	 *
+	 * @since	7.0.0	Initial implementation
 	 *
 	 * @param   string 	$modulepart		Name of module or area concerned ('thirdparty', 'member', 'proposal', 'order', 'invoice', 'supplier_invoice', 'shipment', 'project',  ...)
 	 * @param	int		$id				ID of element
 	 * @param	string	$ref			Ref of element
 	 * @param	string	$sortfield		Sort criteria ('','fullname','relativename','name','date','size')
 	 * @param	string	$sortorder		Sort order ('asc' or 'desc')
+	 * @param	int		$limit			List limit
+	 * @param	int		$page			Page number
+	 * @param	string	$content_type	Filter on content-type (example 'application/pdf' or 'application/pdf,image/jpeg'))
+	 * @param	bool	$pagination_data	If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0*
 	 * @return	array					Array of documents with path
 	 * @phan-return array<array<string,int|string>>
 	 * @phpstan-return array<array<string,int|string>>
@@ -321,9 +339,10 @@ class Documents extends DolibarrApi
 	 * @throws	RestException	500		Error while fetching object
 	 * @throws	RestException	503		Error when retrieve ecm list
 	 */
-	public function getDocumentsListByElement($modulepart, $id = 0, $ref = '', $sortfield = '', $sortorder = '')
+	public function getDocumentsListByElement($modulepart, $id = 0, $ref = '', $sortfield = '', $sortorder = '', $limit = 100, $page = 0, $content_type = '', $pagination_data = false)
 	{
 		global $conf;
+		/** @var Conf $conf */
 
 		if (empty($modulepart)) {
 			throw new RestException(400, 'bad value for parameter modulepart');
@@ -366,6 +385,20 @@ class Documents extends DolibarrApi
 			}
 
 			$upload_dir = $conf->user->dir_output.'/'.get_exdir(0, 0, 0, 0, $object, 'user').'/'.$object->id;
+		} elseif ($modulepart == 'ticket') {
+			require_once DOL_DOCUMENT_ROOT.'/ticket/class/ticket.class.php';
+
+			if (!DolibarrApiAccess::$user->hasRight('ticket', 'read')) {
+				throw new RestException(403);
+			}
+
+			$object = new Ticket($this->db);
+			$result = $object->fetch($id, $ref);
+			if (!$result) {
+				throw new RestException(404, 'Ticket not found');
+			}
+
+			$upload_dir = $conf->ticket->dir_output.'/'.dol_sanitizeFileName($object->ref);
 		} elseif ($modulepart == 'adherent' || $modulepart == 'member') {
 			require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
 
@@ -580,7 +613,18 @@ class Documents extends DolibarrApi
 				throw new RestException(404, 'Contract not found');
 			}
 
-			$upload_dir = $conf->contrat->dir_output . "/" . get_exdir(0, 0, 0, 1, $object, 'contract');
+			$upload_dir = $conf->contract->dir_output . "/" . get_exdir(0, 0, 0, 1, $object, 'contract');
+		} elseif ($modulepart == 'intervention' || $modulepart == 'ficheinter') {
+			$modulepart = 'ficheinter';
+			require_once DOL_DOCUMENT_ROOT . '/fichinter/class/fichinter.class.php';
+
+			$object = new Fichinter($this->db);
+			$result = $object->fetch($id, $ref);
+			if (!$result) {
+				throw new RestException(404, 'Interventional not found');
+			}
+
+			$upload_dir = $conf->ficheinter->dir_output . "/" . get_exdir(0, 0, 0, 1, $object, 'ficheinter');
 		} elseif ($modulepart == 'projet' || $modulepart == 'project') {
 			$modulepart = 'project';
 			require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
@@ -591,7 +635,7 @@ class Documents extends DolibarrApi
 				throw new RestException(404, 'Project not found');
 			}
 
-			$upload_dir = $conf->projet->dir_output . "/" . get_exdir(0, 0, 0, 1, $object, 'project');
+			$upload_dir = $conf->project->dir_output . "/" . get_exdir(0, 0, 0, 1, $object, 'project');
 		} elseif ($modulepart == 'mrp') {
 			$modulepart = 'mrp';
 			require_once DOL_DOCUMENT_ROOT . '/mrp/class/mo.class.php';
@@ -613,6 +657,8 @@ class Documents extends DolibarrApi
 		}
 
 		$filearray = dol_dir_list($upload_dir, $type, $recursive, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ? SORT_DESC : SORT_ASC), 1);
+		$countarray = count($filearray);
+		$filearray = array_slice($filearray, $limit * $page, $limit);
 		if (empty($filearray)) {
 			throw new RestException(404, 'Search for modulepart '.$modulepart.' with Id '.$object->id.(!empty($object->ref) ? ' or Ref '.$object->ref : '').' does not return any document.');
 		} else {
@@ -626,14 +672,34 @@ class Documents extends DolibarrApi
 					$count = count($filearray);
 					for ($i = 0 ; $i < $count ; $i++) {
 						foreach ($ecmfile->lines as $line) {
+							unset($line->db);
 							if ($filearray[$i]['name'] == $line->filename) {
 								// Next line converts EcmFilesLine properties to array
 								$filearray[$i] = array_merge($filearray[$i], (array) $line);
 							}
 						}
+						if (isset($line->filename)) $filearray[$i]['content-type'] = dol_mimetype($line->filename);
+						$arraycontenttype = explode(",", $content_type);
+						if (!empty($content_type) && isset($line->filename) && !in_array(dol_mimetype($line->filename), $arraycontenttype)) {
+							unset($filearray[$i]);
+							$countarray -= 1;
+						}
 					}
 				}
 			}
+		}
+
+		//if $pagination_data is true the response will contain element data with all values and element pagination with pagination data(total,page,limit)
+		if ($pagination_data) {
+			$tmp = $filearray;
+			$filearray = [];
+			$filearray['data'] = $tmp;
+			$filearray['pagination'] = [
+				'total' => (int) $countarray,
+				'page' => $page, //count starts from 0
+				'page_count' => ceil((int) $countarray / $limit),
+				'limit' => $limit
+			];
 		}
 
 		return $filearray;
@@ -655,7 +721,7 @@ class Documents extends DolibarrApi
 
 
 	/**
-	 * Upload a document.
+	 * Upload a document
 	 *
 	 * Test sample for invoice: { "filename": "mynewfile.txt", "modulepart": "invoice", "ref": "FA1701-001", "subdir": "", "filecontent": "content text", "fileencoding": "", "overwriteifexists": "0" }.
 	 * Test sample for supplier invoice: { "filename": "mynewfile.txt", "modulepart": "supplier_invoice", "ref": "FA1701-001", "subdir": "", "filecontent": "content text", "fileencoding": "", "overwriteifexists": "0" }.
@@ -663,20 +729,25 @@ class Documents extends DolibarrApi
 	 *
 	 * Supported modules: invoice, order, supplier_order, task/project_task, product/service, expensereport, fichinter, member, propale, agenda, contact
 	 *
+	 * @since	6.0.0	Initial implementation
+	 *
 	 * @param   string  $filename           	Name of file to create ('FA1705-0123.txt')
 	 * @param   string  $modulepart         	Name of module or area concerned by file upload ('product', 'service', 'invoice', 'proposal', 'project', 'project_task', 'supplier_invoice', 'expensereport', 'member', ...)
 	 * @param   string  $ref                	Reference of object (This will define subdir automatically and store submitted file into it)
-	 * @param   string  $subdir       			Subdirectory (Only if ref not provided)
+	 * @param   string  $subdir       			Subdirectory (Only if $ref is not provided)
 	 * @param   string  $filecontent        	File content (string with file content. An empty file will be created if this parameter is not provided)
 	 * @param   string  $fileencoding       	File encoding (''=no encoding, 'base64'=Base 64)
 	 * @param   int 	$overwriteifexists  	Overwrite file if exists (1 by default)
 	 * @param   int 	$createdirifnotexists  	Create subdirectories if the doesn't exists (1 by default)
 	 * @param   int     $position               Position
 	 * @param   string  $cover                  Cover info
-	 * @param   array   $array_options          array of options
+	 * @param   array   $array_options          Array for extrafields of ECM index table
+	 * @param	int		$generateThumbs			1=Will generate the small and mini thumbs if applicable
+	 * @param	int		$agenda_id				Optional agenda action id to link file
+	 * @return  string
+	 *
 	 * @phan-param   array<string,string>   $array_options
 	 * @phpstan-param   array<string,string>   $array_options
-	 * @return  string
 	 *
 	 * @url POST /upload
 	 *
@@ -685,7 +756,7 @@ class Documents extends DolibarrApi
 	 * @throws	RestException	404		Object not found
 	 * @throws	RestException	500		Error on file operation
 	 */
-	public function post($filename, $modulepart, $ref = '', $subdir = '', $filecontent = '', $fileencoding = '', $overwriteifexists = 0, $createdirifnotexists = 1, $position = 0, $cover = '', $array_options = [])
+	public function post($filename, $modulepart, $ref = '', $subdir = '', $filecontent = '', $fileencoding = '', $overwriteifexists = 0, $createdirifnotexists = 1, $position = 0, $cover = '', $array_options = [], $generateThumbs = 0, $agenda_id = 0)
 	{
 		global $conf;
 
@@ -764,7 +835,7 @@ class Documents extends DolibarrApi
 			} elseif ($modulepart == 'expensereport') {
 				require_once DOL_DOCUMENT_ROOT.'/expensereport/class/expensereport.class.php';
 				$object = new ExpenseReport($this->db);
-			} elseif ($modulepart == 'fichinter') {
+			} elseif ($modulepart == 'ficheinter' || $modulepart == 'intervention') {
 				require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
 				$object = new Fichinter($this->db);
 			} elseif ($modulepart == 'adherent' || $modulepart == 'member') {
@@ -779,6 +850,9 @@ class Documents extends DolibarrApi
 				$modulepart = 'agenda';
 				require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
 				$object = new ActionComm($this->db);
+			} elseif ($modulepart == 'ticket') {
+				require_once DOL_DOCUMENT_ROOT.'/ticket/class/ticket.class.php';
+				$object = new Ticket($this->db);
 			} elseif ($modulepart == 'contact' || $modulepart == 'socpeople') {
 				$modulepart = 'contact';
 				require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
@@ -792,6 +866,8 @@ class Documents extends DolibarrApi
 				$modulepart = 'mrp';
 				require_once DOL_DOCUMENT_ROOT . '/mrp/class/mo.class.php';
 				$object = new Mo($this->db);
+			} elseif ($modulepart == 'ecm') {
+				throw new RestException(500, 'Using a non empty "ref" is not compatible with using modulepart = '.$modulepart);
 			} else {
 				// TODO Implement additional moduleparts
 				throw new RestException(500, 'Modulepart '.$modulepart.' not implemented yet.');
@@ -823,16 +899,16 @@ class Documents extends DolibarrApi
 			}
 
 			// Test on permissions
-			if ($modulepart != 'ecm') {
-				$relativefile = $tmpreldir.dol_sanitizeFileName($object->ref);
-				$tmp = dol_check_secure_access_document($modulepart, $relativefile, $entity, DolibarrApiAccess::$user, $ref, 'write');
-				$upload_dir = $tmp['original_file']; // No dirname here, tmp['original_file'] is already the dir because dol_check_secure_access_document was called with param original_file that is only the dir
-			} else {
+			//if ($modulepart != 'ecm') {	// Here $modulepart is always != 'ecm'
+			$relativefile = $tmpreldir.dol_sanitizeFileName($object->ref);
+			$tmp = dol_check_secure_access_document($modulepart, $relativefile, $entity, DolibarrApiAccess::$user, $ref, 'write');
+			$upload_dir = $tmp['original_file']; // No dirname here, tmp['original_file'] is already the dir because dol_check_secure_access_document was called with param original_file that is only the dir
+			/*} else {
 				if (!DolibarrApiAccess::$user->hasRight('ecm', 'upload')) {
 					throw new RestException(403, 'Missing permission to upload files in ECM module');
 				}
 				$upload_dir = $conf->medias->multidir_output[$conf->entity];
-			}
+			}*/
 
 			if (empty($upload_dir) || $upload_dir == '/') {
 				throw new RestException(500, 'This value of modulepart ('.$modulepart.') does not support yet usage of ref. Check modulepart parameter or try to use subdir parameter instead of ref.');
@@ -959,6 +1035,7 @@ class Documents extends DolibarrApi
 		if (!empty($cover)) {
 			$moreinfo = array_merge($moreinfo, ["cover" => $cover]);
 		}
+		$moreinfo['gen_or_uploaded'] = 'api';
 
 		// Move the temporary file at its final emplacement
 		$result = dol_move($destfiletmp, $dest_file, '0', $overwriteifexists, 1, 1, $moreinfo);
@@ -966,11 +1043,32 @@ class Documents extends DolibarrApi
 			throw new RestException(500, "Failed to move file into '".$dest_file."'");
 		}
 
+		if (is_object($object) && $generateThumbs) {
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+			if (image_format_supported($dest_file)) {
+				$object->addThumbs($dest_file);
+			}
+		}
+
+		if (!empty($agenda_id)) {
+			require_once DOL_DOCUMENT_ROOT.'/ecm/class/ecmfiles.class.php';
+			$rel_file = preg_replace('/^'.preg_quote(DOL_DATA_ROOT, '/').'/', '', $dest_file);
+			$rel_file = preg_replace('/^[\\/]/', '', $rel_file);
+			$ecmfile = new EcmFiles($this->db);
+			$res = $ecmfile->fetch(0, '', $rel_file);
+			if ($res > 0) {
+				$ecmfile->agenda_id = (int) $agenda_id;
+				$ecmfile->update(DolibarrApiAccess::$user);
+			}
+		}
+
 		return dol_basename($destfile);
 	}
 
 	/**
-	 * Delete a document.
+	 * Delete a document
+	 *
+	 * @since	11.0.0	Initial implementation
 	 *
 	 * @param   string  $modulepart     Name of module or area concerned by file download ('product', ...)
 	 * @param   string  $original_file  Relative path with filename, relative to modulepart (for example: PRODUCT-REF-999/IMAGE-999.jpg)

--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -121,7 +121,7 @@ class SupplierInvoices extends DolibarrApi
 
 		// If the internal user must only see his customers, force searching by him
 		$search_sale = 0;
-		if (!DolibarrApiAccess::$user->hasRight("societe", "client", "voir")) {
+		if (empty(DolibarrApiAccess::$user->socid) && !DolibarrApiAccess::$user->hasRight("societe", "client", "voir")) {
 			$search_sale = DolibarrApiAccess::$user->id;
 		}
 

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -134,7 +134,7 @@ class Tasks extends DolibarrApi
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."projet AS p ON p.rowid = t.fk_projet";
 		$sql .= ' WHERE t.entity IN ('.getEntity('project').')';
 		if ($socids) {
-			$sql .= " AND t.fk_soc IN (".$this->db->sanitize((string) $socids).")";
+			$sql .= " AND p.fk_soc IN (".$this->db->sanitize((string) $socids).")";
 		}
 		// Search on sale representative
 		if ($search_sale && $search_sale != '-1') {

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -156,9 +156,12 @@ class Tickets extends DolibarrApi
 		$messages = array();
 		$this->ticket->loadCacheMsgsTicket();
 		if (is_array($this->ticket->cache_msgs_ticket) && count($this->ticket->cache_msgs_ticket) > 0) {
+			require_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
 			$num = count($this->ticket->cache_msgs_ticket);
 			$i = 0;
 			while ($i < $num) {
+				$actioncomm = new ActionComm($this->db);
+				$actioncomm->fetch($this->ticket->cache_msgs_ticket[$i]['id']);
 				if ($this->ticket->cache_msgs_ticket[$i]['fk_user_author'] > 0) {
 					$user_action = new User($this->db);
 					$user_action->fetch($this->ticket->cache_msgs_ticket[$i]['fk_user_author']);
@@ -174,7 +177,12 @@ class Tickets extends DolibarrApi
 					'fk_user_action_string' => $user_action === null ? '' : dolGetFirstLastname($user_action->firstname, $user_action->lastname),
 					'message' => $this->ticket->cache_msgs_ticket[$i]['message'],
 					'datec' => $this->ticket->cache_msgs_ticket[$i]['datec'],
-					'private' => $this->ticket->cache_msgs_ticket[$i]['private']
+					'private' => $this->ticket->cache_msgs_ticket[$i]['private'],
+					'code' => $actioncomm->code,
+					'percentage' => $actioncomm->percentage,
+					'type_code' => $actioncomm->type_code,
+					'type_picto' => $actioncomm->type_picto,
+					'userownerid' => $actioncomm->userownerid
 				);
 				$i++;
 			}
@@ -358,6 +366,12 @@ class Tickets extends DolibarrApi
 		// Check mandatory fields
 		$result = $this->_validateMessage($request_data);
 
+		$return_action_id = false;
+		if (isset($request_data['return_action_id'])) {
+			$return_action_id = !empty($request_data['return_action_id']);
+			unset($request_data['return_action_id']);
+		}
+
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller
@@ -373,8 +387,12 @@ class Tickets extends DolibarrApi
 			throw new RestException(404, 'Ticket not found');
 		}
 		$this->ticket->message = $ticketMessageText;
-		if (!$this->ticket->createTicketMessage(DolibarrApiAccess::$user)) {
+		$actionid = $this->ticket->createTicketMessage(DolibarrApiAccess::$user);
+		if (!$actionid) {
 			throw new RestException(500, 'Error when creating ticket');
+		}
+		if ($return_action_id) {
+			return array('ticket_id' => $this->ticket->id, 'action_id' => $actionid);
 		}
 		return $this->ticket->id;
 	}

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -373,7 +373,9 @@ class Users extends DolibarrApi
 	public function put($id, $request_data = null)
 	{
 		// Check user authorization
-		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'creer') && empty(DolibarrApiAccess::$user->admin)) {
+		$selfUpdateAllowed = ($id == DolibarrApiAccess::$user->id)
+			&& (DolibarrApiAccess::$user->hasRight('user', 'self', 'creer') || DolibarrApiAccess::$user->hasRight('user', 'self', 'write'));
+		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'creer') && empty(DolibarrApiAccess::$user->admin) && !$selfUpdateAllowed) {
 			throw new RestException(403, "User update not allowed");
 		}
 


### PR DESCRIPTION
# NEW|New [*Improve API support for external users and ticket documents*]
This PR introduces several standard API improvements focused on consistency and external-user use cases.

  It fixes task filtering by third party on the project task API, and adjusts supplier invoice filtering so external users linked to a third party are not incorrectly restricted by internal sales-user logic. It also allows users to
  update their own profile through the users API when they have the appropriate self permissions.

  On the ticket/document side, it extends the documents API to support ticket files, allows uploaded files to be linked to the related agenda action, and enriches ticket message handling by optionally returning the created action id and
  exposing additional action metadata in ticket message payloads.
