### PR TITLE
Backport/23 fix amount main currency

### DIFF
--- a/htdocs/admin/remotestore/css/store.css
+++ b/htdocs/admin/remotestore/css/store.css
@@ -111,6 +111,7 @@ div.divsearchfield {
 }
 .updatedApp{
     background-color: #25a580;
+    line-height: 1em;
 }
 .notcompatible {
     color: red;

--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -69,6 +69,15 @@ $error = 0;
  */
 
 $parameters = array('socid' => $socid);
+$dateo = array();
+$label = array();
+$amount = array();
+$amountto = array();
+$accountfrom = array();
+$accountto = array();
+$type = array();
+$number = array();
+$tabnum = array();
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
@@ -76,16 +85,6 @@ if ($reshook < 0) {
 if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 	$langs->load('errors');
 	$i = 1;
-
-	$dateo = array();
-	$label = array();
-	$amount = array();
-	$amountto = array();
-	$accountfrom = array();
-	$accountto = array();
-	$type = array();
-	$number = array();
-	$tabnum = array();
 
 	while ($i < $MAXLINESFORTRANSFERT) {
 		$dateo[$i] = dol_mktime(12, 0, 0, GETPOSTINT($i.'_month'), GETPOSTINT($i.'_day'), GETPOSTINT($i.'_year'));

--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -141,8 +141,10 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			$tmpaccountto = new Account($db);
 			$tmpaccountto->fetch(GETPOSTINT($n.'_account_to'));
 
+			/** @var ?float $amount_main_currency_from */
 			$amount_main_currency_from = null;
-			$amount_main_currency_to   = null;
+			/** @var ?float $amount_main_currency_to */
+			$amount_main_currency_to = null;
 
 			if ($tmpaccountto->currency_code == $tmpaccountfrom->currency_code) {
 				$amountto[$n] = $amount[$n];
@@ -154,11 +156,11 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			}
 
 			if ($tmpaccountfrom->currency_code != $conf->currency && $tmpaccountto->currency_code == $conf->currency) {
-				$amount_main_currency_from = price2num(-1 * (float) $amountto[$n]);
+				$amount_main_currency_from = (float) price2num(-1 * (float) $amountto[$n]);
 			}
 
 			if ($tmpaccountto->currency_code != $conf->currency && $tmpaccountfrom->currency_code == $conf->currency) {
-				$amount_main_currency_to = price2num((float) $amount[$n]);
+				$amount_main_currency_to = (float) price2num((float) $amount[$n]);
 			}
 
 			if ($amountto[$n] < 0) {
@@ -186,13 +188,13 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 				}
 
 				if (!$error) {
-					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], price2num(-1 * (float) $amount[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_from);
+					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], (float) price2num(-1 * (float) $amount[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_from);
 				}
 				if (!($bank_line_id_from > 0)) {
 					$error++;
 				}
 				if (!$error) {
-					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], price2num((float) $amountto[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_to);
+					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], (float) price2num((float) $amountto[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_to);
 				}
 				if (!($bank_line_id_to > 0)) {
 					$error++;

--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -141,6 +141,9 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			$tmpaccountto = new Account($db);
 			$tmpaccountto->fetch(GETPOSTINT($n.'_account_to'));
 
+			$amount_main_currency_from = null;
+			$amount_main_currency_to   = null;
+
 			if ($tmpaccountto->currency_code == $tmpaccountfrom->currency_code) {
 				$amountto[$n] = $amount[$n];
 			} else {
@@ -149,6 +152,15 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 					setEventMessages($langs->trans("ErrorFieldRequired", '#'.$n.' '.$langs->transnoentities("AmountToOthercurrency")), null, 'errors');
 				}
 			}
+
+			if ($tmpaccountfrom->currency_code != $conf->currency && $tmpaccountto->currency_code == $conf->currency) {
+				$amount_main_currency_from = price2num(-1 * (float) $amountto[$n]);
+			}
+
+			if ($tmpaccountto->currency_code != $conf->currency && $tmpaccountfrom->currency_code == $conf->currency) {
+				$amount_main_currency_to = price2num((float) $amount[$n]);
+			}
+
 			if ($amountto[$n] < 0) {
 				$error++;
 				setEventMessages($langs->trans("AmountMustBePositive").' #'.$n, null, 'errors');
@@ -174,13 +186,13 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 				}
 
 				if (!$error) {
-					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], (float) price2num(-1 * (float) $amount[$n]), $number[$n], 0, $user);
+					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], price2num(-1 * (float) $amount[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_from);
 				}
 				if (!($bank_line_id_from > 0)) {
 					$error++;
 				}
 				if (!$error) {
-					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], (float) $amountto[$n], $number[$n], 0, $user);
+					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], price2num((float) $amountto[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_to);
 				}
 				if (!($bank_line_id_to > 0)) {
 					$error++;

--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -141,9 +141,7 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			$tmpaccountto = new Account($db);
 			$tmpaccountto->fetch(GETPOSTINT($n.'_account_to'));
 
-			/** @var ?float $amount_main_currency_from */
 			$amount_main_currency_from = null;
-			/** @var ?float $amount_main_currency_to */
 			$amount_main_currency_to = null;
 
 			if ($tmpaccountto->currency_code == $tmpaccountfrom->currency_code) {
@@ -365,7 +363,7 @@ for ($i = 1 ; $i < $MAXLINESFORTRANSFERT; $i++) {
 
 	// Date
 	print '<td class="nowraponall">';
-	print $form->selectDate((!empty($dateo[$i]) ? $dateo[$i] : ''), $i.'_', 0, 0, 0, 'add');
+	print $form->selectDate((!empty($dateo[$i] ?? null) ? $dateo[$i] : ''), $i.'_', 0, 0, 0, 'add');
 	print "</td>\n";
 
 	// Cheque Number

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -694,9 +694,7 @@ abstract class CommonInvoice extends CommonObject
 	 *  Return if an invoice can be set back to draft.
 	 *	Rule is:
 	 *  If invoice is draft and has a temporary ref -> yes (1)
-	 *  If hidden option INVOICE_CAN_NEVER_BE_REMOVED is 1 -> no (0)
 	 *  If invoice is transferred in bookkeeping -> no (-1)
-	 *  If invoice has a definitive ref, is not last in ref -> no (-2)
 	 *  If invoice has a definitive ref, is not last in a situation cycle -> no (-3)
 	 *  If there is one payment -> no (-4)
 	 *  If already sent by email -> no (-5)

--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -708,9 +708,95 @@ abstract class CommonInvoice extends CommonObject
 	 */
 	public function isEditable()
 	{
-		$test = $this->is_erasable();
+		// phpcs:enable
+		global $hookmanager, $action;
 
-		return $test;
+		// We check if invoice is a temporary number (PROVxxxx)
+		$tmppart = substr($this->ref, 1, 4);
+
+		if ($this->status == self::STATUS_DRAFT && $tmppart === 'PROV') { // If draft invoice and ref not yet defined
+			return 1;
+		}
+
+		/*
+		if (getDolGlobalInt('INVOICE_CAN_NEVER_BE_REMOVED')) {
+			return 0;
+		}
+		*/
+
+		// If not a draft invoice and not temporary invoice
+		if ($tmppart !== 'PROV') {
+			if ($this instanceOf Facture) {
+				/* @var Facture $this */
+				// If sent by email, we refuse
+				if ((int) $this->email_sent_counter > 0) {
+					return -5;
+				}
+
+				// If printed, we refuse
+				if ((int) $this->pos_print_counter > 0) {
+					return -6;
+				}
+
+				include_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php';
+				if (isALNERunningVersion()) {
+					$this->error = 'Action not allowed on the certified version';
+					return -7;
+				}
+			}
+
+			// If in accountancy, we refuse
+			$ventilExportCompta = $this->getVentilExportCompta();
+			if ($ventilExportCompta != 0) {
+				return -1;
+			}
+
+			// Get last number of validated invoice
+			if ($this->element != 'invoice_supplier') {
+				/*
+				if (empty($this->thirdparty)) {
+					$this->fetch_thirdparty(); // We need to have this->thirdparty defined, in case of the numbering rule uses tags that depend on thirdparty (like {t} tag).
+				}
+				$maxref = $this->getNextNumRef($this->thirdparty, 'last');
+				// $maxref can be '' (means not found) if there is no invoice yet, but also if there is no invoice for the new period when there is a reset at each period
+
+				// If invoice to delete is not the last one, we refuse
+				if ($maxref != '' && $maxref != $this->ref) {
+					return -2;
+				}
+				*/
+
+				// TODO If there is payment in bookkeeping, check the payment is not dispatched in accounting and return -2.
+				// ...
+
+				// If invoice is situation type, we refuse if it is not the last in situation cycle
+				if (!getDolGlobalString('INVOICE_SITUATION_CAN_BE_REMOVED_EVEN_IF_NOT_LAST') && $this->situation_cycle_ref && method_exists($this, 'is_last_in_cycle')) {
+					$last = $this->is_last_in_cycle();
+					if (!$last) {
+						return -3;
+					}
+				}
+			}
+
+			// Test if there is at least one payment. If yes, we refuse.
+			if ($this->getSommePaiement() > 0) {
+				return -4;
+			}
+
+			$parameters = array();
+			$reshook = $hookmanager->executeHooks('isEditable', $parameters, $this, $action);
+			if (!empty($hookmanager->resArray['result'])) {
+				$this->error = $hookmanager->resArray['error'];
+				if (!empty($hookmanager->resArray['errors'])) {
+					$this->errors[] = array_merge($this->errors, $this->error, $hookmanager->resArray['errors']);
+				} else {
+					$this->errors[] = array_merge($this->errors, $this->error);
+				}
+				return $hookmanager->resArray['result'];
+			}
+		}
+
+		return 2;
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
@@ -790,7 +876,7 @@ abstract class CommonInvoice extends CommonObject
 				// TODO If there is payment in bookkeeping, check the payment is not dispatched in accounting and return -2.
 				// ...
 
-				// If invoice is situation type, we refuse it it is not the last in situation cycle
+				// If invoice is situation type, we refuse if it is not the last in situation cycle
 				if (!getDolGlobalString('INVOICE_SITUATION_CAN_BE_REMOVED_EVEN_IF_NOT_LAST') && $this->situation_cycle_ref && method_exists($this, 'is_last_in_cycle')) {
 					$last = $this->is_last_in_cycle();
 					if (!$last) {
@@ -799,13 +885,13 @@ abstract class CommonInvoice extends CommonObject
 				}
 			}
 
-			// Test if there is at least one payment. If yes, we refuse to delete.
+			// Test if there is at least one payment. If yes, we refuse.
 			if ($this->getSommePaiement() > 0) {
 				return -4;
 			}
 
 			$parameters = array();
-			$reshook = $hookmanager->executeHooks('isEditable', $parameters, $this, $action);
+			$reshook = $hookmanager->executeHooks('isErasable', $parameters, $this, $action);
 			if (!empty($hookmanager->resArray['result'])) {
 				$this->error = $hookmanager->resArray['error'];
 				if (!empty($hookmanager->resArray['errors'])) {

--- a/htdocs/public/stripe/ipn.php
+++ b/htdocs/public/stripe/ipn.php
@@ -181,14 +181,15 @@ if (getDolGlobalString('MAIN_APPLICATION_TITLE')) {
 	$societeName = getDolGlobalString('MAIN_APPLICATION_TITLE');
 }
 
+
+// Add a delay to be sure that any Stripe action from webhooks are executed after interactive actions that also trigger a webhook
+sleep(2);
+
+
 top_httphead();
 
 dol_syslog("***** Stripe IPN was called with event->type=".$event->type." service=".$service);
 dol_syslog("***** Stripe IPN was called with event->type=".$event->type." service=".$service, LOG_DEBUG, 0, '_payment');
-
-
-// Add a delay to be sure that any Stripe action from webhooks are executed after interactive actions
-sleep(2);
 
 
 if ($event->type == 'payout.created' && getDolGlobalString('STRIPE_AUTO_RECORD_PAYOUT')) {


### PR DESCRIPTION
# FIX|Fix #37425 amount_main_currency not filled correctly for foreign currency bank transfers (backport)

Backport of #37439 to 23.0.

Fixes the filling of `amount_main_currency` when creating transfers between foreign currency accounts.

Original PR:
https://github.com/Dolibarr/dolibarr/pull/37439