### PR TITLE
FIX Backport/23 fix amount main currency

### DIFF
--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -69,6 +69,15 @@ $error = 0;
  */
 
 $parameters = array('socid' => $socid);
+$dateo = array();
+$label = array();
+$amount = array();
+$amountto = array();
+$accountfrom = array();
+$accountto = array();
+$type = array();
+$number = array();
+$tabnum = array();
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
@@ -76,16 +85,6 @@ if ($reshook < 0) {
 if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 	$langs->load('errors');
 	$i = 1;
-
-	$dateo = array();
-	$label = array();
-	$amount = array();
-	$amountto = array();
-	$accountfrom = array();
-	$accountto = array();
-	$type = array();
-	$number = array();
-	$tabnum = array();
 
 	while ($i < $MAXLINESFORTRANSFERT) {
 		$dateo[$i] = dol_mktime(12, 0, 0, GETPOSTINT($i.'_month'), GETPOSTINT($i.'_day'), GETPOSTINT($i.'_year'));

--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -141,8 +141,10 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			$tmpaccountto = new Account($db);
 			$tmpaccountto->fetch(GETPOSTINT($n.'_account_to'));
 
+			/** @var ?float $amount_main_currency_from */
 			$amount_main_currency_from = null;
-			$amount_main_currency_to   = null;
+			/** @var ?float $amount_main_currency_to */
+			$amount_main_currency_to = null;
 
 			if ($tmpaccountto->currency_code == $tmpaccountfrom->currency_code) {
 				$amountto[$n] = $amount[$n];
@@ -154,11 +156,11 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			}
 
 			if ($tmpaccountfrom->currency_code != $conf->currency && $tmpaccountto->currency_code == $conf->currency) {
-				$amount_main_currency_from = price2num(-1 * (float) $amountto[$n]);
+				$amount_main_currency_from = (float) price2num(-1 * (float) $amountto[$n]);
 			}
 
 			if ($tmpaccountto->currency_code != $conf->currency && $tmpaccountfrom->currency_code == $conf->currency) {
-				$amount_main_currency_to = price2num((float) $amount[$n]);
+				$amount_main_currency_to = (float) price2num((float) $amount[$n]);
 			}
 
 			if ($amountto[$n] < 0) {
@@ -186,13 +188,13 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 				}
 
 				if (!$error) {
-					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], price2num(-1 * (float) $amount[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_from);
+					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], (float) price2num(-1 * (float) $amount[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_from);
 				}
 				if (!($bank_line_id_from > 0)) {
 					$error++;
 				}
 				if (!$error) {
-					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], price2num((float) $amountto[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_to);
+					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], (float) price2num((float) $amountto[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_to);
 				}
 				if (!($bank_line_id_to > 0)) {
 					$error++;

--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -141,6 +141,9 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			$tmpaccountto = new Account($db);
 			$tmpaccountto->fetch(GETPOSTINT($n.'_account_to'));
 
+			$amount_main_currency_from = null;
+			$amount_main_currency_to   = null;
+
 			if ($tmpaccountto->currency_code == $tmpaccountfrom->currency_code) {
 				$amountto[$n] = $amount[$n];
 			} else {
@@ -149,6 +152,15 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 					setEventMessages($langs->trans("ErrorFieldRequired", '#'.$n.' '.$langs->transnoentities("AmountToOthercurrency")), null, 'errors');
 				}
 			}
+
+			if ($tmpaccountfrom->currency_code != $conf->currency && $tmpaccountto->currency_code == $conf->currency) {
+				$amount_main_currency_from = price2num(-1 * (float) $amountto[$n]);
+			}
+
+			if ($tmpaccountto->currency_code != $conf->currency && $tmpaccountfrom->currency_code == $conf->currency) {
+				$amount_main_currency_to = price2num((float) $amount[$n]);
+			}
+
 			if ($amountto[$n] < 0) {
 				$error++;
 				setEventMessages($langs->trans("AmountMustBePositive").' #'.$n, null, 'errors');
@@ -174,13 +186,13 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 				}
 
 				if (!$error) {
-					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], (float) price2num(-1 * (float) $amount[$n]), $number[$n], 0, $user);
+					$bank_line_id_from = $tmpaccountfrom->addline($dateo[$n], $typefrom, $label[$n], price2num(-1 * (float) $amount[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_from);
 				}
 				if (!($bank_line_id_from > 0)) {
 					$error++;
 				}
 				if (!$error) {
-					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], (float) $amountto[$n], $number[$n], 0, $user);
+					$bank_line_id_to = $tmpaccountto->addline($dateo[$n], $typeto, $label[$n], price2num((float) $amountto[$n]), '', 0, $user, '', '', '', null, '', $amount_main_currency_to);
 				}
 				if (!($bank_line_id_to > 0)) {
 					$error++;

--- a/htdocs/compta/bank/transfer.php
+++ b/htdocs/compta/bank/transfer.php
@@ -141,9 +141,7 @@ if ($action == 'add' && $user->hasRight('banque', 'transfer')) {
 			$tmpaccountto = new Account($db);
 			$tmpaccountto->fetch(GETPOSTINT($n.'_account_to'));
 
-			/** @var ?float $amount_main_currency_from */
 			$amount_main_currency_from = null;
-			/** @var ?float $amount_main_currency_to */
 			$amount_main_currency_to = null;
 
 			if ($tmpaccountto->currency_code == $tmpaccountfrom->currency_code) {
@@ -365,7 +363,7 @@ for ($i = 1 ; $i < $MAXLINESFORTRANSFERT; $i++) {
 
 	// Date
 	print '<td class="nowraponall">';
-	print $form->selectDate((!empty($dateo[$i]) ? $dateo[$i] : ''), $i.'_', 0, 0, 0, 'add');
+	print $form->selectDate((!empty($dateo[$i] ?? null) ? $dateo[$i] : ''), $i.'_', 0, 0, 0, 'add');
 	print "</td>\n";
 
 	// Cheque Number


### PR DESCRIPTION
Fix https://github.com/Dolibarr/dolibarr/issues/37425 amount_main_currency not filled correctly for foreign currency bank transfers (backport)
Backport of https://github.com/Dolibarr/dolibarr/pull/37439 to 23.0.

Fixes the filling of amount_main_currency when creating transfers between foreign currency accounts.

Original PR:
https://github.com/Dolibarr/dolibarr/pull/37439