### PR TITLE
Fix syslog configuration

### DIFF
--- a/htdocs/core/modules/syslog/mod_syslog_syslog.php
+++ b/htdocs/core/modules/syslog/mod_syslog_syslog.php
@@ -86,7 +86,7 @@ class mod_syslog_syslog extends LogHandler
 	{
 		global $langs;
 
-		$facility = constant(getDolGlobalString('SYSLOG_FACILITY'));
+		$facility = defined(getDolGlobalString('SYSLOG_FACILITY')) ? constant(getDolGlobalString('SYSLOG_FACILITY')) : null;
 
 		if ($facility) {
 			// Only LOG_USER supported on Windows
@@ -117,7 +117,7 @@ class mod_syslog_syslog extends LogHandler
 			return; // Global option to disable output of this handler
 		}
 
-		if (getDolGlobalString('SYSLOG_FACILITY')) {  // Example LOG_USER
+		if (getDolGlobalString('SYSLOG_FACILITY') && defined(getDolGlobalString('SYSLOG_FACILITY'))) {  // Example LOG_USER
 			$facility = constant($conf->global->SYSLOG_FACILITY);
 		} else {
 			$facility = constant('LOG_USER');

--- a/htdocs/core/modules/syslog/mod_syslog_syslog.php
+++ b/htdocs/core/modules/syslog/mod_syslog_syslog.php
@@ -118,7 +118,7 @@ class mod_syslog_syslog extends LogHandler
 		}
 
 		if (getDolGlobalString('SYSLOG_FACILITY') && defined(getDolGlobalString('SYSLOG_FACILITY'))) {  // Example LOG_USER
-			$facility = constant($conf->global->SYSLOG_FACILITY);
+			$facility = constant(getDolGlobalString('SYSLOG_FACILITY'));
 		} else {
 			$facility = constant('LOG_USER');
 		}


### PR DESCRIPTION
Since php 8.0 constant function throws an error exception if the constant is not defined.
This PR fixes a php fatal error if we enter a non existent SYSLOG_FACILITY in the configuration.