### PR TITLE
FIX: Allow to include spaces in email filename

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -2061,8 +2061,10 @@ class CMailFile
 			$i = 0;
 			// We are interested in $matches[1] only (the second set of parenthesis into regex)
 			foreach ($matches[1] as $full) {
+				$full = urldecode($full);
+				
 				$regs = array();
-				if (preg_match('/file=([A-Za-z0-9_\-\/]+[\.]?[A-Za-z0-9]+)?$/i', $full, $regs)) {   // If xxx is 'file=aaa'
+				if (preg_match('/file=([A-Za-z0-9_\-\/ ]+[\.]?[A-Za-z0-9]+)?$/i', $full, $regs)) {   // If xxx is 'file=aaa'
 					$img = $regs[1];
 
 					if (file_exists($images_dir.'/'.$img)) {

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -2062,7 +2062,7 @@ class CMailFile
 			// We are interested in $matches[1] only (the second set of parenthesis into regex)
 			foreach ($matches[1] as $full) {
 				$full = urldecode($full);
-				
+
 				$regs = array();
 				if (preg_match('/file=([A-Za-z0-9_\-\/ ]+[\.]?[A-Za-z0-9]+)?$/i', $full, $regs)) {   // If xxx is 'file=aaa'
 					$img = $regs[1];


### PR DESCRIPTION
One of our user has a inline email signature with an image that contains a space: 'LASTNAME-SIGNATURE MAIL.png'.
This signature wasn't being returned by \CMailFile::findHtmlImages and therefore the error message "Erreur lors de la création de fichiers image dans le répertoire média pour la pièce jointe" was shown.

I have updated the \CMailFile::findHtmlImages method to allow filename with spaces. Maybe the real issue is that the email signature contains a space (I haven't looked at that part of the code) but I think that being flexible could be useful anyway.

Looking forward for feedbacks