### PR TITLE
update mistaken field in recruitment api

### DIFF
--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -418,7 +418,7 @@ class Recruitments extends DolibarrApi
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller
-				$this->jobposition->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
+				$this->candidature->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
 			}
 

--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -422,7 +422,7 @@ class Recruitments extends DolibarrApi
 				continue;
 			}
 
-			$this->jobposition->$field = $this->_checkValForAPI($field, $value, $this->jobposition);
+			$this->candidature->$field = $this->_checkValForAPI($field, $value, $this->candidature);
 		}
 
 		// Clean data


### PR DESCRIPTION
# FIX #[34146]
[
https://github.com/Dolibarr/dolibarr/issues/34146
The issue was that a POST to the recruitment endpoint was confused in the required fields from jobposition, not candidature.
]