### PR TITLE
WIP : UIUX : Add tooltip doc and tooltip css alternatives needed for some cases in full js interface context

### DIFF
--- a/htdocs/admin/tools/ui/class/documentation.class.php
+++ b/htdocs/admin/tools/ui/class/documentation.class.php
@@ -282,6 +282,14 @@ class Documentation
 						'ExperimentalUxContributionTitle' => '#experimental-ux-contribution',
 					),
 				),
+				'UxMenuTooltipTheme' => array(
+					'url' => dol_buildpath($this->baseUrl.'/experimental/tooltip-themes/index.php', 1),
+					'icon' => 'fas fa-comment',
+					'submenu' => array(),
+					'summary' => array(
+						'Introduction' => '#ux-introduction',
+						'TooltipThemesAndOrientation' => '#tooltip-themes',),
+				),
 			)
 		);
 
@@ -538,5 +546,45 @@ class Documentation
 		$doleditor = new DolEditor(md5($content), $content, '', 0, 'Basic', 'In', true, false, 'ace', 0, '99%', 1);
 		print $doleditor->Create(1, '', false, '', $option);
 		print '</div>';
+	}
+
+
+	/**
+	 * Generate lorem ipsum
+	 *
+	 * @param int  $paragraphCount nb paragraph you need
+	 * @param int  $wordsPerParagraph nb words per paragraph you need
+	 * @param bool $html return html formatted paragraph
+	 *
+	 * @return string
+	 */
+	static public function generateLoremIpsum($paragraphCount = 3, $wordsPerParagraph = 50, $html = true)
+	{
+		$baseText = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua Ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur Excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum";
+
+		$words = explode(" ", $baseText);
+		$paragraphs = [];
+
+		for ($p = 0; $p < $paragraphCount; $p++) {
+			$sentence = [];
+			for ($i = 0; $i < $wordsPerParagraph; $i++) {
+				$word = $words[array_rand($words)];
+
+				// Randomly add a comma
+				if ($i > 2 && rand(0, 10) > 8) {
+					$word .= ",";
+				}
+
+				$sentence[] = $word;
+			}
+
+			$paragraphText = ucfirst(implode(" ", $sentence)) . ".";
+			if ($html) {
+				$paragraphText = "<p>$paragraphText</p>";
+			}
+			$paragraphs[] = $paragraphText;
+		}
+
+		return implode($html ? "\n" : "\n\n", $paragraphs);
 	}
 }

--- a/htdocs/admin/tools/ui/experimental/tooltip-themes/index.php
+++ b/htdocs/admin/tools/ui/experimental/tooltip-themes/index.php
@@ -1,0 +1,269 @@
+<?php
+/*
+ * Copyright (C) 2024 Anthony Damhet <a.damhet@progiseize.fr>
+ * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Load Dolibarr environment
+require '../../../../../main.inc.php';
+
+/**
+ * @var DoliDB      $db
+ * @var HookManager $hookmanager
+ * @var Translate   $langs
+ * @var User        $user
+ */
+
+// Protection if external user
+if ($user->socid > 0) {
+	accessforbidden();
+}
+
+// Includes
+require_once DOL_DOCUMENT_ROOT . '/admin/tools/ui/class/documentation.class.php';
+
+// Load documentation translations
+$langs->load('uxdocumentation');
+
+//
+$documentation = new Documentation($db);
+$group = 'ExperimentalUx';
+
+$morejs = [
+	'/includes/ace/src/ace.js',
+	'/includes/ace/src/ext-statusbar.js',
+	'/includes/ace/src/ext-language_tools.js',
+];
+// Output html head + body - Param is Title
+$documentation->docHeader($langs->transnoentitiesnoconv('UxMenuTooltipTheme', $group), $morejs);
+
+// Set view for menu and breadcrumb
+$documentation->view = [$group, 'UxMenuTooltipTheme'];
+
+// Output sidebar
+$documentation->showSidebar(); ?>
+
+<div class="doc-wrapper">
+
+	<?php $documentation->showBreadCrumb(); ?>
+
+	<div class="doc-content-wrapper">
+
+		<h1 class="documentation-title"><?php echo $langs->trans('UxMenuTooltipTheme'); ?></h1>
+		<p class="documentation-text">This page list all tooltips available in Dolibarr.</p>
+
+		<?php $documentation->showSummary(); ?>
+
+		<div class="documentation-section" id="ux-introduction" >
+			<h2 class="documentation-title">Introduction</h2>
+			<p class="documentation-text">
+				Dolibarr uses tooltips throughout the application.<br/>
+				By default, there are two types of tooltips: standard tooltips and AJAX tooltips.<br/>
+				The first type is loaded with the page, while the second one is loaded on demand (typically when the mouse hovers over an element) in order to avoid overloading the initial page load.
+				Ajax tooltips are used for object getNomUrl() function.
+			</p>
+
+			<p class="documentation-text">
+				Dolibarr use jquery tooltip
+			</p>
+
+			<h3>Default tooltips</h3>
+			<?php
+			$lines = array(
+				'<span class="classfortooltip" title="This is a default tooltip">',
+				'	Example of a tooltip : A tooltip',
+				'</span>',
+			);
+			$documentation->showCode($lines, 'php'); ?>
+			<div class="documentation-example">
+
+				<p>
+					<?php print implode('', $lines) ?>
+				</p>
+
+				<p>
+					To create a tooltip, add the class <code>.classfortooltip</code> and a <code>title</code> attribute.
+				</p>
+
+			</div>
+
+			<h3>AJAX tooltips</h3>
+			<?php
+
+			$params = [
+				'id' => $user->id,
+				'objecttype' => $user->element,
+				'infologin' => 0,
+				'option' => '',
+				'hidethirdpartylogo' => 1,
+			];
+
+			$dataparams = ' data-params="'.dol_escape_htmltag(json_encode($params)).'"';
+
+			$lines = array(
+				'<?php',
+				'$params = [',
+				'	\'id\' => $object->id,',
+				'	\'objecttype\' => $object->element',
+				'];',
+				'',
+				'$dataparams = \' data-params="\'.dol_escape_htmltag(json_encode($params)).\'"\';',
+				'',
+				'?>',
+				'<span class="classforajaxtooltip" title="Loading" \'.$dataparams.\'>',
+				'	Example of a tooltip : A tooltip',
+				'</span>',
+			);
+			$documentation->showCode($lines, 'php'); ?>
+			<div class="documentation-example">
+				<p>
+				Example of AJAX tooltip with getNomUrl():  <?php print $user->getNomUrl() ?>
+				</p>
+
+			</div>
+		</div>
+
+
+		<div class="documentation-section" id="tooltip-themes" >
+
+			<h2 class="documentation-title"><?php print $langs->trans('TooltipThemesAndOrientation'); ?></h2>
+
+			<p class="documentation-example">
+				You can create your own tooltips using the jQuery tooltip system by defining a custom tooltip class instead of the default <code>.mytooltip</code> used by Dolibarr.
+			</p>
+
+			<h3>jQuery-based tooltips</h3>
+
+			<p>Advantages:</p>
+			<ul>
+				<li>Tooltips are displayed above all other DOM elements</li>
+				<li>The position automatically adapts to screen boundaries</li>
+				<li>Supports HTML content inside the tooltip</li>
+			</ul>
+
+			<p>Drawbacks:</p>
+			<ul>
+				<li>Not AJAX-friendly by default (see the "initNewContent" event system in the Dolibarr JS context)</li>
+			</ul>
+
+			<?php
+			$lines = array(
+				'<script nonce="<?php print getNonce(); ?>">',
+				'jQuery(function() {',
+				'',
+				'	const quickTooltip = function (target, className) {',
+				'		$(target).tooltip({',
+				'			tooltipClass: className,',
+				'			show: { collision: "flipfit", effect: "toggle", delay: 50, duration: 20 },',
+				'			hide: { delay: 250, duration: 20 },',
+				'			content: function () {',
+				'				return $(this).prop("title");',
+				'			}',
+				'		});',
+				'	}',
+				'',
+				'	quickTooltip(\'.test-tooltip-jquery-dark\', "jquery-tooltip --dark-mode");',
+				'	quickTooltip(\'.test-tooltip-jquery-light\', "jquery-tooltip --light-mode");',
+				'});',
+				'</script>',
+				'',
+				'<button class="button classfortooltip" title="This is an example of default jquery based tooltip theme, used for getNomUrl or long text.<br/>Compatible with alt key to freeze tooltip" >Try default theme</button>',
+				'<button class="button test-tooltip-jquery-dark" title="This is an example of dark jquery based tooltip theme" >Try dark theme</button>',
+				'<button class="button test-tooltip-jquery-light" title="This is an example of light jquery based tooltip theme" >Try light theme</button>',
+				'<button class="button test-tooltip-jquery-light" title="" >Try light long text</button>',
+
+			);
+			$documentation->showCode($lines, 'php'); ?>
+
+
+			<script nonce="<?php print getNonce(); ?>">
+				jQuery(function() {
+
+					const quickTooltip = function (target, className) {
+						$(target).tooltip({
+							tooltipClass: className,
+							show: { collision: "flipfit", effect: "toggle", delay: 50, duration: 20 },
+							hide: { delay: 250, duration: 20 },
+							content: function () {
+								return $(this).prop("title");
+							}
+						});
+					}
+
+					quickTooltip('.test-tooltip-jquery-dark', "jquery-tooltip --dark-mode");
+					quickTooltip('.test-tooltip-jquery-light', "jquery-tooltip --light-mode");
+				});
+			</script>
+
+			<div class="documentation-example">
+				<button class="button classfortooltip" title="This is an example of default theme" >Try default theme</button>
+				<button class="button test-tooltip-jquery-dark" title="This is an example of dark jquery based tooltip theme" >Try dark theme</button>
+				<button class="button test-tooltip-jquery-light" title="This is an example of light jquery based tooltip theme" >Try light theme</button>
+				<hr/>
+				<button class="button classfortooltip" title="<?php print dol_htmlentities(Documentation::generateLoremIpsum()); ?>" >Try default theme with long text</button>
+				<button class="button test-tooltip-jquery-light" title="<?php print dol_htmlentities(Documentation::generateLoremIpsum()); ?>" >Try light theme with long text</button>
+			</div>
+
+			<h3>CSS-only tooltips</h3>
+
+			<p>Advantages:</p>
+			<ul>
+				<li>AJAX-friendly and compatible with DOM manipulations</li>
+				<li>Ideal for short contextual help or replacing the default <code>title</code> attribute with a smooth, dynamic tooltip pop-up</li>
+			</ul>
+
+			<p>Drawbacks:</p>
+			<ul>
+				<li>Tooltip position does not automatically adapt to screen boundaries; you need to use modifier classes such as <code>--tooltip-top</code>, <code>--tooltip-bottom</code>, <code>--tooltip-left</code>, or <code>--tooltip-right</code> to adjust placement</li>
+				<li>Does not support HTML content inside the tooltip</li>
+				<li>Tooltip stacking (<code>z-index</code>) depends on the element itself</li>
+				<li>In some cases tooltip style can by override by parent css rules</li>
+			</ul>
+
+			<?php
+			$lines = array(
+				'<button class="button dol-tooltip --dark-mode" data-title="This is an example of dark css based tooltip theme" >Try dark theme</button>',
+				'<button class="button dol-tooltip" data-title="This is an example of light css based tooltip theme" >Try light theme</button>',
+				'',
+				'<h4>Orientation dark theme</h4>',
+				'',
+				'<button class="button dol-tooltip --dark-mode --tooltip-bottom" data-title="This is an example of dark css based tooltip theme" >Bottom</button>',
+				'<button class="button dol-tooltip --dark-mode --tooltip-left" data-title="This is an example of dark css based tooltip theme" >Left</button>',
+				'<button class="button dol-tooltip --dark-mode --tooltip-right" data-title="This is an example of dark css based tooltip theme" >Right</button>',
+				'<button class="button dol-tooltip --dark-mode --tooltip-top" data-title="This is an example of dark css based tooltip theme" >Top</button>',
+				'',
+				'<h4>Orientation light theme</h4>',
+				'',
+				'<button class="button dol-tooltip --light-mode --tooltip-bottom" data-title="This is an example of light css based tooltip theme" >Bottom</button>',
+				'<button class="button dol-tooltip --light-mode --tooltip-left" data-title="This is an example of light css based tooltip theme" >Left</button>',
+				'<button class="button dol-tooltip --light-mode --tooltip-right" data-title="This is an example of light css based tooltip theme" >Right</button>',
+				'<button class="button dol-tooltip --light-mode --tooltip-top" data-title="This is an example of light css based tooltip theme" >Top</button>',
+			);
+			$documentation->showCode($lines, 'php'); ?>
+			<div class="documentation-example">
+				<?php print implode(' ', $lines) ?>
+			</div>
+		</div>
+
+
+
+	</div>
+
+</div>
+<?php
+// Output close body + html
+$documentation->docFooter();
+?>

--- a/htdocs/langs/en_US/uxdocumentation.lang
+++ b/htdocs/langs/en_US/uxdocumentation.lang
@@ -169,6 +169,9 @@ UxDolibarrContext = JS Dolibarr context
 UxDolibarrContextHowItWork = How it's work
 UxDolibarrContextLangsTool = Langs tool
 
+UxMenuTooltipTheme = Tooltips & themes
+TooltipThemesAndOrientation = Tooltip Themes and orientation
+
 # Start experiements menu title
 ExperimentalUxInputAjaxFeedback = Input feedback
 # End experiements manu tyile

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -9591,3 +9591,13 @@ div.extra_inline_chkbxlst, div.extra_inline_checkbox {
 div.flot-text .flot-tick-label .tickLabel, .fa-color-unset {
 	color: unset;
 }
+
+
+.noselect {
+	-webkit-touch-callout: none; /* iOS Safari */
+	-webkit-user-select: none; /* Safari */
+	-khtml-user-select: none; /* Konqueror HTML */
+	-moz-user-select: none; /* Old versions of Firefox */
+	-ms-user-select: none; /* Internet Explorer/Edge */
+	user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
+}

--- a/htdocs/theme/eldy/tooltips.inc.css
+++ b/htdocs/theme/eldy/tooltips.inc.css
@@ -17,3 +17,249 @@ div.ui-tooltip.mytooltip-hover-tooltip {
 	line-height: 1.6em;
 	max-width: 550px;
 }
+
+:root{
+	--tooltip-txt-color: #1f2937;
+	--tooltip-bg-color:  #ffffff;
+	--tooltip-border-color: #d1d5db;
+
+	--tooltip-txt-color-dark-theme: #f9fafb;
+	--tooltip-bg-color-dark-theme: #1f2937;
+	--tooltip-border-color-dark-theme: #374151;
+}
+
+/* ********************** */
+/* JQUERY TOOLTIPS  THEME */
+/* ********************** */
+
+/** Style tooltip Jquery */
+div.ui-tooltip.jquery-tooltip {
+	padding: 0.5rem 0.75rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.5;
+	font-family: InterVariable, system-ui, sans-serif;
+
+	/* Same as light theme */
+	color: var(--tooltip-txt-color);
+	background-color:  var(--tooltip-bg-color);
+	border: 1px solid var(--tooltip-border-color);
+
+	/*backdrop-filter: blur(3px); */ /* useless if background as no opacity under 1 value */
+
+	border-radius: 0.375rem;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	pointer-events: none;
+}
+
+
+div.ui-tooltip.jquery-tooltip.--dark-mode {
+	color: var(--tooltip-txt-color-dark-theme) !important;
+	background-color:  var(--tooltip-bg-color-dark-theme) !important;
+	border: 1px solid var(--tooltip-border-color-dark-theme);
+}
+
+div.ui-tooltip.jquery-tooltip.--light-mode {
+	color: var(--tooltip-txt-color) !important;
+	background-color:  var(--tooltip-bg-color) !important;
+	border: 1px solid var(--tooltip-border-color);
+}
+
+
+
+/* ************************ */
+/* Native CSS Only tooltips */
+/* ************************ */
+
+.dol-tooltip {
+	--arrow-size: 6px;
+	position: relative;
+}
+
+.dol-tooltip.--dark-mode {
+	--tooltip-txt-color: var(--tooltip-txt-color-dark-theme);
+	--tooltip-bg-color:  var(--tooltip-bg-color-dark-theme);
+	--tooltip-border-color: var(--tooltip-border-color-dark-theme);
+}
+
+.dol-tooltip.--light-mode {
+	--tooltip-txt-color: #1f2937;
+	--tooltip-bg-color:  #ffffff;
+	--tooltip-border-color: #d1d5db;
+}
+
+
+/* Base tooltip */
+.dol-tooltip::after {
+	content: attr(data-title);
+	position: absolute;
+	left: 50%;
+	bottom: calc(100% + 0.5rem);
+	transform: translateX(-50%) translateY(-5px);
+	opacity: 0;
+	visibility: hidden;
+	min-height: 1.5em;
+	white-space: nowrap;
+	z-index: 1000;
+	transition: opacity 120ms ease, transform 120ms ease;
+
+	padding: 0.5rem 0.75rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.5;
+	font-family: InterVariable, system-ui, sans-serif;
+
+	color: var(--tooltip-txt-color) !important;
+	background-color: var(--tooltip-bg-color) !important;
+	border: 1px solid var(--tooltip-border-color);
+
+	border-radius: 0.375rem;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	pointer-events: none;
+
+	text-transform: none;
+	text-align: left;
+
+}
+
+
+/* Arrow */
+.dol-tooltip::before {
+	z-index: 1;
+	content: "";
+	position: absolute;
+	left: 50%;
+	bottom: calc(100%) ;
+	transform: translateX(-50%) translateY(0px);
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 300ms ease, transform 300ms ease;
+	filter: drop-shadow(0 2px 3px rgba(0,0,0,0.3));
+
+	border-width: var(--arrow-size);
+	border-style: solid;
+	border-color: var(--tooltip-bg-color) transparent transparent transparent;
+	pointer-events: none;
+}
+
+
+/* Define delay */
+.dol-tooltip::after,
+.dol-tooltip::before {
+	transition-delay: 120ms; /* delay before visible */
+}
+
+.dol-tooltip:not(:hover)::after,
+.dol-tooltip:not(:hover)::before {
+	transition-delay: 0ms; /* instant off */
+}
+
+
+/* Display */
+.dol-tooltip:hover::after,
+.dol-tooltip:hover::before,
+.dol-tooltip:focus-visible::after,
+.dol-tooltip:focus-visible::before {
+	opacity: 1;
+	visibility: visible;
+}
+
+.dol-tooltip:hover::after,
+.dol-tooltip:focus-visible::after {
+	transform: translateX(-50%) translateY(calc(var(--arrow-size) / -2 ));
+}
+
+.dol-tooltip:hover::before,
+.dol-tooltip:focus-visible::before {
+	transform: translateX(-50%) translateY(0px);
+}
+
+/* Fallback aria-label if no data-title */
+.dol-tooltip:not([data-title])::after {
+	content: attr(aria-label);
+}
+
+/* RTL support */
+body[dir="rtl"] .dol-tooltip::after {
+	direction: rtl;
+	text-align: right;
+}
+
+/* ------------------ */
+/* Direction modifiers */
+/* ------------------ */
+
+/* Top (default already set) */
+.dol-tooltip.--tooltip-top:hover::after{
+	transform: translateX(-50%) translateY(calc(var(--arrow-size) / -2 ));
+}
+.dol-tooltip.--tooltip-top::after {
+	bottom: calc(100% + 0.5rem);
+	left: 50%;
+	transform: translateX(-50%) translateY(0);
+}
+
+.dol-tooltip.--tooltip-top::before {
+	bottom: 100%;
+	left: 50%;
+	transform: translateX(-50%) translateY(0);
+	border-color: var(--tooltip-bg-color) transparent transparent transparent;
+}
+
+/* Bottom */
+.dol-tooltip.--tooltip-bottom:hover::after{
+	transform: translateX(-50%) translateY(0);
+}
+.dol-tooltip.--tooltip-bottom::after {
+	top: calc(100% + 0.5rem);
+	left: 50%;
+	bottom: auto;
+	transform: translateX(-50%) translateY(5px);
+}
+
+.dol-tooltip.--tooltip-bottom::before {
+	top: 100%;
+	left: 50%;
+	bottom: auto;
+	transform: translateX(-50%) translateY(calc(var(--arrow-size) / -2 ));
+	border-color: transparent transparent var(--tooltip-bg-color) transparent;
+}
+
+/* Left */
+.dol-tooltip.--tooltip-left:hover::after{
+	transform: translateX(calc(var(--arrow-size) / -2 )) translateY(-50%);
+}
+.dol-tooltip.--tooltip-left::after {
+	right: calc(100% + 0.5rem);
+	left: auto;
+	top: 50%;
+	transform: translateX(calc(-5px  - (var(--arrow-size) / 2 ))) translateY(-50%);
+}
+
+.dol-tooltip.--tooltip-left::before {
+	right: 100%;
+	left: auto;
+	top: 50%;
+	transform: translateX(0) translateY(-50%);
+	border-color: transparent transparent transparent var(--tooltip-bg-color);
+}
+
+/* Right */
+
+.dol-tooltip.--tooltip-right:hover::after{
+	transform: translateX(calc(var(--arrow-size) / 2 )) translateY(-50%);
+}
+.dol-tooltip.--tooltip-right::after {
+	left: calc(100% + 0.5rem);
+	right: auto;
+	top: 50%;
+	transform: translateX(calc(5px + (var(--arrow-size) / 2 ))) translateY(-50%);
+}
+
+.dol-tooltip.--tooltip-right::before {
+	left: 100%;
+	right: auto;
+	top: 50%;
+	transform: translateX(0) translateY(-50%);
+	border-color: transparent var(--tooltip-bg-color) transparent transparent;
+}

--- a/htdocs/theme/md/style.css.php
+++ b/htdocs/theme/md/style.css.php
@@ -9291,3 +9291,13 @@ if (is_object($db)) {
 div.flot-text .flot-tick-label .tickLabel, .fa-color-unset {
 	color: unset;
 }
+
+
+.noselect {
+	-webkit-touch-callout: none; /* iOS Safari */
+	-webkit-user-select: none; /* Safari */
+	-khtml-user-select: none; /* Konqueror HTML */
+	-moz-user-select: none; /* Old versions of Firefox */
+	-ms-user-select: none; /* Internet Explorer/Edge */
+	user-select: none; /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
+}

--- a/htdocs/theme/md/tooltips.inc.css
+++ b/htdocs/theme/md/tooltips.inc.css
@@ -17,3 +17,249 @@ div.ui-tooltip.mytooltip-hover-tooltip {
 	line-height: 1.6em;
 	max-width: 550px;
 }
+
+:root{
+	--tooltip-txt-color: #1f2937;
+	--tooltip-bg-color:  #ffffff;
+	--tooltip-border-color: #d1d5db;
+
+	--tooltip-txt-color-dark-theme: #f9fafb;
+	--tooltip-bg-color-dark-theme: #1f2937;
+	--tooltip-border-color-dark-theme: #374151;
+}
+
+/* ********************** */
+/* JQUERY TOOLTIPS  THEME */
+/* ********************** */
+
+/** Style tooltip Jquery */
+div.ui-tooltip.jquery-tooltip {
+	padding: 0.5rem 0.75rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.5;
+	font-family: InterVariable, system-ui, sans-serif;
+
+	/* Same as light theme */
+	color: var(--tooltip-txt-color);
+	background-color:  var(--tooltip-bg-color);
+	border: 1px solid var(--tooltip-border-color);
+
+	/*backdrop-filter: blur(3px); */ /* useless if background as no opacity under 1 value */
+
+	border-radius: 0.375rem;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	pointer-events: none;
+}
+
+
+div.ui-tooltip.jquery-tooltip.--dark-mode {
+	color: var(--tooltip-txt-color-dark-theme) !important;
+	background-color:  var(--tooltip-bg-color-dark-theme) !important;
+	border: 1px solid var(--tooltip-border-color-dark-theme);
+}
+
+div.ui-tooltip.jquery-tooltip.--light-mode {
+	color: var(--tooltip-txt-color) !important;
+	background-color:  var(--tooltip-bg-color) !important;
+	border: 1px solid var(--tooltip-border-color);
+}
+
+
+
+/* ************************ */
+/* Native CSS Only tooltips */
+/* ************************ */
+
+.dol-tooltip {
+	--arrow-size: 6px;
+	position: relative;
+}
+
+.dol-tooltip.--dark-mode {
+	--tooltip-txt-color: var(--tooltip-txt-color-dark-theme);
+	--tooltip-bg-color:  var(--tooltip-bg-color-dark-theme);
+	--tooltip-border-color: var(--tooltip-border-color-dark-theme);
+}
+
+.dol-tooltip.--light-mode {
+	--tooltip-txt-color: #1f2937;
+	--tooltip-bg-color:  #ffffff;
+	--tooltip-border-color: #d1d5db;
+}
+
+
+/* Base tooltip */
+.dol-tooltip::after {
+	content: attr(data-title);
+	position: absolute;
+	left: 50%;
+	bottom: calc(100% + 0.5rem);
+	transform: translateX(-50%) translateY(-5px);
+	opacity: 0;
+	visibility: hidden;
+	min-height: 1.5em;
+	white-space: nowrap;
+	z-index: 1000;
+	transition: opacity 120ms ease, transform 120ms ease;
+
+	padding: 0.5rem 0.75rem;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1.5;
+	font-family: InterVariable, system-ui, sans-serif;
+
+	color: var(--tooltip-txt-color) !important;
+	background-color: var(--tooltip-bg-color) !important;
+	border: 1px solid var(--tooltip-border-color);
+
+	border-radius: 0.375rem;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	pointer-events: none;
+
+	text-transform: none;
+	text-align: left;
+
+}
+
+
+/* Arrow */
+.dol-tooltip::before {
+	z-index: 1;
+	content: "";
+	position: absolute;
+	left: 50%;
+	bottom: calc(100%) ;
+	transform: translateX(-50%) translateY(0px);
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 300ms ease, transform 300ms ease;
+	filter: drop-shadow(0 2px 3px rgba(0,0,0,0.3));
+
+	border-width: var(--arrow-size);
+	border-style: solid;
+	border-color: var(--tooltip-bg-color) transparent transparent transparent;
+	pointer-events: none;
+}
+
+
+/* Define delay */
+.dol-tooltip::after,
+.dol-tooltip::before {
+	transition-delay: 120ms; /* delay before visible */
+}
+
+.dol-tooltip:not(:hover)::after,
+.dol-tooltip:not(:hover)::before {
+	transition-delay: 0ms; /* instant off */
+}
+
+
+/* Display */
+.dol-tooltip:hover::after,
+.dol-tooltip:hover::before,
+.dol-tooltip:focus-visible::after,
+.dol-tooltip:focus-visible::before {
+	opacity: 1;
+	visibility: visible;
+}
+
+.dol-tooltip:hover::after,
+.dol-tooltip:focus-visible::after {
+	transform: translateX(-50%) translateY(calc(var(--arrow-size) / -2 ));
+}
+
+.dol-tooltip:hover::before,
+.dol-tooltip:focus-visible::before {
+	transform: translateX(-50%) translateY(0px);
+}
+
+/* Fallback aria-label if no data-title */
+.dol-tooltip:not([data-title])::after {
+	content: attr(aria-label);
+}
+
+/* RTL support */
+body[dir="rtl"] .dol-tooltip::after {
+	direction: rtl;
+	text-align: right;
+}
+
+/* ------------------ */
+/* Direction modifiers */
+/* ------------------ */
+
+/* Top (default already set) */
+.dol-tooltip.--tooltip-top:hover::after{
+	transform: translateX(-50%) translateY(calc(var(--arrow-size) / -2 ));
+}
+.dol-tooltip.--tooltip-top::after {
+	bottom: calc(100% + 0.5rem);
+	left: 50%;
+	transform: translateX(-50%) translateY(0);
+}
+
+.dol-tooltip.--tooltip-top::before {
+	bottom: 100%;
+	left: 50%;
+	transform: translateX(-50%) translateY(0);
+	border-color: var(--tooltip-bg-color) transparent transparent transparent;
+}
+
+/* Bottom */
+.dol-tooltip.--tooltip-bottom:hover::after{
+	transform: translateX(-50%) translateY(0);
+}
+.dol-tooltip.--tooltip-bottom::after {
+	top: calc(100% + 0.5rem);
+	left: 50%;
+	bottom: auto;
+	transform: translateX(-50%) translateY(5px);
+}
+
+.dol-tooltip.--tooltip-bottom::before {
+	top: 100%;
+	left: 50%;
+	bottom: auto;
+	transform: translateX(-50%) translateY(calc(var(--arrow-size) / -2 ));
+	border-color: transparent transparent var(--tooltip-bg-color) transparent;
+}
+
+/* Left */
+.dol-tooltip.--tooltip-left:hover::after{
+	transform: translateX(calc(var(--arrow-size) / -2 )) translateY(-50%);
+}
+.dol-tooltip.--tooltip-left::after {
+	right: calc(100% + 0.5rem);
+	left: auto;
+	top: 50%;
+	transform: translateX(calc(-5px  - (var(--arrow-size) / 2 ))) translateY(-50%);
+}
+
+.dol-tooltip.--tooltip-left::before {
+	right: 100%;
+	left: auto;
+	top: 50%;
+	transform: translateX(0) translateY(-50%);
+	border-color: transparent transparent transparent var(--tooltip-bg-color);
+}
+
+/* Right */
+
+.dol-tooltip.--tooltip-right:hover::after{
+	transform: translateX(calc(var(--arrow-size) / 2 )) translateY(-50%);
+}
+.dol-tooltip.--tooltip-right::after {
+	left: calc(100% + 0.5rem);
+	right: auto;
+	top: 50%;
+	transform: translateX(calc(5px + (var(--arrow-size) / 2 ))) translateY(-50%);
+}
+
+.dol-tooltip.--tooltip-right::before {
+	left: 100%;
+	right: auto;
+	top: 50%;
+	transform: translateX(0) translateY(-50%);
+	border-color: transparent var(--tooltip-bg-color) transparent transparent;
+}


### PR DESCRIPTION
# UI/UX: Add tooltip documentation and CSS alternatives for specific cases in a full JavaScript interface context

Also add a `.noselect` class

This is required for the QuickMemo module.
Once this PR is validated, PR #37422 will be updated to use these tooltip elements and associated CSS instead of the current QuickMemo-specific implementation.