### PR TITLE
NEW - concat supplier order ref/date in mass invoice line descriptions

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -459,6 +459,10 @@ if (empty($reshook)) {
 
 					for ($i = 0; $i < $num; $i++) {
 						$desc = ($lines[$i]->desc ? $lines[$i]->desc : $lines[$i]->libelle);
+						// If we build one invoice for several supplier orders, append the source order reference on the invoice line.
+						if (!empty($createbills_onebythird)) {
+							$desc = dol_concatdesc($desc, $langs->trans("SupplierOrder").' '.$cmd->ref.' - '.dol_print_date($cmd->date, 'day'));
+						}
 						if ($lines[$i]->subprice < 0) {
 							require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
 


### PR DESCRIPTION
# NEW - concat supplier order ref/date in mass invoice line descriptions

Mirror the customer mass-invoicing behavior on supplier orders by appending the source supplier order reference and date to generated invoice line descriptions when grouping multiple orders into one invoice.


