### PR TITLE
FIX: preselected best supplier price should consider discount

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4484,7 +4484,7 @@ class Form
 		if (!getDolGlobalString('PRODUCT_BEST_SUPPLIER_PRICE_PRESELECTED')) {
 			$sql .= " ORDER BY s.nom, pfp.ref_fourn DESC";
 		} else {
-			$sql .= " ORDER BY pfp.unitprice ASC";
+			$sql .= " ORDER BY pfp.unitprice - pfp.unitprice * pfp.remise_percent / 100 ASC";
 		}
 
 		dol_syslog(get_class($this) . "::select_product_fourn_price", LOG_DEBUG);


### PR DESCRIPTION
# FIX: preselected best supplier price should consider discount
If PRODUCT_BEST_SUPPLIER_PRICE_PRESELECTED const is set, we might get the wrong best price if a discounted purchase beats another one that was better without discount 

<img width="1346" height="195" alt="image" src="https://github.com/user-attachments/assets/f2cf05fc-84ea-43c7-8d99-ca4693d1401b" />

This complements #32324 
