### PR TITLE
Fix/extrafield visibility on doc

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1782,8 +1782,14 @@ abstract class CommonDocGenerator
 					$enabled = (int) dol_eval((string) $extrafields->attributes[$object->table_element]['enabled'][$key], 1, 1, '2');
 				}
 
+				if (!$enabled) {
+					continue;
+				}
+
+				// Reset enabled: only printable attribute determines PDF visibility
+				$enabled = 0;
 				$disableOnEmpty = 0;
-				if ($enabled && !empty($extrafields->attributes[$object->table_element]['printable'][$key])) {
+				if (!empty($extrafields->attributes[$object->table_element]['printable'][$key])) {
 					$printable = intval($extrafields->attributes[$object->table_element]['printable'][$key]);
 					if (in_array($printable, $params['printableEnable']) || in_array($printable, $params['printableEnableNotEmpty'])) {
 						$enabled = 1;

--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -1738,7 +1738,7 @@ function get_left_menu_accountancy($mainmenu, &$newmenu, $usemenuhider = 1, $lef
 			//$newmenu->add("/accountancy/index.php?leftmenu=accountancy", $langs->trans("MenuAccountancy"), 0, $permtoshowmenu, '', $mainmenu, 'accountancy');
 
 			// Configuration
-			$newmenu->add("/accountancy/index.php?leftmenu=accountancy_admin", $langs->trans("Setup"), 0, $user->hasRight('accounting', 'chartofaccount'), '', $mainmenu, 'accountancy_admin', 1, '', '', '', img_picto('', 'technic', 'class="paddingright pictofixedwidth"'));
+			$newmenu->add("/accountancy/admin/index.php?mainmenu=accountancy&leftmenu=accountancy_admin", $langs->trans("Setup"), 0, $user->hasRight('accounting', 'chartofaccount'), '', $mainmenu, 'accountancy_admin', 1, '', '', '', img_picto('', 'technic', 'class="paddingright pictofixedwidth"'));
 			if ($usemenuhider || empty($leftmenu) || preg_match('/accountancy_admin/', $leftmenu)) {
 				global $mysoc;
 				$newmenu->add("/accountancy/admin/index.php?mainmenu=accountancy&leftmenu=accountancy_admin", $langs->trans("General"), 1, $user->hasRight('accounting', 'chartofaccount'), '', $mainmenu, 'accountancy_admin_general', 10);


### PR DESCRIPTION
# FIX|Fix #
Avant le dernier  commit 22.0.4  :                                                                                                                         
  1. $enabled n'était pas initialisé à 0 avant                                                                                              
  2. La condition printable était vérifiée indépendamment                                                                                   
                                                                                                                                            
  Après le commit (code actuel) :                                                                                                           
  1. $enabled est initialisé à 0 (ligne 1780)
  2. Il est évalué via dol_eval sur le champ enabled (ligne 1781-1783)                                                                      
  3. MAIS à la ligne 1786, la condition if ($enabled && ...) empêche d'entrer dans le bloc printable quand enabled vaut 0
                                                                                                                                            
  Le problème est subtil : la logique est inversée. La propriété enabled d'un extrafield contrôle sa visibilité générale (souvent 1 par     
  défaut). La propriété printable contrôle spécifiquement la visibilité sur les PDF.                                                        
                                                                                                                                            
  Le vrai bug est que quand enabled = 1 (extrafield activé) ET printable = 0 (pas visible sur PDF), le code entre dans le if ($enabled &&   
  ...) à ligne 1786, mais comme printable est 0, !empty(...) est faux, donc on ne rentre pas dans le bloc... et $enabled reste à 1. Donc
  l'extrafield s'affiche quand même.                                                                                                        
                                                                
  Avant le commit, quand on ne rentrait pas dans le bloc printable, $enabled restait à sa valeur par défaut (non définie/false), et le      
  continue à ligne 1797 l'excluait.
                                                                                                                                            
  Maintenant, $enabled est mis à 1 par le dol_eval en ligne 1782 et n'est jamais remis à 0 si printable vaut 0.                             
   
  Le fix : quand enabled est vrai mais printable ne correspond pas, il faut remettre $enabled = 0.           