### PR TITLE
Fix: Button to hide paid supplier orders in project overview not work

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -12,6 +12,7 @@
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Günter Lukas			<github@gl.co.at>
  * Copyright (C) 2026		Joachim Kueter       <git-jk@bloxera.com>
+ * Copyright (C) 2026  		Ferran Marcet           <fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1463,6 +1464,8 @@ foreach ($listofreferent as $key => $value) {
 
 				if ($key == "order_supplier" && ($element->status == 6 || $element->status == 7)) {
 					print '<tr class="oddeven tr_canceled">';
+				} else if ($key == "order_supplier" && ($element->billed)) {
+					print '<tr class="oddeven tr_paid">';
 				} else {
 					print '<tr class="oddeven" >';
 				}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1464,7 +1464,7 @@ foreach ($listofreferent as $key => $value) {
 
 				if ($key == "order_supplier" && ($element->status == 6 || $element->status == 7)) {
 					print '<tr class="oddeven tr_canceled">';
-				} else if ($key == "order_supplier" && ($element->billed)) {
+				} elseif ($key == "order_supplier" && ($element->billed)) {
 					print '<tr class="oddeven tr_paid">';
 				} else {
 					print '<tr class="oddeven" >';


### PR DESCRIPTION
The button to hide paid supplier orders in the project overview is not working