### PR TITLE
fix Fatal error:  Uncaught Error: Call to a member function formSelec…

### DIFF
--- a/htdocs/commande/list_det.php
+++ b/htdocs/commande/list_det.php
@@ -1897,6 +1897,10 @@ if ($resql) {
 			if ($obj->warehouse > 0) {
 				print img_picto('', 'stock', 'class="paddingrightonly"');
 			}
+			if (!is_object($formproduct)) {
+				require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
+				$formproduct = new FormProduct($db);
+			}
 			$formproduct->formSelectWarehouses($_SERVER['PHP_SELF'], $obj->warehouse, 'none');
 			print "</td>\n";
 			if (!$i) {


### PR DESCRIPTION
# Instructions
FIX for a fatal error resolved by this PR :  [https://github.com/Dolibarr/dolibarr/pull/37547](url)

This time, instead of refactoring, I am applying a more targeted fix. A fatal error can indeed occur in list_det.php under specific conditions.

If the WAREHOUSE_ASK_WAREHOUSE_DURING_ORDER configuration is disabled and the "Warehouse" column is displayed, the list crashes with a fatal error.



