### PR TITLE
FIX | Fix wrong date displayed in linked objects block for shipments

### DIFF
--- a/htdocs/expedition/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/expedition/tpl/linkedobjectblock.tpl.php
@@ -50,7 +50,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 		<td><?php echo $langs->trans("Shipment"); ?></td>
 		<td class="tdoverflowmax125"><?php echo $objectlink->getNomUrl(1); ?></td>
 		<td class="tdoverflowmax125" title="<?php dolPrintHTMLForAttribute($objectlink->ref_customer); ?>"><?php echo dolPrintHTML($objectlink->ref_customer); ?></td>
-		<td class="center"><?php echo dol_print_date($objectlink->date_delivery ? $objectlink->date_delivery : $objectlink->date_creation, 'day'); ?></td>
+		<td class="center"><?php echo dol_print_date($objectlink->date_creation, 'day'); ?></td>
 		<td class="right"><?php
 		if ($user->hasRight('expedition', 'lire')) {
 			$total += $objectlink->total_ht;


### PR DESCRIPTION
# FIX | Fix wrong date displayed in linked objects block for shipments

In `expedition/tpl/linkedobjectblock.tpl.php`, the date column in the "Related Objects" 
table was displaying `date_delivery` (the estimated/planned delivery date) instead of 
the actual shipment date.

- `date_delivery` is the **planned** delivery date, which is misleading in the linked objects block
- `date_expedition` is always `NULL` in practice, so it cannot be used as a reliable fallback
- `date_creation` represents the date the shipment was actually created, 
which is the most accurate and reliable core field available

Before:
```php
dol_print_date($objectlink->date_delivery ? $objectlink->date_delivery : $objectlink->date_creation, 'day')
```

After:
```php
dol_print_date($objectlink->date_creation, 'day')
```

<img width="537" height="242" alt="image" src="https://github.com/user-attachments/assets/af96db79-e799-42c1-8fa8-b1a2653c72c7" />

<img width="893" height="153" alt="image" src="https://github.com/user-attachments/assets/6df3de53-d281-4388-93b0-fb754be7f1f1" />
