### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -1,6 +1,8 @@
 name: "CI-PUSH"
 
 on: [push]
+permissions:
+  contents: read
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Potential fix for [https://github.com/Dolibarr/dolibarr/security/code-scanning/1](https://github.com/Dolibarr/dolibarr/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions:` block to limit the `GITHUB_TOKEN` to the minimal access needed. Since this workflow only orchestrates reusable workflows and doesn’t itself perform any write operations, a safe default is `contents: read` at the workflow root. This applies to all jobs that don’t override permissions and documents that the workflow expects only read access.

The best minimal-change fix is to add a root-level `permissions:` section right after the `name:` (or after `on:`; either is fine). We’ll set `contents: read` as a conservative baseline, which is equivalent to the “read-only” default. We won’t modify any jobs individually, because there’s no evidence in the provided snippet that they need write permissions, and the reusable workflows they `uses:` may still declare their own `permissions` if necessary.

Concretely, in `.github/workflows/ci-on-push.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `on: [push]` and `jobs:` (or equivalently between `name:` and `on:`; I’ll place it after `on:` to keep triggers grouped together). No imports or additional code constructs are needed; this is a pure YAML configuration change inside the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
