### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -2,6 +2,9 @@ name: "CI-PUSH"
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     uses: ./.github/workflows/pre-commit.yml


### PR DESCRIPTION
Potential fix for [https://github.com/Dolibarr/dolibarr/security/code-scanning/2](https://github.com/Dolibarr/dolibarr/security/code-scanning/2)

In general, this should be fixed by adding an explicit `permissions:` block that grants the least privileges required by this workflow and the reusable workflows it calls. For CI tasks that only read repository content and do not push commits, releases, or other write operations, `contents: read` is typically sufficient and is the recommended minimal baseline.

In this specific file, the simplest and safest fix without changing existing functionality is to add a top-level `permissions:` block after the `on:` declaration. This root-level block will apply to all jobs in this workflow (unless a job or called reusable workflow explicitly overrides permissions). Given the names and nature of the jobs (`pre-commit`, `phan`, `phpstan`, `windows-ci`), they are classic read-only CI checks, so `contents: read` is an appropriate minimal setting. No other files or imports are involved, and no job definitions need to be altered.

Concretely, in `.github/workflows/ci-on-push.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on: [push]` line and the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
