### PR TITLE
Fix: Not showing documents on webportal

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -12,6 +12,7 @@
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Günter Lukas			<github@gl.co.at>
  * Copyright (C) 2026		Joachim Kueter       <git-jk@bloxera.com>
+ * Copyright (C) 2026  		Ferran Marcet           <fmarcet@2byte.es>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1463,6 +1464,8 @@ foreach ($listofreferent as $key => $value) {
 
 				if ($key == "order_supplier" && ($element->status == 6 || $element->status == 7)) {
 					print '<tr class="oddeven tr_canceled">';
+				} else if ($key == "order_supplier" && ($element->billed)) {
+					print '<tr class="oddeven tr_paid">';
 				} else {
 					print '<tr class="oddeven" >';
 				}

--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1464,7 +1464,7 @@ foreach ($listofreferent as $key => $value) {
 
 				if ($key == "order_supplier" && ($element->status == 6 || $element->status == 7)) {
 					print '<tr class="oddeven tr_canceled">';
-				} else if ($key == "order_supplier" && ($element->billed)) {
+				} elseif ($key == "order_supplier" && ($element->billed)) {
 					print '<tr class="oddeven tr_paid">';
 				} else {
 					print '<tr class="oddeven" >';

--- a/htdocs/webportal/controllers/documentlist.controller.class.php
+++ b/htdocs/webportal/controllers/documentlist.controller.class.php
@@ -95,7 +95,7 @@ class DocumentListController extends AbstractDocumentController
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
 			$client_dir_name = dol_sanitizeFileName($thirdparty->id);
 			$dir_ged_tiers = $conf->societe->multidir_output[$thirdparty->entity ?? $conf->entity]."/".$client_dir_name;
-			$fileList = dol_dir_list($dir_ged_tiers, 'files', 0, '', '', 'date', SORT_DESC,1);
+			$fileList = dol_dir_list($dir_ged_tiers, 'files', 0, '', '', 'date', SORT_DESC, 1);
 
 			// 2. Define the link builder function
 			/**

--- a/htdocs/webportal/controllers/documentlist.controller.class.php
+++ b/htdocs/webportal/controllers/documentlist.controller.class.php
@@ -93,7 +93,7 @@ class DocumentListController extends AbstractDocumentController
 		if (!empty($thirdparty) && $thirdparty->id) {
 			// 1. Prepare data
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
-			$client_dir_name = dol_sanitizeFileName($thirdparty->id);
+			$client_dir_name = $thirdparty->id;
 			$dir_ged_tiers = $conf->societe->multidir_output[$thirdparty->entity ?? $conf->entity]."/".$client_dir_name;
 			$fileList = dol_dir_list($dir_ged_tiers, 'files', 0, '', '', 'date', SORT_DESC, 1);
 

--- a/htdocs/webportal/controllers/documentlist.controller.class.php
+++ b/htdocs/webportal/controllers/documentlist.controller.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Schaffhauser sébastien		<sebastien@webmaster67.fr>
+ * Copyright (C) 2026		Ferran Marcet				<fmarcet@2byte.es>
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3 of the License, or
@@ -19,6 +20,7 @@
 
 
 require_once __DIR__ . '/abstractdocument.controller.class.php';
+include_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 
 /**
  * \file        htdocs/webportal/controllers/documentlist.controller.class.php
@@ -91,9 +93,9 @@ class DocumentListController extends AbstractDocumentController
 		if (!empty($thirdparty) && $thirdparty->id) {
 			// 1. Prepare data
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
-			$client_dir_name = dol_sanitizeFileName($thirdparty->ref);
-			$dir_ged_tiers = $conf->societe->dir_output . '/' . $client_dir_name;
-			$fileList = dol_dir_list($dir_ged_tiers, 'files', 0, '', '', 'date', SORT_DESC);
+			$client_dir_name = dol_sanitizeFileName($thirdparty->id);
+			$dir_ged_tiers = $conf->societe->multidir_output[$thirdparty->entity ?? $conf->entity]."/".$client_dir_name;
+			$fileList = dol_dir_list($dir_ged_tiers, 'files', 0, '', '', 'date', SORT_DESC,1);
 
 			// 2. Define the link builder function
 			/**


### PR DESCRIPTION
The attempt was to upload documents from a folder with the third party's name, instead of the id which is the nomenclature used.