### PR TITLE
fix: add null check before setting _renderItem on jQuery UI autocomplete widget

### DIFF
--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -924,12 +924,15 @@ function confirmConstantAction(action, url, code, input, box, entity, yesButton,
 				})
 				.addClass( "ui-widget ui-widget-content ui-corner-left dolibarrcombobox" );
 
-			input.data("ui-autocomplete")._renderItem = function( ul, item ) {
-				return $("<li>")
-					.data( "ui-autocomplete-item", item ) // jQuery UI > 1.10.0
-					.append( "<a>" + item.label + "</a>" )
-					.appendTo( ul );
-			};
+			var widgetInstance = input.data("ui-autocomplete");
+			if (widgetInstance) {
+				widgetInstance._renderItem = function( ul, item ) {
+					return $("<li>")
+						.data( "ui-autocomplete-item", item ) // jQuery UI > 1.10.0
+						.append( "<a>" + item.label + "</a>" )
+						.appendTo( ul );
+				};
+			}
 
 			this.button = $( "<button type=\'button\'>&nbsp;</button>" )
 				.attr( "tabIndex", -1 )

--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -924,7 +924,7 @@ function confirmConstantAction(action, url, code, input, box, entity, yesButton,
 				})
 				.addClass( "ui-widget ui-widget-content ui-corner-left dolibarrcombobox" );
 
-			var widgetInstance = input.data("ui-autocomplete");
+			const widgetInstance = input.data("ui-autocomplete");
 			if (widgetInstance) {
 				widgetInstance._renderItem = function( ul, item ) {
 					return $("<li>")

--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -278,12 +278,16 @@ function ajax_autocompleter($selected, $htmlname, $url, $urloption = '', $minLen
     						$("#search_'.$htmlnamejquery.'").trigger("change");	// We have changed value of the combo select, we must be sure to trigger all js hook binded on this event. This is required to trigger other javascript change method binded on original field by other code.
     					}
     					,delay: 500
-					}).data("'.$dataforrenderITem.'")._renderItem = function( ul, item ) {
-						return $("<li>")
-						.data( "'.$dataforitem.'", item ) // jQuery UI > 1.10.0
-						.append( \'<a><span class="tag">\' + item.label + "</span></a>" )
-						.appendTo(ul);
-					};
+					});
+					var widgetData = $("input#search_'.$htmlnamejquery.'").data("'.$dataforrenderITem.'");
+					if (widgetData) {
+						widgetData._renderItem = function( ul, item ) {
+							return $("<li>")
+							.data( "'.$dataforitem.'", item ) // jQuery UI > 1.10.0
+							.append( \'<a><span class="tag">\' + item.label + "</span></a>" )
+							.appendTo(ul);
+						};
+					}
 
   				});';
 	$script .= '</script>';

--- a/htdocs/core/lib/ajax.lib.php
+++ b/htdocs/core/lib/ajax.lib.php
@@ -279,7 +279,7 @@ function ajax_autocompleter($selected, $htmlname, $url, $urloption = '', $minLen
     					}
     					,delay: 500
 					});
-					var widgetData = $("input#search_'.$htmlnamejquery.'").data("'.$dataforrenderITem.'");
+					const widgetData = $("input#search_'.$htmlnamejquery.'").data("'.$dataforrenderITem.'");
 					if (widgetData) {
 						widgetData._renderItem = function( ul, item ) {
 							return $("<li>")


### PR DESCRIPTION
# FIX - Add null check before setting _renderItem on jQuery UI autocomplete widget

TypeError: Cannot set properties of undefined (setting '_renderItem') was occurring on /ticket/card.php (and potentially any page using Dolibarr's autocomplete or combobox).                                        
                                                            
The code was chaining .data("ui-autocomplete")._renderItem = ... right after widget init. If init fails (missing DOM element, JS conflict, race condition), .data() returns undefined → crash.                                    
                                                                                                                                                                                                                                                                                
Fix: store .data() result in a variable and check it exists before accessing _renderItem. No functional change when the widget initializes correctly.                                                                             



