### PR TITLE
FIX intervention API line delete

### DIFF
--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -606,7 +606,7 @@ class Interventions extends DolibarrApi
 
 		$updateRes = $objectline->deleteLine(DolibarrApiAccess::$user);
 
-		if ($updateRes > 0) {
+		if ($updateRes >= 0) {
 			return $this->_cleanObjectDatas($this->fichinter);
 		} else {
 			throw new RestException(405, $this->fichinter->error);


### PR DESCRIPTION
# FIX intervention API line delete
API was always throwing a 405 error even when line was correctly deleted. Underlying method returns 0 when line is deleted.

