### PR TITLE
FIX intervention API update line

### DIFF
--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -789,7 +789,7 @@ class Interventions extends DolibarrApi
 	 * @param	array $request_data   InternventionalLine data
 	 * @phan-param ?array<string,string> $request_data
 	 * @phpstan-param ?array<string,string> $request_data
-	 * @return	Object|false		  Object with cleaned properties
+	 * @return	Object		  Object with cleaned properties
 	 *
 	 * @throws RestException
 	 *

--- a/htdocs/fichinter/class/api_interventions.class.php
+++ b/htdocs/fichinter/class/api_interventions.class.php
@@ -823,10 +823,16 @@ class Interventions extends DolibarrApi
 
 		$updateRes = $objectline->update(DolibarrApiAccess::$user);
 
-		if ($updateRes > 0) {
-			return $this->_cleanObjectDatas($this->fichinter);
+		if ($updateRes >= 0) {
+			$result = $this->fichinter->fetch($id);
+			if ($result > 0) {
+				return $this->_cleanObjectDatas($this->fichinter);
+			} else {
+				throw new RestException(500, $this->fichinter->error);
+			}
+		} else {
+			throw new RestException(500, $objectline->error);
 		}
-		return false;
 	}
 
 


### PR DESCRIPTION
# FIX intervention API update line
Update line method could return false even if line had been correctly updated. Underlying line update method can return 0 or more.

