### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ See the [ChangeLog](https://github.com/Dolibarr/dolibarr/blob/develop/ChangeLog)
 - MariaDB, MySQL or PostgreSQL
 - Compatible with all Cloud solutions that match PHP & MySQL or PostgreSQL prerequisites.
 
-See exact requirements on the [Wiki](https://wiki.dolibarr.org/index.php/Prerequisite)
+See exact requirements on the [Wiki](https://wiki.dolibarr.org/index.php/Prerequisites)
 
 ### Extending
 


### PR DESCRIPTION
# QUAL|Qual Fix broken link to prerequisites in README.md

Fix a missing `s` at the end of the prerequisites URL in the
**System Environment / Requirements** section of README.md.
The link was pointing to an empty page instead of the correct
documentation page.
