### PR TITLE
Fix line ordering during situation or replacement invoice creation

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1179,6 +1179,9 @@ class Facture extends CommonInvoice
 		// Source invoice load
 		$facture = new Facture($this->db);
 
+		// Avoid updating the row ranks
+		$facture->context['createfromclone'] = 1;
+
 		// Retrieve all extrafield
 		// fetch optionals attributes and labels
 		$this->fetch_optionals();


### PR DESCRIPTION
Description
This Pull Request fixes a recurring issue where the line order (rank) is not preserved when generating a new invoice via the createFromCurrent method (mainly used for situation and replacement invoices).

Identified Issue
In the `createFromCurrent` method, lines from the source invoice are copied to the new invoice with their original ranks. However, during the` $facture->create()` call, the Core `addline() `method detects a rank "collision" because it is unaware that it is operating within a mass duplication context.

This triggers an automatic rank recalculation (updateRangOfLine) that shifts lines inconsistently. As a result, certain lines (such as free text lines) can end up at the top of the invoice instead of maintaining their original position.

Proposed Solution
Set `$facture->context['createfromclone'] = 1`; before calling the creation method.

Why this solution?

- **Core Standard:** The createfromclone flag is the standard mechanism used by Dolibarr in other objects (Orders, Proposals) to signal addline() that it should not attempt to automatically reorder ranks.

- **Safety:** This neutralizes the conflicting code block in addline() specifically for this operation, ensuring that the ranks defined in createFromCurrent are inserted exactly as intended into the database.

- Non-intrusive: This modification does not change any function signatures and has no impact on third-party modules.