### PR TITLE
FIX: Timezone offset issue in agenda module causing 1-hour time shift

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -565,7 +565,8 @@ $viewmode .= '<span class="marginrightonly"></span>';	// To add a space before t
 $newparam = '';
 $newcardbutton = '';
 if ($user->hasRight('agenda', 'myactions', 'create') || $user->hasRight('agenda', 'allactions', 'create')) {
-	$tmpforcreatebutton = dol_getdate(dol_now('tzuserrel'), true);
+	// Force user timezone to get correct hour regardless of server timezone
+	$tmpforcreatebutton = dol_getdate(dol_now('gmt'), true, !empty($_SESSION['dol_tz_string']) ? $_SESSION['dol_tz_string'] : 'UTC');
 
 	$newparam .= '&month='.((int) $month).'&year='.((int) $tmpforcreatebutton['year']).'&mode='.urlencode($mode);
 

--- a/htdocs/comm/action/list.php
+++ b/htdocs/comm/action/list.php
@@ -751,7 +751,8 @@ $viewmode .= '</div>';
 
 $viewmode .= '<span class="marginrightonly"></span>';
 
-$tmpforcreatebutton = dol_getdate(dol_now('tzuserrel'), true);
+// Force user timezone to get correct hour regardless of server timezone
+$tmpforcreatebutton = dol_getdate(dol_now('gmt'), true, !empty($_SESSION['dol_tz_string']) ? $_SESSION['dol_tz_string'] : 'UTC');
 
 $newparam = '&month='.str_pad((string) $month, 2, "0", STR_PAD_LEFT).'&year='.$tmpforcreatebutton['year'];
 

--- a/htdocs/comm/action/pertype.php
+++ b/htdocs/comm/action/pertype.php
@@ -487,7 +487,8 @@ $viewmode .= '<span class="marginrightonly"></span>';
 $newparam = '';
 $newcardbutton = '';
 if ($user->hasRight('agenda', 'myactions', 'create') || $user->hasRight('agenda', 'allactions', 'create')) {
-	$tmpforcreatebutton = dol_getdate(dol_now('tzuserrel'), true);
+	// Force user timezone to get correct hour regardless of server timezone
+	$tmpforcreatebutton = dol_getdate(dol_now('gmt'), true, !empty($_SESSION['dol_tz_string']) ? $_SESSION['dol_tz_string'] : 'UTC');
 
 	$newparam .= '&month='.str_pad($month, 2, "0", STR_PAD_LEFT).'&year='.$tmpforcreatebutton['year'];
 

--- a/htdocs/comm/action/peruser.php
+++ b/htdocs/comm/action/peruser.php
@@ -513,7 +513,8 @@ $viewmode .= '<span class="marginrightonly"></span>';
 $newparam = '';
 $newcardbutton = '';
 if ($user->hasRight('agenda', 'myactions', 'create') || $user->hasRight('agenda', 'allactions', 'create')) {
-	$tmpforcreatebutton = dol_getdate(dol_now('tzuserrel'), true);
+	// Force user timezone to get correct hour regardless of server timezone
+	$tmpforcreatebutton = dol_getdate(dol_now('gmt'), true, !empty($_SESSION['dol_tz_string']) ? $_SESSION['dol_tz_string'] : 'UTC');
 
 	$newparam .= '&month='.urlencode(str_pad((string) $month, 2, "0", STR_PAD_LEFT)).'&year='.((int) $tmpforcreatebutton['year']);
 	if ($begin_h !== '') {


### PR DESCRIPTION
# Fix 
## 🐛 Bug Description

When creating a new event in the agenda module, the default time displayed in the form was shifted by 1 hour compared to the actual current time. This issue occurred when clicking the "+ Add Action" button from various agenda views (list, calendar, per user, per type).

**Example:** At 15:00, the form would display 16:00 as the default time.

## 🔍 Root Cause

The bug was caused by a **double timezone offset** being applied when generating the URL parameters for the "Add Action" button:

1. `dol_now('tzuserrel')` was returning a timestamp with the user's timezone offset already applied
2. `dol_getdate()` was then applying the server's timezone offset again
3. This resulted in the timezone offset being added twice to the `aphour` parameter in the URL

The issue was particularly visible on servers configured with a non-UTC timezone (e.g., Europe/Paris).

## ✅ Solution

The fix modifies the button generation code in all 4 agenda view files:

Changed from:
```php
$tmpforcreatebutton = dol_getdate(dol_now('tzuserrel'), true);
```

To:
```php
// Force user timezone to get correct hour regardless of server timezone
$tmpforcreatebutton = dol_getdate(dol_now('gmt'), true, !empty($_SESSION['dol_tz_string']) ? $_SESSION['dol_tz_string'] : 'UTC');
```

This ensures the timezone offset is applied only once by:
- Starting with a GMT timestamp (`dol_now('gmt')`)
- Explicitly passing the user's timezone to `dol_getdate()`

## 📝 Modified Files

- `htdocs/comm/action/index.php` - Fixed button generation in calendar view
- `htdocs/comm/action/list.php` - Fixed button generation in list view
- `htdocs/comm/action/peruser.php` - Fixed button generation in per-user view
- `htdocs/comm/action/pertype.php` - Fixed button generation in per-type view

## 🧪 Testing

### How to reproduce the bug (before fix):
1. Set your server timezone to Europe/Paris (or any non-UTC timezone)
2. Go to Agenda module → Click "+ Add Action"
3. Check the default time in the form → It will be shifted by 1 hour

### How to verify the fix:
1. Apply the patch
2. Clear PHP cache (restart Apache/PHP-FPM)
3. Clear browser cache
4. Go to Agenda module → Click "+ Add Action"
5. The default time should now match the current time

### Tested environments:
- ✅ Server with UTC timezone
- ✅ Server with Europe/Paris timezone
- ✅ Different user timezones (Europe/Paris, America/New_York, etc.)