### PR TITLE
Fix #37618 bad order on situation invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2210,7 +2210,7 @@ if (empty($reshook)) {
 				// Special properties of replacement invoice
 
 				$object->situation_counter += 1;
-
+				$object->context['createfromclone'] = 'createfromclone';
 				$id = $object->createFromCurrent($user);
 				if ($id <= 0) {
 					$mesg = $object->error;


### PR DESCRIPTION
# Fix #37618 

@see Facture->addline function 

`if (!isset($this->context['createfromclone'])) {
					if (!empty($fk_parent_line)) {
						// Always reorder if child line
						$this->line_order(true, 'DESC');
					} elseif ($ranktouse > 0 && $ranktouse <= count($this->lines)) {
						// Update all rank of all other lines starting from the same $ranktouse
						$linecount = count($this->lines);
						for ($ii = $ranktouse; $ii <= $linecount; $ii++) {
							$this->updateRangOfLine($this->lines[$ii - 1]->id, $ii + 1);
						}
					}

					$this->lines[] = $this->line;
				}`

Not tested, but I feel adding $this->context['createfromclone'] = 'createfromclone' when creating new situation is usefull too for facture extrafields 
@see insertExtraFields method of CommonObject 