### PR TITLE
FIX: do not print Extrafields in PDF if printable is 0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,7 +39,7 @@ FIX: 18.0: GETPOSTDATE and buildParamDate assumed HTTP param names 'minute' and 
 FIX: not remove value of others extra-fields on update extras action
 NEW: Automatically release docker image for each GitHub release
 FIX: getDolGlobalInt
-SEC: fix IDOR attack on employee evaluation. Missing permision test https://github.com/atm-florianm/dolibarr/commit/7ed0af2a138a34e7c7005b95c85ffc791976a6cf
+SEC: fix IDOR attack on employee evaluation. Missing permission test https://github.com/atm-florianm/dolibarr/commit/7ed0af2a138a34e7c7005b95c85ffc791976a6cf
 FIX: Implementation of multi-company compatibility with inventory/warehouse management
 FIX: 17.0: perweek.php resets task progress to 0% when: (#36401)
 FIX: DA027383: permissions not checked on HRM evaluation card (#36328) (#36399)
@@ -61,7 +61,7 @@ FIX: wrong check of hook return
 FIX: 16.0: extrafield of type link to category causes SQL error in selectForFormsList() (#36074)
 FIX: 16.0 (up to 19.0): extrafield of type link to category causes SQL error in selectForFormsList
 FIX: missing "printFieldListValue" hook (#35990)
-FIX: add action paramter
+FIX: add action parameter
 FIX: remove duplicate object
 FIX: expense report card: use correct bank module designator for detection
 FIX: wrong check of hook return

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1458,7 +1458,10 @@ abstract class CommonDocGenerator
 				}
 
 				$disableOnEmpty = 0;
-				$printable = intval($extrafields->attributes[$object->table_element]['printable'][$key]);
+				$printable = 0;
+				if (isset($extrafields->attributes[$object->table_element]['printable'][$key])) {
+					$printable = (int) $extrafields->attributes[$object->table_element]['printable'][$key];
+				}
 				if ($enabled && !empty($printable)) {
 					if (in_array($printable, $params['printableEnable']) || in_array($printable, $params['printableEnableNotEmpty'])) {
 						$enabled = 1;

--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1458,8 +1458,8 @@ abstract class CommonDocGenerator
 				}
 
 				$disableOnEmpty = 0;
-				if ($enabled && !empty($extrafields->attributes[$object->table_element]['printable'][$key])) {
-					$printable = intval($extrafields->attributes[$object->table_element]['printable'][$key]);
+				$printable = intval($extrafields->attributes[$object->table_element]['printable'][$key]);
+				if ($enabled && !empty($printable)) {
 					if (in_array($printable, $params['printableEnable']) || in_array($printable, $params['printableEnableNotEmpty'])) {
 						$enabled = 1;
 					}
@@ -1469,7 +1469,7 @@ abstract class CommonDocGenerator
 					}
 				}
 
-				if (empty($enabled)) {
+				if (empty($enabled) || empty($printable)) {
 					continue;
 				}
 

--- a/htdocs/core/lib/geturl.lib.php
+++ b/htdocs/core/lib/geturl.lib.php
@@ -30,7 +30,7 @@
  *
  * @param	string                      $url 			    URL to call.
  * @param	string                      $postorget		    'POST', 'GET', 'HEAD', 'PUT', 'PUTALREADYFORMATED', 'POSTALREADYFORMATED', 'DELETE'
- * @param	string|array<mixed,mixed>	$param			    Parameters of URL (x=value1&y=value2) or may be a formated content with $postorget='PUTALREADYFORMATED'
+ * @param	string|array<mixed,mixed>	$param			    Parameters of URL (x=value1&y=value2) or may be a formatted content with $postorget='PUTALREADYFORMATED'
  * @param	integer                     $followlocation		0=Do not follow, 1=Follow location.
  * @param	string[]                    $addheaders			Array of string to add into header. Example: ('Accept: application/xrds+xml', ....)
  * @param	string[]                    $allowedschemes		List of schemes that are allowed ('http' + 'https' only by default)


### PR DESCRIPTION
# Instructions
Since https://github.com/Dolibarr/dolibarr/pull/37442 even if an extrafield is not printable it is printed in all PDF

This bug exists in 19.0,20.0,21.0,22.0,23.0,

fix: #37544

[*Test case*]

Extrafields in Propal header and line setup
<img width="1628" height="438" alt="image" src="https://github.com/user-attachments/assets/59449b3b-bc21-46c3-9ede-68d64fa55c49" />

<img width="1644" height="403" alt="image" src="https://github.com/user-attachments/assets/86d69921-badf-4c91-96e6-670b5003b0ef" />

Sample Propal :
<img width="1690" height="735" alt="image" src="https://github.com/user-attachments/assets/55c8f85e-cc41-4efd-8150-d0fba90d93e9" />

[*Actual Result*]
<img width="1118" height="621" alt="image" src="https://github.com/user-attachments/assets/2b225f7e-1c3b-49d9-9df2-b46145ff60e0" />


[*With this PR*]
<img width="883" height="537" alt="image" src="https://github.com/user-attachments/assets/169831b1-fbf9-412e-a5ea-d391609eed23" />




