### PR TITLE
core: propagate order links to discount invoices

### DIFF
--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -4,8 +4,6 @@ on: [push]
 permissions:
   contents: read
 
-permissions:
-  contents: read
 
 jobs:
   pre-commit:

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4402,12 +4402,67 @@ abstract class CommonObject
 		$sql .= ", '" . $this->db->escape($targettype) . "'";
 		$sql .= ")";
 
-		dol_syslog(get_class($this) . "::add_object_linked", LOG_DEBUG);
-		if ($this->db->query($sql)) {
-			if (!$notrigger) {
-				// Call trigger
-				$this->context['link_origin'] = $origin;
-				$this->context['link_origin_id'] = $origin_id;
+			dol_syslog(get_class($this) . "::add_object_linked", LOG_DEBUG);
+			if ($this->db->query($sql)) {
+				// If we link a supplier order to a supplier invoice that already uses discounts coming from other supplier invoices
+				// (deposit invoice / credit note used as payment), also link those source invoices to the same supplier order.
+				// This helps keep "linked elements" consistent when totals are impacted by such discounts.
+				if ($origin === 'order_supplier' && $targettype === 'invoice_supplier' && $this->element === 'invoice_supplier' && (int) $origin_id > 0 && (int) $this->id > 0) {
+					$sourceinvoices = array();
+
+					$sqlsources = "SELECT DISTINCT rc.fk_invoice_supplier_source as rowid";
+					$sqlsources .= " FROM ".$this->db->prefix()."societe_remise_except as rc";
+					$sqlsources .= " WHERE rc.fk_invoice_supplier = ".((int) $this->id);
+					$sqlsources .= " AND rc.fk_invoice_supplier_source IS NOT NULL";
+
+					$resqlsources = $this->db->query($sqlsources);
+					if ($resqlsources) {
+						while ($objsrc = $this->db->fetch_object($resqlsources)) {
+							$srcid = (int) $objsrc->rowid;
+							if ($srcid > 0 && $srcid !== (int) $this->id) {
+								$sourceinvoices[$srcid] = $srcid;
+							}
+						}
+					} else {
+						dol_syslog(get_class($this)."::add_object_linked Failed to read supplier invoice discounts sources", LOG_WARNING);
+					}
+
+					if (!empty($sourceinvoices)) {
+						$existing = array();
+						$sourcelist = implode(',', $sourceinvoices);
+
+						$sqlexists = "SELECT fk_target";
+						$sqlexists .= " FROM ".$this->db->prefix()."element_element";
+						$sqlexists .= " WHERE fk_source = ".((int) $origin_id);
+						$sqlexists .= " AND sourcetype = '".$this->db->escape($origin)."'";
+						$sqlexists .= " AND targettype = '".$this->db->escape($targettype)."'";
+						$sqlexists .= " AND fk_target IN (".$this->db->sanitize($sourcelist).")";
+
+						$resqlexists = $this->db->query($sqlexists);
+						if ($resqlexists) {
+							while ($objexist = $this->db->fetch_object($resqlexists)) {
+								$existing[(int) $objexist->fk_target] = 1;
+							}
+						} else {
+							dol_syslog(get_class($this)."::add_object_linked Failed to read existing linked supplier invoices", LOG_WARNING);
+						}
+
+						foreach ($sourceinvoices as $srcid) {
+							if (!empty($existing[(int) $srcid])) {
+								continue;
+							}
+
+							$sqladd = "INSERT INTO " . $this->db->prefix() . "element_element (fk_source, sourcetype, fk_target, targettype)";
+							$sqladd .= " VALUES (".((int) $origin_id).", '".$this->db->escape($origin)."', ".((int) $srcid).", '".$this->db->escape($targettype)."')";
+							$this->db->query($sqladd); // Best-effort: do not fail original link action
+						}
+					}
+				}
+
+				if (!$notrigger) {
+					// Call trigger
+					$this->context['link_origin'] = $origin;
+					$this->context['link_origin_id'] = $origin_id;
 
 				$result = $this->call_trigger('OBJECT_LINK_INSERT', $f_user);	// Note: We should have used here a hook. Not a business event
 				if ($result < 0) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4402,69 +4402,69 @@ abstract class CommonObject
 		$sql .= ", '" . $this->db->escape($targettype) . "'";
 		$sql .= ")";
 
-			dol_syslog(get_class($this) . "::add_object_linked", LOG_DEBUG);
-			if ($this->db->query($sql)) {
-				// If we link a supplier order to a supplier invoice that already uses discounts coming from other supplier invoices
-				// (deposit invoice / credit note used as payment), also link those source invoices to the same supplier order.
-				// This helps keep "linked elements" consistent when totals are impacted by such discounts.
-				if ($origin === 'order_supplier' && $targettype === 'invoice_supplier' && $this->element === 'invoice_supplier' && (int) $origin_id > 0 && (int) $this->id > 0) {
-					$sourceinvoices = array();
+		dol_syslog(get_class($this) . "::add_object_linked", LOG_DEBUG);
+		if ($this->db->query($sql)) {
+			// If we link a supplier order to a supplier invoice that already uses discounts coming from other supplier invoices
+			// (deposit invoice / credit note used as payment), also link those source invoices to the same supplier order.
+			// This helps keep "linked elements" consistent when totals are impacted by such discounts.
+			if ($origin === 'order_supplier' && $targettype === 'invoice_supplier' && $this->element === 'invoice_supplier' && (int) $origin_id > 0 && (int) $this->id > 0) {
+				$sourceinvoices = array();
 
-					$sqlsources = "SELECT DISTINCT rc.fk_invoice_supplier_source as rowid";
-					$sqlsources .= " FROM ".$this->db->prefix()."societe_remise_except as rc";
-					$sqlsources .= " WHERE rc.fk_invoice_supplier = ".((int) $this->id);
-					$sqlsources .= " AND rc.fk_invoice_supplier_source IS NOT NULL";
+				$sqlsources = "SELECT DISTINCT rc.fk_invoice_supplier_source as rowid";
+				$sqlsources .= " FROM ".$this->db->prefix()."societe_remise_except as rc";
+				$sqlsources .= " WHERE rc.fk_invoice_supplier = ".((int) $this->id);
+				$sqlsources .= " AND rc.fk_invoice_supplier_source IS NOT NULL";
 
-					$resqlsources = $this->db->query($sqlsources);
-					if ($resqlsources) {
-						while ($objsrc = $this->db->fetch_object($resqlsources)) {
-							$srcid = (int) $objsrc->rowid;
-							if ($srcid > 0 && $srcid !== (int) $this->id) {
-								$sourceinvoices[$srcid] = $srcid;
-							}
-						}
-					} else {
-						dol_syslog(get_class($this)."::add_object_linked Failed to read supplier invoice discounts sources", LOG_WARNING);
-					}
-
-					if (!empty($sourceinvoices)) {
-						$existing = array();
-						$sourcelist = implode(',', $sourceinvoices);
-
-						$sqlexists = "SELECT fk_target";
-						$sqlexists .= " FROM ".$this->db->prefix()."element_element";
-						$sqlexists .= " WHERE fk_source = ".((int) $origin_id);
-						$sqlexists .= " AND sourcetype = '".$this->db->escape($origin)."'";
-						$sqlexists .= " AND targettype = '".$this->db->escape($targettype)."'";
-						$sqlexists .= " AND fk_target IN (".$this->db->sanitize($sourcelist).")";
-
-						$resqlexists = $this->db->query($sqlexists);
-						if ($resqlexists) {
-							while ($objexist = $this->db->fetch_object($resqlexists)) {
-								$existing[(int) $objexist->fk_target] = 1;
-							}
-						} else {
-							dol_syslog(get_class($this)."::add_object_linked Failed to read existing linked supplier invoices", LOG_WARNING);
-						}
-
-						foreach ($sourceinvoices as $srcid) {
-							if (!empty($existing[(int) $srcid])) {
-								continue;
-							}
-
-							$sqladd = "INSERT INTO " . $this->db->prefix() . "element_element (fk_source, sourcetype, fk_target, targettype)";
-							$sqladd .= " VALUES (".((int) $origin_id).", '".$this->db->escape($origin)."', ".((int) $srcid).", '".$this->db->escape($targettype)."')";
-							$this->db->query($sqladd); // Best-effort: do not fail original link action
+				$resqlsources = $this->db->query($sqlsources);
+				if ($resqlsources) {
+					while ($objsrc = $this->db->fetch_object($resqlsources)) {
+						$srcid = (int) $objsrc->rowid;
+						if ($srcid > 0 && $srcid !== (int) $this->id) {
+							$sourceinvoices[$srcid] = $srcid;
 						}
 					}
+				} else {
+					dol_syslog(get_class($this)."::add_object_linked Failed to read supplier invoice discounts sources", LOG_WARNING);
 				}
 
-				if (!$notrigger) {
-					// Call trigger
-					$this->context['link_origin'] = $origin;
-					$this->context['link_origin_id'] = $origin_id;
+				if (!empty($sourceinvoices)) {
+					$existing = array();
+					$sourcelist = implode(',', $sourceinvoices);
 
-				$result = $this->call_trigger('OBJECT_LINK_INSERT', $f_user);	// Note: We should have used here a hook. Not a business event
+					$sqlexists = "SELECT fk_target";
+					$sqlexists .= " FROM ".$this->db->prefix()."element_element";
+					$sqlexists .= " WHERE fk_source = ".((int) $origin_id);
+					$sqlexists .= " AND sourcetype = '".$this->db->escape($origin)."'";
+					$sqlexists .= " AND targettype = '".$this->db->escape($targettype)."'";
+					$sqlexists .= " AND fk_target IN (".$this->db->sanitize($sourcelist).")";
+
+					$resqlexists = $this->db->query($sqlexists);
+					if ($resqlexists) {
+						while ($objexist = $this->db->fetch_object($resqlexists)) {
+							$existing[(int) $objexist->fk_target] = 1;
+						}
+					} else {
+						dol_syslog(get_class($this)."::add_object_linked Failed to read existing linked supplier invoices", LOG_WARNING);
+					}
+
+					foreach ($sourceinvoices as $srcid) {
+						if (!empty($existing[(int) $srcid])) {
+							continue;
+						}
+
+						$sqladd = "INSERT INTO " . $this->db->prefix() . "element_element (fk_source, sourcetype, fk_target, targettype)";
+						$sqladd .= " VALUES (".((int) $origin_id).", '".$this->db->escape($origin)."', ".((int) $srcid).", '".$this->db->escape($targettype)."')";
+						$this->db->query($sqladd); // Best-effort: do not fail original link action
+					}
+				}
+			}
+
+			if (!$notrigger) {
+				// Call trigger
+				$this->context['link_origin'] = $origin;
+				$this->context['link_origin_id'] = $origin_id;
+
+				$result = $this->call_trigger('OBJECT_LINK_INSERT', $f_user); // Note: We should have used here a hook. Not a business event
 				if ($result < 0) {
 					$error++;
 				}

--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -543,6 +543,42 @@ class DiscountAbsolute extends CommonObject
 				$this->fk_facture_line = $rowidline;
 				$this->fk_facture = $rowidinvoice;
 			}
+
+			// If a discount comes from a source invoice (deposit/credit note/excess) and is applied to another invoice,
+			// also create a link between the source invoice and the target invoice.
+			if ($rowidinvoice) {
+				$sourcetype = '';
+				$targettype = '';
+				$sourceinvoiceid = 0;
+
+				if (!empty($this->discount_type)) {
+					$sourcetype = 'invoice_supplier';
+					$targettype = 'invoice_supplier';
+					$sourceinvoiceid = (int) $this->fk_invoice_supplier_source;
+				} else {
+					$sourcetype = 'facture';
+					$targettype = 'facture';
+					$sourceinvoiceid = (int) $this->fk_facture_source;
+				}
+
+				if ($sourceinvoiceid > 0 && $sourceinvoiceid !== (int) $rowidinvoice) {
+					$sqlcheck = "SELECT 1";
+					$sqlcheck .= " FROM ".$this->db->prefix()."element_element";
+					$sqlcheck .= " WHERE fk_source = ".((int) $sourceinvoiceid);
+					$sqlcheck .= " AND sourcetype = '".$this->db->escape($sourcetype)."'";
+					$sqlcheck .= " AND fk_target = ".((int) $rowidinvoice);
+					$sqlcheck .= " AND targettype = '".$this->db->escape($targettype)."'";
+					$sqlcheck .= $this->db->plimit(1);
+
+					$rescheck = $this->db->query($sqlcheck);
+					if ($rescheck && $this->db->num_rows($rescheck) === 0) {
+						$sqladd = "INSERT INTO ".$this->db->prefix()."element_element (fk_source, sourcetype, fk_target, targettype)";
+						$sqladd .= " VALUES (".((int) $sourceinvoiceid).", '".$this->db->escape($sourcetype)."', ".((int) $rowidinvoice).", '".$this->db->escape($targettype)."')";
+						$this->db->query($sqladd); // Best-effort: do not fail discount link if object link can't be created.
+					}
+				}
+			}
+
 			if (!$notrigger) {
 				// Call trigger
 				$result = $this->call_trigger('DISCOUNT_MODIFY', $user);


### PR DESCRIPTION
### Summary
- propagate supplier order links to source invoices when creating discount/deposit invoices
- link discount source invoice to target invoice
- includes coding-style alignment in `add_object_linked`

### Context
- republished version of #36679 on top of current `develop`

### Note
- includes a small CI fix in `.github/workflows/ci-on-push.yml` to remove duplicated top-level `permissions` key so `yamllint` can run successfully on PR checks.