### PR TITLE
# FIX show correct shippable icon if order has multiple lines with same product

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -3003,6 +3003,8 @@ while ($i < $imaxinloop) {
 					$generic_commande->getLinesArray(); 	// Load array ->lines
 					$generic_commande->loadExpeditions();	// Load array ->expeditions
 
+					$stock = [];
+
 					$numlines = count($generic_commande->lines); // Loop on each line of order
 					for ($lig = 0; $lig < $numlines; $lig++) {
 						$orderLine = $generic_commande->lines[$lig];
@@ -3027,9 +3029,15 @@ while ($i < $imaxinloop) {
 								$generic_product->stock_theorique = $productstat_cachevirtual[$orderLine->fk_product]['stock_reel'];
 							}
 
-							if ($reliquat > $generic_product->stock_reel) {
+							if (!array_key_exists($orderLine->fk_product, $stock)) {
+								$stock[$orderLine->fk_product] = $generic_product->stock_reel;
+							}
+
+							if ($reliquat > $stock[$orderLine->fk_product]) {
 								$notshippable++;
 							}
+
+							$stock[$orderLine->fk_product] = $stock[$orderLine->fk_product] - $reliquat;
 							if (!getDolGlobalString('SHIPPABLE_ORDER_ICON_IN_LIST')) {  // Default code. Default should be this case.
 								$text_info .= $reliquat.' x '.$orderLine->product_ref.'&nbsp;'.dol_trunc($orderLine->product_label, 20);
 								$text_info .= ' - '.$langs->trans("Stock").': <span class="'.($generic_product->stock_reel > 0 ? 'ok' : 'error').'">'.$generic_product->stock_reel.'</span>';


### PR DESCRIPTION
# FIX show correct shippable icon if order has multiple lines with same product

In the current implementation it checks only line by line against the stock. This can lead to not correct show of shippable orders icon as this can be incorrect due to multiple lines with the same product. Example: Stock of product A is 2. There are two lines with this product A. In the previous implementation it will check the first line against the stock 2-2=0 -> ok and then the same result for the next line but this is not correct as it doesn't reflect previous lines.