### PR TITLE
On expensereport stats use date_debut instead date_valid

### DIFF
--- a/htdocs/expensereport/class/expensereportstats.class.php
+++ b/htdocs/expensereport/class/expensereportstats.class.php
@@ -2,8 +2,9 @@
 /* Copyright (C) 2003      Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (c) 2005-2008 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
- * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024       Frédéric France     <frederic.france@free.fr>
+ * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Charlene Benke      <charlemen@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,7 +66,7 @@ class ExpenseReportStats extends Stats
 	/**
 	 * @var string
 	 */
-	private $datetouse = 'date_valid';
+	private $datetouse = 'date_debut';
 
 
 	/**


### PR DESCRIPTION
It's common practice to submit expense reports for the previous month the following month, which can lead to confusion. That's why I suggest using the start date of the expense report instead of its creation and/or approval date.
