### PR TITLE
FIX: avoid string + float TypeError

### DIFF
--- a/.github/scripts/get_changed_php.sh
+++ b/.github/scripts/get_changed_php.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+b!/bin/bash
 # Copyright (C) 2025		MDW	<mdeweerd@users.noreply.github.com>
 
 set -euo pipefail
@@ -73,6 +73,7 @@ all_changed_files=$(IFS=" " ; echo "${changed_php_files[*]}")
 all_changed_lang=$(IFS=" " ; echo "${changed_lang_files[*]}")
 
 
+forbidden_files=""
 #forbidden_files=$(echo "$all_changed_lang" | grep -E 'htdocs/langs/([^/]+)/.*\.lang$' | grep -v 'htdocs/langs/en_US/')
 #if [ -n "$forbidden_files" ]; then
 #  echo "You tried to modify one or more language files that are not allowed to be modified in Pull requests."

--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -10,7 +10,7 @@
  * Copyright (C) 2016		Ferran Marcet   		<fmarcet@2byte.es>
  * Copyright (C) 2019		JC Prieto				<jcprieto@virtual20.com><prietojc@gmail.com>
  * Copyright (C) 2022-2025  Frédéric France         <frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1426,7 +1426,7 @@ class Account extends CommonObject
 
 			while ($obj = $this->db->fetch_object($resql)) {
 				$response->nbtodo++;
-				if ($this->db->jdate($obj->datefin) < ($now - $conf->bank->rappro->warning_delay)) {
+				if ((int) $this->db->jdate($obj->datefin) < ($now - $conf->bank->rappro->warning_delay)) {
 					$response->nbtodolate++;
 				}
 			}
@@ -2626,7 +2626,7 @@ class AccountLine extends CommonObjectLine
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$obj = $this->db->fetch_object($resql);
-			$newdate = $this->db->jdate($obj->datev) + (3600 * 24 * $sign);
+			$newdate = (int) $this->db->jdate($obj->datev) + (3600 * 24 * $sign);
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."bank SET";
 			$sql .= " datev = '".$this->db->idate($newdate)."'";
@@ -2689,7 +2689,7 @@ class AccountLine extends CommonObjectLine
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$obj = $this->db->fetch_object($resql);
-			$newdate = $this->db->jdate($obj->dateo) + (3600 * 24 * $sign);
+			$newdate = (int) $this->db->jdate($obj->dateo) + (3600 * 24 * $sign);
 
 			$sql = "UPDATE ".MAIN_DB_PREFIX."bank SET";
 			$sql .= " dateo = '".$this->db->idate($newdate)."'";


### PR DESCRIPTION
# FIX: Avoid string + float TypeError

DoliDB::jdate() can return empty string which resulted in
`[php:error] [pid 1131683:tid 1131683] [client 192.168.0.254:28642] PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string + float in .../htdocs/compta/bank/class/account.class.php:262`.
Cast jdate result to int where it is used in numerical comparisons or numeric expressions.
