### PR TITLE
Fix #37677 changing date in existing time spent entry failed

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -2079,7 +2079,7 @@ class Task extends CommonObjectLine
 		}
 
 		// Clean parameters
-		if (empty($this->timespent_datehour)) {
+		if (empty($this->timespent_datehour) || ($this->timespent_date != $this->timespent_datehour)) {
 			$this->timespent_datehour = $this->timespent_date;
 		}
 		if (isset($this->timespent_note)) {


### PR DESCRIPTION
Updating date in existing time spent entry does not change date if done via UI in v22.

In v23+ changing date alone via UI works, but when also changing task at same time, date will not get changed without this fix. 

See description in issue #37677


