### PR TITLE
fix(ticket): clear stale attachments when opening a new ticket form

### DIFF
--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -256,7 +256,7 @@ class modTicket extends DolibarrModules
 			'type' => 'left',
 			'titre' => 'NewTicket',
 			'mainmenu' => 'ticket',
-			'url' => '/ticket/card.php?action=create',
+			'url' => '/ticket/card.php?action=create&mode=init',
 			'langs' => 'ticket',
 			'position' => 102,
 			'enabled' => '$conf->ticket->enabled',

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -713,6 +713,10 @@ if ($action == 'create' || $action == 'presend') {
 
 	print load_fiche_titre($langs->trans('NewTicket'), '', 'ticket');
 
+	if (GETPOST("mode", "aZ09") == 'init' && empty($_POST)) {
+		$formticket->clear_attached_files();
+	}
+
 	$formticket->trackid = '';		// TODO Use a unique key to avoid conflict in upload file feature
 	$formticket->withfromsocid = $socid ? $socid : $user->socid;
 	$formticket->withfromcontactid = $contactid ? $contactid : '';

--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -730,7 +730,7 @@ if ($projectid) {
 	print '<input type="hidden" name="projectid" value="'.$projectid.'" >';
 }
 
-$url = DOL_URL_ROOT.'/ticket/card.php?action=create'.($socid ? '&socid='.$socid : '').($projectid ? '&origin=projet_project&originid='.$projectid : '');
+$url = DOL_URL_ROOT.'/ticket/card.php?action=create&mode=init'.($socid ? '&socid='.$socid : '').($projectid ? '&origin=projet_project&originid='.$projectid : '');
 if (!empty($socid)) {
 	$url .= '&socid='.$socid;
 }


### PR DESCRIPTION
# FIX|Fix #[*clear stale attachments when opening a new ticket form*]

## Problem

  On Dolibarr v16, opening a new ticket form could still show attachments added in a previous, not-yet-submitted ticket form.

  ### Previous behavior

  1. Open `New ticket`
  2. Add a file and click `Attach this file`
  3. Before saving the ticket, click `New ticket` again
  4. A new creation form opens, but the attachment from the previous form is still displayed

  This is incorrect because a newly opened ticket creation form should not inherit temporary attachments from a previous creation attempt.

  ## Root cause

  In our v16 flow, the real menu entry used to open the ticket creation form did not include `mode=init`, unlike newer Dolibarr versions.

  As a result, the form initialization logic that clears temporary attached files was not triggered when opening a new ticket form.

  ## Solution

  This PR aligns the v16 ticket creation flow with newer Dolibarr behavior:

  - add `mode=init` to ticket creation links
  - clear temporary attached files when the creation form is opened with `mode=init`
  - keep attachments during the current form workflow by only clearing them on the initial form load, not during POST actions such as `Attach this file`

  ## Result

  ### New behavior

  1. Open `New ticket`
  2. Add a file and click `Attach this file`
  3. The attachment remains visible in the current form
  4. Click `New ticket` again
  5. The new form opens without any attachment from the previous form

  This restores the expected behavior for a fresh ticket creation form.

  ## Notes

  On existing instances, if the menu URL was already stored in `llx_menu`, the database entry may also need to be updated or the Ticket module menu reinitialized so the rendered link includes `mode=init`.

