### PR TITLE
Bring hurl tests for invoices up to date so it doesn't fail

### DIFF
--- a/test/hurl/api/compta/facture/10_facture.hurl
+++ b/test/hurl/api/compta/facture/10_facture.hurl
@@ -39,7 +39,7 @@ jsonpath "$.pagination.limit" == 100
 # GET invoice with ID 0 - which should not exist
 GET http://{{hostnport}}/api/index.php/invoices/0
 HTTP 400
-{"error":{"code":400,"message":"Bad Request: No invoice with id=0 can exist"}}
+{"error":{"code":400,"message":"Bad Request: No invoice can be found with no criteria"}}
 
 # POST {}
 POST http://{{hostnport}}/api/index.php/invoices


### PR DESCRIPTION
# Qual Bring hurl tests for invoices up to date
API responses for invoices had changed, so the hurl test had to change too