### PR TITLE
fix: correct date handling in updateTimeSpent() to avoid stale element_datehour

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -2084,7 +2084,7 @@ class Task extends CommonObjectLine
 		}
 
 		// Clean parameters
-		if (empty($this->timespent_datehour)) {
+		if (empty($this->timespent_datehour) || ($this->timespent_date != $this->timespent_datehour)) {
 			$this->timespent_datehour = $this->timespent_date;
 		}
 		if (isset($this->timespent_note)) {


### PR DESCRIPTION
## Summary

Fixes #37677

When editing a time spent entry, `updateTimeSpent()` could write a stale `element_datehour` to the database because the existing fallback only checked if `timespent_datehour` was empty, not whether it matched the (possibly updated) `timespent_date`.

## Fix

The condition is extended to also recalculate `timespent_datehour` when it differs from `timespent_date`, aligning the behavior with `addTimeSpent()`.

```php
// Before
if (empty($this->timespent_datehour)) {

// After  
if (empty($this->timespent_datehour) || ($this->timespent_date != $this->timespent_datehour)) {
```

## Testing

- Edit a time spent entry and change only the date → date now saves correctly
- Edit a time spent entry and change both date and task assignment → date now saves correctly