### PR TITLE
FIX: API setup extrafield PUT fails for "type": "separate"

### DIFF
--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -1714,6 +1714,7 @@ class Setup extends DolibarrApi
 	 */
 	public function updateExtrafields($attrname, $elementtype, $request_data = null)
 	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
 		if (!DolibarrApiAccess::$user->admin) {
 			throw new RestException(403, 'Only an admin user can create an extrafield');
 		}

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1037,10 +1037,12 @@ class ExtraFields
 	 */
 	public function fetch_name_optionals_label($elementtype, $forceload = false, $attrname = '')
 	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
 		// phpcs:enable
 		global $conf,$hookmanager;
 
 		if (empty($elementtype)) {
+			dol_syslog(__METHOD__.'::empty elementtype', LOG_DEBUG);
 			return array();
 		}
 
@@ -1055,6 +1057,7 @@ class ExtraFields
 		}
 
 		if ($elementtype != 'all' && isset($this->attributes[$elementtype]) && $this->attributes[$elementtype]['loaded'] == 1 && !$forceload && isset($this->attributes[$elementtype]['label'])) {
+			dol_syslog(__METHOD__.'::long if', LOG_DEBUG);
 			return $this->attributes[$elementtype]['label'];
 		}
 
@@ -1089,6 +1092,8 @@ class ExtraFields
 					// We can add this attribute to object. TODO Remove this and return $this->attributes[$elementtype]['label']
 					if ($tab->type != 'separate') {
 						$array_name_label[$tab->name] = $tab->label;
+					} else {
+						$array_name_label[$tab->name] = $tab->type;
 					}
 
 

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1037,7 +1037,6 @@ class ExtraFields
 	 */
 	public function fetch_name_optionals_label($elementtype, $forceload = false, $attrname = '')
 	{
-		dol_syslog(__METHOD__, LOG_DEBUG);
 		// phpcs:enable
 		global $conf,$hookmanager;
 

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1056,7 +1056,6 @@ class ExtraFields
 		}
 
 		if ($elementtype != 'all' && isset($this->attributes[$elementtype]) && $this->attributes[$elementtype]['loaded'] == 1 && !$forceload && isset($this->attributes[$elementtype]['label'])) {
-			dol_syslog(__METHOD__.'::long if', LOG_DEBUG);
 			return $this->attributes[$elementtype]['label'];
 		}
 


### PR DESCRIPTION
# FIX #36610 API setup extrafield PUT failed for "type": "separate"
This PR makes it so you can use the API to PUT extrafields of type `separate`and this PR should close #36610.

Tested with this JSON
```
{
  "type": "separate",
  "label": "Below is not used",
  "size": "",
  "elementtype": "product",
  "default": null,
  "computed": null,
  "unique": "0",
  "required": "0",
  "param": {
    "options": {
      "": null
    }
  },
  "pos": "666",
  "alwayseditable": "0",
  "perms": null,
  "list": "3",
  "printable": "1",
  "totalizable": "0",
  "langs": null,
  "help": null,
  "css": null,
  "cssview": null,
  "csslist": null
}
```