### PR TITLE
Fix: remove redundant reinsert in societe_perentity

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1116,38 +1116,6 @@ class Societe extends CommonObject
 
 				$ret = $this->update($this->id, $user, 0, 1, 1, 'add');
 
-				// update accountancy for this entity
-				if (getDolGlobalString('MAIN_COMPANY_PERENTITY_SHARED')) {
-					$this->db->query("DELETE FROM ".MAIN_DB_PREFIX."societe_perentity WHERE fk_soc = ".((int) $this->id)." AND entity = ".((int) $conf->entity));
-
-					$sql = "INSERT INTO ".MAIN_DB_PREFIX."societe_perentity (";
-					$sql .= " fk_soc";
-					$sql .= ", entity";
-					$sql .= ", vat_reverse_charge";
-					$sql .= ", accountancy_code_customer_general";
-					$sql .= ", accountancy_code_customer";
-					$sql .= ", accountancy_code_supplier_general";
-					$sql .= ", accountancy_code_supplier";
-					$sql .= ", accountancy_code_buy";
-					$sql .= ", accountancy_code_sell";
-					$sql .= ") VALUES (";
-					$sql .= $this->id;
-					$sql .= ", ".((int) $conf->entity);
-					$sql .= ", ".(empty($this->vat_reverse_charge) ? '0' : '1');
-					$sql .= ", '".$this->db->escape($this->accountancy_code_customer_general)."'";
-					$sql .= ", '".$this->db->escape($this->accountancy_code_customer)."'";
-					$sql .= ", '".$this->db->escape($this->accountancy_code_supplier_general)."'";
-					$sql .= ", '".$this->db->escape($this->accountancy_code_supplier)."'";
-					$sql .= ", '".$this->db->escape($this->accountancy_code_buy)."'";
-					$sql .= ", '".$this->db->escape($this->accountancy_code_sell)."'";
-					$sql .= ")";
-					$result = $this->db->query($sql);
-					if (!$result) {
-						$error++;
-						$this->error = 'ErrorFailedToUpdateAccountancyForEntity';
-					}
-				}
-
 				// Addition of the assigned sales representative
 				if ($this->commercial_id != '' && $this->commercial_id != -1) {
 					$this->add_commercial($user, $this->commercial_id);


### PR DESCRIPTION
# FIX|Fix Accountancy codes silently overwritten with empty values on third-party creation

In the `create()` method of `Societe`, there was a **redundant INSERT INTO `llx_societe_perentity`** block that executed **after** the `$this->update()` call.  

This redundant block **silently overwrote** the accountancy codes that `update()` had just correctly saved.  

**Root cause:**  
The redundant block was using the fields `$this->accountancy_code_customer` and `$this->accountancy_code_supplier`, but the actual object properties set at creation time are `$this->code_compta_client` and `$this->code_compta_fournisseur`.  
Since the former fields are never set during creation, this caused **empty values** to be written to the database, erasing the correct accountancy codes.  

**Solution:**  
The `$this->update($this->id, $user, 0, 1, 1, 'add')` method already handles persisting accountancy codes correctly.  
The redundant `INSERT` block was **unnecessary and harmful**, so it has been **removed** from `create()`.