### PR TITLE
GUI mass email generation - add event attendees, company email or booth thirdparties based on their status

### DIFF
--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -857,6 +857,44 @@ if ($action == 'create') {	// aaa
 			print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddProject") . '"></span></a>';
 			print '</td>';
 			print '</tr>';
+			if (isModEnabled('eventorganization')) {
+				require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorbooth.class.php';
+				require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
+				$attendee = new ConferenceOrBoothAttendee($db);
+				$booth = new ConferenceOrBooth($db);
+
+				$epreselected = array();
+				$ekey_in_label = 0;
+				$evalue_as_key = 1;
+				$emorecss = '';
+				$etranslate = 1;
+				$ewidth = '390';
+				$emoreattrib = '';
+				$enu = '';
+				$eplaceholder = $langs->trans("ExtrafieldCheckBox").' — '. $langs->trans("NoneOrSeveral");
+				$eaddjscombo = -1;
+				// Event attendees email
+				print '<tr class="field_addattendees">';
+				print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailAttendee").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
+				print $form->multiselectarray('EmailAttendee', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+				print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add '.$langs->trans("EmailAttendee").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
+				print '</td></tr>';
+
+				// Event attendees company email
+				print '<tr class="field_addcompanymail">';
+				print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailCompany").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
+				print $form->multiselectarray('EmailCompany', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+				print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("EmailCompany").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
+				print '</td></tr>';
+
+				// Conference or booth
+				$ewidth = '465';
+				print '<tr class="field_addbooth">';
+				print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("ConferenceOrBooth").' <small>('.$langs->trans("ThirdParties").')</small></td><td>'.$langs->trans("Statut").':&#8194;';
+				print $form->multiselectarray('ConferenceOrBooth', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+				print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("ThirdParties").' of the '.$langs->trans("ListOfConferencesOrBooths").' with the selected '.$langs->trans("Statut").'"></span></a>';
+				print '</td></tr>';
+			}
 	}
 
 	if (getDolGlobalInt('EMAILINGS_SUPPORT_ALSO_SMS')) {

--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -865,7 +865,7 @@ if ($action == 'create') {	// aaa
 
 			$epreselected = array();
 			$ekey_in_label = 0;
-			$evalue_as_key = 1;
+			$evalue_as_key = 0;
 			$emorecss = '';
 			$etranslate = 1;
 			$ewidth = '390';

--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -876,14 +876,14 @@ if ($action == 'create') {	// aaa
 			// Event attendees email
 			print '<tr class="field_addattendees">';
 			print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailAttendee").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
-			print $form->multiselectarray('EmailAttendee', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+			print $form->multiselectarray('EmailAttendee', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo);
 			print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add '.$langs->trans("EmailAttendee").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
 			print '</td></tr>';
 
 			// Event attendees company email
 			print '<tr class="field_addcompanymail">';
 			print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailCompany").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
-			print $form->multiselectarray('EmailCompany', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+			print $form->multiselectarray('EmailCompany', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo);
 			print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("EmailCompany").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
 			print '</td></tr>';
 
@@ -891,7 +891,7 @@ if ($action == 'create') {	// aaa
 			$ewidth = '465';
 			print '<tr class="field_addbooth">';
 			print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("ConferenceOrBooth").' <small>('.$langs->trans("ThirdParties").')</small></td><td>'.$langs->trans("Statut").':&#8194;';
-			print $form->multiselectarray('ConferenceOrBooth', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+			print $form->multiselectarray('ConferenceOrBooth', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo);
 			print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("ThirdParties").' of the '.$langs->trans("ListOfConferencesOrBooths").' with the selected '.$langs->trans("Statut").'"></span></a>';
 			print '</td></tr>';
 		}

--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -850,51 +850,51 @@ if ($action == 'create') {	// aaa
 
 	// Project
 	if (isModEnabled('project')) {
-			$langs->load("projects");
-			print '<tr class="field_projectid">';
-			print '<td class="titlefieldcreate">' . $langs->trans("Project") . '</td><td class="valuefieldcreate">';
-			print img_picto('', 'project', 'class="pictofixedwidth"') . $formproject->select_projects(-1, (string) $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 1, 0, 'maxwidth500 widthcentpercentminusxx');
-			print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddProject") . '"></span></a>';
-			print '</td>';
-			print '</tr>';
-			if (isModEnabled('eventorganization')) {
-				require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorbooth.class.php';
-				require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
-				$attendee = new ConferenceOrBoothAttendee($db);
-				$booth = new ConferenceOrBooth($db);
+		$langs->load("projects");
+		print '<tr class="field_projectid">';
+		print '<td class="titlefieldcreate">' . $langs->trans("Project") . '</td><td class="valuefieldcreate">';
+		print img_picto('', 'project', 'class="pictofixedwidth"') . $formproject->select_projects(-1, (string) $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 1, 0, 'maxwidth500 widthcentpercentminusxx');
+		print ' <a href="' . DOL_URL_ROOT . '/projet/card.php?action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans("AddProject") . '"></span></a>';
+		print '</td>';
+		print '</tr>';
+		if (isModEnabled('eventorganization')) {
+			require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorbooth.class.php';
+			require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
+			$attendee = new ConferenceOrBoothAttendee($db);
+			$booth = new ConferenceOrBooth($db);
 
-				$epreselected = array();
-				$ekey_in_label = 0;
-				$evalue_as_key = 1;
-				$emorecss = '';
-				$etranslate = 1;
-				$ewidth = '390';
-				$emoreattrib = '';
-				$enu = '';
-				$eplaceholder = $langs->trans("ExtrafieldCheckBox").' — '. $langs->trans("NoneOrSeveral");
-				$eaddjscombo = -1;
-				// Event attendees email
-				print '<tr class="field_addattendees">';
-				print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailAttendee").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
-				print $form->multiselectarray('EmailAttendee', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
-				print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add '.$langs->trans("EmailAttendee").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
-				print '</td></tr>';
+			$epreselected = array();
+			$ekey_in_label = 0;
+			$evalue_as_key = 1;
+			$emorecss = '';
+			$etranslate = 1;
+			$ewidth = '390';
+			$emoreattrib = '';
+			$enu = '';
+			$eplaceholder = $langs->trans("ExtrafieldCheckBox").' — '. $langs->trans("NoneOrSeveral");
+			$eaddjscombo = -1;
+			// Event attendees email
+			print '<tr class="field_addattendees">';
+			print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailAttendee").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
+			print $form->multiselectarray('EmailAttendee', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+			print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add '.$langs->trans("EmailAttendee").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
+			print '</td></tr>';
 
-				// Event attendees company email
-				print '<tr class="field_addcompanymail">';
-				print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailCompany").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
-				print $form->multiselectarray('EmailCompany', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
-				print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("EmailCompany").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
-				print '</td></tr>';
+			// Event attendees company email
+			print '<tr class="field_addcompanymail">';
+			print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("EmailCompany").'</td><td>'.$langs->trans("Attendees").' '.$langs->trans("Statut").':&#8194;';
+			print $form->multiselectarray('EmailCompany', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+			print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("EmailCompany").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut").'"></span></a>';
+			print '</td></tr>';
 
-				// Conference or booth
-				$ewidth = '465';
-				print '<tr class="field_addbooth">';
-				print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("ConferenceOrBooth").' <small>('.$langs->trans("ThirdParties").')</small></td><td>'.$langs->trans("Statut").':&#8194;';
-				print $form->multiselectarray('ConferenceOrBooth', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
-				print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("ThirdParties").' of the '.$langs->trans("ListOfConferencesOrBooths").' with the selected '.$langs->trans("Statut").'"></span></a>';
-				print '</td></tr>';
-			}
+			// Conference or booth
+			$ewidth = '465';
+			print '<tr class="field_addbooth">';
+			print '<td>&#8627;'.$langs->trans("Add").' '.$langs->trans("ConferenceOrBooth").' <small>('.$langs->trans("ThirdParties").')</small></td><td>'.$langs->trans("Statut").':&#8194;';
+			print $form->multiselectarray('ConferenceOrBooth', $attendee->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo );
+			print '<span class="fa fa-info-circle valignmiddle paddingleft" title="Will add any '.$langs->trans("ThirdParties").' of the '.$langs->trans("ListOfConferencesOrBooths").' with the selected '.$langs->trans("Statut").'"></span></a>';
+			print '</td></tr>';
+		}
 	}
 
 	if (getDolGlobalInt('EMAILINGS_SUPPORT_ALSO_SMS')) {


### PR DESCRIPTION
# NEW Add mass email GUI extended with add event attendees, company email or booth thirdparties based on their status
This PR makes it possible to add all `event attendees`, `company email` or `booth thirdparties` based on their status. If none has the selected status - or none exists, nothing will be added. If no company email it is not added.
