### PR TITLE
Shorten conferenceorboothattendee to just attendee

### DIFF
--- a/dev/build/phpstan/phpstan-baseline.neon
+++ b/dev/build/phpstan/phpstan-baseline.neon
@@ -7012,37 +7012,37 @@ parameters:
 			message: '#^Call to function method_exists\(\) with Project and ''fetchComments'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
-			path: ../../../htdocs/eventorganization/conferenceorboothattendee_card.php
+			path: ../../../htdocs/eventorganization/attendee_card.php
 
 		-
 			message: '#^If condition is always false\.$#'
 			identifier: if.alwaysFalse
 			count: 1
-			path: ../../../htdocs/eventorganization/conferenceorboothattendee_card.php
+			path: ../../../htdocs/eventorganization/attendee_card.php
 
 		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
-			path: ../../../htdocs/eventorganization/conferenceorboothattendee_card.php
+			path: ../../../htdocs/eventorganization/attendee_card.php
 
 		-
 			message: '#^Call to function method_exists\(\) with Project and ''fetchComments'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
-			path: ../../../htdocs/eventorganization/conferenceorboothattendee_list.php
+			path: ../../../htdocs/eventorganization/attendee_list.php
 
 		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
-			path: ../../../htdocs/eventorganization/conferenceorboothattendee_list.php
+			path: ../../../htdocs/eventorganization/attendee_list.php
 
 		-
 			message: '#^Right side of \|\| is always true\.$#'
 			identifier: booleanOr.rightAlwaysTrue
 			count: 1
-			path: ../../../htdocs/eventorganization/conferenceorboothattendee_list.php
+			path: ../../../htdocs/eventorganization/attendee_list.php
 
 		-
 			message: '#^Property ExpeditionLigne\:\:\$detail_children \(array\<int, array\<int, float\|int\>\>\) on left side of \?\? is not nullable\.$#'

--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -367,7 +367,7 @@ function societe_prepare_head(Societe $object, $subtabs = '')
 		dol_syslog('Company::societe_prepare_head::isModEnabled::eventorganization', LOG_DEBUG);
 		$langs->load('eventorganization');
 		if ($subtabs == 'attendees') {
-			$url_for_list = '/eventorganization/conferenceorboothattendee_list.php';
+			$url_for_list = '/eventorganization/attendee_list.php';
 		} else {
 			// this seems to be the default elsewhere, so let's keep that
 			$url_for_list = '/eventorganization/conferenceorbooth_list.php';

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -220,7 +220,7 @@ class mailing_eventorganization extends MailingTargets
 	public function url($id, $sourcetype = 'thirdparty')
 	{
 		if ($sourcetype == 'project') {
-			return '<a href="'.DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_card.php?id='.((int) $id).'">'.img_object('', "eventorganization").'</a>';
+			return '<a href="'.DOL_URL_ROOT.'/eventorganization/attendee_card.php?id='.((int) $id).'">'.img_object('', "eventorganization").'</a>';
 		}
 
 		return '';

--- a/htdocs/core/modules/modEventOrganization.class.php
+++ b/htdocs/core/modules/modEventOrganization.class.php
@@ -328,7 +328,7 @@ class modEventOrganization extends DolibarrModules
 			'fk_menu' => 'fk_mainmenu=project,fk_leftmenu=eventorganizationconforattendee',	    // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
 			'type' => 'left',			                // This is a Left menu entry
 			'titre' => 'List',
-			'url' => '/eventorganization/conferenceorboothattendee_list.php?withproject=0&mainmenu=project',
+			'url' => '/eventorganization/attendee_list.php?withproject=0&mainmenu=project',
 			'langs' => 'eventorganization',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
 			'position' => 1000 + $r,
 			'enabled' => 'isModEnabled("eventorganization")',  // Define condition to show or hide menu entry. Use '$conf->eventorganization->enabled' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.

--- a/htdocs/eventorganization/attendee_card.php
+++ b/htdocs/eventorganization/attendee_card.php
@@ -19,7 +19,7 @@
  */
 
 /**
- *    \file       htdocs/eventorganization/conferenceorboothattendee_card.php
+ *    \file       htdocs/eventorganization/attendee_card.php
  *    \ingroup    eventorganization
  *    \brief      Page to create/edit/view conferenceorboothattendee
  */
@@ -154,9 +154,9 @@ if ($reshook < 0) {
 
 if (empty($reshook)) {
 	//if (!empty($withproject)) {
-	$backurlforlist = DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_list.php?withproject=1&fk_project='.((int) $fk_project);
+	$backurlforlist = DOL_URL_ROOT.'/eventorganization/attendee_list.php?withproject=1&fk_project='.((int) $fk_project);
 	//} else {
-	//	$backurlforlist = DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_list.php';
+	//	$backurlforlist = DOL_URL_ROOT.'/eventorganization/attendee_list.php';
 	//}
 
 	if (empty($backtopage) || ($cancel && empty($id))) {
@@ -164,7 +164,7 @@ if (empty($reshook)) {
 			if (empty($id) && (($action != 'add' && $action != 'create') || $cancel)) {
 				$backtopage = $backurlforlist;
 			} else {
-				$backtopage = DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_card.php?fk_project='.((int) $fk_project).'&id='.($id > 0 ? $id : '__ID__').'&withproject=1';
+				$backtopage = DOL_URL_ROOT.'/eventorganization/attendee_card.php?fk_project='.((int) $fk_project).'&id='.($id > 0 ? $id : '__ID__').'&withproject=1';
 			}
 		}
 	}
@@ -624,7 +624,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 	// Object card
 	// ------------------------------------------------------------
-	$linkback = '<a href="'.dol_buildpath('/eventorganization/conferenceorboothattendee_list.php', 1).'?restore_lastsearch_values=1'.$moreparam.'">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.dol_buildpath('/eventorganization/attendee_list.php', 1).'?restore_lastsearch_values=1'.$moreparam.'">'.$langs->trans("BackToList").'</a>';
 
 	$morehtmlref = '<div class="refidno">';
 

--- a/htdocs/eventorganization/attendee_list.php
+++ b/htdocs/eventorganization/attendee_list.php
@@ -20,7 +20,7 @@
  */
 
 /**
- *    \file       htdocs/eventorganization/conferenceorboothattendee_list.php
+ *    \file       htdocs/eventorganization/attendee_list.php
  *    \ingroup    eventorganization
  *    \brief      List page for conferenceorboothattendee
  */
@@ -395,7 +395,7 @@ $num = $db->num_rows($resql);
 if ($num == 1 && getDolGlobalInt('MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE') && $search_all && !$page) {
 	$obj = $db->fetch_object($resql);
 	$id = $obj->rowid;
-	header("Location: ".DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_card.php?id='.((int) $id));
+	header("Location: ".DOL_URL_ROOT.'/eventorganization/attendee_card.php?id='.((int) $id));
 	exit;
 }
 
@@ -856,7 +856,7 @@ print '<input type="hidden" name="mode" value="'.$mode.'">';
 
 $params = array('morecss' => 'reposition');
 
-$urlnew = DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_card.php?action=create'.(!empty($confOrBooth->id) ? '&conforboothid='.$confOrBooth->id : '').(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : '').$withProjectUrl.'&backtopage='.urlencode($_SERVER['PHP_SELF'].'?projectid='.$projectstatic->id.(empty($confOrBooth->id) ? '' : '&conforboothid='.$confOrBooth->id).$withProjectUrl);
+$urlnew = DOL_URL_ROOT.'/eventorganization/attendee_card.php?action=create'.(!empty($confOrBooth->id) ? '&conforboothid='.$confOrBooth->id : '').(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : '').$withProjectUrl.'&backtopage='.urlencode($_SERVER['PHP_SELF'].'?projectid='.$projectstatic->id.(empty($confOrBooth->id) ? '' : '&conforboothid='.$confOrBooth->id).$withProjectUrl);
 
 $newcardbutton = '';
 $newcardbutton .= dolGetButtonTitle($langs->trans('New'), '', 'fa fa-plus-circle', $urlnew, '', $permissiontoadd, $params);

--- a/htdocs/eventorganization/attendee_note.php
+++ b/htdocs/eventorganization/attendee_note.php
@@ -18,7 +18,7 @@
  */
 
 /**
- *    \file       htdocs/eventorganization/conferenceorboothattendee_note.php
+ *    \file       htdocs/eventorganization/attendee_note.php
  *    \ingroup    eventorganization
  *    \brief      Tab for notes on ConferenceOrBoothAttendee
  */
@@ -100,7 +100,7 @@ if ($id > 0 || !empty($ref)) {
 
 	// Object card
 	// ------------------------------------------------------------
-	$linkback = '<a href="'.dol_buildpath('/eventorganization/conferenceorboothattendee_list.php', 1).'?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.dol_buildpath('/eventorganization/attendee_list.php', 1).'?restore_lastsearch_values=1'.(!empty($socid) ? '&socid='.$socid : '').'">'.$langs->trans("BackToList").'</a>';
 
 	$morehtmlref = '<div class="refidno">';
 	/*

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -798,7 +798,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		$label .= '<br><b>'.$langs->trans('DateOfRegistration').':</b> '.dol_print_date($this->date_subscription, 'dayhour');
 		$label .= '<br><b>'.$langs->trans('AmountPaid').':</b> '.$this->amount;
 
-		$url = DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_card.php?id='.$this->id;
+		$url = DOL_URL_ROOT.'/eventorganization/attendee_card.php?id='.$this->id;
 
 		if ($option != 'nolink') {
 			// Add param to save lastsearch_values or not
@@ -819,7 +819,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 			}
 
 			if ($option == 'thirdpartyid') {
-				$url = DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_list.php?thirdpartyid='.$this->id;
+				$url = DOL_URL_ROOT.'/eventorganization/attendee_list.php?thirdpartyid='.$this->id;
 			}
 
 			if ($option == 'conforboothidproject') {

--- a/htdocs/eventorganization/lib/eventorganization_conferenceorbooth.lib.php
+++ b/htdocs/eventorganization/lib/eventorganization_conferenceorbooth.lib.php
@@ -57,7 +57,7 @@ function conferenceorboothPrepareHead($object, $with_project = 0)
 	}
 
 	/*
-	$head[$h][0] = DOL_URL_ROOT.'/eventorganization/conferenceorboothattendee_list.php?conforboothid='.$object->id.$withProjectUrl;
+	$head[$h][0] = DOL_URL_ROOT.'/eventorganization/attendee_list.php?conforboothid='.$object->id.$withProjectUrl;
 	$head[$h][1] = $langs->trans("Attendees");
 	$head[$h][2] = 'attendees';
 	// Enable caching of conf or booth count attendees
@@ -154,7 +154,7 @@ function conferenceorboothProjectPrepareHead($object)
 	}
 	$h++;
 
-	$head[$h][0] = DOL_URL_ROOT . '/eventorganization/conferenceorboothattendee_list.php?fk_project=' . $object->id . '&withproject=1';
+	$head[$h][0] = DOL_URL_ROOT . '/eventorganization/attendee_list.php?fk_project=' . $object->id . '&withproject=1';
 	$head[$h][1] = $langs->trans("Attendees");
 	$head[$h][2] = 'attendees';
 	// Enable caching of conf or booth count attendees
@@ -229,7 +229,7 @@ function conferenceorboothThirdpartyPrepareHead($object)
 	}
 	$h++;
 
-	$head[$h][0] = DOL_URL_ROOT . '/eventorganization/conferenceorboothattendee_list.php?thirdpartyid=' . $object->id . '&withthirdparty=1';
+	$head[$h][0] = DOL_URL_ROOT . '/eventorganization/attendee_list.php?thirdpartyid=' . $object->id . '&withthirdparty=1';
 	$head[$h][1] = $langs->trans("Attendees");
 	$head[$h][2] = 'attendees';
 	// Enable caching of conf or booth count attendees
@@ -276,7 +276,7 @@ function conferenceorboothAttendeePrepareHead($object)
 	$h = 0;
 	$head = array();
 
-	$head[$h][0] = DOL_URL_ROOT . "/eventorganization/conferenceorboothattendee_card.php?id=" . ((int) $object->id) . ($object->fk_actioncomm > 0 ? '&conforboothid=' . ((int) $object->fk_actioncomm) : '') . ($object->fk_project > 0 ? '&withproject=1&fk_project=' . ((int) $object->fk_project) : '');
+	$head[$h][0] = DOL_URL_ROOT . "/eventorganization/attendee_card.php?id=" . ((int) $object->id) . ($object->fk_actioncomm > 0 ? '&conforboothid=' . ((int) $object->fk_actioncomm) : '') . ($object->fk_project > 0 ? '&withproject=1&fk_project=' . ((int) $object->fk_project) : '');
 	$head[$h][1] = $langs->trans("Card");
 	$head[$h][2] = 'card';
 	$h++;

--- a/test/hurl/gui/eventorganization/conferenceorboothattendee_list.hurl
+++ b/test/hurl/gui/eventorganization/conferenceorboothattendee_list.hurl
@@ -1,5 +1,5 @@
 # Check list of open Organized events
-GET http://{{hostnport}}/eventorganization/conferenceorboothattendee_list.php
+GET http://{{hostnport}}/eventorganization/attendee_list.php
 HTTP 200
 [Asserts]
 body contains "List of attendees of event projects"


### PR DESCRIPTION
#Qual shorten conferenceorboothattendee to just attendee
This PR shortens the long filenames conferenceorboothattendee to just attendee.

This PR is a minimalist alternative to PR #37764 which introduced subfolders and had to make changes to modulebuilder too

## Hurl tests
```
----- Run hurl test on APIs ---
INFO: 1. Running tests (API,GUI,public) that do not require authentication
Success gui/00_HOME.hurl (1 request(s) in 29 ms)
Success api/00_foobar.hurl (1 request(s) in 35 ms)
Success api/00_explorer.hurl (1 request(s) in 35 ms)
Success api/status/00_status.hurl (1 request(s) in 40 ms)
Success public/payment/00_payment_newpayment.hurl (1 request(s) in 46 ms)
Success public/onlinesign/00_onlinesign_newonlinesign.hurl (1 request(s) in 47 ms)
Success api/login/00_login_POST.hurl (1 request(s) in 1048 ms)
Success api/login/00_login_GET.hurl (1 request(s) in 1049 ms)
--------------------------------------------------------------------------------
Executed files:    8
Executed requests: 8 (7.6/s)
Succeeded files:   8 (100.0%)
Failed files:      0 (0.0%)
Duration:          1052 ms (0h:0m:1s:52ms)

INFO: Using existing DOLAPIKEY.
INFO: 2.a. Running API tests that do require authentication
Success api/status/10_status.hurl (1 request(s) in 42 ms)
Success api/setup/10_setup_company.hurl (1 request(s) in 343 ms)
Success api/setup/10_setup_conf.hurl (1 request(s) in 368 ms)
Success api/users/10_groups.hurl (15 request(s) in 1099 ms)
Success api/eventattendees/10_eventattendees.hurl (19 request(s) in 1124 ms)
Success api/emailtemplates/10_emailtemplates.hurl (23 request(s) in 1520 ms)
Success api/users/10_users.hurl (17 request(s) in 1220 ms)
Success api/mailings/10_mailings.hurl (34 request(s) in 2153 ms)
Success api/warehouses/10_warehouses.hurl (34 request(s) in 3487 ms)
Success api/setup/10_setup_modules.hurl (13 request(s) in 3588 ms)
Success api/commande/10_commande.hurl (21 request(s) in 4239 ms)
Success api/comm/propal/10_propal.hurl (21 request(s) in 4398 ms)
Success api/compta/facture/10_facture.hurl (20 request(s) in 5767 ms)
--------------------------------------------------------------------------------
Executed files:    13
Executed requests: 220 (38.1/s)
Succeeded files:   13 (100.0%)
Failed files:      0 (0.0%)
Duration:          5771 ms (0h:0m:5s:771ms)

Success gui/save_login_cookie.hurl (2 request(s) in 179 ms)
--------------------------------------------------------------------------------
Executed files:    1
Executed requests: 2 (11.1/s)
Succeeded files:   1 (100.0%)
Failed files:      0 (0.0%)
Duration:          180 ms (0h:0m:0s:180ms)

INFO: 2.b. Running GUI tests that do require authentication
Success gui/10_HOME.hurl (1 request(s) in 93 ms)
Success gui/eventorganization/10_conferenceorbooth_list.hurl (1 request(s) in 155 ms)
Success gui/comm/mailing/10_mailing.hurl (1 request(s) in 236 ms)
Success gui/admin/10_mails_templates.hurl (1 request(s) in 271 ms)
Success gui/eventorganization/10_eventorganization.hurl (4 request(s) in 522 ms)
Success gui/projet/10_projet_element.hurl (15 request(s) in 999 ms)
--------------------------------------------------------------------------------
Executed files:    6
Executed requests: 23 (22.9/s)
Succeeded files:   6 (100.0%)
Failed files:      0 (0.0%)
Duration:          1003 ms (0h:0m:1s:3ms)
```
