### PR TITLE
FIX #37772 Deposit invoice incorrectly marked as paid when converting to credit without payment

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1137,14 +1137,23 @@ if (empty($reshook)) {
 			}
 
 			if (empty($error)) {
-				// Set invoice as paid
-				$result = $object->setPaid($user);	// We can close the invoice. Even if we got an excess received, it is now into discounts.
-				if ($result >= 0) {
-					$object->fetch($object->id);	// Reload properties
+				// Set invoice as paid, unless it's a deposit converted to credit without any payment received
+				// (option DEPOSIT_AS_CREDIT_AVAILABLE_EVEN_UNPAID allows creating the discount/credit even if the deposit
+				// has not been paid yet; in that case we must NOT mark it as paid since no payment was actually received)
+				$skipSetPaid = ($object->type == Facture::TYPE_DEPOSIT && getDolGlobalInt('DEPOSIT_AS_CREDIT_AVAILABLE_EVEN_UNPAID') && price2num($object->getSommePaiement(), 'MT') == 0);
+
+				if ($skipSetPaid) {
+					$object->fetch($object->id);    // Reload properties
 					$db->commit();
 				} else {
-					setEventMessages($object->error, $object->errors, 'errors');
-					$db->rollback();
+					$result = $object->setPaid($user);  // We can close the invoice. Even if we got an excess received, it is now into discounts.
+					if ($result >= 0) {
+						$object->fetch($object->id);    // Reload properties
+						$db->commit();
+					} else {
+						setEventMessages($object->error, $object->errors, 'errors');
+						$db->rollback();
+					}
 				}
 			} else {
 				setEventMessages($discount->error, $discount->errors, 'errors');


### PR DESCRIPTION
# FIX Fix #37772 Deposit invoice incorrectly marked as paid when converting to credit without payment

When the hidden option `DEPOSIT_AS_CREDIT_AVAILABLE_EVEN_UNPAID` is enabled,
clicking "Mark as credit available" on an unpaid deposit invoice was incorrectly
calling `setPaid()`, flagging the invoice as paid even though no payment was received.

This is a regression for workflows where the credit needs to be created upfront
for important customers, with the actual payment expected later.

The fix skips the `setPaid()` call when all three conditions are met:
- invoice type is `TYPE_DEPOSIT`
- constant `DEPOSIT_AS_CREDIT_AVAILABLE_EVEN_UNPAID` is enabled
- `getSommePaiement() == 0` (no payment has been received)

The deposit invoice remains in `STATUS_VALIDATED`/unpaid state after the credit is created.
Payment can be recorded later, at which point the invoice will correctly transition to paid.