### PR TITLE
Fix/doctemplates path entity centralized

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -2942,9 +2942,15 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		$accessallowed = ($user->admin && basename($original_file) == $original_file && preg_match('/^dolibarr.*\.(log|json)$/', basename($original_file)));
 		$original_file = $dolibarr_main_data_root.'/'.$original_file;
 	} elseif ($modulepart == 'doctemplates' && !empty($dolibarr_main_data_root)) {
-		// Wrapping for doctemplates
 		$accessallowed = $user->admin;
-		$original_file = $dolibarr_main_data_root.'/doctemplates/'.$original_file;
+		$relative_file = $original_file;
+		$ent = ($entity > 0 ? $entity : $conf->entity);
+		$path_with_entity = $dolibarr_main_data_root . '/' . $ent . '/doctemplates/' . $relative_file;
+		if ($ent > 1 && file_exists(dol_osencode($path_with_entity))) {
+			$original_file = $path_with_entity;
+		} else {
+			$original_file = $dolibarr_main_data_root . '/doctemplates/' . $relative_file;
+		}
 	} elseif ($modulepart == 'doctemplateswebsite' && !empty($dolibarr_main_data_root)) {
 		// Wrapping for doctemplates of websites
 		$accessallowed = ($fuser->hasRight('website', 'write') && preg_match('/\.jpg$/i', basename($original_file)));

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -248,10 +248,9 @@ $sqlprotectagainstexternals = $check_access['sqlprotectagainstexternals'];
 $fullpath_original_file     = $check_access['original_file']; // $fullpath_original_file is now a full path name
 //var_dump($modulepart.' '.$fullpath_original_file.' '.$original_file.' '.$accessallowed);exit;
 
+// Fix for multi-entity on doctemplates
 if ($modulepart == 'doctemplates') {
-	// 1. On teste d'abord l'entité passée en paramètre ou celle de la session
 	$ent_to_test = ($entity > 1 ? $entity : $conf->entity);
-
 	if ($ent_to_test > 1) {
 		$path_with_entity = DOL_DATA_ROOT . '/' . $ent_to_test . '/doctemplates/' . $original_file;
 		if (file_exists(dol_osencode($path_with_entity))) {

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -248,18 +248,6 @@ $sqlprotectagainstexternals = $check_access['sqlprotectagainstexternals'];
 $fullpath_original_file     = $check_access['original_file']; // $fullpath_original_file is now a full path name
 //var_dump($modulepart.' '.$fullpath_original_file.' '.$original_file.' '.$accessallowed);exit;
 
-// Fix for multi-entity on doctemplates
-if ($modulepart == 'doctemplates') {
-	$ent_to_test = ($entity > 1 ? $entity : $conf->entity);
-	if ($ent_to_test > 1) {
-		$path_with_entity = DOL_DATA_ROOT . '/' . $ent_to_test . '/doctemplates/' . $original_file;
-		if (file_exists(dol_osencode($path_with_entity))) {
-			$fullpath_original_file = $path_with_entity;
-		}
-	}
-}
-$fullpath_original_file_osencoded = dol_osencode($fullpath_original_file);
-
 if (!empty($hashp)) {
 	$accessallowed = 1; // When using hashp, link is public so we force $accessallowed
 	$sqlprotectagainstexternals = '';

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -248,6 +248,19 @@ $sqlprotectagainstexternals = $check_access['sqlprotectagainstexternals'];
 $fullpath_original_file     = $check_access['original_file']; // $fullpath_original_file is now a full path name
 //var_dump($modulepart.' '.$fullpath_original_file.' '.$original_file.' '.$accessallowed);exit;
 
+if ($modulepart == 'doctemplates') {
+	// 1. On teste d'abord l'entité passée en paramètre ou celle de la session
+	$ent_to_test = ($entity > 1 ? $entity : $conf->entity);
+
+	if ($ent_to_test > 1) {
+		$path_with_entity = DOL_DATA_ROOT . '/' . $ent_to_test . '/doctemplates/' . $original_file;
+		if (file_exists(dol_osencode($path_with_entity))) {
+			$fullpath_original_file = $path_with_entity;
+		}
+	}
+}
+$fullpath_original_file_osencoded = dol_osencode($fullpath_original_file);
+
 if (!empty($hashp)) {
 	$accessallowed = 1; // When using hashp, link is public so we force $accessallowed
 	$sqlprotectagainstexternals = '';


### PR DESCRIPTION
**FIX|Fix access to ODT templates in multi-entity environment**

- Short description
Fixes ODT template access (download and deletion) when the Multi-Company (Multi-Entity) module is enabled.

- Long description
This PR resolves a critical issue where ODT template files could not be downloaded or deleted when working in an entity other than the default one (ID 1).

**Issues addressed:**

- Incomplete URL: The doc_generic_contract_odt module was not passing the entity parameter to the document.php wrapper, causing the system to lose context of where the file was stored.
- Incorrect path resolution: The document.php wrapper (specifically for modulepart=doctemplates) was not accounting for the entity-specific directory structure (documents/XX/doctemplates/) and was only looking at the global root (documents/doctemplates/).

**Changes performed:**

- htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php: Added the &entity= parameter to the download and delete links generated in the module configuration view.

- htdocs/document.php: Added a specific condition for modulepart == 'doctemplates'. When an entity ID > 1 is detected, the script now attempts to resolve the physical file path within the entity's subfolder before falling back to the default path.

**Technical details**
Previously, the system would search for:
`documents/doctemplates/contracts/template.odt`
Even if the file was actually located in:
`documents/5/doctemplates/contracts/template.odt`

With this fix, document.php correctly reconstructs the path using the provided entity ID.

**Test performed**

- **Environment :** Multi-entity module enabled.
- **Scenario :** Uploaded an ODT template while logged into Entity 5.
- **Download Test :** Clicked the "magnifier" icon. The file is now correctly served instead of returning an ErrorFileDoesNotExists error.
- **Delete Test :** Clicked the "trash" icon. The file is now correctly removed from the storage disk in the entity's subfolder.