### PR TITLE
FIX: do not print Extrafields in PDF if printable is 0

### DIFF
--- a/htdocs/core/class/commondocgenerator.class.php
+++ b/htdocs/core/class/commondocgenerator.class.php
@@ -1458,8 +1458,8 @@ abstract class CommonDocGenerator
 				}
 
 				$disableOnEmpty = 0;
-				if ($enabled && !empty($extrafields->attributes[$object->table_element]['printable'][$key])) {
-					$printable = intval($extrafields->attributes[$object->table_element]['printable'][$key]);
+				$printable =  (int) $extrafields->attributes[$object->table_element]['printable'][$key];
+				if ($enabled && !empty($printable)) {
 					if (in_array($printable, $params['printableEnable']) || in_array($printable, $params['printableEnableNotEmpty'])) {
 						$enabled = 1;
 					}
@@ -1469,7 +1469,7 @@ abstract class CommonDocGenerator
 					}
 				}
 
-				if (empty($enabled)) {
+				if (empty($enabled) || empty($printable)) {
 					continue;
 				}
 

--- a/htdocs/core/lib/geturl.lib.php
+++ b/htdocs/core/lib/geturl.lib.php
@@ -30,7 +30,7 @@
  *
  * @param	string                      $url 			    URL to call.
  * @param	string                      $postorget		    'POST', 'GET', 'HEAD', 'PUT', 'PUTALREADYFORMATED', 'POSTALREADYFORMATED', 'DELETE'
- * @param	string|array<mixed,mixed>	$param			    Parameters of URL (x=value1&y=value2) or may be a formated content with $postorget='PUTALREADYFORMATED'
+ * @param	string|array<mixed,mixed>	$param			    Parameters of URL (x=value1&y=value2) or may be a formatted content with $postorget='PUTALREADYFORMATED'
  * @param	integer                     $followlocation		0=Do not follow, 1=Follow location.
  * @param	string[]                    $addheaders			Array of string to add into header. Example: ('Accept: application/xrds+xml', ....)
  * @param	string[]                    $allowedschemes		List of schemes that are allowed ('http' + 'https' only by default)


### PR DESCRIPTION
Since https://github.com/Dolibarr/dolibarr/pull/37442 even if an extrafield is not printable it is printed in all PDF

This bug exists in 19.0,20.0,21.0,22.0,23.0,

fix: https://github.com/Dolibarr/dolibarr/issues/37544


[Test case]

Extrafields in Propal header and line setup
<img width="1628" height="438" alt="image" src="https://github.com/user-attachments/assets/a5c9dec5-b8ed-442b-a08e-8627632f9511" />

<img width="1644" height="403" alt="image" src="https://github.com/user-attachments/assets/836c10c9-a0d2-438f-b189-81f5603d6bd2" />


[Actual Result]

<img width="1118" height="621" alt="image" src="https://github.com/user-attachments/assets/f8e21910-24db-419a-bf8c-d520f6828613" />


[With this PR]
<img width="883" height="537" alt="image" src="https://github.com/user-attachments/assets/96174045-ac76-4c4e-a438-48e652e2ad71" />


