### PR TITLE
Fix GETPOST filter inconsistency

### DIFF
--- a/htdocs/admin/emailcollector_card.php
+++ b/htdocs/admin/emailcollector_card.php
@@ -178,7 +178,7 @@ if ($action == 'deletefilter') {
 if (GETPOST('addoperation', 'alpha')) {
 	$emailcollectoroperation = new EmailCollectorAction($db);
 	$emailcollectoroperation->type = GETPOST('operationtype', 'aZ09');
-	$emailcollectoroperation->actionparam = GETPOST('operationparam', 'restricthtml');
+	$emailcollectoroperation->actionparam = GETPOST('operationparam', 'alphawithlgt');
 	$emailcollectoroperation->fk_emailcollector = $object->id;
 	$emailcollectoroperation->status = 1;
 	$emailcollectoroperation->position = 50;


### PR DESCRIPTION
# Fix GETPOST filter inconsistency

The GETPOST filter for adding and updating the emal collector operation paramater is not the same. This PR fixes this inconsistency

see 
https://github.com/Dolibarr/dolibarr/blob/9c8c34777993a580b694dd18561132c1e19f6ed5/htdocs/admin/emailcollector_card.php#L181
and
https://github.com/Dolibarr/dolibarr/blob/9c8c34777993a580b694dd18561132c1e19f6ed5/htdocs/admin/emailcollector_card.php#L213


