### PR TITLE
FIX: Site root missing in $backtopage.

### DIFF
--- a/htdocs/accountancy/bookkeeping/card.php
+++ b/htdocs/accountancy/bookkeeping/card.php
@@ -56,7 +56,7 @@ $confirm = GETPOST('confirm', 'alpha');
 $type = GETPOST('type', 'alpha');
 $backtopage = GETPOST('backtopage', 'alpha');
 if (empty($backtopage)) {
-	$backtopage = '/accountancy/bookkeeping/list.php';
+	$backtopage = DOL_URL_ROOT . '/accountancy/bookkeeping/list.php';
 }
 
 $optioncss = GETPOST('optioncss', 'aZ'); // Option for the css output (always '' except when 'print')


### PR DESCRIPTION
# FIX#37786 Wrong $backtopage in accountancy/bookkeeping/card.php

DOL_URL_ROOT was missing in the $backtopage definition. This doesn't prevent any action to complete but some
will end with a 404 error if Dolibarr isn't installed at the site root.
