### PR TITLE
FIX: Stripe payment validation for zero-decimal currencies

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -422,7 +422,13 @@ if (isModEnabled('stripe') && $paymentmethod === 'stripe') {
 				}
 
 				// Check amount and currency
-				$expectedAmount = (int) round($FinalPaymentAmt * 100); // Stripe uses cents
+				// Handle zero-decimal currencies that don't use cents/subunits
+				$zeroDecimalCurrencies = ['JPY', 'KRW', 'CLP', 'VND', 'XAF', 'XOF', 'XPF', 'BIF', 'CLP', 'DJF', 'GNF', 'ISK', 'KMF', 'MGA', 'PYG', 'RWF', 'UGX', 'VUV'];
+				if (in_array(strtoupper($currencyCodeType), $zeroDecimalCurrencies)) {
+					$expectedAmount = (int) round($FinalPaymentAmt); // No cents for these currencies
+				} else {
+					$expectedAmount = (int) round($FinalPaymentAmt * 100); // Stripe uses cents for most currencies
+				}
 				$expectedCurrency = strtolower($currencyCodeType);
 
 				if ((int) $paymentIntent->amount !== $expectedAmount || strtolower($paymentIntent->currency) !== $expectedCurrency) {

--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -423,7 +423,7 @@ if (isModEnabled('stripe') && $paymentmethod === 'stripe') {
 
 				// Check amount and currency
 				// Handle zero-decimal currencies that don't use cents/subunits
-				$zeroDecimalCurrencies = ['JPY', 'KRW', 'CLP', 'VND', 'XAF', 'XOF', 'XPF', 'BIF', 'CLP', 'DJF', 'GNF', 'ISK', 'KMF', 'MGA', 'PYG', 'RWF', 'UGX', 'VUV'];
+				$zeroDecimalCurrencies = array('BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG', 'RWF', 'VND', 'VUV', 'XAF', 'XOF', 'XPF');
 				if (in_array(strtoupper($currencyCodeType), $zeroDecimalCurrencies)) {
 					$expectedAmount = (int) round($FinalPaymentAmt); // No cents for these currencies
 				} else {


### PR DESCRIPTION
Fixed an issue where Stripe payment validation was incorrectly multiplying amounts by 100 for all currencies, causing validation failures for zero-decimal currencies like JPY and KRW that don't use cents or subunits.

Added proper currency checking to only apply the cents conversion for currencies that actually use subunits.

Fixes #37650