### PR TITLE
FIX: Add missing date_cloture field in proposals fetch method

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1659,6 +1659,7 @@ class Propal extends CommonObject
 		$sql .= ", p.datec";
 		$sql .= ", p.date_signature as dates";
 		$sql .= ", p.date_valid as datev";
+		$sql .= ", p.date_cloture";
 		$sql .= ", p.datep as dp";
 		$sql .= ", p.fin_validite as dfv";
 		$sql .= ", p.date_livraison as delivery_date";
@@ -1745,6 +1746,7 @@ class Propal extends CommonObject
 				$this->date_validation = $this->db->jdate($obj->datev); //Validation date
 				$this->date_modification = $this->db->jdate($obj->date_modification); // tms
 				$this->date_signature = $this->db->jdate($obj->dates); // Signature date
+				$this->date_cloture = $this->db->jdate($obj->date_cloture); // Closing date
 				$this->date                 = $this->db->jdate($obj->dp); // Proposal date
 				$this->datep                = $this->db->jdate($obj->dp); // deprecated
 				$this->fin_validite         = $this->db->jdate($obj->dfv);


### PR DESCRIPTION
The date_cloture field was missing from the SQL SELECT query in the proposals fetch() method, causing it to always return null in REST API responses.

Added p.date_cloture to the SELECT clause and mapped it to the object property.

Fixes #37765