### PR TITLE
FIX: Set SOCIETE_FISCAL_MONTH_START default to 1 (#37662)

### DIFF
--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -95,7 +95,7 @@ class modSociete extends DolibarrModules
 
 		$this->const[$r][0] = "SOCIETE_FISCAL_MONTH_START";
 		$this->const[$r][1] = "chaine";
-		$this->const[$r][2] = "0";
+		$this->const[$r][2] = "1";
 		$this->const[$r][3] = "Enter the month number of the first month of the fiscal year, e. g. 9 for September";
 		$this->const[$r][4] = 0;
 		$r++;


### PR DESCRIPTION
The constant SOCIETE_FISCAL_MONTH_START was initialized to 0 when enabling the Thirdparty module, but accountancy functions expect valid month numbers 1-12. This caused TypeError in date functions like dol_get_last_day.

Changed the default value from 0 to 1 to provide a valid month number.

Fixes #37662