### PR TITLE
QUAL - Supplier modules - Split - Add compatibility layer in hasRight()

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -941,6 +941,40 @@ class User extends CommonObject
 			$module = $moduletomoduletouse[$module];
 		}
 
+		// Compatibility layer for the supplier module split transition (MAIN_USE_NEW_SUPPLIERMOD).
+		// Allows both old and new permission syntaxes to work in parallel during migration.
+		// - Old: $user->hasRight('fournisseur', 'commande', 'lire')
+		// - New: $user->hasRight('supplier_order', 'lire')
+		// External modules are also transparently supported without any change on their side.
+		if (getDolGlobalInt('MAIN_USE_NEW_SUPPLIERMOD')) {
+			// New module names introduced by the split, mapped to their legacy equivalent.
+			// Format: 'new_module' => ['legacy_module', 'legacy_permlevel1']
+			$supplierNewToLegacy = array(
+				'supplier_order'   => array('fournisseur', 'commande'),
+				'supplier_invoice' => array('fournisseur', 'facture'),
+			);
+
+			if (isset($supplierNewToLegacy[$module])) {
+				// Caller used new syntax: rewrite to legacy so the rights object resolves correctly.
+				// e.g. hasRight('supplier_order', 'lire') -> hasRight('fournisseur', 'commande', 'lire')
+				$permlevel2 = $permlevel1;
+				$permlevel1 = $supplierNewToLegacy[$module][1];  // e.g. 'commande'
+				$module     = $supplierNewToLegacy[$module][0];  // e.g. 'fournisseur'
+			}
+		} else {
+			// Legacy mode: translate new module names back to old ones in case some
+			// updated code calls the new syntax while the option is not yet enabled.
+			$supplierLegacyCompat = array(
+				'supplier_order'   => 'fournisseur',
+				'supplier_invoice' => 'fournisseur',
+			);
+
+			if (isset($supplierLegacyCompat[$module])) {
+				// e.g. hasRight('supplier_order', 'lire') stays routed through 'fournisseur'
+				$module = $supplierLegacyCompat[$module];
+			}
+		}
+
 		$moduleRightsMapping = array(
 			'product' => 'produit',
 			'margin' => 'margins',

--- a/htdocs/user/group/perms.php
+++ b/htdocs/user/group/perms.php
@@ -1,12 +1,13 @@
 <?php
-/* Copyright (C) 2002-2005	Rodolphe Quiedeville	<rodolphe@quiedeville.org>
- * Copyright (C) 2002-2003	Jean-Louis Bergamo		<jlb@j1b.org>
- * Copyright (C) 2004-2020	Laurent Destailleur		<eldy@users.sourceforge.net>
- * Copyright (C) 2004		Eric Seigne				<eric.seigne@ryxeo.com>
- * Copyright (C) 2005-2017	Regis Houssin			<regis.houssin@inodbox.com>
- * Copyright (C) 2020		Tobias Sekan			<tobias.sekan@startmail.com>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
+/* Copyright (C) 2002-2005  Rodolphe Quiedeville        <rodolphe@quiedeville.org>
+ * Copyright (C) 2002-2003  Jean-Louis Bergamo          <jlb@j1b.org>
+ * Copyright (C) 2004-2020  Laurent Destailleur         <eldy@users.sourceforge.net>
+ * Copyright (C) 2004       Eric Seigne                 <eric.seigne@ryxeo.com>
+ * Copyright (C) 2005-2017  Regis Houssin               <regis.houssin@inodbox.com>
+ * Copyright (C) 2020       Tobias Sekan                <tobias.sekan@startmail.com>
+ * Copyright (C) 2024       MDW                         <mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2026       Alexandre Spangaro          <alexandre@inovea-conseil.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -180,6 +181,9 @@ print dol_get_fiche_head($head, 'rights', $title, -1, 'group');
 $modules = array();
 $modulesdir = dolGetModulesDirs();
 
+// Modules to ignore depending on supplier module mode
+$excludedModules = getDolGlobalInt('MAIN_USE_NEW_SUPPLIERMOD') ? array('modFournisseur') : array('modSupplierOrder', 'modSupplierInvoice');
+
 $db->begin();
 
 foreach ($modulesdir as $dir) {
@@ -190,6 +194,11 @@ foreach ($modulesdir as $dir) {
 				$modName = substr($file, 0, dol_strlen($file) - 10);
 
 				if ($modName) {
+					// Exclude old/new supplier descriptors depending on MAIN_USE_NEW_SUPPLIERMOD
+					if (in_array($modName, $excludedModules, true)) {
+						continue;
+					}
+
 					include_once $dir.$file;
 					$objMod = new $modName($db);
 					'@phan-var-force DolibarrModules $objMod';


### PR DESCRIPTION
As part of the progressive split of the monolithic `fournisseur` module into
dedicated modules (`supplier_order`, `supplier_invoice`), this PR introduces
a compatibility layer **inside `User::hasRight()`** to handle both permission
syntaxes transparently during the transition.

## Problem

When `MAIN_USE_NEW_SUPPLIERMOD` is enabled, calls using the legacy syntax:
```php
$user->hasRight('fournisseur', 'commande', 'lire')
```
and calls using the new syntax:
```php
$user->hasRight('supplier_order', 'read')
```
must both resolve correctly, without requiring any change in the calling code.

## Solution

A mapping is added at the top of `hasRight()`, **before the `isModEnabled()`
check**, to translate new module names to their legacy equivalents when
`MAIN_USE_NEW_SUPPLIERMOD` is not yet set, and vice versa when it is.

See discussion in this PR : https://github.com/Dolibarr/dolibarr/pull/37785