### PR TITLE
FIX TCPDI: honor K_TCPDF_THROW_EXCEPTION_ERROR and enable exceptions by default

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6258,26 +6258,32 @@ abstract class CommonObject
 		// update model_pdf in object
 		$this->model_pdf = $saved_model;
 
-		if ($obj instanceof ModelePDFMember) {
-			if ($this instanceof Adherent) {
-				$resultwritefile = $obj->write_file($this, $outputlangs, $srctemplatepath, 'member', 1, 'tmp_cards');
+		try {
+			if ($obj instanceof ModelePDFMember) {
+				if ($this instanceof Adherent) {
+					$resultwritefile = $obj->write_file($this, $outputlangs, $srctemplatepath, 'member', 1, 'tmp_cards');
+				} else {
+					$resultwritefile = -1;
+					dol_syslog("Error generating document - Provided ".get_class($this)." to ".get_class($obj)."::write_file()", LOG_ERR);
+				}
+			} elseif ($obj instanceof ModeleDon) {
+				// Only 3 arguments
+				if ($this instanceof Don) {
+					$resultwritefile = $obj->write_file($this, $outputlangs /*, $currency */);
+				} else {
+					$resultwritefile = -1;
+					dol_syslog("Error generating document - Provided ".get_class($this)." to Don::write_file()", LOG_ERR);
+				}
 			} else {
-				$resultwritefile = -1;
-				dol_syslog("Error generating document - Provided ".get_class($this)." to ".get_class($obj)."::write_file()", LOG_ERR);
+				// TODO: Try to set type above again
+				'@phan-var-force ModeleBarCode|ModeleExports|ModeleImports|ModelePDFAsset|ModelePDFContract|ModelePDFDeliveryOrder|ModelePDFEvaluation|ModelePDFFactures|ModelePDFFicheinter|ModelePDFMo|ModelePDFMovement|ModelePDFProduct|ModelePDFProjects|ModelePDFPropales|ModelePDFRecruitmentJobPosition|ModelePDFStock|ModelePDFStockTransfer|ModelePDFSupplierProposal|ModelePDFSuppliersInvoices|ModelePDFSuppliersOrders|ModelePDFSuppliersPayments|ModelePDFTask|ModelePDFTicket|ModelePDFUser|ModelePDFUserGroup|ModelePdfExpedition|ModelePdfReception|ModeleThirdPartyDoc $obj';
+				$this->context['moreparams'] = $moreparams;
+				$resultwritefile = $obj->write_file($this, $outputlangs, $srctemplatepath, $hidedetails, $hidedesc, $hideref);  // @phan-suppress-line-PhanTypeMismatchArgument
 			}
-		} elseif ($obj instanceof ModeleDon) {
-			// Only 3 arguments
-			if ($this instanceof Don) {
-				$resultwritefile = $obj->write_file($this, $outputlangs /*, $currency */);
-			} else {
-				$resultwritefile = -1;
-				dol_syslog("Error generating document - Provided ".get_class($this)." to Don::write_file()", LOG_ERR);
-			}
-		} else {
-			// TODO: Try to set type above again
-			'@phan-var-force ModeleBarCode|ModeleExports|ModeleImports|ModelePDFAsset|ModelePDFContract|ModelePDFDeliveryOrder|ModelePDFEvaluation|ModelePDFFactures|ModelePDFFicheinter|ModelePDFMo|ModelePDFMovement|ModelePDFProduct|ModelePDFProjects|ModelePDFPropales|ModelePDFRecruitmentJobPosition|ModelePDFStock|ModelePDFStockTransfer|ModelePDFSupplierProposal|ModelePDFSuppliersInvoices|ModelePDFSuppliersOrders|ModelePDFSuppliersPayments|ModelePDFTask|ModelePDFTicket|ModelePDFUser|ModelePDFUserGroup|ModelePdfExpedition|ModelePdfReception|ModeleThirdPartyDoc $obj';
-			$this->context['moreparams'] = $moreparams;
-			$resultwritefile = $obj->write_file($this, $outputlangs, $srctemplatepath, $hidedetails, $hidedesc, $hideref);  // @phan-suppress-line-PhanTypeMismatchArgument
+		} catch (\Throwable $e) {
+			$resultwritefile = -1;
+			$this->error = $e->getMessage();
+			dol_syslog("Exception in write_file() for ".get_class($this).": ".$e->getMessage(), LOG_ERR);
 		}
 		// After call of write_file $obj->result['fullpath'] is set with generated file. It will be used to update the ECM database index.
 
@@ -6316,10 +6322,14 @@ abstract class CommonObject
 			return 1;
 		} else {
 			$outputlangs->charset_output = $sav_charset_output;
-			$this->error = $obj->error;
-			$this->errors = $obj->errors;
+			if (empty($this->error)) {
+				$this->error = $obj->error;
+			}
+			if (empty($this->errors)) {
+				$this->errors = $obj->errors;
+			}
 			$this->warnings = $obj->warnings;
-			dol_syslog("Error generating document for ".__CLASS__.". Error: ".$obj->error, LOG_ERR);
+			dol_syslog("Error generating document for ".__CLASS__.". Error: ".$this->error, LOG_ERR);
 			return -1;
 		}
 	}

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -162,7 +162,12 @@ function pdf_getInstance($format = '', $metric = 'mm', $pagetype = 'P')
 		define('K_SMALL_RATIO', 2 / 3);
 		define('K_THAI_TOPCHARS', true);
 		define('K_TCPDF_CALLS_IN_HTML', true);
-		if (getDolGlobalString('TCPDF_THROW_ERRORS_INSTEAD_OF_DIE')) {
+		// Default: throw exceptions on TCPDF/TCPDI errors instead of die().
+		// A die() in a PDF library produces white pages on web requests and kills
+		// batch jobs on the first bad PDF. Exceptions can be caught and surfaced as
+		// normal Dolibarr errors. Users can opt out by setting
+		// TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = 0 to restore the legacy die() behavior.
+		if (getDolGlobalString('TCPDF_THROW_ERRORS_INSTEAD_OF_DIE', '1')) {
 			define('K_TCPDF_THROW_EXCEPTION_ERROR', true);
 		} else {
 			define('K_TCPDF_THROW_EXCEPTION_ERROR', false);

--- a/htdocs/includes/tcpdi/tcpdi_parser.php
+++ b/htdocs/includes/tcpdi/tcpdi_parser.php
@@ -1441,7 +1441,11 @@ class tcpdi_parser {
      * @since 1.0.000 (2011-05-23)
      */
     public function Error($msg) {
-        // exit program and print error
+        // Respect K_TCPDF_THROW_EXCEPTION_ERROR like TCPDF does
+        if (defined('K_TCPDF_THROW_EXCEPTION_ERROR') && K_TCPDF_THROW_EXCEPTION_ERROR) {
+            throw new \Exception("TCPDI_PARSER ERROR [{$this->uniqueid}]: ".$msg);
+        }
+        // Default: exit program and print error
         die("<strong>TCPDI_PARSER ERROR [{$this->uniqueid}]: </strong>".$msg);
     }
 


### PR DESCRIPTION
## Problem

`tcpdi_parser::Error()` calls `die()` unconditionally, causing:

- **White pages** on PDF import failures (corrupted background, missing template) — user gets no message, no way to recover
- **Broken batch jobs** — one bad PDF kills the entire queue
- **No error propagation** — the message is lost before any handler can display it

TCPDF already supports exception mode via `K_TCPDF_THROW_EXCEPTION_ERROR`, and Dolibarr already exposes `TCPDF_THROW_ERRORS_INSTEAD_OF_DIE` in `core/lib/pdf.lib.php` to control it. TCPDI, derived from TCPDF, never honored it — so the setting only half-worked.

Related issues: #35826 (white page on payment creation), #35194 (TCPDI PHP 8.2+ issues).

## Solution — 4 changes across 3 files

### 1. `htdocs/includes/tcpdi/tcpdi_parser.php` — throw instead of die

```diff
     public function Error($msg) {
-        // exit program and print error
+        // Respect K_TCPDF_THROW_EXCEPTION_ERROR like TCPDF does
+        if (defined('K_TCPDF_THROW_EXCEPTION_ERROR') && K_TCPDF_THROW_EXCEPTION_ERROR) {
+            throw new \Exception("TCPDI_PARSER ERROR [{$this->uniqueid}]: ".$msg);
+        }
+        // Default: exit program and print error
         die("<strong>TCPDI_PARSER ERROR [{$this->uniqueid}]: </strong>".$msg);
     }
```

### 2. `htdocs/core/class/commonobject.class.php` — try/catch around `write_file()`

Wrap the `write_file()` dispatch in `commonGenerateDocument()` with `try/catch (\Throwable $e)` so exceptions thrown from TCPDI (or anywhere deeper in the PDF stack) are converted into `$resultwritefile = -1` with `$this->error` preserved from the exception message.

### 3. Same file — protect `$this->error` from being overwritten

The error path unconditionally overwrote `$this->error` with `$obj->error`, which is empty after an exception was caught in the `try` block. Guard both `$this->error` and `$this->errors` with `if (empty(...))`.

### 4. `htdocs/core/lib/pdf.lib.php` — enable exception mode by default

Flip the default of `TCPDF_THROW_ERRORS_INSTEAD_OF_DIE` from `0` to `1`. See rationale below.

## Why enable it by default?

`die()` in a PDF library has no legitimate production use case:

- **Web users** are always hurt by it (white page, no recovery)
- **CLI / batch scripts** are better served by exceptions — they can `try/catch` and continue the queue rather than the whole PHP process dying mid-loop
- **Custom modules** catching errors via output buffering were already broken by TCPDF's own exception mode; any module wanting reliability would already have opted in
- **Dolibarr's own call sites** (like `commonGenerateDocument()`, now patched) benefit unambiguously

Users who specifically need the legacy `die()` behavior can opt out with `TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = 0`. The opt-out path is fully preserved.

## Why all 4 changes together?

| Without | Result |
|---|---|
| Only #1 | TCPDI throws, but uncaught → "Uncaught Exception" page |
| Only #2 | try/catch has nothing to catch, TCPDI still `die()`s |
| Only #1 + #2 | Exception caught but error message lost (overwritten by empty `$obj->error`) |
| #1 + #2 + #3 only | Works, but requires users to find & set an obscure constant |
| **All four** | **Out-of-the-box: TCPDI throws → catch sets `$this->error` → error preserved → red Dolibarr banner** |

## Backward compatibility

- Users who already set `TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = 1`: no change
- Users who never set it: now get exception mode (the fix) — which is strictly better for any code path that was working before, since `commonGenerateDocument()` catches throwables and converts them to the same `-1` return + error message that `die()` would have produced a white page for
- Users who explicitly need `die()` back: set `TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = 0`

## Testing

Tested end-to-end against `dolibarr/dolibarr:develop` Docker image with a deliberately corrupted PDF set as `MAIN_ADD_PDF_BACKGROUND`:

1. **Default (no constant set)**: red Dolibarr banner `"TCPDI_PARSER ERROR [/var/www/documents/mycompany/corrupt.pdf]: Unable to find startxref"`, user stays on invoice page ✓
2. **Explicit `TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = 1`**: same behavior ✓
3. **Explicit `TCPDF_THROW_ERRORS_INSTEAD_OF_DIE = 0`**: legacy white-page `die()` output preserved ✓
4. **Normal PDF generation** (no corrupt background): works unchanged in all three modes ✓

## Before / After

**Before:** User clicks "Generate PDF" → `die()` → white page, no message, process dead.

**After:** User clicks "Generate PDF" → exception → caught in `commonGenerateDocument()` → red Dolibarr banner with the TCPDI error message → user stays on page, can fix and retry.

---

_Assisted by Claude, maybe it needs a human verification ;)_