### PR TITLE
Fix: fallback to numeric VAT rate match when default_vat_code is null

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -943,13 +943,19 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 									<?php
 								} ?>
 							}
-							// Set the VAT rate combo: try exact match first (rate + code), fallback to numeric match
-							if ($('#tva_tx option[value="' + stringforvatrateselection + '"]').length) {
-								$('#tva_tx').val(stringforvatrateselection);
+							// Set vat rate: handle both input box and combo cases
+							if ($('#tva_tx option').length) {
+								// It is a combo: try exact match first (rate + code), fallback to numeric match
+								if ($('#tva_tx option[value="' + stringforvatrateselection + '"]').length) {
+									$('#tva_tx').val(stringforvatrateselection);
+								} else {
+									$('#tva_tx option').filter(function () {
+										return parseFloat($(this).val()) === parseFloat(tva_tx);
+									}).first().prop('selected', true);
+								}
 							} else {
-								$('#tva_tx option').filter(function () {
-									return parseFloat($(this).val()) === parseFloat(tva_tx);
-								}).first().prop('selected', true);
+								// It is an input box
+								$('#tva_tx').val(tva_tx);
 							}
 
 								<?php

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -943,13 +943,14 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 									<?php
 								} ?>
 							}
-							// Set vat rate if field is an input box
-							$('#tva_tx').val(tva_tx);
-							// Set vat rate by selecting the combo
-							//$('#tva_tx option').val(tva_tx);	// This is bugged, it replaces the vat key of all options
-							$('#tva_tx option').removeAttr('selected');
-							console.log("stringforvatrateselection="+stringforvatrateselection+" -> value of option label for this key="+$('#tva_tx option[value="'+stringforvatrateselection+'"]').val());
-							$('#tva_tx option[value="'+stringforvatrateselection+'"]').prop('selected', true);
+							// Set the VAT rate combo: try exact match first (rate + code), fallback to numeric match
+							if ($('#tva_tx option[value="' + stringforvatrateselection + '"]').length) {
+								$('#tva_tx').val(stringforvatrateselection);
+							} else {
+								$('#tva_tx option').filter(function () {
+									return parseFloat($(this).val()) === parseFloat(tva_tx);
+								}).first().prop('selected', true);
+							}
 
 								<?php
 								if (getDolGlobalInt('PRODUIT_AUTOFILL_DESC') == 1) {


### PR DESCRIPTION
# FIX|Fix VAT rate not selected when adding a product line to an invoice or order


When selecting a product on an invoice or order line, the VAT rate combo box was not pre-selecting the correct rate, leaving it at 0%.


The root cause is in `objectline_create.tpl.php`: the original JS code used `$('#tva_tx option').removeAttr('selected')` followed by `.prop('selected', true)` on the target option. In jQuery 3.x, `removeAttr` on boolean attributes also sets the DOM property to `false` on all options, and when no exact match is found for `stringforvatrateselection` (which happens when the product has no `default_vat_code` stored in `llx_product`), no option gets selected.
                                                                                                                                                                                                                                                 
The fix tries an exact match on `stringforvatrateselection` first (e.g. `"20 (TEST CODE)"`), then falls back to a `parseFloat` numeric comparison when no exact match is found (e.g. product has `tva_tx = 20` but `default_vat_code` is null). This is consistent with the existing fallback logic already implemented server-side in `load_tva()` (`html.form.class.php` line 7480).