### PR TITLE
Qual doc for hook reloadDocumentLine

### DIFF
--- a/htdocs/admin/tools/ui/class/documentation.class.php
+++ b/htdocs/admin/tools/ui/class/documentation.class.php
@@ -264,6 +264,12 @@ class Documentation
 					'submenu' => array(),
 					'summary' => array(),
 				),
+				'UxDolibarrContextKnowsHooks' => array(
+					'url' => dol_buildpath($this->baseUrl.'/dolibarr-context/knows-hooks.php', 1),
+					'icon' => 'fa fa-anchor',
+					'submenu' => array(),
+					'summary' => array(),
+				),
 			)
 		);
 

--- a/htdocs/admin/tools/ui/dolibarr-context/knows-hooks.php
+++ b/htdocs/admin/tools/ui/dolibarr-context/knows-hooks.php
@@ -1,0 +1,143 @@
+<?php
+/*
+ * Copyright (C) 2025 Anthony Damhet <a.damhet@progiseize.fr>
+ * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Load Dolibarr environment
+require '../../../../main.inc.php';
+
+/**
+ * @var DoliDB      $db
+ * @var HookManager $hookmanager
+ * @var Translate   $langs
+ * @var User        $user
+ */
+
+// Protection if external user
+if ($user->socid > 0) {
+	accessforbidden();
+}
+
+// Includes
+require_once DOL_DOCUMENT_ROOT . '/admin/tools/ui/class/documentation.class.php';
+
+// Load documentation translations
+$langs->load('uxdocumentation');
+
+//
+$documentation = new Documentation($db);
+$group = 'UxDolibarrContext';
+$experimentName = 'UxDolibarrContextKnowsHooks';
+
+$js = [
+	'/includes/ace/src/ace.js',
+	'/includes/ace/src/ext-statusbar.js',
+	'/includes/ace/src/ext-language_tools.js'
+];
+$css = [];
+
+// Output html head + body - Param is Title
+$documentation->docHeader($langs->trans($experimentName, $group), $js, $css);
+
+// Set view for menu and breadcrumb
+$documentation->view = [$group, 'UxDolibarrContext', $experimentName];
+
+// Output sidebar
+$documentation->showSidebar(); ?>
+
+<div class="doc-wrapper">
+
+	<?php $documentation->showBreadCrumb(); ?>
+
+	<div class="doc-content-wrapper">
+
+		<h1 class="documentation-title"><?php echo $langs->trans($experimentName); ?></h1>
+
+		<?php $documentation->showSummary(); ?>
+
+		<div class="documentation-section">
+			<h2 id="titlesection-basicusage" class="documentation-title">Introduction</h2>
+
+			<p>
+				Some hooks are not natively triggered by Dolibarr; instead, they rely on external modules. Therefore, we document them here to ensure everyone uses the same method of triggering them, until we provide a standardized native trigger, which does not yet exist.<br/>
+				Please refer to the "How it works" section for further details.
+			</p>
+
+		</div>
+
+		<div class="documentation-section">
+			<h2 id="reloadDocumentLine" class="documentation-title">Hook : reloadDocumentLine</h2>
+			<p>
+				Next, let’s focus on the “reloadDocumentLine” hook. First, it’s important to note that this hook is not triggered automatically by Dolibarr.
+				<br/>Instead, it must be activated via external modules. In the future, we plan to introduce a class directly tied to the object within Dolibarr tools, allowing this hook to be triggered natively. However, although Dolibarr does not currently initiate the trigger itself, it does listen for it.
+				<br/>This is because it uses this trigger to reload certain elements on the lines, particularly the drag-and-drop system for rearranging line items in the document.
+			</p>
+			<p>
+				In the meantime, here is how you can use the event listener.
+				<br/>The process involves two steps: first, you trigger the event, and then you handle it with an event listener.
+				<br/>Below, you will find a code example of how to implement this.
+			</p>
+			<h4>Listen event</h4>
+			<div class="documentation-example">
+				<?php
+				$lines = array(
+					'<script>',
+					'Dolibarr.on(\'reloadDocumentLine\',',
+					'	/** @param {{lineId:number, lineElement:string}} data */',
+					'	function (data) {',
+					'		// Do your stuff',
+					'	}',
+					');',
+					'</script>',
+				);
+				$documentation->showCode($lines, 'php');
+				?>
+			</div>
+
+			<h4>Trigger event</h4>
+			<div class="documentation-example">
+				<?php
+				$lines = array(
+					'<script>',
+					'	const rowSelector = \'#row-\' + lineId;',
+					'	const $row = $(rowSelector);',
+					'',
+					'	// newRow is the newly created row element that will replace the existing row',
+					'	$row.replaceWith(newRow);',
+					'',
+					'	// Trigger the hook to dispatch reloaded line event.',
+					'	// This hook will by used to rebuild drag and drop lines order system for example ',
+					'	Dolibarr.executeHook(\'reloadDocumentLine\', {lineId, lineElement});',
+					'',
+					'	// Trigger initNewContent for all common Dom reloaded content. This will reload tooltips system for example ',
+					'	// This will reload tooltips system for example ',
+					'	Dolibarr.initNewContent(rowSelector);',
+					'</script>',
+				);
+				$documentation->showCode($lines, 'php');
+				?>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+</div>
+<?php
+// Output close body + html
+$documentation->docFooter();
+?>

--- a/htdocs/admin/tools/ui/dolibarr-context/langs-tool.php
+++ b/htdocs/admin/tools/ui/dolibarr-context/langs-tool.php
@@ -40,7 +40,7 @@ $langs->load('uxdocumentation');
 
 //
 $documentation = new Documentation($db);
-$group = 'ExperimentalUx';
+$group = 'UxDolibarrContext';
 $experimentName = 'UxDolibarrContextLangsTool';
 
 $experimentAssetsPath = dolBuildUrl('/public/includes/dolibarr-js-context');

--- a/htdocs/langs/en_US/uxdocumentation.lang
+++ b/htdocs/langs/en_US/uxdocumentation.lang
@@ -168,6 +168,7 @@ ExperimentalUxContributionEnd = This structure ensures a clear and modular organ
 UxDolibarrContext = JS Dolibarr context
 UxDolibarrContextHowItWork = How it's work
 UxDolibarrContextLangsTool = Langs tool
+UxDolibarrContextKnowsHooks = Common JS Hooks list
 
 UxMenuTooltipTheme = Tooltips & themes
 TooltipThemesAndOrientation = Tooltip Themes and orientation


### PR DESCRIPTION
# Qual

see #37850 , it include new hook event listener for ajax document lines dom reloaded. 

This is a new doc section for somes hooks names and standard usage 

<img width="923" height="833" alt="image" src="https://github.com/user-attachments/assets/07ad065a-c623-45af-9a74-ecd6ff22f9bb" />
<img width="941" height="484" alt="image" src="https://github.com/user-attachments/assets/215e84a2-7810-4ea9-9322-799b05959b7d" />
