### PR TITLE
FIX #36949 API Contract Creation Fails for Non-Admin Users in v22+

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -79,7 +79,7 @@ class Contrat extends CommonObject
 	 * 0=Default, 1=View may be restricted to sales representative only if no permission to see all or to company of external user if external user
 	 * @var integer
 	 */
-	public $restrictiononfksoc = 1;
+	public $restrictiononfksoc = 0;
 
 	/**
 	 * {@inheritdoc}


### PR DESCRIPTION
## Summary

Fixes #36949 - API contract creation fails for non-admin users with correct 
permissions (`contract->creer`, ID 162) in Dolibarr v22+. This is a regression 
bug introduced in v22.0.2 that was not resolved by PR #36521.

## Root Cause

The root cause is in `htdocs/contrat/class/contrat.class.php`:

```php
// line 82
public $restrictiononfksoc = 1;
```

When set to `1`, the `add_contact()` method in `CommonObject` performs an 
overly restrictive validation that requires the user to either:
- Have global permission `societe->client->voir` (see ALL thirdparties), OR
- Be a sales representative of the thirdparty

This validation fires during contract creation when associating 
`commercial_signature_id` and `commercial_suivi_id`, causing a ROLLBACK 
even when the user has already passed all permission checks in 
`api_contracts.class.php`.

This property was `0` in v21.x, which is why it worked correctly before.

## Fix

```diff
- public $restrictiononfksoc = 1;
+ public $restrictiononfksoc = 0;
```

## Testing

Tested on Dolibarr 23.0.2 with:
- Non-admin external user with permission ID 162 (`contract->creer`)
- User assigned as sales representative to the thirdparty
- `POST /api/index.php/contracts` → ✅ Contract created successfully
- `PUT /api/index.php/contracts/{id}` → ✅ Contract updated successfully

## Related

- Fixes #36949
- Related to #35655
- Related to PR #36521 (fixed a different validation layer, not the root cause)