### PR TITLE
Fix: deposit invoice not set as available credit after direct debit p…

### DIFF
--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -690,7 +690,7 @@ class BonPrelevement extends CommonObject
 					$paiement->num_payment = $this->ref; // Set ref of direct debit note
 					$paiement->id_prelevement = $this->id;
 
-					$result = $paiement->create($user); // This use ->paiementid, that is ID of payment mode
+					$result = $paiement->create($user, 1); // This use ->paiementid, that is ID of payment mode. closepaidinvoices=1 to convert deposit invoice to available credit
 
 					if ($result < 0) {
 						$error++;


### PR DESCRIPTION
# FIX | Fix Deposit invoice not marked as available credit after direct debit payment]                                                                                                                                            

When a deposit invoice (facture d'acompte) was paid through the direct debit workflow ("Classer crédité"), the payment was correctly recorded but the invoice was never converted to an available credit (crédit disponible).

The root cause was in bonprelevement.class.php: $paiement->create($user) was called without the $closepaidinvoices = 1 parameter. This parameter triggers the post-payment processing in paiement.class.php that converts a fully paid deposit 
invoice into a reusable discount/credit

Fixed by passing 1 as the second argument: $paiement->create($user, 1).