### PR TITLE
NEW Add event attendee to mass mailing based on their event attende status (v2)

### DIFF
--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -119,7 +119,7 @@ class FormProjets extends Form
 		}
 		if ($discard_closed > 0) {
 			if (!empty($form)) {
-				$out .= $form->textwithpicto('', $langs->trans("ClosedProjectsAreHidden"));
+				$out .= $form->textwithpicto('', $langs->trans("ClosedProjectsAreHidden").' Choosing 1 or more '.$langs->trans("Statut").' will add '.$langs->trans("EmailAttendee").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut"));
 			}
 		}
 
@@ -157,7 +157,7 @@ class FormProjets extends Form
 	public function select_projects_list($socid = -1, $selected = 0, $htmlname = 'projectid', $maxlength = 24, $option_only = 0, $show_empty = 1, $discard_closed = 0, $forcefocus = 0, $disabled = 0, $mode = 0, $filterkey = '', $nooutput = 0, $forceaddid = 0, $htmlid = '', $morecss = 'maxwidth500', $morefilter = '')
 	{
 		// phpcs:enable
-		global $user, $conf, $langs;
+		global $user, $conf, $langs, $form;
 
 		require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 
@@ -296,6 +296,28 @@ class FormProjets extends Form
 			}
 
 			$this->db->free($resql);
+
+			$out .= '<!-- Begin statusFilter -->';
+			$out .= '<div class="tagtd left valignmiddle">';
+			require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
+			$attendeeforstatus = new ConferenceOrBoothAttendee($this->db);
+
+			$epreselected = array();
+			$ekey_in_label = 0;
+			$evalue_as_key = 0;
+			$emorecss = '';
+			$etranslate = 1;
+			$ewidth = '390';
+			$emoreattrib = '';
+			$enu = '';
+			$eplaceholder = $langs->trans("Attendees").' '.$langs->trans("Statut").' — '.$langs->trans("ExtrafieldCheckBox").' — '. $langs->trans("NoneOrSeveral");
+			$eaddjscombo = -1;
+			// Event attendees statuses to add from
+			$out .= '<span class="fas fa-users  em088 infobox-project pictofixedwidth" style="" title="Organized event attendees"></span>';
+			$out .= '<tr class="field_addattendees">';
+			$out .= $form->multiselectarray('attendeeStatusList', $attendeeforstatus->fields['status']['arrayofkeyval'], $epreselected, $ekey_in_label, $evalue_as_key, $emorecss, $etranslate, $ewidth, $emoreattrib, $enu, $eplaceholder, $eaddjscombo);
+			$out .= '</td></tr>';
+			$out .= '<!-- End statusFilter -->';
 
 			if (!$mode) {
 				if (empty($option_only)) {

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -78,12 +78,13 @@ class mailing_eventorganization extends MailingTargets
 	{
 		// phpcs:enable
 		global $conf, $langs;
+		dol_syslog(__METHOD__, LOG_DEBUG);
 
 		$cibles = array();
 		$addDescription = '';
 
 		$sql = "SELECT p.ref, p.entity, e.rowid as id, e.fk_project, e.email as email, e.email_company as company_name, e.firstname as firstname, e.lastname as lastname,";
-		$sql .= " 'eventorganizationattendee' as source";
+		$sql .= " 'eventorganizationattendee' as source, e.status as status";
 		$sql .= " FROM ".MAIN_DB_PREFIX."eventorganization_conferenceorboothattendee as e,";
 		$sql .= " ".MAIN_DB_PREFIX."projet as p";
 		$sql .= " WHERE e.email <> ''";
@@ -92,6 +93,11 @@ class mailing_eventorganization extends MailingTargets
 		$sql .= " AND e.email NOT IN (SELECT email FROM ".MAIN_DB_PREFIX."mailing_cibles WHERE fk_mailing=".((int) $mailing_id).")";
 		if (GETPOSTINT('filter_eventorganization') > 0) {
 			$sql .= " AND e.fk_project = ".(GETPOSTINT('filter_eventorganization'));
+		}
+		if (GETPOSTISSET('attendeeStatusList')) {
+			$attendeeStatusList = (GETPOST('attendeeStatusList', 'array'));
+			$attendeeStatusListStr = implode(", ", $attendeeStatusList);
+			$sql .= " AND e.status IN (".$this->db->escape($attendeeStatusListStr).")";
 		}
 		if (empty($this->evenunsubscribe)) {
 			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = e.email and mu.entity = ".((int) $conf->entity).")";


### PR DESCRIPTION
# NEW Add event attendee to mass mailing based on their event attende status
This PR can add event attendee to mass mailings based on the status of their event attendee registration. If you don't select any status you get them all, status filtering are only done as long as you select 1 or more statuses.

Best of all, these statuses are directly pulled from eventorganisation status fields, so if new are added, or changed, or ... then this should still work.

This PR is a partial fulfilment of #37686