### PR TITLE
FIX wrong hook init in module_parts

### DIFF
--- a/htdocs/core/modules/modQuickMemo.class.php
+++ b/htdocs/core/modules/modQuickMemo.class.php
@@ -118,11 +118,8 @@ class modQuickMemo extends DolibarrModules
 			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'
 
 			'hooks' => array(
-				   'data' => array(
-					   'globalcard',
-					   'index',
-				   ),
-				   'entity' => '0',
+				'globalcard',
+				'index'
 			),
 
 			// Set this to 1 if features of module are opened to external users

--- a/htdocs/quickmemo/class/actions_quickmemo.class.php
+++ b/htdocs/quickmemo/class/actions_quickmemo.class.php
@@ -86,9 +86,14 @@ class ActionsQuickMemo extends CommonHookActions
 	 */
 	public function llxFooter($parameters, &$object, &$action, $hookmanager)
 	{
+		if (!isModEnabled('quickmemo')) {
+			return 0;
+		}
 
 		$context = Memo::getMemoContext($parameters['context']??'');
-		if (empty($context)) { return 0; }
+		if (empty($context)) {
+			return 0;
+		}
 
 		$jsConfVars = [
 			'context' => $context,
@@ -119,6 +124,9 @@ class ActionsQuickMemo extends CommonHookActions
 	 */
 	public function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager)
 	{
+		if (!isModEnabled('quickmemo')) {
+			return 0;
+		}
 
 		if (empty($object) || !is_object($object) || !isset($object->element)) {
 			return 0;


### PR DESCRIPTION
@eldy @thersane-john 

Entity '0' is defined only if the module needs to be activated globally for all entities. Otherwise, when hook calls within the module fail to check if the module is activated, the hooks will be executed on entities that do not use the module.

```
'hooks' => array(
	'data' => array(
	    'globalcard',
	     'index',
	),
	'entity' => '0',
),
```
use instead to add hook init for each entity : 

```
'hooks' => array(
	'globalcard',
	'index'
),
```