### PR TITLE
New: Complete context tab isolation for QuickMemo module

### DIFF
--- a/htdocs/contrat/document.php
+++ b/htdocs/contrat/document.php
@@ -92,7 +92,7 @@ $upload_dir = $conf->contrat->multidir_output[$object->entity ?? $conf->entity].
 $modulepart = 'contract';
 
 // Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context
-$hookmanager->initHooks(array('contractcard', 'globalcard'));
+$hookmanager->initHooks(array('contractcard', 'contractdocument', 'globalcard'));
 
 $permissiontoadd = $user->hasRight('contrat', 'creer');	// Used by the include of actions_dellink.inc.php
 

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -156,7 +156,7 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	public $menu = array();
 
 	/**
-	 * @var array{triggers?:int<0,1>,login?:int<0,1>,substitutions?:int<0,1>,menus?:int<0,1>,theme?:int<0,1>,tpl?:int<0,1>,barcode?:int<0,1>,models?:int<0,1>,printing?:int<0,1>,css?:string[],js?:string[],hooks?:array{data?:string[],entity?:string},moduleforexternal?:int<0,1>,websitetemplates?:int<0,1>,contactelement?:int<0,1>} Module parts
+	 * @var array{triggers?:int<0,1>,login?:int<0,1>,substitutions?:int<0,1>,menus?:int<0,1>,theme?:int<0,1>,tpl?:int<0,1>,barcode?:int<0,1>,models?:int<0,1>,printing?:int<0,1>,css?:string[],js?:string[],hooks?:array{data?:string[],entity?:string}|string[],moduleforexternal?:int<0,1>,websitetemplates?:int<0,1>,contactelement?:int<0,1>} Module parts
 	 *  array(
 	 *      // Set this to 1 if module has its own trigger directory (/mymodule/core/triggers)
 	 *      'triggers' => 0,

--- a/htdocs/core/modules/modQuickMemo.class.php
+++ b/htdocs/core/modules/modQuickMemo.class.php
@@ -99,7 +99,7 @@ class modQuickMemo extends DolibarrModules
 		$compatibleHooks = array_unique($compatibleHooks);
 		// Security check
 		$compatibleHooks = array_filter($compatibleHooks, function (string $k) {
-			return is_string($k) && preg_match('/^[a-zA-Z0-9_]+$/', $k);
+			return preg_match('/^[a-zA-Z0-9_]+$/', $k);
 		});
 
 		// Define some features supported by module (triggers, login, substitutions, menus, css, etc...)

--- a/htdocs/core/modules/modQuickMemo.class.php
+++ b/htdocs/core/modules/modQuickMemo.class.php
@@ -99,7 +99,6 @@ class modQuickMemo extends DolibarrModules
 		$compatibleHooks = array_unique($compatibleHooks);
 		// Security check
 		$compatibleHooks = array_filter($compatibleHooks, function (string $k) {
-			if (!is_string($k)) { return false; }
 			return preg_match('/^[a-zA-Z0-9_]+$/', $k);
 		});
 

--- a/htdocs/core/modules/modQuickMemo.class.php
+++ b/htdocs/core/modules/modQuickMemo.class.php
@@ -93,13 +93,13 @@ class modQuickMemo extends DolibarrModules
 		$compatibleHooks = [];
 		foreach ($contextTabMapping as $values) {
 			foreach ((array) $values as $value) {
-				$compatibleHooks[] = $value;
+				$compatibleHooks[] = (string) $value;
 			}
 		}
 		$compatibleHooks = array_unique($compatibleHooks);
 		// Security check
 		$compatibleHooks = array_filter($compatibleHooks, function (string $k) {
-			return preg_match('/^[a-zA-Z0-9_]+$/', $k);
+			return is_string($k) && preg_match('/^[a-zA-Z0-9_]+$/', $k);
 		});
 
 		// Define some features supported by module (triggers, login, substitutions, menus, css, etc...)

--- a/htdocs/core/modules/modQuickMemo.class.php
+++ b/htdocs/core/modules/modQuickMemo.class.php
@@ -27,6 +27,7 @@
  *  \brief      Description and activation file for module QuickMemo
  */
 include_once DOL_DOCUMENT_ROOT.'/core/modules/DolibarrModules.class.php';
+require_once DOL_DOCUMENT_ROOT.'/quickmemo/class/memo.class.php';
 
 
 /**
@@ -87,6 +88,20 @@ class modQuickMemo extends DolibarrModules
 		// To use a supported fa-xxx css style of font awesome, use this->picto='xxx'
 		$this->picto = 'fa-sticky-note_far_#9bdb07';
 
+		// Define hooks
+		$contextTabMapping = Memo::getAvailableMemoContextMapping(null, false);
+		$compatibleHooks = [];
+		foreach ($contextTabMapping as $values) {
+			foreach ((array) $values as $value) {
+				$compatibleHooks[] = $value;
+			}
+		}
+		$compatibleHooks = array_unique($compatibleHooks);
+		// Security check
+		$compatibleHooks = array_filter($compatibleHooks, function ($k) {
+			return preg_match('/^[a-zA-Z0-9_]+$/', $k);
+		});
+
 		// Define some features supported by module (triggers, login, substitutions, menus, css, etc...)
 		$this->module_parts = array(
 			// Set this to 1 if module has its own trigger directory (core/triggers)
@@ -117,13 +132,7 @@ class modQuickMemo extends DolibarrModules
 			),
 			// Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'
 
-			'hooks' => array(
-				   'data' => array(
-					   'globalcard',
-					   'index',
-				   ),
-				   'entity' => '0',
-			),
+			'hooks' => $compatibleHooks,
 
 			// Set this to 1 if features of module are opened to external users
 			'moduleforexternal' => 0,

--- a/htdocs/core/modules/modQuickMemo.class.php
+++ b/htdocs/core/modules/modQuickMemo.class.php
@@ -98,7 +98,7 @@ class modQuickMemo extends DolibarrModules
 		}
 		$compatibleHooks = array_unique($compatibleHooks);
 		// Security check
-		$compatibleHooks = array_filter($compatibleHooks, function ($k) {
+		$compatibleHooks = array_filter($compatibleHooks, function (string $k) {
 			if (!is_string($k)) { return false; }
 			return preg_match('/^[a-zA-Z0-9_]+$/', $k);
 		});

--- a/htdocs/core/modules/modQuickMemo.class.php
+++ b/htdocs/core/modules/modQuickMemo.class.php
@@ -99,6 +99,7 @@ class modQuickMemo extends DolibarrModules
 		$compatibleHooks = array_unique($compatibleHooks);
 		// Security check
 		$compatibleHooks = array_filter($compatibleHooks, function ($k) {
+			if (!is_string($k)) { return false; }
 			return preg_match('/^[a-zA-Z0-9_]+$/', $k);
 		});
 

--- a/htdocs/quickmemo/class/actions_quickmemo.class.php
+++ b/htdocs/quickmemo/class/actions_quickmemo.class.php
@@ -87,7 +87,7 @@ class ActionsQuickMemo extends CommonHookActions
 	public function llxFooter($parameters, &$object, &$action, $hookmanager)
 	{
 
-		$context = Memo::getMemoContext($parameters['context']??'');
+		$context = Memo::getMemoContext($parameters['context']??'', $object);
 		if (empty($context)) { return 0; }
 
 		$jsConfVars = [
@@ -128,7 +128,7 @@ class ActionsQuickMemo extends CommonHookActions
 			'archivesUrlParams' => '&search_fk_element='. (int) $object->id .'&search_element_type='.$object->element,
 			'elementId' => (int) $object->id,
 			'elementType' => $object->element,
-			'context' => Memo::getMemoContext($parameters['context']??''),
+			'context' => Memo::getMemoContext($parameters['context']??'', $object),
 		];
 
 		Memo::loadQuickMemoJsInterface($jsConfVars);

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1408,7 +1408,7 @@ class Memo extends CommonObject
 	/**
 	 * Get available memo context
 	 *
-	 * @return mixed|mixed[]|string[]
+	 * @return string[]
 	 */
 	public static function getAvailableMemoContext()
 	{
@@ -1425,19 +1425,16 @@ class Memo extends CommonObject
 		$object = null;
 		$reshook = $hookmanager->executeHooks('getAvailableMemoContext', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
-			return $hookmanager->resArray;
+			$list = $hookmanager->resArray;
 		}
 
 		// Security check
-		/** @var array<string, mixed> $list */
 		$result = [];
-
 		foreach ($list as $k => $v) {
-			if (!is_string($k)) { continue; }
-			if (strlen($k) > 64) { continue; }
+			if (!is_string($v)) { continue; }
+			if (strlen($v) > 64) { continue; }
 			if (preg_match('/^[a-zA-Z0-9_]+$/', $k) !== 1) { continue; }
-
-			$result[$k] = $v;
+			$result[] = $v;
 		}
 
 		return $result;

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1430,8 +1430,7 @@ class Memo extends CommonObject
 
 		// Security check
 		return array_filter($list, function (string $k) {
-			if (!is_string($k)) { return false; }
-			return strlen((string) $k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', (string) $k);
+			return strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k);
 		}, ARRAY_FILTER_USE_KEY);
 	}
 

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1430,11 +1430,17 @@ class Memo extends CommonObject
 
 		// Security check
 		/** @var array<string, mixed> $list */
-		return array_filter($list, function ($k) {
-			return is_string($k)
-				&& strlen($k) <= 64
-				&& preg_match('/^[a-zA-Z0-9_]+$/', $k) === 1;
-		}, ARRAY_FILTER_USE_KEY);
+		$result = [];
+
+		foreach ($list as $k => $v) {
+			if (!is_string($k)) { continue; }
+			if (strlen($k) > 64) { continue; }
+			if (preg_match('/^[a-zA-Z0-9_]+$/', $k) !== 1) { continue; }
+
+			$result[$k] = $v;
+		}
+
+		return $result;
 	}
 
 

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1429,8 +1429,11 @@ class Memo extends CommonObject
 		}
 
 		// Security check
+		/** @var array<string, mixed> $list */
 		return array_filter($list, function ($k) {
-			return is_string($k) && strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k) === 1;
+			return is_string($k)
+				&& strlen($k) <= 64
+				&& preg_match('/^[a-zA-Z0-9_]+$/', $k) === 1;
 		}, ARRAY_FILTER_USE_KEY);
 	}
 

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1279,23 +1279,33 @@ class Memo extends CommonObject
 	 * Get memo context
 	 *
 	 * @param string|array<string> $context Context
+	 * @param CommonObject|null    $object the common Dolibarr object
+	 *
 	 * @return mixed|string
 	 */
-	public static function getMemoContext($context)
+	public static function getMemoContext($context, $object = null)
 	{
 		global $db,$action, $hookmanager;
+
+		if (!isModEnabled('quickmemo')) {
+			return '';
+		}
 
 		if (!is_array($context)) {
 			$context = explode(':', $context);
 		}
 
-		$memoContext = '';
-		if (in_array('index', $context)) {
-			$memoContext = 'index';
-		} elseif (in_array('globalcard', $context)) {
-			$memoContext = 'card';
-		}
+		$contextMapping = self::getAvailableMemoContextMapping();
 
+		$memoContext = '';
+		foreach ($contextMapping as $key => $values) {
+			$values = (array) $values;
+
+			if (array_intersect($context, $values)) {
+				$memoContext = $key;
+				break;
+			}
+		}
 
 		$staticMemo = new self($db);
 
@@ -1303,7 +1313,7 @@ class Memo extends CommonObject
 		$parameters = array(
 			'memoContext' =>& $memoContext
 		);
-		$object = null;
+
 		$reshook = $hookmanager->executeHooks('getMemoContext', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
 			return $hookmanager->resPrint;
@@ -1315,13 +1325,97 @@ class Memo extends CommonObject
 	/**
 	 * Get available memo context
 	 *
+	 * @param null $object the common Dolibarr object
+	 * @param bool $onlyActiveModules on true return only
+	 *
+	 * @return array|string[]
+	 */
+	public static function getAvailableMemoContextMapping($object = null, $onlyActiveModules = true)
+	{
+		global $db,$action, $hookmanager;
+
+		$contextTabMapping = [];
+
+		$commonCardContext = ['document', 'agenda', 'contactcard', 'stats'];
+		foreach ($commonCardContext as $context) {
+			// init common contexts
+			$contextTabMapping[$context] = [];
+		}
+
+		// Start Correction of no standard Dolibarr context and special context
+		if (isModEnabled('propal') || !$onlyActiveModules) {
+			$contextTabMapping['contactcard'][] = 'proposalcontactcard';
+		}
+
+		if (isModEnabled('supplier_order') || !$onlyActiveModules) {
+			$contextTabMapping['contactcard'][] = 'ordersuppliercontactcard';
+			$contextTabMapping['document'][] = 'ordersuppliercarddocument';
+			$contextTabMapping['agenda'][] = 'ordersuppliercardinfo';
+			$contextTabMapping['ordersupplierdispatch'][] = 'ordersupplierdispatch';
+		}
+
+		if (isModEnabled('contract') || !$onlyActiveModules) {
+			$contextTabMapping['agenda'][] = 'agendacontract';
+		}
+
+		if (isModEnabled('order') || !$onlyActiveModules) {
+			$contextTabMapping['ordershipmentcard'][] = 'ordershipmentcard';
+		}
+
+		// End of corrections
+
+		// Generate standard context
+		foreach (['order', 'propal', 'invoice', 'supplier_proposal', 'supplier_order', 'supplier_invoice', 'contract'] as $module) {
+			if (!isModEnabled($module) && $onlyActiveModules) {
+				continue;
+			}
+
+			$moduleClean = str_replace('_', '', $module);
+
+			foreach ($commonCardContext as $context) {
+				$contextTabMapping[$context][] = $moduleClean.$context;
+			}
+		}
+
+		if (!empty($object) && !empty($object->element)) {
+			foreach ($commonCardContext as $context) {
+				$contextTabMapping[$context][] = $object->element.$context;
+			}
+		}
+
+		$contextTabMapping = array_replace_recursive($contextTabMapping, [
+			// Need to by at end of tests
+			'index' => 'index',
+			'card' => 'globalcard'
+		]);
+
+		$staticMemo = new self($db);
+		$hookmanager->initHooks(array($staticMemo->element.'dao'));
+		$parameters = array(
+			'contextTabMapping' =>& $contextTabMapping,
+			'onlyActiveModules' => $onlyActiveModules
+		);
+
+		$reshook = $hookmanager->executeHooks('getAvailableMemoContextMapping', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		if ($reshook > 0) {
+			return $hookmanager->resArray;
+		}
+
+		return $contextTabMapping;
+	}
+
+
+	/**
+	 * Get available memo context
+	 *
 	 * @return mixed|mixed[]|string[]
 	 */
 	public static function getAvailableMemoContext()
 	{
 		global $db,$action, $hookmanager;
 
-		$list = ['card', 'index'];
+		$contextMapping = self::getAvailableMemoContextMapping();
+		$list = array_keys($contextMapping);
 
 		$staticMemo = new self($db);
 		$hookmanager->initHooks(array($staticMemo->element.'dao'));
@@ -1334,7 +1428,10 @@ class Memo extends CommonObject
 			return $hookmanager->resArray;
 		}
 
-		return $list;
+		// Security check
+		return array_filter($list, function ($k) {
+			return strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k);
+		}, ARRAY_FILTER_USE_KEY);
 	}
 
 
@@ -1485,6 +1582,10 @@ class Memo extends CommonObject
 	public static function loadQuickMemoJsInterface($jsConfVars)
 	{
 		global $user;
+
+		if (!isModEnabled('quickmemo')) {
+			return false;
+		}
 
 		// DO NOT LOAD TWICE
 		if (defined('QUICKMEMOJS')) {

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1429,7 +1429,7 @@ class Memo extends CommonObject
 		}
 
 		// Security check
-		return array_filter($list, function ($k): bool {
+		return array_filter($list, function ($k) {
 			return is_string($k) && strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k) === 1;
 		}, ARRAY_FILTER_USE_KEY);
 	}

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1430,7 +1430,8 @@ class Memo extends CommonObject
 
 		// Security check
 		return array_filter($list, function ($k) {
-			return strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k);
+			if (!is_string($k)) { return false; }
+			return strlen((string) $k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', (string) $k);
 		}, ARRAY_FILTER_USE_KEY);
 	}
 

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1430,7 +1430,7 @@ class Memo extends CommonObject
 
 		// Security check
 		return array_filter($list, function (string $k) {
-			return strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k);
+			return strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k) ? 1 : 0;
 		}, ARRAY_FILTER_USE_KEY);
 	}
 

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1429,8 +1429,8 @@ class Memo extends CommonObject
 		}
 
 		// Security check
-		return array_filter($list, function (string $k) {
-			return strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k) ? 1 : 0;
+		return array_filter($list, function ($k): bool {
+			return is_string($k) && strlen($k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', $k) === 1;
 		}, ARRAY_FILTER_USE_KEY);
 	}
 

--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1429,7 +1429,7 @@ class Memo extends CommonObject
 		}
 
 		// Security check
-		return array_filter($list, function ($k) {
+		return array_filter($list, function (string $k) {
 			if (!is_string($k)) { return false; }
 			return strlen((string) $k) <= 64 && preg_match('/^[a-zA-Z0-9_]+$/', (string) $k);
 		}, ARRAY_FILTER_USE_KEY);


### PR DESCRIPTION
# New
Quick Memo was created to allow adding notes on each card tab independently, as well as on any specific page where needed.

Instead of introducing a global "all" context, I prefer to explicitly define all compatible contexts. This approach avoids issues with external or public pages.

This PR is the first of type.

