### PR TITLE
FIX : restore supplier proposal hover in linked objects block

### DIFF
--- a/htdocs/supplier_proposal/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/supplier_proposal/tpl/linkedobjectblock.tpl.php
@@ -58,7 +58,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	} ?>
 	<tr class="<?php echo $trclass; ?>">
 		<td class="tdoverflowmax125" title="<?php echo dolPrintHTMLForAttribute($langs->trans("SupplierProposal")); ?>"><?php echo dolPrintHTML($langs->trans("SupplierProposal")); ?></td>
-		<td><a href="<?php echo DOL_URL_ROOT.'/supplier_proposal/card.php?id='.$objectlink->id ?>"><?php echo img_object($langs->trans("ShowSupplierProposal"), "supplier_proposal").' '.$objectlink->ref; ?></a></td>
+		<td><?php echo $objectlink->getNomUrl(1); ?></td>
 		<td></td>
 		<td class="center"><?php echo dol_print_date($objectlink->date_creation, 'day'); ?></td>
 		<td class="right"><?php


### PR DESCRIPTION
# FIX|Fix #[*restore supplier proposal hover in linked objects block*]

The linked supplier proposal was correctly created and attached to the source order/proposal, but the standard linked objects template for supplier proposals was rendering a plain HTML link instead of using SupplierProposal::getNomUrl(). Because of that, the tooltip classes and data attributes used by Dolibarr hover previews were never added. This change switches the linked object rendering to getNomUrl(1), restoring the standard hover
behavior.

