### PR TITLE
NEW Add event attendee to mass mailing based on their event attende status (v3)

### DIFF
--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -65,6 +65,54 @@ class FormProjets extends Form
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 
 	/**
+	 * Output a combo list with the different status a ConferenceOrBoothAttendee can have
+	 * 2026 - copy of public static function multiselectarray
+	 *
+	 * @param 	string 		$htmlname 		Name of select
+	 * @param 	string[]	$selected 		Array of keys preselected
+	 * @param 	int<0,1>	$key_in_label 	1 to show key like in "[key] value"
+	 * @param 	int<0,1>	$value_as_key 	1 to use value as key
+	 * @param 	string 		$morecss 		Add more css style
+	 * @param 	int<0,1> 	$translate 		Translate and encode value
+	 * @param 	int|string 	$width 			Force width of select box. May be used only when using jquery couch. Example: 250, '95%'
+	 * @param 	string 		$moreattrib 	Add more options on select component. Example: 'disabled'
+	 * @param 	string 		$nu		 		Not used
+	 * @param 	string 		$placeholder 	String to use as placeholder
+	 * @param 	int<-1,1> 	$addjscombo 	Add js combo
+	 * @param int 			$nooutput 		No print output. Return it only.
+	 * @return string               		Return html content
+	 */
+	public function select_attendee_status_list($htmlname = 'attendeeStatusList', $selected = array(), $key_in_label = 0, $value_as_key = 0, $morecss = 'maxwidth500', $translate = 0, $width = 390, $moreattrib = '', $nu = '', $placeholder = '', $addjscombo = -1, $nooutput = 0)
+	{
+		// phpcs:enable
+		global $langs, $conf, $form;
+
+		require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
+		$attendeestatic = new ConferenceOrBoothAttendee($this->db);
+		$statusarray = $attendeestatic->fields['status']['arrayofkeyval'];
+		$placeholder = $langs->trans("Attendees").' '.$langs->trans("Statut").' — '.$langs->trans("ExtrafieldCheckBox").' — '. $langs->trans("NoneOrSeveral");
+		$translate = 1;
+
+		$out = '';
+
+		$out .= '<!-- Begin select_attendee_status_list -->';
+		// Event attendees statuses to add from
+		$out .= '<span class="fas fa-users  em088 infobox-attendee-status pictofixedwidth" style="" title="Organized event attendee status"></span>';
+		$out .= $form->multiselectarray($htmlname, $statusarray, $selected, $key_in_label, $value_as_key, $morecss, $translate, $width, $moreattrib, $nu, $placeholder, $addjscombo);
+		$out .= $form->textwithpicto('', 'Choosing 1 or more '.$langs->trans("Statut").' will add '.$langs->trans("EmailAttendee").' of the '.$langs->trans("Event").' '.$langs->trans("Attendees").' with the selected '.$langs->trans("Statut"));
+		$out .= '<!-- End select_attendee_status_list -->';
+
+		if (empty($nooutput)) {
+			print $out;
+			return '';
+		} else {
+			return $out;
+		}
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+
+	/**
 	 * Output a combo list with projects qualified for a third party / user
 	 *
 	 * @param int 					$socid 				Id third party (-1=all, 0=only projects not linked to a third party, id=projects not linked or linked to third party id)

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -96,8 +96,8 @@ class mailing_eventorganization extends MailingTargets
 		}
 		if (GETPOSTISSET('attendeeStatusList')) {
 			$attendeeStatusList = (GETPOST('attendeeStatusList', 'array'));
-			$attendeeStatusListStr = implode(", ", $attendeeStatusList);
-			$sql .= " AND e.status IN (".$this->db->escape($attendeeStatusListStr).")";
+			$attendeeStatusListStr = implode(",", $attendeeStatusList);
+			$sql .= " AND e.status IN (".$this->db->sanitize($attendeeStatusListStr).")";
 		}
 		if (empty($this->evenunsubscribe)) {
 			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = e.email and mu.entity = ".((int) $conf->entity).")";

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -78,12 +78,13 @@ class mailing_eventorganization extends MailingTargets
 	{
 		// phpcs:enable
 		global $conf, $langs;
+		dol_syslog(__METHOD__, LOG_DEBUG);
 
 		$cibles = array();
 		$addDescription = '';
 
 		$sql = "SELECT p.ref, p.entity, e.rowid as id, e.fk_project, e.email as email, e.email_company as company_name, e.firstname as firstname, e.lastname as lastname,";
-		$sql .= " 'eventorganizationattendee' as source";
+		$sql .= " 'eventorganizationattendee' as source, e.status as status";
 		$sql .= " FROM ".MAIN_DB_PREFIX."eventorganization_conferenceorboothattendee as e,";
 		$sql .= " ".MAIN_DB_PREFIX."projet as p";
 		$sql .= " WHERE e.email <> ''";
@@ -92,6 +93,11 @@ class mailing_eventorganization extends MailingTargets
 		$sql .= " AND e.email NOT IN (SELECT email FROM ".MAIN_DB_PREFIX."mailing_cibles WHERE fk_mailing=".((int) $mailing_id).")";
 		if (GETPOSTINT('filter_eventorganization') > 0) {
 			$sql .= " AND e.fk_project = ".(GETPOSTINT('filter_eventorganization'));
+		}
+		if (GETPOSTISSET('attendeeStatusList')) {
+			$attendeeStatusList = (GETPOST('attendeeStatusList', 'array'));
+			$attendeeStatusListStr = implode(", ", $attendeeStatusList);
+			$sql .= " AND e.status IN (".$this->db->escape($attendeeStatusListStr).")";
 		}
 		if (empty($this->evenunsubscribe)) {
 			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = e.email and mu.entity = ".((int) $conf->entity).")";
@@ -197,14 +203,16 @@ class mailing_eventorganization extends MailingTargets
 	public function formFilter()
 	{
 		global $conf, $langs;
+		dol_syslog(__METHOD__, LOG_DEBUG);
 
-		$langs->load("companies");
+		$langs->load("eventorganization");
 
 		include_once DOL_DOCUMENT_ROOT.'/core/class/html.formprojet.class.php';
 		$formproject = new FormProjets($this->db);
 
 		$s = img_picto($langs->trans("OrganizedEvent"), 'project', 'class="pictofixedwidth"');
 		$s .= $formproject->select_projects(-1, '0', "filter_eventorganization", 0, 0, $langs->trans("OrganizedEvent"), 1, 0, 0, 0, '', 1, 0, '', '', 'usage_organize_event=1');
+		$s .= $formproject->select_attendee_status_list('attendeeStatusList');
 
 		return $s;
 	}

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -212,7 +212,7 @@ class mailing_eventorganization extends MailingTargets
 
 		$s = img_picto($langs->trans("OrganizedEvent"), 'project', 'class="pictofixedwidth"');
 		$s .= $formproject->select_projects(-1, '0', "filter_eventorganization", 0, 0, $langs->trans("OrganizedEvent"), 1, 0, 0, 0, '', 1, 0, '', '', 'usage_organize_event=1');
-		$s .= $formproject->select_attendee_status_list('attendeeStatusList', array(), 0, 0, 'maxwidth500', 0, 390, '', '', '', -1, 1);
+		$s .= '<br>'.$formproject->select_attendee_status_list('attendeeStatusList', array(), 0, 0, 'maxwidth500', 0, 390, '', '', '', -1, 1);
 
 		return $s;
 	}

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -212,7 +212,7 @@ class mailing_eventorganization extends MailingTargets
 
 		$s = img_picto($langs->trans("OrganizedEvent"), 'project', 'class="pictofixedwidth"');
 		$s .= $formproject->select_projects(-1, '0', "filter_eventorganization", 0, 0, $langs->trans("OrganizedEvent"), 1, 0, 0, 0, '', 1, 0, '', '', 'usage_organize_event=1');
-		$s .= $formproject->select_attendee_status_list('attendeeStatusList');
+		$s .= $formproject->select_attendee_status_list('attendeeStatusList', array(), 0, 0, 'maxwidth500', 0, 390, '', '', '', -1, 1);
 
 		return $s;
 	}


### PR DESCRIPTION
# NEW Add event attendee to mass mailing based on their event attende status
This PR can add event attendee to mass mailings based on the status of their event attendee registration. If you don't select any status you get them all, status filtering are only done as long as you select 1 or more statuses.

Best of all, these statuses are directly pulled from eventorganisation status fields, so if new are added, or changed, or ... then this should still work.

This PR is a partial fulfilment of #37686