### PR TITLE
NEW delete event attendee from mass mailing

### DIFF
--- a/htdocs/comm/mailing/targetemailing.php
+++ b/htdocs/comm/mailing/targetemailing.php
@@ -113,7 +113,6 @@ if (empty($action) && empty($object->id)) {
 $permissiontoread = $user->hasRight('mailing', 'lire');
 $permissiontocreate = $user->hasRight('mailing', 'creer');
 $permissiontovalidatesend = $user->hasRight('mailing', 'valider');
-$permissiontodelete = $user->hasRight('mailing', 'supprimer');
 
 
 /*
@@ -126,9 +125,8 @@ if (GETPOST('cancel', 'alpha')) {
 if (!GETPOST('confirmmassaction', 'alpha')) {
 	$massaction = '';
 }
-
-if ($action == 'add' && $permissiontocreate) {		// Add recipients
-	$module = GETPOST("module", 'alpha');
+$module = GETPOST("module", 'alpha');
+if ($action == 'change' && $permissiontocreate) {		// Change recipients
 	$result = -1;
 	$obj = null;
 
@@ -140,12 +138,12 @@ if ($action == 'add' && $permissiontocreate) {		// Add recipients
 		// Loading Class
 		$file = $dir."/".$module.".modules.php";
 		$classname = "mailing_".$module;
+		$buttonaction = GETPOST('button_'.$module, 'aZ09');
 
 		if (file_exists($file)) {
 			include_once $file;
 
 			// Add targets into database
-			dol_syslog("Call add_to_target() on class ".$classname." evenunsubscribe=".$object->evenunsubscribe);
 
 			$obj = null;
 			if (class_exists($classname)) {
@@ -153,7 +151,18 @@ if ($action == 'add' && $permissiontocreate) {		// Add recipients
 				'@phan-var-force MailingTargets $obj';
 				$obj->evenunsubscribe = $object->evenunsubscribe;
 
-				$result = $obj->add_to_target($id);
+				if ($buttonaction == 'Add') {
+					dol_syslog("Call add_to_target() on class ".$classname." evenunsubscribe=".$object->evenunsubscribe);
+					$result = $obj->add_to_target($id);
+				} elseif ($buttonaction == 'Delete') {
+					dol_syslog("Call delete_from_target() on class ".$classname." evenunsubscribe=".$object->evenunsubscribe);
+					$result = $obj->delete_from_target($id);
+				} else {
+					dol_syslog("targetmailing.php::action::add::unknown buttonaction=".$buttonaction, LOG_ERR);
+					setEventMessages($langs->trans("Unknown").' buttonaction='.$buttonaction, null, 'errors');
+					$result -1;
+					break;
+				}
 
 				$sqlmessage = $obj->sql;
 			} else {
@@ -162,20 +171,38 @@ if ($action == 'add' && $permissiontocreate) {		// Add recipients
 			}
 		}
 	}
-	if ($result > 0) {
-		// If status of emailing is sent completely, change to to send partially
-		if ($object->status == $object::STATUS_SENTCOMPLETELY) {
-			$object->setStatut($object::STATUS_SENTPARTIALY);
-		}
+	if ($buttonaction == 'Add') {
+		if ($result > 0) {
+			// If status of emailing is sent completely, change to to send partially
+			if ($object->status == $object::STATUS_SENTCOMPLETELY) {
+				$object->setStatut($object::STATUS_SENTPARTIALY);
+			}
 
-		setEventMessages($langs->trans("XTargetsAdded", $result), null, 'mesgs');
-		$action = '';
-	}
-	if ($result == 0) {
-		setEventMessages($langs->trans("WarningNoEMailsAdded"), null, 'warnings');
-	}
-	if ($result < 0 && is_object($obj)) {
-		setEventMessages($langs->trans("Error").($obj->error ? ' '.$obj->error : ''), null, 'errors');
+			setEventMessages($langs->trans("XTargetsAdded", $result), null, 'mesgs');
+			$action = '';
+		}
+		if ($result == 0) {
+			setEventMessages($langs->trans("WarningNoEMailsAdded"), null, 'warnings');
+		}
+		if ($result < 0 && is_object($obj)) {
+			setEventMessages($langs->trans("Error").($obj->error ? ' '.$obj->error : ''), null, 'errors');
+		}
+	} elseif ($buttonaction == 'Delete') {
+		if ($result > 0) {
+			// If status of emailing is sent completely, change to to send partially
+			if ($object->status == $object::STATUS_SENTCOMPLETELY) {
+				$object->setStatut($object::STATUS_SENTPARTIALY);
+			}
+
+			setEventMessages($langs->trans("RemoveRecipient").': '.$result.' '.$langs->trans("ItemsCount"), null, 'mesgs');
+			$action = '';
+		}
+		if ($result == 0) {
+			setEventMessages($langs->trans("NothingToDelete", $result), null, 'warnings');
+		}
+		if ($result < 0 && is_object($obj)) {
+			setEventMessages($langs->trans("Error").($obj->error ? ' '.$obj->error : ''), null, 'errors');
+		}
 	}
 }
 
@@ -506,6 +533,7 @@ if ($object->fetch($id) >= 0) {
 
 	$newcardbutton = '';
 	$allowaddtarget = ($object->status == $object::STATUS_DRAFT);
+	$allowdeletetarget = ($object->status == $object::STATUS_DRAFT);
 	if (GETPOST('allowaddtarget')) {
 		$allowaddtarget = 1;
 	}
@@ -594,7 +622,7 @@ if ($object->fetch($id) >= 0) {
 					if ($allowaddtarget) {
 						print '<form class="oddeven trforbreakperms trforbreaknobg impair tagtr" name="'.$modulename.'" action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&module='.$modulename.'" method="POST" enctype="multipart/form-data">';
 						print '<input type="hidden" name="token" value="'.newToken().'">';
-						print '<input type="hidden" name="action" value="add">';
+						print '<input type="hidden" name="action" value="change">';
 						print '<input type="hidden" name="page_y" value="'.newToken().'">';
 					} else {
 						print '<div class="oddeven trforbreakperms trforbreaknobg impair tagtr">';
@@ -647,9 +675,15 @@ if ($object->fetch($id) >= 0) {
 
 					print '<div class="tagtd right valignmiddle">';
 					if ($allowaddtarget) {
-						print '<input type="submit" class="button button-add small reposition" name="button_'.$modulename.'" value="'.$langs->trans("Add").'">';
+						print '<input type="submit" class="butAction button-add small reposition" name="button_'.$modulename.'" value="'.$langs->trans("Add").'">';
+						if ($allowdeletetarget && $modulename == 'eventorganization') {
+							print '<input type="submit" class="butActionDelete button-delete small reposition" name="button_'.$modulename.'" value="'.$langs->trans("Delete").'">';
+						}
 					} else {
-						print '<input type="submit" class="button small disabled" disabled="disabled" name="button_'.$modulename.'" value="'.$langs->trans("Add").'">';
+						print '<input type="submit" class="butAction small disabled" disabled="disabled" name="button_'.$modulename.'" value="'.$langs->trans("Add").'">';
+						if ($allowdeletetarget && $modulename == 'eventorganization') {
+							print '<input type="submit" class="butActionDelete button-delete small disabled" disabled="disabled" name="button_'.$modulename.'" value="'.$langs->trans("Delete").'">';
+						}
 						//print $langs->trans("MailNoChangePossible");
 						print "&nbsp;";
 					}

--- a/htdocs/comm/mailing/targetemailing.php
+++ b/htdocs/comm/mailing/targetemailing.php
@@ -126,6 +126,7 @@ if (!GETPOST('confirmmassaction', 'alpha')) {
 	$massaction = '';
 }
 $module = GETPOST("module", 'alpha');
+$buttonaction = GETPOST('button_'.$module, 'aZ09');
 if ($action == 'change' && $permissiontocreate) {		// Change recipients
 	$result = -1;
 	$obj = null;
@@ -138,7 +139,6 @@ if ($action == 'change' && $permissiontocreate) {		// Change recipients
 		// Loading Class
 		$file = $dir."/".$module.".modules.php";
 		$classname = "mailing_".$module;
-		$buttonaction = GETPOST('button_'.$module, 'aZ09');
 
 		if (file_exists($file)) {
 			include_once $file;
@@ -160,7 +160,7 @@ if ($action == 'change' && $permissiontocreate) {		// Change recipients
 				} else {
 					dol_syslog("targetmailing.php::action::add::unknown buttonaction=".$buttonaction, LOG_ERR);
 					setEventMessages($langs->trans("Unknown").' buttonaction='.$buttonaction, null, 'errors');
-					$result -1;
+					$result = -1;
 					break;
 				}
 

--- a/htdocs/comm/mailing/targetemailing.php
+++ b/htdocs/comm/mailing/targetemailing.php
@@ -113,7 +113,7 @@ if (empty($action) && empty($object->id)) {
 $permissiontoread = $user->hasRight('mailing', 'lire');
 $permissiontocreate = $user->hasRight('mailing', 'creer');
 $permissiontovalidatesend = $user->hasRight('mailing', 'valider');
-
+$permissiontodelete = $user->hasRight('mailing', 'supprimer');
 
 /*
  * Actions

--- a/htdocs/comm/mailing/targetemailing.php
+++ b/htdocs/comm/mailing/targetemailing.php
@@ -126,7 +126,8 @@ if (!GETPOST('confirmmassaction', 'alpha')) {
 	$massaction = '';
 }
 $module = GETPOST("module", 'alpha');
-$buttonaction = GETPOST('button_'.$module, 'aZ09');
+$buttonadd = GETPOST('button_'.$module, 'aZ09');
+$buttondelete = GETPOST('button_delete_'.$module, 'aZ09');
 if ($action == 'change' && $permissiontocreate) {		// Change recipients
 	$result = -1;
 	$obj = null;
@@ -151,17 +152,13 @@ if ($action == 'change' && $permissiontocreate) {		// Change recipients
 				'@phan-var-force MailingTargets $obj';
 				$obj->evenunsubscribe = $object->evenunsubscribe;
 
-				if ($buttonaction == 'Add') {
+				if ($buttonadd) {
 					dol_syslog("Call add_to_target() on class ".$classname." evenunsubscribe=".$object->evenunsubscribe);
 					$result = $obj->add_to_target($id);
-				} elseif ($buttonaction == 'Delete') {
+				}
+				if ($buttondelete) {
 					dol_syslog("Call delete_from_target() on class ".$classname." evenunsubscribe=".$object->evenunsubscribe);
 					$result = $obj->delete_from_target($id);
-				} else {
-					dol_syslog("targetmailing.php::action::add::unknown buttonaction=".$buttonaction, LOG_ERR);
-					setEventMessages($langs->trans("Unknown").' buttonaction='.$buttonaction, null, 'errors');
-					$result = -1;
-					break;
 				}
 
 				$sqlmessage = $obj->sql;
@@ -171,7 +168,7 @@ if ($action == 'change' && $permissiontocreate) {		// Change recipients
 			}
 		}
 	}
-	if ($buttonaction == 'Add') {
+	if ($buttonadd) {
 		if ($result > 0) {
 			// If status of emailing is sent completely, change to to send partially
 			if ($object->status == $object::STATUS_SENTCOMPLETELY) {
@@ -187,7 +184,8 @@ if ($action == 'change' && $permissiontocreate) {		// Change recipients
 		if ($result < 0 && is_object($obj)) {
 			setEventMessages($langs->trans("Error").($obj->error ? ' '.$obj->error : ''), null, 'errors');
 		}
-	} elseif ($buttonaction == 'Delete') {
+	}
+	if ($buttondelete) {
 		if ($result > 0) {
 			// If status of emailing is sent completely, change to to send partially
 			if ($object->status == $object::STATUS_SENTCOMPLETELY) {
@@ -677,12 +675,12 @@ if ($object->fetch($id) >= 0) {
 					if ($allowaddtarget) {
 						print '<input type="submit" class="butAction button-add small reposition" name="button_'.$modulename.'" value="'.$langs->trans("Add").'">';
 						if ($allowdeletetarget && $modulename == 'eventorganization') {
-							print '<input type="submit" class="butActionDelete button-delete small reposition" name="button_'.$modulename.'" value="'.$langs->trans("Delete").'">';
+							print '<input type="submit" class="butActionDelete button-delete small reposition" name="button_delete_'.$modulename.'" value="'.$langs->trans("Delete").'">';
 						}
 					} else {
 						print '<input type="submit" class="butAction small disabled" disabled="disabled" name="button_'.$modulename.'" value="'.$langs->trans("Add").'">';
 						if ($allowdeletetarget && $modulename == 'eventorganization') {
-							print '<input type="submit" class="butActionDelete button-delete small disabled" disabled="disabled" name="button_'.$modulename.'" value="'.$langs->trans("Delete").'">';
+							print '<input type="submit" class="butActionDelete button-delete small disabled" disabled="disabled" name="button_delete_'.$modulename.'" value="'.$langs->trans("Delete").'">';
 						}
 						//print $langs->trans("MailNoChangePossible");
 						print "&nbsp;";

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -69,7 +69,7 @@ class mailing_eventorganization extends MailingTargets
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
-	 *    This is the main function that returns the array of emails
+	 *    This is the main function that returns the array of emails to add
 	 *
 	 *    @param	int		$mailing_id    	Id of mailing. No need to use it.
 	 *    @return   int 					Return integer <0 if error, number of emails added if ok
@@ -141,6 +141,68 @@ class mailing_eventorganization extends MailingTargets
 		return parent::addTargetsToDatabase($mailing_id, $cibles);
 	}
 
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *    This is the main function that returns the array of emails to delete
+	 *
+	 *    @param	int		$mailing_id    	Id of mailing. No need to use it.
+	 *    @return   int 					Return integer <0 if error, number of emails added if ok
+	 */
+	public function delete_from_target($mailing_id)
+	{
+		// phpcs:enable
+		global $conf, $langs;
+
+		$cibles = array();
+		$addDescription = '';
+
+		$sql = "SELECT p.ref, p.entity, e.rowid as id, e.fk_project, e.email as email, e.email_company as company_name, e.firstname as firstname, e.lastname as lastname,";
+		$sql .= " 'eventorganizationattendee' as source";
+		$sql .= " FROM ".MAIN_DB_PREFIX."projet as p,";
+		$sql .= " ".MAIN_DB_PREFIX."eventorganization_conferenceorboothattendee as e";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."mailing_cibles as mc ON e.email = mc.email";
+		$sql .= " WHERE e.email <> ''";
+		$sql .= " AND e.fk_project = p.rowid";
+		$sql .= " AND p.entity IN (".getEntity('project').")";
+		$sql .= " AND fk_mailing=".((int) $mailing_id);
+		if (GETPOSTINT('filter_eventorganization') > 0) {
+			$sql .= " AND e.fk_project = ".(GETPOSTINT('filter_eventorganization'));
+		}
+		$sql .= " ORDER BY e.email";
+
+		// Stock recipients emails into targets table
+		$result = $this->db->query($sql);
+		if ($result) {
+			$num = $this->db->num_rows($result);
+			$i = 0;
+			$j = 0;
+
+			dol_syslog(get_class($this)."::delete_from_target mailing ".$num." targets found");
+
+			$old = '';
+			while ($i < $num) {
+				$obj = $this->db->fetch_object($result);
+				if ($old != $obj->email) {
+					$cibles[$j] = array(
+								'email' => $obj->email,
+								'lastname' => $obj->lastname,
+								'firstname' => $obj->firstname,
+								'source' => $obj->source
+					);
+					$old = $obj->email;
+					$j++;
+				}
+
+				$i++;
+			}
+		} else {
+			dol_syslog($this->db->error());
+			$this->error = $this->db->error();
+			return -1;
+		}
+
+		return parent::deleteTargetsFromDatabase($mailing_id, $cibles);
+	}
 
 	/**
 	 *	On the main mailing area, there is a box with statistics.

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -157,7 +157,7 @@ class mailing_eventorganization extends MailingTargets
 		$addDescription = '';
 
 		$sql = "SELECT p.ref, p.entity, e.rowid as id, e.fk_project, e.email as email, e.email_company as company_name, e.firstname as firstname, e.lastname as lastname,";
-		$sql .= " 'eventorganizationattendee' as source";
+		$sql .= " 'eventorganizationattendee' as source_type";
 		$sql .= " FROM ".MAIN_DB_PREFIX."projet as p,";
 		$sql .= " ".MAIN_DB_PREFIX."eventorganization_conferenceorboothattendee as e";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."mailing_cibles as mc ON e.email = mc.email";
@@ -187,7 +187,7 @@ class mailing_eventorganization extends MailingTargets
 								'email' => $obj->email,
 								'lastname' => $obj->lastname,
 								'firstname' => $obj->firstname,
-								'source' => $obj->source
+								'source_type' => $obj->source_type
 					);
 					$old = $obj->email;
 					$j++;

--- a/htdocs/core/modules/mailings/modules_mailings.php
+++ b/htdocs/core/modules/mailings/modules_mailings.php
@@ -320,7 +320,6 @@ class MailingTargets // This can't be abstract as it is used for some method
 					$this->error = $this->db->error().' : '.$targetarray['email'];
 					$this->db->rollback();
 					return -1;
-					}
 				}
 			}
 		}

--- a/htdocs/core/modules/mailings/modules_mailings.php
+++ b/htdocs/core/modules/mailings/modules_mailings.php
@@ -316,12 +316,10 @@ class MailingTargets // This can't be abstract as it is used for some method
 				if ($result) {
 					$j++;
 				} else {
-					if ($this->db->errno() != 'DB_ERROR_RECORD_ALREADY_EXISTS') {
-						// Si erreur autre que doublon
-						dol_syslog($this->db->error().' : '.$targetarray['email']);
-						$this->error = $this->db->error().' : '.$targetarray['email'];
-						$this->db->rollback();
-						return -1;
+					dol_syslog($this->db->error().' : '.$targetarray['email']);
+					$this->error = $this->db->error().' : '.$targetarray['email'];
+					$this->db->rollback();
+					return -1;
 					}
 				}
 			}

--- a/htdocs/core/modules/mailings/modules_mailings.php
+++ b/htdocs/core/modules/mailings/modules_mailings.php
@@ -282,6 +282,56 @@ class MailingTargets // This can't be abstract as it is used for some method
 		return $j;
 	}
 
+	/**
+	 * Delete a list of targets from the database
+	 *
+	 * @param	int		$mailing_id    Id of emailing
+	 * @param	array<array{fk_contact?:int,lastname:string,firstname:string,email:string,other:string,source_url:string,source_id?:int,source_type:string,id?:int}>		$cibles		Array with targets
+	 * @return  int      			   Return integer < 0 if error, nb added if OK
+	 */
+	public function deleteTargetsFromDatabase($mailing_id, $cibles)
+	{
+		global $conf;
+
+		$this->db->begin();
+
+		// Insert emailing targets from array into database
+		$j = 0;
+		$num = count($cibles);
+		foreach ($cibles as $targetarray) {
+			if (!empty($targetarray['email'])) {
+				$sql = "DELETE FROM ".$this->db->prefix()."mailing_cibles WHERE";
+				$sql .= " fk_mailing = ".((int) $mailing_id);
+				$sql .= " AND ";
+				$sql .= " email = '".((string) $targetarray['email'])."'";
+				$sql .= " AND ";
+				$sql .= " firstname = '".((string) $targetarray['firstname'])."'";
+				$sql .= " AND ";
+				$sql .= " lastname = '".((string) $targetarray['lastname'])."'";
+				$sql .= " AND ";
+				$sql .= " source_type = '".((string) $targetarray['source'])."'";
+
+				dol_syslog(__METHOD__, LOG_DEBUG);
+				$result = $this->db->query($sql);
+				if ($result) {
+					$j++;
+				} else {
+					if ($this->db->errno() != 'DB_ERROR_RECORD_ALREADY_EXISTS') {
+						// Si erreur autre que doublon
+						dol_syslog($this->db->error().' : '.$targetarray['email']);
+						$this->error = $this->db->error().' : '.$targetarray['email'];
+						$this->db->rollback();
+						return -1;
+					}
+				}
+			}
+		}
+
+		$this->db->commit();
+
+		return $j;
+	}
+
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
 	 *  Supprime tous les destinataires de la table des cibles

--- a/htdocs/core/modules/mailings/modules_mailings.php
+++ b/htdocs/core/modules/mailings/modules_mailings.php
@@ -516,4 +516,20 @@ class MailingTargets // This can't be abstract as it is used for some method
 		dol_syslog($msg, LOG_ERR);
 		return -1;
 	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *  Delete recipients from the targets table
+	 *
+	 *  @param  int     $mailing_id     Id of emailing
+	 *  @return int                     Return integer < 0 on error, count of added when ok
+	 */
+	public function delete_from_target($mailing_id)
+	{
+		// phpcs:enable
+		// Needs to be implemented in child class
+		$msg = get_class($this)."::".__FUNCTION__." not implemented";
+		dol_syslog($msg, LOG_ERR);
+		return -1;
+	}
 }

--- a/htdocs/core/modules/mailings/modules_mailings.php
+++ b/htdocs/core/modules/mailings/modules_mailings.php
@@ -286,7 +286,7 @@ class MailingTargets // This can't be abstract as it is used for some method
 	 * Delete a list of targets from the database
 	 *
 	 * @param	int		$mailing_id    Id of emailing
-	 * @param	array<array{fk_contact?:int,lastname:string,firstname:string,email:string,other:string,source_url:string,source_id?:int,source_type:string,id?:int}>		$cibles		Array with targets
+	 * @param	array<array{lastname:string,firstname:string,email:string,source_type:string}>		$cibles		Array with targets
 	 * @return  int      			   Return integer < 0 if error, nb added if OK
 	 */
 	public function deleteTargetsFromDatabase($mailing_id, $cibles)
@@ -309,7 +309,7 @@ class MailingTargets // This can't be abstract as it is used for some method
 				$sql .= " AND ";
 				$sql .= " lastname = '".((string) $targetarray['lastname'])."'";
 				$sql .= " AND ";
-				$sql .= " source_type = '".((string) $targetarray['source'])."'";
+				$sql .= " source_type = '".((string) $targetarray['source_type'])."'";
 
 				dol_syslog(__METHOD__, LOG_DEBUG);
 				$result = $this->db->query($sql);


### PR DESCRIPTION
# NEW delete event attendee from mass mailing
This PR deletes event attendees in a given event from the mass mailing. This can be used to:

1. Add all event attendees from last event
2. Remove all event attendees from current event
3. What should be left are all those who has not yet registered to the current event
4. Send email asking them to register

This PR is a partial fix of #37686 and #35845