### PR TITLE
Harmonizing create proposal, order and invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3889,7 +3889,7 @@ if ($action == 'create') {
 	}
 	print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
 	print '<input name="ref" type="hidden" value="provisoire">';
-	print '<input name="ref_client" type="hidden" value="'.$ref_client.'">';
+	//print '<input name="ref_client" type="hidden" value="'.$ref_client.'">';
 	print '<input name="force_cond_reglement_id" type="hidden" value="0">';
 	print '<input name="force_mode_reglement_id" type="hidden" value="0">';
 	print '<input name="force_fk_account" type="hidden" value="0">';
@@ -3916,13 +3916,20 @@ if ($action == 'create') {
 		}
 
 		// Ref
-		/*
 		print '<tr><td class="fieldrequired titlefieldcreate">'.$langs->trans('Ref').'</td>';
 		print '<td colspan="2">';
 		print $langs->trans("Draft");
 		print '</td>';
 		print '</tr>'."\n";
-		*/
+
+		// Customer Ref
+		print '<tr><td>' . $langs->trans('RefCustomer') . '</td><td>';
+		if (!empty($origin) && !empty($originid)) {
+			print '<input type="text" name="ref_client" value="' . $ref_client . '"></td>';
+		} else {
+			print '<input type="text" name="ref_client" value="' . GETPOST('ref_client') . '"></td>';
+		}
+		print '</tr>'."\n";
 
 		// Thirdparty
 		if ($soc->id > 0 && (!GETPOSTINT('fac_rec') || !empty($invoice_predefined->frequency))) {


### PR DESCRIPTION
Add ref and customer ref on invoice to have the same create fields on proposal, order and invoice


<img width="878" height="445" alt="Capture d’écran 2026-04-18 à 08 57 50" src="https://github.com/user-attachments/assets/6783090f-f2c1-4aea-a115-8772dd9c0203" />
<img width="773" height="331" alt="Capture d’écran 2026-04-18 à 08 57 45" src="https://github.com/user-attachments/assets/2792ec2c-2168-41ec-9c5f-8af015ee558d" />
<img width="715" height="340" alt="Capture d’écran 2026-04-18 à 08 57 41" src="https://github.com/user-attachments/assets/a79208ee-6aba-4c21-a8dd-a051fe437628" />
