### PR TITLE
UXUI Improve public ticket message list

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1910,7 +1910,7 @@ class FormTicket
 		$formai = new FormAI($this->db);
 
 		$formmail->withfckeditor = $ckeditorenabledforticket ? 1 : 0;
-		$formmail->withlayout = $ckeditorenabledforticket ? 'email' : '';
+		$formmail->withlayout = (string) $ckeditorenabledforticket ? 'email' : '';
 		$formmail->withaiprompt = isModEnabled('ai') ? 'text' : '';
 		$formai = new FormAI($this->db);
 
@@ -1922,7 +1922,6 @@ class FormTicket
 		$htmlname = 'message';
 
 		$formai->substit = $this->substit;
-		//$formai->substit_lines = $this->substit_lines;
 
 		// Fill $out
 		$db = $this->db;

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -449,7 +449,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 		print '<div class="ticketpublicarea ticketlargemargin">';
 		print '<h3>';
 		print load_fiche_titre($langs->trans('TicketMessagesList'), '', 'conversation');
-		print '<h3>';
+		print '</h3>';
 		print '</div>';
 
 		$object->viewTicketMessages(false, true, $object->dao);

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -255,7 +255,7 @@ llxHeaderTicket($langs->trans("Tickets"), "", 0, 0, $arrayofjs, $arrayofcss);
 
 if ($action == "view_ticket" || $action == "presend" || $action == "close" || $action == "confirm_public_close") {
 	if ($display_ticket) {
-		print '<!-- public view ticket -->';
+		print '<!-- public view ticket if if -->';
 		print '<div class="ticketpublicarea ticketlargemargin">';
 
 		// Confirmation close
@@ -447,14 +447,16 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 
 		// Message list
 		print '<div class="ticketpublicarea ticketlargemargin">';
+		print '<h3>';
 		print load_fiche_titre($langs->trans('TicketMessagesList'), '', 'conversation');
+		print '<h3>';
 		print '</div>';
 
 		$object->viewTicketMessages(false, true, $object->dao);
 
 		print '<br>';
 	} else {
-		print '<!-- public view ticket -->';
+		print '<!-- public view ticket if else -->';
 		print '<div class="ticketpublicarea ticketlargemargin">';
 
 		print '<div class="error">Not Allowed<br><a href="'.$_SERVER['PHP_SELF'].'?track_id='.$object->dao->track_id.(!empty($entity) && isModEnabled('multicompany') ? '?entity='.$entity : '').'" rel="nofollow noopener">'.$langs->trans("GoBack").'</a></div>';
@@ -462,7 +464,7 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 		print '</div>';
 	}
 } else {
-	print '<!-- public view ticket -->';
+	print '<!-- public view ticket else -->';
 	print '<div class="ticketpublicarea ticketlargemargin">';
 
 	print '<div class="center opacitymedium margintoponly marginbottomonly ticketlargemargin">'.$langs->trans("TicketPublicMsgViewLogIn").'</div>';

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -221,13 +221,24 @@ class ActionsTicket extends CommonHookActions
 		print '<table class="border tableforfield centpercent margintable">';
 		print '<tr class="liste_titre trforfield"><td class="nowrap titlefield">';
 
-		print '<table class="nobordernopadding centpercent"><tr><td class="none noborder">';
-		print $langs->trans('InitialMessage');
-		if ($action != 'edit_message_init' && $permissiontoadd && !in_array($object->status, $closeStatuses)) {
-			print '</td><td class="right noborder">';
-			print '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=edit_message_init&token='.newToken().'&track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a>';
+		if ($action == '' || $action == 'view') {
+			print $langs->trans('InitialMessage');
+		} elseif ($action == 'presend') {
+			print '<h4>';
+			print $langs->trans('InitialMessage');
+			print '&emsp;<small>';
+			print img_picto('', 'object_action', 'class="paddingright"');
+			print dol_print_date($object->datec, "dayhour").'</small>';
+			print '</h4>';
+		} else {
+			print '<table class="nobordernopadding centpercent "><tr><td class="noborder">';
+			print $langs->trans('InitialMessage');
+			if ($action != 'edit_message_init' && $permissiontoadd && !in_array($object->status, $closeStatuses)) {
+				print '</td><td class="right noborder">';
+				print '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=edit_message_init&token='.newToken().'&track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a>';
+			}
+			print '</td></tr></table>';
 		}
-		print '</td></tr></table>';
 
 		print '</td><td>';
 		if ($action == 'edit_message_init' && $permissiontoadd && !in_array($object->status, $closeStatuses)) {
@@ -237,7 +248,7 @@ class ActionsTicket extends CommonHookActions
 		print '</td></tr>';
 
 		print '<tr>';
-		print '<td colspan="2">';
+		print '<td colspan="3">';
 		if ($permissiontoadd && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// Message
 			$msg = GETPOSTISSET('message_initial') ? GETPOST('message_initial', 'restricthtml') : $object->message;
@@ -302,24 +313,30 @@ class ActionsTicket extends CommonHookActions
 
 			print '<tr class="liste_titre">';
 
-			print '<td>';
+			print '<td align="left" class="borderbottom">';
+			print '<h4>';
 			print $langs->trans('TicketMessagesList');
+			print '</h4>';
 			print '</td>';
 
 			if ($show_author) {
-				print '<td>';
+				print '<td align="left" class="borderbottom">';
+				print '<h4>';
 				print $langs->trans('Author');
+				print '</h4>';
 				print '</td>';
 			}
 			print '</tr>';
+			print '<!-- pre additional messages of ticket -->';
 
+			$ticket_message_nr = 1;
 			foreach ($this->dao->cache_msgs_ticket as $id => $arraymsgs) {
 				if (!$arraymsgs['private']
 					|| ($arraymsgs['private'] == "1" && $show_private)
 				) {
 					//print '<tr>';
-					print '<tr class="oddeven nohover">';
-					print '<td><strong>';
+					print '<tr id="ticket_message_header_'.$ticket_message_nr.'" class="oddeven nohover">';
+					print '<td align="left">';
 					print img_picto('', 'object_action', 'class="paddingright"').dol_print_date($arraymsgs['datep'], 'dayhour');
 					print '<strong></td>';
 					if ($show_author) {
@@ -331,10 +348,15 @@ class ActionsTicket extends CommonHookActions
 								print img_picto('', 'user', 'class="pictofixedwidth"');
 								print $userstat->getNomUrl(0);
 							}
+							print '</td><td align="left">';
 						} elseif (isset($arraymsgs['fk_contact_author'])) {
+							print '</td><td align="left">';
 							$contactstat = new Contact($this->db);
 							$res = $contactstat->fetch(0, null, '', $arraymsgs['fk_contact_author']);
-							if ($res) {
+							if ($res == 2) {
+								print img_picto('', 'email', 'class="pictofixedwidth"');
+								print $arraymsgs['fk_contact_author'];
+							} elseif ($res) {
 								print img_picto('', 'contact', 'class="pictofixedwidth"');
 								print $contactstat->getNomUrl(0, 'nolink');
 							} else {
@@ -347,7 +369,7 @@ class ActionsTicket extends CommonHookActions
 					}
 					print '</tr>';
 
-					print '<tr class="oddeven nohover borderbottom">';
+					print '<tr id="ticket_message_body_'.$ticket_message_nr.'" class="oddeven nohover">';
 					print '<td'.($show_author ? ' colspan="2"' : '').'>';
 					print $arraymsgs['message'];
 
@@ -427,6 +449,7 @@ class ActionsTicket extends CommonHookActions
 					print '</td>';
 					print '</tr>';
 				}
+				$ticket_message_nr++;
 			}
 
 			print '</table>';

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -221,22 +221,13 @@ class ActionsTicket extends CommonHookActions
 		print '<table class="border tableforfield centpercent margintable">';
 		print '<tr class="liste_titre trforfield"><td class="nowrap titlefield">';
 
-		if ($action == 'presend') {
-			print '<h4>';
-			print $langs->trans('InitialMessage');
-			print '&emsp;<small>';
-			print img_picto('', 'object_action', 'class="paddingright"');
-			print dol_print_date($object->datec, "dayhour").'</small>';
-			print '</h4>';
-		} else {
-			print '<table class="nobordernopadding centpercent "><tr><td class="noborder" style="border-bottom: none !important;">';
-			print $langs->trans('InitialMessage');
-			if ($action != 'edit_message_init' && $permissiontoadd && !in_array($object->status, $closeStatuses)) {
-				print '</td><td class="right noborder" style="border-bottom: none !important;">';
-				print '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=edit_message_init&token='.newToken().'&track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a>';
-			}
-			print '</td></tr></table>';
+		print '<table class="nobordernopadding centpercent "><tr><td class="noborder" style="border-bottom: none !important;">';
+		print $langs->trans('InitialMessage');
+		if ($action != 'edit_message_init' && $permissiontoadd && !in_array($object->status, $closeStatuses)) {
+			print '</td><td class="right noborder" style="border-bottom: none !important;">';
+			print '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=edit_message_init&token='.newToken().'&track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a>';
 		}
+		print '</td></tr></table>';
 
 		print '</td><td>';
 		if ($action == 'edit_message_init' && $permissiontoadd && !in_array($object->status, $closeStatuses)) {

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -318,7 +318,7 @@ class ActionsTicket extends CommonHookActions
 			print '</td>';
 
 			if ($show_author) {
-				print '<td align="left" class="borderbottom">';
+				print '<td>';
 				print '<h4>';
 				print $langs->trans('Author');
 				print '</h4>';

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -221,9 +221,8 @@ class ActionsTicket extends CommonHookActions
 		print '<table class="border tableforfield centpercent margintable">';
 		print '<tr class="liste_titre trforfield"><td class="nowrap titlefield">';
 
-		if ($action == '' || $action == 'view') {
-			print $langs->trans('InitialMessage');
-		} elseif ($action == 'presend') {
+
+		if ($action == 'presend') {
 			print '<h4>';
 			print $langs->trans('InitialMessage');
 			print '&emsp;<small>';
@@ -231,10 +230,10 @@ class ActionsTicket extends CommonHookActions
 			print dol_print_date($object->datec, "dayhour").'</small>';
 			print '</h4>';
 		} else {
-			print '<table class="nobordernopadding centpercent "><tr><td class="noborder">';
+			print '<table class="nobordernopadding centpercent "><tr><td class="noborder" style="border-bottom: none !important;">';
 			print $langs->trans('InitialMessage');
 			if ($action != 'edit_message_init' && $permissiontoadd && !in_array($object->status, $closeStatuses)) {
-				print '</td><td class="right noborder">';
+				print '</td><td class="right noborder" style="border-bottom: none !important;">';
 				print '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=edit_message_init&token='.newToken().'&track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a>';
 			}
 			print '</td></tr></table>';

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -221,7 +221,6 @@ class ActionsTicket extends CommonHookActions
 		print '<table class="border tableforfield centpercent margintable">';
 		print '<tr class="liste_titre trforfield"><td class="nowrap titlefield">';
 
-
 		if ($action == 'presend') {
 			print '<h4>';
 			print $langs->trans('InitialMessage');
@@ -247,7 +246,7 @@ class ActionsTicket extends CommonHookActions
 		print '</td></tr>';
 
 		print '<tr>';
-		print '<td colspan="3">';
+		print '<td colspan="2">';
 		if ($permissiontoadd && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// Message
 			$msg = GETPOSTISSET('message_initial') ? GETPOST('message_initial', 'restricthtml') : $object->message;
@@ -312,7 +311,7 @@ class ActionsTicket extends CommonHookActions
 
 			print '<tr class="liste_titre">';
 
-			print '<td align="left" class="borderbottom">';
+			print '<td>';
 			print '<h4>';
 			print $langs->trans('TicketMessagesList');
 			print '</h4>';
@@ -326,7 +325,6 @@ class ActionsTicket extends CommonHookActions
 				print '</td>';
 			}
 			print '</tr>';
-			print '<!-- pre additional messages of ticket -->';
 
 			$ticket_message_nr = 1;
 			foreach ($this->dao->cache_msgs_ticket as $id => $arraymsgs) {
@@ -335,7 +333,7 @@ class ActionsTicket extends CommonHookActions
 				) {
 					//print '<tr>';
 					print '<tr id="ticket_message_header_'.$ticket_message_nr.'" class="oddeven nohover">';
-					print '<td align="left">';
+					print '<td><strong>';
 					print img_picto('', 'object_action', 'class="paddingright"').dol_print_date($arraymsgs['datep'], 'dayhour');
 					print '<strong></td>';
 					if ($show_author) {
@@ -347,9 +345,7 @@ class ActionsTicket extends CommonHookActions
 								print img_picto('', 'user', 'class="pictofixedwidth"');
 								print $userstat->getNomUrl(0);
 							}
-							print '</td><td align="left">';
 						} elseif (isset($arraymsgs['fk_contact_author'])) {
-							print '</td><td align="left">';
 							$contactstat = new Contact($this->db);
 							$res = $contactstat->fetch(0, null, '', $arraymsgs['fk_contact_author']);
 							if ($res == 2) {


### PR DESCRIPTION
# UIUX Improve public ticket message list
This PR improves the public ticket message list by adding a 3. column for the Contact/Address that is responsible for a message. This makes it faster to see who wrote the message. Also actually added the border between each message, but did not get oddeven to work. Table headers changed to h4 headlines which also makes it distinct. Finally this PR adds the creation date right next to the text `Initial Message` such that people does not have to scroll up to see it.

This PR removes the table in a table which created a strange line just below the text `Initial Message` - even on the Ticket Card inside Dolibarr.

This PR is a partial fix of #37925