### PR TITLE
Uxui remove border under classification of ticket

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -1236,10 +1236,10 @@ if ($action == 'create' || $action == 'presend') {
 		print '<table class="border tableforfield centpercent margintable bordertopimp">';
 		print '<tr class="liste_titre">';
 		print '<td class="valignmiddle titlefield">';
-		print '<table class="nobordernopadding centpercent"><tr><td class="none noborder">';
+		print '<table class="nobordernopadding centpercent"><tr><td class="none" style="border-bottom: none !important;">';
 		print $langs->trans('TicketProperties');
 		if (GETPOST('set', 'alpha') != 'properties' && isset($object->status) && ($object->status < $object::STATUS_NEED_MORE_INFO || !getDolGlobalInt('TICKET_DISALLOW_CLASSIFICATION_MODIFICATION_EVEN_IF_CLOSED')) && $permissiontoadd) {
-			print '</td><td class="right noborder"><a class="editfielda" href="card.php?track_id='.$object->track_id.'&set=properties">'.img_edit($langs->trans('Modify')).'</a>';
+			print '</td><td class="right" style="border-bottom: none !important;"><a class="editfielda" href="card.php?track_id='.$object->track_id.'&set=properties">'.img_edit($langs->trans('Modify')).'</a>';
 		}
 		print '</td></tr></table>';
 		print '</td>';


### PR DESCRIPTION
# Uxui remove border under classification of ticket
This PR removes the ugly border under `classification` on the ticket card.

## New UI
<img width="245" height="194" alt="image" src="https://github.com/user-attachments/assets/1193ffe0-2027-4b3e-87e2-ee4c0bbcba45" />
