### PR TITLE
UXUI Message Summary on ticket messages

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2023-2025  Charlene Benke	        <charlene.r@patas-monkey.com>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024	    Irvine FLEITH		    <irvine.fleith@atm-consulting.fr>
+ * Copyright (C) 2026		Jon Bendtsen          	<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1775,7 +1776,20 @@ class FormTicket
 
 		$uselocalbrowser = false;
 
-		// Subject/topic
+		// Summary
+		if ($this->withtitletopic) {
+			print '<tr><td><label for="summary"><span>'.$langs->trans("Summary").'</span></label></td><td>';
+			// Answer to a ticket : display of the thread title in readonly
+			if ($this->withtopicreadonly) {
+				print $langs->trans('Summary').' '.$this->topic_title;
+			} else {
+				if (isset($this->withreadid) && $this->withreadid > 0) {
+					$subject = $langs->trans('Summary').' '.$this->withreadid.' : '.$this->topic_title;
+				}
+				print '<input class="text minwidth500" maxlength="42" id="summary" name="summary" value="'.dolPrintHTMLForAttribute($this->topic_title).'"'.(empty($this->withemail) ? ' autofocus' : '').' />';
+			}
+			print '</td></tr>';
+		}
 		$topic = "";
 		foreach ($formmail->lines_model as $line) {
 			if (!empty($this->substit) && $this->param['models_id'] == $line->id) {

--- a/htdocs/public/ticket/view.php
+++ b/htdocs/public/ticket/view.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2018-2024	Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2023		Benjamin Falière		<benjamin.faliere@altairis.fr>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jon Bendtsen          	<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -406,6 +407,8 @@ if ($action == "view_ticket" || $action == "presend" || $action == "close" || $a
 
 			$formticket->withfile = 2;
 			$formticket->withcancel = 1;
+			$formticket->withtitletopic = 1;
+			$formticket->topic_title = $langs->trans('Summary').' '.$langs->trans('CreatedByPublicPortal');
 
 			$formticket->showMessageForm('100%');
 		}

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2023      Benjamin Falière		<benjamin.faliere@altairis.fr>
  * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024	   Irvine FLEITH		<irvine.fleith@atm-consulting.fr>
+ * Copyright (C) 2026		Jon Bendtsen        <jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1600,6 +1601,9 @@ if ($action == 'create' || $action == 'presend') {
 			$formticket->withsubstit = 1;
 			$formticket->substit = $substitutionarray;
 			$formticket->backtopage = $backtopage;
+
+			$formticket->withtitletopic = 1;
+			$formticket->topic_title = $langs->trans('Message').' '.$langs->trans('Summary');
 
 			$formticket->showMessageForm('100%');
 			print '</div>';

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2023-2024  Benjamin Falière	    <benjamin.faliere@altairis.fr>
  * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jon Bendtsen          	<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1888,11 +1889,12 @@ class Ticket extends CommonObject
 	 * @param	string[]	$mimefilename_list	List of attached file name in message
 	 * @param	bool		$send_email			Whether the message is sent by email
 	 * @param	int<0,1>	$public_area		0=Default, 1 if we are creating the message from a public area (so we can search contact from email to add it as contact of ticket if TICKET_ASSIGN_CONTACT_TO_MESSAGE is set)
+	 * @param	string		$summary			''=Default means using subject, else insert the summary as label
 	 * @return	int								Return integer <0 if KO, ID of actioncomm create if OK
 	 */
-	public function createTicketMessage($user, $notrigger = 0, $filename_list = array(), $mimetype_list = array(), $mimefilename_list = array(), $send_email = false, $public_area = 0)
+	public function createTicketMessage($user, $notrigger = 0, $filename_list = array(), $mimetype_list = array(), $mimefilename_list = array(), $send_email = false, $public_area = 0, $summary = '')
 	{
-		global $conf;
+		global $conf, $langs;
 		$error = 0;
 
 		$now = dol_now();
@@ -1923,7 +1925,16 @@ class Ticket extends CommonObject
 			$actioncomm->email_from = $_SESSION['email_customer'];
 		}
 		$actioncomm->socid = $this->socid;
-		$actioncomm->label = $this->subject;
+		if ($summary) {
+			if ($this->private) {
+				$actioncomm->label = '['.$langs->trans('Private').'] '.((string) $summary);
+			} else {
+				$actioncomm->label = (string) $summary;
+			}
+			$actioncomm->email_subject = $this->subject;
+		} else {
+			$actioncomm->label = $this->subject;
+		}
 		$actioncomm->note_private = $this->message;
 		$actioncomm->userassigned = array($user->id => array('id' => $user->id,'transparency' => 0));
 		$actioncomm->userownerid = $user->id;
@@ -2781,6 +2792,7 @@ class Ticket extends CommonObject
 		}
 
 		if (!$error) {
+			$summary = mb_strcut(GETPOST('summary', 'alphanohtml'), 0, 42, 'UTF-8');
 			$object->subject = GETPOST('subject', 'alphanohtml');
 			$object->message = GETPOST("message", "restricthtml");
 			$object->private = GETPOST("private_message", "alpha");
@@ -2801,7 +2813,7 @@ class Ticket extends CommonObject
 			// Add the ticket message in database (even if email is requested, we store a simple record
 			// like a simple private message, with no information about emails) because
 			// information about emails sent will be fill later after email sending.
-			$id = $object->createTicketMessage($user, 0, $listofpaths, $listofmimes, $listofnames, $send_email, $public_area);
+			$id = $object->createTicketMessage($user, 0, $listofpaths, $listofmimes, $listofnames, $send_email, $public_area, $summary);
 
 			if ($id <= 0) {
 				$error++;


### PR DESCRIPTION
# UXUI #37925 Message Summary on ticket messages
This PR adds a message summary when writing a message to an existing ticket. This summary is max 42 characters and will be shown as the title in the last 10 events and in the agenda view.

If a private message is added, there will be an insert `[Private]` in front of the up to 42 characters summary.

Before this PR, the text in the title column would just be the email subject, which is still unchanged, the summary is not even added to the email message 

This PR would close #37925

<img width="699" height="371" alt="ticket_card_last_10_events" src="https://github.com/user-attachments/assets/0b233c36-bc07-40e2-b003-a3f54c9cb364" />
