### PR TITLE
Qual: Set cs2pr version to downloadable release

### DIFF
--- a/.github/workflows/ci-phpstan_baseline.yml
+++ b/.github/workflows/ci-phpstan_baseline.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: ${{ env.PHP_VERSION }}
           coverage: none # disable xdebug, pcov
-          tools: phpstan:2.1.12, cs2pr
+          tools: phpstan:2.1.12
           extensions: calendar, json, imagick, gd, zip, mbstring, intl, opcache, imap,
               mysql, pgsql, sqlite3, ldap, xml, mcrypt
         env:

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           php-version: 8.2
           coverage: none # disable xdebug, pcov
-          tools: cs2pr,phan:5.5.2
+          tools: cs2pr:1.8.6,phan:5.5.2
 
 
       - name: Run Phan analysis

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none # disable xdebug, pcov
-          tools: phpstan:2.1.12, cs2pr
+          tools: phpstan:2.1.12, cs2pr:1.8.6
           extensions: calendar, json, imagick, gd, zip, mbstring, intl, opcache, imap,
             mysql, pgsql, sqlite3, ldap, xml, mcrypt
 


### PR DESCRIPTION
# Qual: Set cs2pr version to downloadable release

At least the phan github workflow failed because cs2pr could not be downloaded.
This updates the workflow files to set a specific cs2pr version and also removes it for a workflow where it is no longer needed.