### PR TITLE
UXUI Change mass mailing icon to bulk-mail

### DIFF
--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -47,7 +47,7 @@ class Mailing extends CommonObject
 	/**
 	 * @var string String with name of icon for myobject. Must be the part after the 'object_' into object_myobject.png
 	 */
-	public $picto = 'email';
+	public $picto = 'mail-bulk';
 
 	/**
 	 * @var string Type of message ('email', 'sms')

--- a/htdocs/comm/mailing/list.php
+++ b/htdocs/comm/mailing/list.php
@@ -486,7 +486,7 @@ if ($user->hasRight('mailing', 'creer')) {
 	$newcardbutton .= dolGetButtonTitle($langs->trans('NewMailing'), '', 'fa fa-plus-circle', $url);
 }
 
-print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, 'object_email', 0, $newcardbutton, '', $limit, 0, 0, 1);
+print_barre_liste($title, $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, $massactionbutton, $num, $nbtotalofrecords, $object->picto, 0, $newcardbutton, '', $limit, 0, 0, 1);
 
 // Add code for pre mass action (confirmation or email presend form)
 $topicmail = "SendMailingRef";

--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -2588,7 +2588,7 @@ function get_left_menu_tools($mainmenu, &$newmenu, $usemenuhider = 1, $leftmenu 
 				$titleindex .= ' | '.$langs->trans("SMSings");
 				$titlenew .= ' | '.$langs->trans("NewSMSing");
 			}
-			$newmenu->add(dolBuildUrl('/comm/mailing/index.php', ['leftmenu' => 'mailing']), $titleindex, 0, $user->hasRight('mailing', 'lire'), '', $mainmenu, 'mailing', 15, '', '', '', img_picto('', 'email', 'class="paddingright pictofixedwidth"'));
+			$newmenu->add(dolBuildUrl('/comm/mailing/index.php', ['leftmenu' => 'mailing']), $titleindex, 0, $user->hasRight('mailing', 'lire'), '', $mainmenu, 'mailing', 15, '', '', '', img_picto('', 'mail-bulk', 'class="paddingright pictofixedwidth"'));
 			$newmenu->add(dolBuildUrl('/comm/mailing/card.php', ['leftmenu' => 'mailing', 'action' => 'create']), $titlenew, 1, $user->hasRight('mailing', 'creer'));
 			$newmenu->add(dolBuildUrl('/comm/mailing/list.php', ['leftmenu' => 'mailing']), $titlelist, 1, $user->hasRight('mailing', 'lire'));
 		}


### PR DESCRIPTION
# UXUI Change mass mailing icon to bulk-mail
This PR changes the mass mailing icon in left menu, on lists of mass mailings and on mass mailing cards.

<img width="414" height="291" alt="image" src="https://github.com/user-attachments/assets/daa09f4e-45a0-4060-a9be-89a6bbe406d5" />

The reason for this change is that I want to add a new massaction which adds/subtracts the selected to/from a mass mailing, and for that I wanted a different icon to separate it from the existing `Send by email`

<img width="235" height="159" alt="image" src="https://github.com/user-attachments/assets/1b4a6dc2-dc42-4ac8-ad69-98bde6be3173" />

And to keep the consistency in Dolibarr, I now propose changing the mass mailing icon.