### PR TITLE
Fix TakePos receipt prints wrong ticket when a provisional invoice is active

### DIFF
--- a/htdocs/takepos/receipt.php
+++ b/htdocs/takepos/receipt.php
@@ -85,7 +85,7 @@ if (!$user->hasRight('takepos', 'run')) {
 
 top_htmlhead('', '', 1);
 
-if ((string) $place != '' && !empty($_SESSION["takeposterminal"])) {
+if (!$facid && (string) $place != '' && !empty($_SESSION["takeposterminal"])) {
 	$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."facture";
 	$sql .= " WHERE ref = '(PROV-POS".$db->escape($_SESSION["takeposterminal"]."-".$place).")'";
 	$sql .= " AND entity IN (".getEntity('invoice').")";


### PR DESCRIPTION
# FIX #37959
TakePos receipt prints wrong ticket when a provisional invoice is active

## Problem

In `htdocs/takepos/receipt.php`, when a provisional invoice is active on the terminal (place 0), printing a receipt from an explicit `facid` (via TakePos history or the "POS ticket" button on an invoice) always prints the provisional invoice instead.

`$place` defaults to `0` when not provided. Since `(string) 0 === '0'` is not empty, the place-based SQL lookup always ran and overwrote the passed `facid`.

## Fix

Only run the place-based lookup when no `facid` was explicitly provided.
