### PR TITLE
Fix credit note refund payment recording and invoice status

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -319,7 +319,8 @@ if (empty($reshook)) {
 		// Add the payment
 		if (!$error && $res >= 0) {
 			$remaintopay = $invoice->getRemainToPay();
-			if ($remaintopay > 0) {
+			// Credit notes have negative remaintopay; regular invoices have positive
+			if (($remaintopay > 0 && $invoice->type != Facture::TYPE_CREDIT_NOTE) || ($remaintopay < 0 && $invoice->type == Facture::TYPE_CREDIT_NOTE)) {
 				$payment = new Paiement($db);
 
 				$payment->datepaye = $now;


### PR DESCRIPTION
# Fix #37962

In TakePos, when a credit note is validated at the payment step, `getRemainToPay()` returns a negative value (the amount owed back to the customer). The previous condition `if ($remaintopay > 0)` skipped the payment creation block entirely. Since `$remaintopay` was also not `0`, `setPaid()` was never called either, leaving the credit note in an open/unpaid state.

Fix by also entering the payment block when `$remaintopay < 0` and the invoice is a credit note:

```php
if ($remaintopay > 0 || ($remaintopay < 0 && $invoice->type == Facture::TYPE_CREDIT_NOTE)) {
```
