### PR TITLE
Fix TakePos to remain on closed cash control page after validation

### DIFF
--- a/htdocs/compta/cashcontrol/cashcontrol_card.php
+++ b/htdocs/compta/cashcontrol/cashcontrol_card.php
@@ -233,7 +233,7 @@ if ($action == "valid" && $permissiontoadd) {	// validate = close
 	if ($contextpage == 'takepos') {
 		print "
 		<script>
-		parent.location.href='../../takepos/index.php?place='+parent.place;
+		location.href='cashcontrol_card.php?id=".$id."&contextpage=takepos';
 		</script>";
 		exit;
 	}


### PR DESCRIPTION
# FIX #37964 

When closing a cash control from TakePos, after clicking "Validate", the user was redirected back to TakePos instead of staying on the finalized cash control page.
This prevented access to the print buttons (detailed report, Z-report) available on the closed record.