### PR TITLE
Fix: thirdparty list - search_all preserved in hidden field conflicts with specific field filters giving no results

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -147,6 +147,11 @@ $search_parent_name = trim(GETPOST('search_parent_name', 'alpha'));
 $search_note_public = GETPOST('search_note_public', 'alphanohtml');
 $search_note_private = GETPOST('search_note_private', 'alphanohtml');
 
+// If specific field filters are set, discard search_all to avoid combining both modes with no results
+if ($search_all && ($search_nom || $search_alias || $search_nom_only || $search_ref_ext || $search_barcode || $search_customer_code || $search_supplier_code || $search_account_customer_code || $search_account_supplier_code || $search_address || $search_zip || $search_town || $search_email || $search_phone || $search_phone_mobile || $search_fax || $search_url || $search_vat || $search_idprof1 || $search_idprof2 || $search_idprof3 || $search_idprof4 || $search_idprof5 || $search_idprof6 || $search_parent_name || $search_note_public || $search_note_private || ($search_id > 0))) {
+	$search_all = '';
+}
+
 $search_date_creation_startmonth = GETPOSTINT('search_date_creation_startmonth');
 $search_date_creation_startyear = GETPOSTINT('search_date_creation_startyear');
 $search_date_creation_startday = GETPOSTINT('search_date_creation_startday');


### PR DESCRIPTION
# Fix Thirdparty list - search_all combined with specific field filters gives no results

When a user performs a global search (`search_all`) on the thirdparty list, the template `massactions_pre.tpl.php` injects a hidden input `<input type="hidden" name="search_all">` inside the main filter form to preserve it.

When the user then uses a specific column filter (e.g. `search_nom`), both `search_all` and the specific field are submitted together in the POST. The SQL query combines them with AND, resulting in no results even though each filter individually would return results.

Fix: in `societe/list.php`, clear `search_all` when any specific field filter is also set, making both search modes mutually exclusive.