### PR TITLE
Qual: if statement always false removed

### DIFF
--- a/scripts/bank/export-bank-receipts.php
+++ b/scripts/bank/export-bank-receipts.php
@@ -212,9 +212,6 @@ $sql .= " WHERE b.fk_account = ".((int) $acct->id);
 if ($listofnum) {
 	$sql .= " AND b.num_releve IN (".$db->sanitize($listofnum, 1).")";
 }
-if (!isset($num)) {
-	$sql .= " OR b.num_releve is null";
-}
 $sql .= " AND b.fk_account = ba.rowid";
 $sql .= $db->order("b.num_releve, b.datev, b.datec", "ASC"); // We add date of creation to have correct order when everything is done the same day
 // print $sql;


### PR DESCRIPTION
# Qual:

`$num `is set here: https://github.com/Dolibarr/dolibarr/blob/b806fcbf78dbce73d972ac6cb41c8bac06f3e608/scripts/bank/export-bank-receipts.php#L83
Therefore, the following if statement will always evaluate to false, we can remove it.
https://github.com/Dolibarr/dolibarr/blob/b806fcbf78dbce73d972ac6cb41c8bac06f3e608/scripts/bank/export-bank-receipts.php#L215