### PR TITLE
FIX - AJAX Inventory POST

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -1323,10 +1323,11 @@ print '<script type="text/javascript">
    							var actionURL = "'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&page='.($page).$paramwithsearch.'";
    							$.ajax({
       					 	url: actionURL,
+        					type: "POST",
         					data: form.serialize(),
         					cache: false,
         					success: function(result){
-           				 	window.location.href = "'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&page='.($page - 1).$paramwithsearch.'&action=record";
+           				 	window.location.href = "'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&page='.($page).$paramwithsearch.'&action=record";
        					 	}});
 							return false;
 						});


### PR DESCRIPTION
# FIX - AJAX Inventory POST
 The "Generate movements and close" button is supposed to save the entered quantities and generate stock movements in a single action.

It does so via an AJAX call that saves the form before redirecting to the confirmationdialog. 
However, this AJAX call was using GET instead of POST. On inventories with many lines, the serialized form data exceeds the URL length limit, causing the quantities to never be persisted to the database.

The movement generation then reads null or stale qty_view values and produces nothing. Users were forced to manually click "Save" before "Generate" as a workaround.

A second bug also redirected to page - 1 instead of page, which could cause inconsistent line display between sessions.  


