### PR TITLE
FIX Sync conf->global when user overrides MAIN_CHECKBOX_LEFT_COLUMN

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1186,6 +1186,7 @@ if (!defined('NOLOGIN')) {
 	// Overwrite main_checkbox_left_column from user setup
 	if (isset($user->conf->MAIN_CHECKBOX_LEFT_COLUMN)) {	// If a user setup exists
 		$conf->main_checkbox_left_column = getDolUserInt('MAIN_CHECKBOX_LEFT_COLUMN'); // Can be 0
+		$conf->global->MAIN_CHECKBOX_LEFT_COLUMN = $conf->main_checkbox_left_column; // Sync so getDolGlobalString() picks it up
 	}
 
 	// Replace conf->css by personalized value if theme not forced


### PR DESCRIPTION
## Summary

When a user-level setup for \`MAIN_CHECKBOX_LEFT_COLUMN\` exists, \`\$conf->main_checkbox_left_column\` was updated but \`\$conf->global->MAIN_CHECKBOX_LEFT_COLUMN\` was not synced.

This caused \`getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')\` to return the system default instead of the user preference on list pages — meaning the checkbox column position was always determined by the global admin setting, ignoring per-user configuration.

**Fix:** After updating \`\$conf->main_checkbox_left_column\`, also write the value back into \`\$conf->global\` so \`getDolGlobalString()\` picks it up correctly.

Regression introduced in: a4908abc (*New Main checkbox left column to manage this conf for each users* #30439)

## Test plan

- [x] Set a user-level preference for \`MAIN_CHECKBOX_LEFT_COLUMN\` differing from the global setting
- [x] Open any list page and verify the checkbox column appears on the correct side per user preference