### PR TITLE
Fix #37994 - Handle mail sending error and disable option

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -3197,8 +3197,11 @@ class Ticket extends CommonObject
 					if ($mailfile->error) {
 						setEventMessages($langs->trans('ErrorFailedToSendMail', $from, $receiver), null, 'errors');
 						dol_syslog($langs->trans('ErrorFailedToSendMail', $from, $receiver).' : '.$mailfile->error);
-					} else {
+					} elseif (getDolGlobalString('MAIN_DISABLE_ALL_MAILS')) {
 						setEventMessages('No mail sent. Feature is disabled by option MAIN_DISABLE_ALL_MAILS', null, 'errors');
+					} else {
+						setEventMessages($langs->trans('ErrorFailedToSendMail', $from, $receiverstring), null, 'errors');
+						dol_syslog('ErrorFailedToSendMail (no error details) from='.$from.' to='.$receiverstring, LOG_WARNING);
 					}
 				}
 			}


### PR DESCRIPTION
FIX #37994

Fix misleading "MAIN_DISABLE_ALL_MAILS" error message in sendTicketMessageByEmail()

When `sendfile()` returned `false` without setting `$mailfile->error` (e.g. on transient SMTP failures), the fallback unconditionally displayed "No mail sent. Feature is disabled by option MAIN_DISABLE_ALL_MAILS" — even when that option was not set. This PR adds an explicit check for `MAIN_DISABLE_ALL_MAILS` and falls back to the standard `ErrorFailedToSendMail` message for all other failures.

