### PR TITLE
NEW: Show name_alias in parentheses in thirdparty dropdown lists

### DIFF
--- a/htdocs/core/class/html.formcompany.class.php
+++ b/htdocs/core/class/html.formcompany.class.php
@@ -753,7 +753,7 @@ class FormCompany extends Form
 			return $socid;
 		} else {
 			// Search to list thirdparties
-			$sql = "SELECT s.rowid, s.nom as name ";
+			$sql = "SELECT s.rowid, s.nom as name, s.name_alias";
 			if (getDolGlobalString('SOCIETE_ADD_REF_IN_LIST')) {
 				$sql .= ", s.code_client, s.code_fournisseur";
 			}
@@ -807,19 +807,20 @@ class FormCompany extends Form
 						if (is_array($limitto) && count($limitto) && !in_array($obj->rowid, $limitto)) {
 							$disabled = 1;
 						}
+						$nameAlias = !empty($obj->name_alias) ? ' (' . $obj->name_alias . ')' : '';
 						if ($selected > 0 && $selected == $obj->rowid) {
 							print '<option value="' . $obj->rowid . '"';
 							if ($disabled) {
 								print ' disabled';
 							}
-							print ' selected>' . dol_escape_htmltag($obj->name, 0, 0, '', 0, 1) . '</option>';
+							print ' selected>' . dol_escape_htmltag($obj->name, 0, 0, '', 0, 1) . $nameAlias . '</option>';
 							$firstCompany = $obj->rowid;
 						} else {
 							print '<option value="' . $obj->rowid . '"';
 							if ($disabled) {
 								print ' disabled';
 							}
-							print '>' . dol_escape_htmltag($obj->name, 0, 0, '', 0, 1) . '</option>';
+							print '>' . dol_escape_htmltag($obj->name, 0, 0, '', 0, 1) . $nameAlias . '</option>';
 						}
 						$i++;
 					}

--- a/htdocs/societe/ajax/ajaxcompanies.php
+++ b/htdocs/societe/ajax/ajaxcompanies.php
@@ -159,6 +159,9 @@ if ($resql) {
 		}
 
 		$label .= $row['nom'];
+		if (!empty($row['name_alias'])) {
+			$label .= ' (' . $row['name_alias'] . ')';
+		}
 
 		if (getDolGlobalString('COMPANY_SHOW_ADDRESS_SELECTLIST')) {
 			$label .= ($row['address'] ? ' - '.$row['address'] : '').($row['zip'] ? ' - '.$row['zip'] : '').($row['town'] ? ' '.$row['town'] : '');


### PR DESCRIPTION
# NEW|New Show name_alias in parentheses in thirdparty dropdown lists
Add display of the alternative name (`name_alias`) in parentheses next to the company name in thirdparty dropdown lists and autocomplete fields.                                                                                                                         
Affected functions:
- `selectCompaniesForNewContact()` in `core/class/html.formcompany.class.php`                                           
- autocomplete endpoint `societe/ajax/ajaxcompanies.php`

Example: a company named "TEST" with alias "Test name alias" will now appear as `TEST (Test name alias)` in dropdowns, making it easier to identify the right thirdparty when multiple entries share a similar name.