### PR TITLE
New: Sorting of payment and invoice details

### DIFF
--- a/htdocs/compta/tva/clients.php
+++ b/htdocs/compta/tva/clients.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2006		Yannick Warnier			<ywarnier@beeznest.org>
  * Copyright (C) 2014		Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2018-2024	Frédéric France			<frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Juan Pablo Farber		<jfarber55@hotmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -454,6 +454,9 @@ if (!is_array($x_coll) || !is_array($x_paye)) {
 				print '</tr>'."\n";
 
 				foreach ($x_both[$thirdparty_id]['coll']['detail'] as $index => $fields) {
+					// Sort by payment date/invoice date
+					usort($x_both[$thirdparty_id]['coll']['detail'], 'cmp_fields_date');
+
 					// Define type
 					// We MUST use dtype (type in line). We can use something else, only if dtype is really unknown.
 					$type = (isset($fields['dtype']) ? $fields['dtype'] : $fields['ptype']);
@@ -644,6 +647,9 @@ if (!is_array($x_coll) || !is_array($x_paye)) {
 				print '</tr>'."\n";
 
 				foreach ($x_both[$thirdparty_id]['paye']['detail'] as $index => $fields) {
+					// Sort by payment date/invoice date
+					usort($x_both[$thirdparty_id]['paye']['detail'], 'cmp_fields_date');
+
 					// Define type
 					// We MUST use dtype (type in line). We can use something else, only if dtype is really unknown.
 					$type = (isset($fields['dtype']) ? $fields['dtype'] : $fields['ptype']);
@@ -810,3 +816,20 @@ print '</div>';
 llxFooter();
 
 $db->close();
+
+/**
+ * Helper compare function to sort lines by payment date first
+ *
+ * @param array{datep:int,datef:int}	$a	Left argument to compare
+ * @param array{datep:int,datef:int}	$b	Right argument to compare
+ * @return int<-1,1>  Indicates sort order between arguments
+ */
+function cmp_fields_date(&$a, &$b)
+{
+	// Compare payment date
+	if ($a['datep'] != $b['datep']) {
+		return $a['datep'] <=> $b['datep'];
+	}
+	// In case the payment date is the same, order by invoice date
+	return $a['datef'] <=> $b['datef'];
+}

--- a/htdocs/compta/tva/clients.php
+++ b/htdocs/compta/tva/clients.php
@@ -423,6 +423,7 @@ if (!is_array($x_coll) || !is_array($x_paye)) {
 	print '</tr>';
 
 	$action = "tvadetail";
+	$parameters = array();
 	$parameters["mode"] = $modetax;
 	$parameters["start"] = $date_start;
 	$parameters["end"] = $date_end;


### PR DESCRIPTION
# New: Sorting of payment and invoice details

In compta/tva/clients.php when its better to order by payment date.  Currently when there are multiple payments for the same invoice for instance, the payments are not grouped. This fixes that.

Example of undesired order:

<img width="553" height="289" alt="image" src="https://github.com/user-attachments/assets/e603887e-9533-4ee3-910f-8c1fc2b11d9f" />

After fix:
<img width="597" height="280" alt="image" src="https://github.com/user-attachments/assets/b1cca3a1-0f6c-468d-be67-4cd80608d3aa" />

Implementation:
- Added sorting functionality for payment and invoice details based on payment date and invoice date
- Implemented a helper function `cmp_fields_date` to compare and sort the details
- Applied the sorting to both payment and invoice details sections in the code