### PR TITLE
# FIX Notification email template lookup with notifsupported and emailElementlist hooks

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -1290,7 +1290,7 @@ class Notify
 				if (!empty($mailTemplateLabel)) {
 					include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
 					$formmail = new FormMail($this->db);
-					$emailTemplate = $formmail->getEMailTemplate($this->db, $object_type.'_send', $user, $outputlangs, 0, 1, $mailTemplateLabel);
+					$emailTemplate = $formmail->getEMailTemplate($this->db, $object_type, $user, $outputlangs, 0, 1, $mailTemplateLabel);
 				}
 				if (!empty($mailTemplateLabel) && is_object($emailTemplate) && $emailTemplate->id > 0) {
 					if (property_exists($object, 'thirdparty')) {


### PR DESCRIPTION
# FIX Notification email template lookup with notifsupported and emailElementlist hooks

A mismatch could occur between the email template type configured for a notification event and the email template type searched when the notification was sent.

The issue comes from the fact that `Notify::send()` could add the `_send` suffix to the event `elementtype` before calling `getEMailTemplate()`.

As a result, `getEMailTemplate()` could search for:

- `<elementtype>_send`
- or even `<elementtype>_send_send`

while the email template type declared by the module through the `emailElementlist` hook was simply:

- `<elementtype>`

For example, an external module declaring an email template type `timesheetweek` could expose its notification events through the `notifsupported` hook, but the notification system could later look for `timesheetweek_send` or `timesheetweek_send_send` instead of `timesheetweek`.

This mainly broke the practical use of the `notifsupported` hook when combined with the `emailElementlist` hook for external modules.

The consequence was that:

- the notification event was correctly exposed in the Notification module setup;
- the email template type was correctly exposed by `emailElementlist`;
- but `Notify::send()` / `getEMailTemplate()` could fail to find the configured template because of the inconsistent `_send` suffix handling;
- the notification then fell back to the generic email instead of using the configured template.

This issue exists at least in Dolibarr v22, v23 and v24, and may also affect previous versions.

This patch fixes the conflict between `Notify::send()` and `getEMailTemplate()` by ensuring that the email template type is used consistently.

Expected behavior after this fix:

- if `<ACTIONCODE>_TEMPLATE` is configured and points to a valid template, `Notify::send()` uses it;
- if no template is configured, the generic notification email is sent;
- no extra `_send` suffix is added when the selected template already provides the correct type;
- external modules can reliably combine `notifsupported` and `emailElementlist`.