### PR TITLE
FIX : use company default RIB when it is defined

### DIFF
--- a/htdocs/compta/facture/prelevement.php
+++ b/htdocs/compta/facture/prelevement.php
@@ -821,20 +821,21 @@ if ($object->id > 0) {
 				print $langs->trans('CustomerIBAN').' ';
 
 				// if societe rib in model invoice, we preselect it
-				$selectedRib = '';
+				$selectedRibId = 0;
 				if ($object->element == 'invoice' && $object->fk_fac_rec_source) {
 					$facturerec = new FactureRec($db);
 					$facturerec->fetch($object->fk_fac_rec_source);
 					if ($facturerec->fk_societe_rib) {
 						$companyBankAccount = new CompanyBankAccount($db);
 						$res = $companyBankAccount->fetch($facturerec->fk_societe_rib);
-						$selectedRib = $companyBankAccount->id;
+						$selectedRibId = $companyBankAccount->id;
 					}
 				}
-
-				$selectedRib = $form->selectRib($selectedRib, 'accountcustomerid', 'fk_soc='.$object->socid, 1, '', 1);
-
 				$defaultRibId = $object->thirdparty->getDefaultRib();
+				if (empty($selectedRibId)) $selectedRibId = (int) $defaultRibId;
+
+				$selectedRib = $form->selectRib($selectedRibId, 'accountcustomerid', 'fk_soc='.$object->socid, 1, '', 1);
+
 				if ($defaultRibId) {
 					$companyBankAccount = new CompanyBankAccount($db);
 					$res = $companyBankAccount->fetch($defaultRibId);


### PR DESCRIPTION
# FIX : use company default RIB/IBAN when it is defined

On V18, when the default RIB of a company is defined, it is pre-filled on `/compta/facture/prelevement.php`.

On V22, this feature has been lost because another feature was added inbetween (#31698). After #31698, the RIB is only filled in case of a facture_rec.
<img width="1791" height="789" alt="prelevement" src="https://github.com/user-attachments/assets/9bb58e98-1976-407b-afaa-6a71d7929782" />




This bug has been observed on V22 and develop.

