### PR TITLE
NEW Add retained warranty amount on customer invoices

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -102,8 +102,9 @@ ALTER TABLE llx_categorie_mo ADD CONSTRAINT fk_categorie_mo_fk_mo_rowid FOREIGN 
 
 
 ALTER TABLE llx_facture ADD COLUMN fk_thirdparty_rib_id integer NULL;
-ALTER TABLE llx_facture_fourn ADD COLUMN fk_thirdparty_rib_id integer NULL;
+ALTER TABLE llx_facture ADD COLUMN amount_retained_warranty double(24,8) DEFAULT 0 NOT NULL AFTER retained_warranty;
 
+ALTER TABLE llx_facture_fourn ADD COLUMN fk_thirdparty_rib_id integer NULL;
 ALTER TABLE llx_facture_fourn ADD COLUMN payment_reference varchar(25);
 ALTER TABLE llx_facture_fourn ADD COLUMN dispute_status	integer DEFAULT 0;
 


### PR DESCRIPTION
# NEW|New Add retained warranty amount on customer invoices

This PR adds the `amount_retained_warranty` field to customer invoices.

## Purpose of the field

In construction and public works contracts, a retained warranty may be applied to an invoice. It represents an amount withheld from the payment of the invoice and usually released later, according to the contract conditions.

Dolibarr already has invoice-level information related to retained warranty, but it does not currently store the computed monetary amount separately.

The new `amount_retained_warranty` field stores the monetary amount of the retained warranty applied to the invoice.

## Meaning of the field

`amount_retained_warranty` is the amount of the invoice that is retained as warranty.

It is stored as an amount in the invoice currency.

It does not replace the invoice total. It identifies the part of the invoice amount that is deferred and not immediately payable.

## Why this field belongs to `llx_facture`

The retained warranty amount is related to the invoice as a whole, not to one specific invoice line.

It affects the payment schedule and the amount immediately payable for the customer invoice, so it belongs to the invoice header table `llx_facture`.

## Example use case

A construction company issues a situation invoice for a works contract.

Example values:

- Invoice amount before retained warranty: `10000.00`
- Retained warranty rate: `5.00000000`
- Retained warranty amount: `500.00000000`

Stored value:

```sql
amount_retained_warranty = 500.00000000
```
The invoice still represents `10000.00` of works, but `500.00` is retained and will be released later according to the contract.

Future usage

This field will allow future improvements for:

- situation invoices
- construction contract invoices
- public works contract invoices
- invoice PDF output
- amount-to-pay calculation
- accounting or e-invoicing exports

This PR only adds the database field and does not change the invoice calculation logic.

Database change
```sql
ALTER TABLE llx_facture ADD COLUMN amount_retained_warranty double(24,8) DEFAULT 0 NOT NULL;
```