### PR TITLE
NEW Add prorata account field on customer invoices

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -102,8 +102,9 @@ ALTER TABLE llx_categorie_mo ADD CONSTRAINT fk_categorie_mo_fk_mo_rowid FOREIGN 
 
 
 ALTER TABLE llx_facture ADD COLUMN fk_thirdparty_rib_id integer NULL;
-ALTER TABLE llx_facture_fourn ADD COLUMN fk_thirdparty_rib_id integer NULL;
+ALTER TABLE llx_facture ADD COLUMN prorata_account double(24,8) DEFAULT 0 NOT NULL AFTER amount_retained_warranty;
 
+ALTER TABLE llx_facture_fourn ADD COLUMN fk_thirdparty_rib_id integer NULL;
 ALTER TABLE llx_facture_fourn ADD COLUMN payment_reference varchar(25);
 ALTER TABLE llx_facture_fourn ADD COLUMN dispute_status	integer DEFAULT 0;
 


### PR DESCRIPTION
# NEW|New Add prorata account rate on customer invoices

This PR adds the `prorata_account` field to customer invoices.

## Purpose of the field

In construction and public works contracts, a prorata account may be used to distribute common site expenses between companies involved in the project.

The prorata account is often applied as a percentage of the invoice amount. This percentage is then used to calculate a prorata account amount deducted from, or applied to, the invoice.

The new `prorata_account` field stores the prorata account rate applied to the customer invoice.

## Meaning of the field

`prorata_account` stores the prorata account rate used for the invoice.

It is not the computed monetary amount. The computed monetary amount is expected to be stored separately.

The value is expressed as a percentage.

For example:

```text
1.50000000 means 1.5%
```

Why this field belongs to llx_facture

The prorata account rate is usually defined at invoice level for a given construction contract or situation invoice.

It is not linked to a specific product or service line. It is a global contractual adjustment applied to the invoice.

Therefore, the field belongs to the invoice header table llx_facture.

Example use case

A customer invoice is issued for a construction project where the contract includes a prorata account of 1.5%.

Example values:

* Invoice amount before prorata account: `10000.00`
* Prorata account rate: `1.50000000`
* Computed prorata account amount: `150.00000000`

Stored value:

```sql
prorata_account = 1.50000000
```

The prorata account amount can then be calculated and stored separately as:
```
10000.00 * 1.5% = 150.00
```

## Future usage

This field will allow future improvements for:

- construction contract invoices
- public works contract invoices
- situation invoices
- prorata account calculation
- invoice PDF output
- amount-to-pay calculation
- accounting or e-invoicing exports

This PR only adds the database field and does not change the invoice calculation logic.

Database change
```sql
ALTER TABLE llx_facture ADD COLUMN prorata_account double(24,8) DEFAULT 0 NOT NULL;
```
## Variante recommandée avec meilleur nom

Si tu acceptes de renommer, je proposerais plutôt :

```sql
ALTER TABLE llx_facture ADD COLUMN prorata_account_rate double(24,8) DEFAULT 0 NOT NULL;