### PR TITLE
NEW Add payment delegation amount on customer invoices

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -100,10 +100,10 @@ ALTER TABLE llx_categorie_mo ADD INDEX idx_categorie_mo_fk_mo (fk_mo);
 ALTER TABLE llx_categorie_mo ADD CONSTRAINT fk_categorie_mo_categorie_rowid FOREIGN KEY (fk_categorie) REFERENCES llx_categorie (rowid);
 ALTER TABLE llx_categorie_mo ADD CONSTRAINT fk_categorie_mo_fk_mo_rowid FOREIGN KEY (fk_mo) REFERENCES llx_mrp_mo (rowid);
 
-
 ALTER TABLE llx_facture ADD COLUMN fk_thirdparty_rib_id integer NULL;
-ALTER TABLE llx_facture_fourn ADD COLUMN fk_thirdparty_rib_id integer NULL;
+ALTER TABLE llx_facture ADD COLUMN amount_payment_delegation double(24,8) DEFAULT 0 NOT NULL AFTER amount_price_review;
 
+ALTER TABLE llx_facture_fourn ADD COLUMN fk_thirdparty_rib_id integer NULL;
 ALTER TABLE llx_facture_fourn ADD COLUMN payment_reference varchar(25);
 ALTER TABLE llx_facture_fourn ADD COLUMN dispute_status	integer DEFAULT 0;
 


### PR DESCRIPTION
# NEW|New Add payment delegation amount on customer invoices

This PR adds the `amount_payment_delegation` field to customer invoices.

## Purpose of the field

In construction contracts, especially with public works contracts or large private contractors, part of the invoice amount may be paid directly by the customer to a third party.

This is commonly known as payment delegation.

The new `amount_payment_delegation` field stores the monetary amount of the invoice that is subject to payment delegation.

## Meaning of the field

`amount_payment_delegation` is the amount of the invoice that is delegated for direct payment to a third party.

It is stored as an amount in the invoice currency.

It does not mean that the invoice amount is reduced from an accounting or contractual point of view. It identifies the part of the invoice that will not be paid directly to the invoice issuer because it is paid to another party.

## Why this field belongs to `llx_facture`

Payment delegation is applied at invoice level.

It affects the amount directly payable to the invoice issuer, but it is not linked to a specific invoice line, product or service.

Therefore, it belongs to the invoice header table `llx_facture`.

## Example use case

A customer invoice is issued for a construction contract.

Example values:

- Invoice amount before payment delegation: `10000.00`
- Amount paid directly by the customer to a delegated third party: `2000.00000000`

Stored value:

```sql
amount_payment_delegation = 2000.00000000
```

The invoice still represents `10000.00` of works, but `2000.00` is identified as an amount paid directly to a third party instead of being paid to the invoice issuer.

## Future usage

This field will allow future improvements for:

- public works contract invoices
- large private construction contract invoices
- situation invoices
- amount directly payable calculation
- invoice PDF output
- accounting or e-invoicing exports

This PR only adds the database field and does not change the invoice calculation logic.

Database change

```sql
ALTER TABLE llx_facture ADD COLUMN amount_payment_delegation double(24,8) DEFAULT 0 NOT NULL;
```