### PR TITLE
NEW From product Related invoices do massaction add to massmailing

### DIFF
--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2025       Jon Bendtsen            <jon.bendtsen.github@jonb.dk>
+ * Copyright (C) 2025-2026  Jon Bendtsen            <jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -561,6 +561,86 @@ class Mailing extends CommonObject
 
 				$records[$record->id] = $record;
 
+				$i++;
+			}
+			$this->db->free($resql);
+
+			return $records;
+		} else {
+			$this->errors[] = 'Error '.$this->db->lasterror();
+			dol_syslog(__METHOD__.' '.implode(',', $this->errors), LOG_ERR);
+
+			return -1;
+		}
+	}
+
+	/**
+	 * Load id of mass mailings, either in a project or not
+	 *
+	 * @param	User		$user			Object user to evaluate for project permissions
+	 * @param	int			$include      	Return only the mass mailing ids which is assigned to this project, 0 means return all mass mailing and is the default
+	 * @param	int			$exclude      	Return only the mass mailing ids which is not assigned to this project, 0 means return all mass mailing and is the default
+	 * @param	int			$limit        	limit
+	 * @param	int			$offset       	Offset
+	 * @param	int			$showmin 		Mass mailings with status below this value will not be shown. Default is 0 (draft)
+	 * @param	int			$showmax 		Mass mailings with status above this value will not be shown. Default is 3 (sentcompletely)
+	 *
+	 * @return	int|int[]		-1 if KO, else OK either [] for nothing found or a list of id's
+	 */
+	public function fetchMassMailingIds($user, $include = 0, $exclude = 0, $limit = 0, $offset = 0, $showmin = 0, $showmax = 3)
+	{
+		dol_syslog(__CLASS__.'::'.__METHOD__, LOG_DEBUG);
+		if (getDolGlobalInt('USER_ONLY_NEEDS_PROJECT_READ_FOR_MAILING_ADD')) {
+			$checkProjectAccessRight = 'read';
+		} else {
+			$checkProjectAccessRight = 'write';
+		}
+		// do not want to load this at every iteration of the while loop
+		require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
+		$mailingprojectstatic = new Project($this->db);
+
+
+		$records = array();
+
+		$sql = 'SELECT rowid, fk_project';
+		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element.' as t';
+		if (isset($this->ismultientitymanaged) && $this->ismultientitymanaged == 1) {
+			$sql .= ' WHERE t.entity IN ('.getEntity($this->element).')';
+		} else {
+			$sql .= ' WHERE 1 = 1';
+		}
+		if ($include > 0) {
+			$sql .= ' AND fk_project = '.(int) $include;
+		}
+		if ($exclude > 0) {
+			$sql .= ' AND (fk_project != '.(int) $exclude;
+			$sql .= ' OR fk_project IS NULL)';
+		}
+		$sql .= ' AND statut >= '.(int) $showmin;
+		$sql .= ' AND statut <= '.(int) $showmax;
+
+		if (!empty($limit)) {
+			$sql .= $this->db->plimit($limit, $offset);
+		}
+
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$num = $this->db->num_rows($resql);
+			$i = 0;
+			while ($i < ($limit ? min($limit, $num) : $num)) {
+				$obj = $this->db->fetch_object($resql);
+
+				$mailing_fk_project = $obj->fk_project;
+				if (is_null($mailing_fk_project)) {
+					$records[] = $obj->rowid;
+				} elseif ($mailingprojectstatic->fetch($mailing_fk_project)) {
+					$userHasProjectRights = $mailingprojectstatic->restrictedProjectArea($user, $checkProjectAccessRight);
+					if ($userHasProjectRights > 0) {
+						$records[] = $obj->rowid;
+					} else {
+						dol_syslog('Excluding mailingid='.$obj->rowid.' with projectid='.$mailing_fk_project.' because user='.$user->id.' does not have accessRight='.$checkProjectAccessRight, LOG_DEBUG);
+					}
+				}
 				$i++;
 			}
 			$this->db->free($resql);

--- a/htdocs/comm/mailing/class/mailing_targets.class.php
+++ b/htdocs/comm/mailing/class/mailing_targets.class.php
@@ -1,6 +1,6 @@
 <?php
 /* Copyright (C) 2025		Cloned from htdocs/comm/mailing/class/mailing.class.php then modified
- * Copyright (C) 2025		Jon Bendtsen <jon.bendtsen.github@jonb.dk>
+ * Copyright (C) 2025-2026	Jon Bendtsen <jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,9 +51,19 @@ class MailingTarget extends CommonObject
 	public $fk_mailing;
 
 	/**
+	 * @var int Thirdparty id that this mailing_target is related to.
+	 */
+	public $fk_soc;
+
+	/**
 	 * @var int Contact id that this mailing_target is related to.
 	 */
 	public $fk_contact;
+
+	/**
+	 * @var int eventattendee id that this mailing_target is related to.
+	 */
+	public $fk_attendee;
 
 	/**
 	 * @var string lastname of the mailing_target
@@ -198,16 +208,14 @@ class MailingTarget extends CommonObject
 
 		$this->db->begin();
 
-
-		// 2025-10-09 06:33:26 DEBUG   192.168.127.1        52     33  sql=INSERT INTO llx_mailing_cibles (fk_mailing, fk_contact, email, statut) VALUES ('4',  .((int) 0)., 'jon@jonb.dk',  .((int) )).
-		//2025-10-09 06:35:13 DEBUG   192.168.127.1        54     33  sql=INSERT INTO llx_mailing_cibles (fk_mailing, fk_contact, email, statut) VALUES (4,  .((int) 0)., 'jon@jonb.dk',  .((int) )).
-
 		$sql = "INSERT INTO ".MAIN_DB_PREFIX."mailing_cibles";
-		$sql .= " (fk_mailing, fk_contact, email, statut)";
+		$sql .= " (fk_mailing, fk_soc, fk_contact, fk_attendee, email, statut)";
 		$sql .= " VALUES (".((int) $this->fk_mailing).", ";
+		$sql .=  ((int) $this->fk_soc).", ";
 		$sql .=  ((int) $this->fk_contact).", ";
+		$sql .=  ((int) $this->fk_attendee).", ";
 		$sql .= "'".$this->db->escape($this->email)."', ";
-		$sql .=  ((int) $conf->statut)." )";
+		$sql .=  ((int) $this->statut)." )";
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 
@@ -229,9 +237,15 @@ class MailingTarget extends CommonObject
 				return -2;
 			}
 		} else {
-			$this->error = $this->db->lasterror();
-			$this->db->rollback();
-			return -1;
+			if ($this->db->errno() == 'DB_ERROR_RECORD_ALREADY_EXISTS') {
+				$this->error = $langs->transnoentitiesnoconv("ErrorRecordAlreadyExists").' '.$this->db->escape($this->email);
+				$this->db->rollback();
+				return 0;
+			} else {
+				$this->error = $this->db->lasterror();
+				$this->db->rollback();
+				return -1;
+			}
 		}
 	}
 
@@ -374,6 +388,25 @@ class MailingTarget extends CommonObject
 	}
 
 	/**
+	 *  Check if email address is found in llx_mailing_unsubscribe
+	 *
+	 *  @param	string	$email 		Email to check if it is listed in llx_mailing_unsubscribe
+	 * 	@return	int					-1 means DB error, 0 means this email is not UnSubscribed, any higher number means No Contact has been requested
+	 */
+	public function checkEmailUnsubscribed($email)
+	{
+		$sql = "SELECT COUNT(rowid) as nb FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE entity IN (".getEntity('mailing', 0).") AND email = '".$this->db->escape($email)."'";
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$obj = $this->db->fetch_object($resql);
+			return $obj->nb;
+		} else {
+			$this->error = $this->db->lasterror();
+			return -1;
+		}
+	}
+
+	/**
 	 *  Update an Mailing Target
 	 *
 	 *  @param  User	$user 		Object of user making change
@@ -409,9 +442,11 @@ class MailingTarget extends CommonObject
 
 		$sql = "UPDATE ".MAIN_DB_PREFIX."mailing_cibles";
 		$sql .= " SET fk_mailing = '".((int) $this->fk_mailing)."'";
+		$sql .= ", fk_soc = '".((int) $this->fk_soc)."'";
 		$sql .= ", fk_contact = '".((int) $this->fk_contact)."'";
-		$sql .= ", lastname = '".$this->db->escape($this->lastname)."'";
-		$sql .= ", firstname = '".$this->db->escape($this->firstname)."'";
+		$sql .= ", fk_attendee = '".((int) $this->fk_attendee)."'";
+		$sql .= ", lastname = '".$this->db->escape((string) $this->lastname)."'";
+		$sql .= ", firstname = '".$this->db->escape((string) $this->firstname)."'";
 		$sql .= ", email = '".$this->db->escape($this->email)."'";
 		$sql .= ", other = '".$this->db->escape($this->other)."'";
 		$sql .= ", tag = '".$this->db->escape($this->tag)."'";
@@ -445,28 +480,63 @@ class MailingTarget extends CommonObject
 	/**
 	 *	Get object from database
 	 *
-	 *	@param	int		$rowid      Id of Mailing Target
-	 *	@return	int					Return integer <0 if KO, >0 if OK
+	 *	@param	int		$rowid      	Id of Mailing Target
+	 *	@param	int		$fk_mailing     fk_mailing of Mailing Target, default 0
+	 *	@param	string	$email      	Email of Mailing Target, default ''
+	 *	@return	int						Return integer <0 if KO, >0 if OK
 	 */
-	public function fetch($rowid)
+	public function fetch($rowid, $fk_mailing = 0, $email = '')
 	{
-		$sql = "SELECT t.rowid";
-		$sql .= ", t.fk_mailing";
-		$sql .= ", t.fk_contact";
-		$sql .= ", t.lastname";
-		$sql .= ", t.firstname";
-		$sql .= ", t.email";
-		$sql .= ", t.other";
-		$sql .= ", t.tag";
-		$sql .= ", t.statut as status";
-		$sql .= ", t.source_url";
-		$sql .= ", t.source_id";
-		$sql .= ", t.source_type";
-		$sql .= ", t.date_envoi";
-		$sql .= ", t.tms as date_modification";
-		$sql .= ", t.error_text";
-		$sql .= " FROM ".MAIN_DB_PREFIX."mailing_cibles as t";
-		$sql .= " WHERE t.rowid = ".(int) $rowid;
+		dol_syslog(__CLASS__.'::'.__METHOD__);
+
+		// testing parameter combinations
+		if ($rowid == 0 && ($fk_mailing == 0 || empty($email))) {
+			dol_syslog(__CLASS__.'::'.__METHOD__.'::Wrong parameter combination, either rowid>0 or both fk_mailing>0 and not empty email', LOG_ERR);
+			return -3;
+		}
+
+		if ($rowid == 0 && $fk_mailing > 0 && !empty($email)) {
+			$sql = "SELECT t.rowid";
+			$sql .= ", t.fk_mailing";
+			$sql .= ", t.fk_soc";
+			$sql .= ", t.fk_contact";
+			$sql .= ", t.fk_attendee";
+			$sql .= ", t.lastname";
+			$sql .= ", t.firstname";
+			$sql .= ", t.email";
+			$sql .= ", t.other";
+			$sql .= ", t.tag";
+			$sql .= ", t.statut as status";
+			$sql .= ", t.source_url";
+			$sql .= ", t.source_id";
+			$sql .= ", t.source_type";
+			$sql .= ", t.date_envoi";
+			$sql .= ", t.tms as date_modification";
+			$sql .= ", t.error_text";
+			$sql .= " FROM ".MAIN_DB_PREFIX."mailing_cibles as t";
+			$sql .= " WHERE t.fk_mailing = ".(int) $fk_mailing;
+			$sql .= " AND t.email = '".$this->db->escape($email)."' ";
+		} else {
+			$sql = "SELECT t.rowid";
+			$sql .= ", t.fk_mailing";
+			$sql .= ", t.fk_soc";
+			$sql .= ", t.fk_contact";
+			$sql .= ", t.fk_attendee";
+			$sql .= ", t.lastname";
+			$sql .= ", t.firstname";
+			$sql .= ", t.email";
+			$sql .= ", t.other";
+			$sql .= ", t.tag";
+			$sql .= ", t.statut as status";
+			$sql .= ", t.source_url";
+			$sql .= ", t.source_id";
+			$sql .= ", t.source_type";
+			$sql .= ", t.date_envoi";
+			$sql .= ", t.tms as date_modification";
+			$sql .= ", t.error_text";
+			$sql .= " FROM ".MAIN_DB_PREFIX."mailing_cibles as t";
+			$sql .= " WHERE t.rowid = ".(int) $rowid;
+		}
 
 		dol_syslog(get_class($this)."::fetch", LOG_DEBUG);
 		$result = $this->db->query($sql);
@@ -476,7 +546,9 @@ class MailingTarget extends CommonObject
 
 				$this->id = $obj->rowid;
 				$this->fk_mailing = $obj->fk_mailing;
+				$this->fk_soc = $obj->fk_soc;
 				$this->fk_contact = $obj->fk_contact;
+				$this->fk_attendee = $obj->fk_attendee;
 				$this->lastname = $obj->lastname;
 				$this->firstname = $obj->firstname;
 				$this->email = $obj->email;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1685,6 +1685,7 @@ abstract class CommonObject
 						'rowid' => $obj->rowid,
 						'code' => $obj->code,
 						'libelle' => $libelle_type,
+						'label' => $libelle_type,
 						'status' => (int) $obj->statuslink,
 						'fk_c_type_contact' => $obj->fk_c_type_contact
 					);
@@ -1988,6 +1989,7 @@ abstract class CommonObject
 	 */
 	public function fetch_thirdparty($force_thirdparty_id = 0)
 	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
 		// phpcs:enable
 		if (empty($this->socid) && empty($this->fk_soc) && empty($force_thirdparty_id)) {
 			return 0;

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1594,7 +1594,7 @@ abstract class CommonObject
 	 *    @param    string      $code       	Filter on this code of contact type ('SHIPPING', 'BILLING', ...)
 	 *    @param	int			$status			Status of user or company
 	 *    @param	int[]		$arrayoftcids	Array with ID of type of contacts. If we provide this, we can filter on ec.fk_c_type_contact IN ($arrayoftcids) to avoid a link on c_type_contact table (faster).
-	 *    @return array<int,array{parentId:int,source:string,socid:int,id:int,nom:string,civility:string,lastname:string,firstname:string,email:string,login:string,photo:string,gender:string,statuscontact:int,rowid:int,code:string,libelle:string,status:int,fk_c_type_contact:int}>|int<-1,-1>        	Array of contacts, -1 if error
+	 *    @return array<int,array{parentId:int,source:string,socid:int,id:int,nom:string,civility:string,lastname:string,firstname:string,email:string,login:string,photo:string,gender:string,statuscontact:int,rowid:int,code:string,libelle:string,label:string,status:int,fk_c_type_contact:int}>|int<-1,-1>        	Array of contacts, -1 if error
 	 */
 	public function liste_contact($statusoflink = -1, $source = 'external', $list = 0, $code = '', $status = -1, $arrayoftcids = array())
 	{

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -468,9 +468,26 @@ trait CommonPeople
 		$unsubscribed = $mailingtarget->checkEmailUnsubscribed($email);
 		if ($ignorenocontact > 0 || $unsubscribed == 0) {
 			$mailingtarget->fk_mailing = $fk_mailing;
-			$mailingtarget->fk_soc = $this->element == 'societe' ? $this->id : null;
-			$mailingtarget->fk_contact = $this->element == 'contact' ? $this->id : null;
-			$mailingtarget->fk_attendee = $this->element == 'conferenceorboothattendee' ? $this->id : null;
+			if ($this->element == 'societe') {
+				$mailingtarget->fk_soc = $this->id;
+			} else {
+				$mailingtarget->fk_soc = isset($this->fk_soc) ? $this->fk_soc : null;
+			}
+			if ($this->element == 'contact') {
+				$mailingtarget->fk_contact = $this->id;
+			} else {
+				$mailingtarget->fk_contact = isset($this->fk_contact) ? $this->fk_contact : null;
+			}
+			if ($this->element == 'conferenceorboothattendee') {
+				$mailingtarget->fk_attendee = $this->id;
+			} else {
+				$mailingtarget->fk_attendee = isset($this->fk_attendee) ? $this->fk_attendee : null;
+			}
+			if ($this->element == 'member') {
+				$mailingtarget->fk_member = $this->id;
+			} else {
+				$mailingtarget->fk_member = isset($this->fk_member) ? $this->fk_member : null;
+			}
 			$mailingtarget->lastname = $this->lastname;
 			$mailingtarget->firstname = $this->firstname;
 			$mailingtarget->email = $email;

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -402,9 +402,9 @@ trait CommonPeople
 	}
 
 	/**
-	 *  Add this objects communication email adddress to a mass mailing
+	 *  Add this objects communication email address to a mass mailing
 	 *
-	 *  @param	int	$fk_mailing				The id of the mass mailing to add this objects communication email adddress to
+	 *  @param	int	$fk_mailing				The id of the mass mailing to add this objects communication email address to
 	 *  @param	int	$source_id				The id of the object that this new object is sourced from
 	 *  @param	string	$source_type		The element of the object that this object is sourced from
 	 *  @param	string	$other				The text that describes the source
@@ -517,9 +517,9 @@ trait CommonPeople
 	}
 
 	/**
-	 *  Delete this objects communication email adddress from a mass mailing
+	 *  Delete this objects communication email address from a mass mailing
 	 *
-	 *  @param	int	$fk_mailing				The id of the mass mailing to delete this objects communication email adddress from
+	 *  @param	int	$fk_mailing				The id of the mass mailing to delete this objects communication email address from
 	 *  @param	int	$refreshNbOfTargets		Set to 1 or higher if you really want to refresh recipient counting after each delete
 	 *
 	 *  @return		int						-1 Permission denied, -2 no fk_mailing, -3 fetch fk_mailing failed, -4 (unused), -5 no valid email found, -6 (this number is not used), -7 no permission on the fk_project, -8 deletion failed 0 if KO, Id of created mailing_target if OK

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -491,8 +491,16 @@ trait CommonPeople
 			} else {
 				$mailingtarget->fk_member = isset($this->fk_member) ? $this->fk_member : null;
 			}
-			$mailingtarget->lastname = $this->lastname;
-			$mailingtarget->firstname = $this->firstname;
+			if ($this->element == 'societe') {
+				$mailingtarget->lastname = null;
+			} else {
+				$mailingtarget->lastname = isset($this->lastname) ? $this->lastname : null;
+			}
+			if ($this->element == 'societe') {
+				$mailingtarget->firstname = isset($this->nom) ? $this->nom : null;;
+			} else {
+				$mailingtarget->firstname = isset($this->firstname) ? $this->firstname : null;
+			}
 			$mailingtarget->email = $email;
 			$mailingtarget->other = $other;
 			$mailingtarget->tag = $this->db->escape(dol_hash($conf->file->instance_unique_id.";".$this->email.";".$this->lastname.";".((int) $fk_mailing).";".getDolGlobalString('MAILING_EMAIL_UNSUBSCRIBE_KEY'), 'md5'));

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -492,14 +492,14 @@ trait CommonPeople
 				$mailingtarget->fk_member = isset($this->fk_member) ? $this->fk_member : null;
 			}
 			if ($this->element == 'societe') {
-				$mailingtarget->lastname = null;
+				$mailingtarget->lastname = '';
 			} else {
-				$mailingtarget->lastname = isset($this->lastname) ? $this->lastname : null;
+				$mailingtarget->lastname = isset($this->lastname) ? $this->lastname : '';
 			}
 			if ($this->element == 'societe') {
-				$mailingtarget->firstname = isset($this->nom) ? $this->nom : null;;
+				$mailingtarget->firstname = isset($this->nom) ? $this->nom : '';
 			} else {
-				$mailingtarget->firstname = isset($this->firstname) ? $this->firstname : null;
+				$mailingtarget->firstname = isset($this->firstname) ? $this->firstname : '';
 			}
 			$mailingtarget->email = $email;
 			$mailingtarget->other = $other;

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -404,7 +404,7 @@ trait CommonPeople
 	/**
 	 *  Add this "commonpeople" objects communication email adddress(es) to a mass mailing
 	 *
-	 *  @param	int	$fk_mailing				The id of the mass mailing to add this objects communication email adddress(es) to, see mailsrc
+	 *  @param	int	$fk_mailing				The id of the mass mailing to add this objects communication email adddress(es) to
 	 *  @param	int	$source_id				The id of the object that this "commonpeople" object is assigned to
 	 *  @param	string	$source_type		The element of the object that this "commonpeople" object is assigned to
 	 *  @param	string	$other				The text that describes the source
@@ -496,6 +496,68 @@ trait CommonPeople
 			return -6;
 		} else {
 			$this->error = $mailingtarget->error;
+			return 0;
+		}
+	}
+
+	/**
+	 *  Delete this "commonpeople" objects communication email adddress(es) from a mass mailing
+	 *
+	 *  @param	int	$fk_mailing				The id of the mass mailing to delete this objects communication email adddress(es) from
+	 *  @param	int	$refreshNbOfTargets		Set to 1 or higher if you really want to refresh recipient counting after each delete
+	 *
+	 *  @return		int						-1 Permission denied, -2 no fk_mailing, -3 fetch fk_mailing failed, -4 (unused), -5 no valid email found, -6 (this number is not used), -7 no permission on the fk_project, -8 deletion failed 0 if KO, Id of created mailing_target if OK
+	 */
+	public function deleteFromMassMailing($fk_mailing, $refreshNbOfTargets = 0)
+	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
+		global $conf, $langs, $user;
+		$langs->loadLangs(array("errors", "admin", "main", "mailings", "user", "stock"));
+		if (!$user->hasRight('mailing', 'write')) {
+			dol_syslog('User='.$user->id.' has no write access to mailing in '.__CLASS__.'::'.__METHOD__, LOG_ERR);
+			$this->error = $langs->trans("None").': '.$langs->trans("Permission222");
+			return -1;
+		}
+		if (!$fk_mailing > 0) {
+			dol_syslog('No such fk_mailing='.$fk_mailing.' in '.__CLASS__.'::'.__METHOD__, LOG_ERR);
+			$this->error = $langs->trans("ErrorWrongValueForParameterX", $langs->trans("EMailings"));
+			return -2;
+		}
+		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
+		$mailingstatic = new Mailing($this->db);
+		$fmresult = $mailingstatic->fetch($fk_mailing);
+		if (!$fmresult) {
+			dol_syslog('Fetch failed fk_mailing='.$fk_mailing.' in '.__CLASS__.'::'.__METHOD__, LOG_ERR);
+			$this->error = $langs->trans("ObjectNotFound", $langs->trans("EMailings"));
+			return -3;
+		}
+
+		$email = isValidEmail(@$this->email) ? $this->email : '';
+		if (empty($email)) {
+			dol_syslog(__CLASS__.'::'.__METHOD__.'::No valid email found in '.$this->element.'='.$this->id, LOG_ERR);
+			$this->error = $langs->trans("ErrorWrongValueForParameterX", $langs->trans("Email"));
+			return -5;
+		}
+
+		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing_targets.class.php';
+		$mailingtarget = new MailingTarget($this->db);
+
+		$mtfresult = $mailingtarget->fetch(0, $fk_mailing, $email);
+		if ($mtfresult > 0) {
+			$delresult = $mailingtarget->delete($user);
+			if ($delresult) {
+				if ($refreshNbOfTargets) {
+					$mailingstatic->refreshNbOfTargets();
+				}
+				return $delresult;
+			} else {
+				$this->error = $mailingtarget->error;
+				dol_syslog(__METHOD__ . ' ' . $this->error, LOG_ERR);
+				return -8;
+			}
+		} else {
+			$this->error = $mailingtarget->error;
+			dol_syslog(__METHOD__ . ' ' . $this->error, LOG_ERR);
 			return 0;
 		}
 	}

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -402,11 +402,11 @@ trait CommonPeople
 	}
 
 	/**
-	 *  Add this "commonpeople" objects communication email adddress(es) to a mass mailing
+	 *  Add this objects communication email adddress to a mass mailing
 	 *
-	 *  @param	int	$fk_mailing				The id of the mass mailing to add this objects communication email adddress(es) to
-	 *  @param	int	$source_id				The id of the object that this "commonpeople" object is assigned to
-	 *  @param	string	$source_type		The element of the object that this "commonpeople" object is assigned to
+	 *  @param	int	$fk_mailing				The id of the mass mailing to add this objects communication email adddress to
+	 *  @param	int	$source_id				The id of the object that this new object is sourced from
+	 *  @param	string	$source_type		The element of the object that this object is sourced from
 	 *  @param	string	$other				The text that describes the source
 	 *  @param	int	$ignorenocontact		Ignore that this email address has requested no contact (no marketing), default 0.
 	 *  @param	int	$refreshNbOfTargets		Set to 1 or higher if you really want to refresh recipient counting after each insert
@@ -416,7 +416,6 @@ trait CommonPeople
 	public function addToMassMailing($fk_mailing, $source_id, $source_type, $other, $ignorenocontact = 0, $refreshNbOfTargets = 0)
 	{
 		dol_syslog(__METHOD__, LOG_DEBUG);
-		dol_syslog(__METHOD__.'::ignorenocontact='.$ignorenocontact, LOG_DEBUG);
 		global $conf, $langs, $user;
 		$langs->loadLangs(array("errors", "admin", "main", "mailings", "user", "stock"));
 		if (isset($this->element)) {
@@ -518,9 +517,9 @@ trait CommonPeople
 	}
 
 	/**
-	 *  Delete this "commonpeople" objects communication email adddress(es) from a mass mailing
+	 *  Delete this objects communication email adddress from a mass mailing
 	 *
-	 *  @param	int	$fk_mailing				The id of the mass mailing to delete this objects communication email adddress(es) from
+	 *  @param	int	$fk_mailing				The id of the mass mailing to delete this objects communication email adddress from
 	 *  @param	int	$refreshNbOfTargets		Set to 1 or higher if you really want to refresh recipient counting after each delete
 	 *
 	 *  @return		int						-1 Permission denied, -2 no fk_mailing, -3 fetch fk_mailing failed, -4 (unused), -5 no valid email found, -6 (this number is not used), -7 no permission on the fk_project, -8 deletion failed 0 if KO, Id of created mailing_target if OK

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -464,7 +464,11 @@ trait CommonPeople
 
 		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing_targets.class.php';
 		$mailingtarget = new MailingTarget($this->db);
-		$unsubscribed = $mailingtarget->checkEmailUnsubscribed($email);
+		if ($ignorenocontact) {
+			$unsubscribed = 0;
+		} else {
+			$unsubscribed = $mailingtarget->checkEmailUnsubscribed($email);
+		}
 		if ($ignorenocontact > 0 || $unsubscribed == 0) {
 			$mailingtarget->fk_mailing = $fk_mailing;
 			if ($this->element == 'societe') {

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2023-2025  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026  		Jon Bendtsen            	<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -400,6 +401,104 @@ trait CommonPeople
 		}
 	}
 
+	/**
+	 *  Add this "commonpeople" objects communication email adddress(es) to a mass mailing
+	 *
+	 *  @param	int	$fk_mailing				The id of the mass mailing to add this objects communication email adddress(es) to, see mailsrc
+	 *  @param	int	$source_id				The id of the object that this "commonpeople" object is assigned to
+	 *  @param	string	$source_type		The element of the object that this "commonpeople" object is assigned to
+	 *  @param	string	$other				The text that describes the source
+	 *  @param	int	$ignorenocontact		Ignore that this email address has requested no contact (no marketing), default 0.
+	 *  @param	int	$refreshNbOfTargets		Set to 1 or higher if you really want to refresh recipient counting after each insert
+	 *
+	 *  @return		int						-1 Permission denied, -2 no fk_mailing, -3 fetch fk_mailing failed, -4 saved for future project check, -5 no valid email found, -6 must respect NoContact, -7 no permission on the fk_project, -8 empty source_id, -9 empty source_type, -10 other is empty, 0 if KO, Id of created mailing_target if OK
+	 */
+	public function addToMassMailing($fk_mailing, $source_id, $source_type, $other, $ignorenocontact = 0, $refreshNbOfTargets = 0)
+	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
+		dol_syslog(__METHOD__.'::ignorenocontact='.$ignorenocontact, LOG_DEBUG);
+		global $conf, $langs, $user;
+		$langs->loadLangs(array("errors", "admin", "main", "mailings", "user", "stock"));
+		if (isset($this->element)) {
+			$langs->loadLangs(array($this->element));
+		}
+		if (!$user->hasRight('mailing', 'write')) {
+			dol_syslog('User='.$user->id.' has no write access to mailing in '.__CLASS__.'::'.__METHOD__, LOG_ERR);
+			$this->error = $langs->trans("None").': '.$langs->trans("Permission222");
+			return -1;
+		}
+		if (!$fk_mailing > 0) {
+			dol_syslog('No such fk_mailing='.$fk_mailing.' in '.__CLASS__.'::'.__METHOD__, LOG_ERR);
+			$this->error = $langs->trans("ErrorWrongValueForParameterX", $langs->trans("EMailings"));
+			return -2;
+		}
+		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
+		$mailingstatic = new Mailing($this->db);
+		$fmresult = $mailingstatic->fetch($fk_mailing);
+		if (!$fmresult) {
+			dol_syslog('Fetch failed fk_mailing='.$fk_mailing.' in '.__CLASS__.'::'.__METHOD__, LOG_ERR);
+			$this->error = $langs->trans("ObjectNotFound", $langs->trans("EMailings"));
+			return -3;
+		}
+
+		$email = isValidEmail(@$this->email) ? $this->email : '';
+		if (empty($email)) {
+			dol_syslog(__CLASS__.'::'.__METHOD__.'::No valid email found in '.$this->element.'='.$this->id, LOG_ERR);
+			$this->error = $langs->trans("ErrorWrongValueForParameterX", $langs->trans("Email"));
+			return -5;
+		}
+		if (empty($source_id)) {
+			dol_syslog(__CLASS__.'::'.__METHOD__.'::Empty source_id', LOG_ERR);
+			$this->error = $langs->trans("ErrorBadValueForParameter", 'empty', 'source_id');
+			return -8;
+		}
+		if (empty($source_type)) {
+			dol_syslog(__CLASS__.'::'.__METHOD__.'::Empty source_type', LOG_ERR);
+			$this->error = $langs->trans("ErrorBadValueForParameter", 'empty', 'source_type');
+			return -9;
+		}
+		if (empty($other)) {
+			dol_syslog(__CLASS__.'::'.__METHOD__.'::Empty other', LOG_ERR);
+			$this->error = $langs->trans("ErrorBadValueForParameter", 'empty', 'other');
+			return -10;
+		}
+
+		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing_targets.class.php';
+		$mailingtarget = new MailingTarget($this->db);
+		$unsubscribed = $mailingtarget->checkEmailUnsubscribed($email);
+		if ($ignorenocontact > 0 || $unsubscribed == 0) {
+			$mailingtarget->fk_mailing = $fk_mailing;
+			$mailingtarget->fk_soc = $this->element == 'societe' ? $this->id : null;
+			$mailingtarget->fk_contact = $this->element == 'contact' ? $this->id : null;
+			$mailingtarget->fk_attendee = $this->element == 'conferenceorboothattendee' ? $this->id : null;
+			$mailingtarget->lastname = $this->lastname;
+			$mailingtarget->firstname = $this->firstname;
+			$mailingtarget->email = $email;
+			$mailingtarget->other = $other;
+			$mailingtarget->tag = $this->db->escape(dol_hash($conf->file->instance_unique_id.";".$this->email.";".$this->lastname.";".((int) $fk_mailing).";".getDolGlobalString('MAILING_EMAIL_UNSUBSCRIBE_KEY'), 'md5'));
+			$mailingtarget->source_id = $source_id;
+			$mailingtarget->source_type = $source_type;
+			$mailingtarget->statut = 0;
+			$mailingtarget->status = 0;
+			$mtcresult = $mailingtarget->create($user);
+			if ($mtcresult > 0) {
+				if ($refreshNbOfTargets) {
+					$mailingstatic->refreshNbOfTargets();
+				}
+				return $mtcresult;
+			} else {
+				$this->error = $mailingtarget->error;
+				dol_syslog(__METHOD__ . ' ' . $this->error, LOG_ERR);
+				return 0;
+			}
+		} elseif ($unsubscribed > 0) {
+			$this->error = $email.' - '.$langs->trans("EmailOptedOut");
+			return -6;
+		} else {
+			$this->error = $mailingtarget->error;
+			return 0;
+		}
+	}
 
 	// Methods used by this Trait that must be implemented in the parent class.
 	// Note: this helps static type checking

--- a/htdocs/core/class/html.formmailing.class.php
+++ b/htdocs/core/class/html.formmailing.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2014 Florian Henry florian.henry@open-concept.pro
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026  		Jon Bendtsen            	<jon.bendtsen.github@jonb.dk>
  *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -58,5 +59,150 @@ class FormMailing extends Form
 
 		// Note -1 is used for error, so we use -2 for tempty value
 		return Form::selectarray($htmlname, $options, $selectedid, ($show_empty ? -2 : 0), 0, 0, '', 1, 0, 0, '', $morecss);
+	}
+
+	/**
+	 * Output a form with Multi Selection of Mass Mailings
+	 *
+	 * @param 	string 		$page 		Page - if empty no form tags are printed, else they are
+	 * @param	string		$htmlname	Name of HTML field
+	 * @param 	string 		$title 		Text above the multi select form., default is '' and not shown, could be a <h4>...</h4>
+	 * @param	int[] 		$toplist 	List of mass mailing ids in top/main optgroup
+	 * @param 	string 		$toptext 	Text in top/main optgroup (optional) - default is '' and not shown
+	 * @param	int[] 		$endlist 	List of mass mailing ids in below optgroup (optional) - default array() - not used, not shown
+	 * @param 	string 		$endtext 	Text in below optgroup (optional) - default is '' and not shown
+	 * @param	int 		$size 		How high the table should be in lines, default is 16
+	 * @param	string 		$morecss 	More css
+	 * @param	int			$nooutput 	No print output. Return it only.
+	 *
+	 * @return 	string 					HTML
+	 */
+	public function formMultiSelectMassMailing($page, $htmlname, $title = '', $toplist = array(), $toptext = '', $endlist = array(), $endtext = '', $size = 16, $morecss = '', $nooutput = 0)
+	{
+		dol_syslog(__CLASS__.'::'.__METHOD__.'::', LOG_DEBUG);
+		global $langs;
+		$langs->load("mails");
+
+		$out = '';
+		if (!empty($page)) {
+			$out .= '<form action="'.$page.'">';
+		}
+		if (!empty($title)) {
+			$out .= $title;
+		}
+
+		$out .= '<div id="select_mailing">';
+		$out .= '<select class="select" name="select_mailing[]" id="select_mailing" multiple size="'.$size.'" style="'.$morecss.'">';
+
+		if (!empty($toptext)) {
+			$out .= '  <optgroup class="optgroup" label="'.$toptext.'">';
+		}
+		require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
+		$mailingstatic = new Mailing($this->db);
+		foreach ($toplist as $mailingid) {
+			$fmresult = $mailingstatic->fetch($mailingid);
+			if ($fmresult) {
+				$out .= '    <option class="option" value="'.$mailingstatic->id.'">'.$mailingstatic->title.'</option>';
+			} else {
+				dol_syslog(__CLASS__.'::'.__METHOD__.'::fetching mailing with id='.$mailingid.' failed with result='.$fmresult, LOG_ERR);
+			}
+		}
+		$out .= '    <option class="option" value="" disabled>&mdash;&mdash;&mdash;</option>';
+		if (!empty($toptext)) {
+			$out .= '  </optgroup>';
+		}
+
+		if (!empty($endtext) && count($endlist) > 0) {
+			$out .= '  <optgroup class="optgroup" label="'.$endtext.'">';
+		}
+		foreach ($endlist as $mailingid) {
+			$fmresult = $mailingstatic->fetch($mailingid);
+			if ($fmresult) {
+				$out .= '    <option class="option" value="'.$mailingstatic->id.'">'.$mailingstatic->title.'</option>';
+			} else {
+				dol_syslog(__CLASS__.'::'.__METHOD__.'::fetching mailing with id='.$mailingid.' failed with result='.$fmresult, LOG_ERR);
+			}
+		}
+		if (!empty($endtext)) {
+			$out .= '  </optgroup>';
+		}
+
+		$out .= '</select>';
+		$out .= '</div>';
+
+		$out .= '<br>';
+
+		$out .= '<input type="checkbox" id="verbosereporting" name="verbosereporting" value="1"><label for="verbosereporting">'.$langs->trans("Show").' '.$langs->trans("ListOf", $langs->trans("EMails")).'</label><br>';
+		$out .= '<input type="checkbox" id="ignorenocontact" name="ignorenocontact" value="1"><label for="ignorenocontact">'.$langs->trans("EvenUnsubscribe").'</label><br>';
+		$out .= '<br>';
+
+		$out .= '<!-- select and options for '.$htmlname .' -->';
+		if ($htmlname == 'conferenceorboothattendee' ) {
+			$out .= '<label for="select_mailsrc">'.$langs->trans("Source").' '.$langs->trans("ListOf", $langs->trans("Email")).'</label>';
+			$out .= '<select class="select" name="select_mailsrc[]" id="select_mailsrc" size="8" multiple>';
+			$out .= '    <option class="option" value="0" selected>'.$langs->trans("auto").'</option>';
+			$out .= '    <option class="option" value="10">'.$langs->trans("Attendees").'</option>';
+			$out .= '    <option class="option" value="20">'.$langs->trans("SearchIntoContacts").'</option>';
+			$out .= '    <option class="option" value="30">'.$langs->trans("SearchIntoThirdparties").'</option>';
+			$out .= '    <option class="option" value="40">'.$langs->trans("EmailCompany").'</option>';
+			$out .= '</select>';
+		} elseif ($htmlname == 'facture' ) {
+			require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
+			$facturestatic = new Facture($this->db);
+			$contacttypes = $facturestatic->liste_type_contact('external', 'rowid', 1, 1) ?? array();
+			$size = (int) round(3 + (log(count($contacttypes)) > 0 ? log(count($contacttypes)) : 0));
+
+			$transThirdPartyEmail = $langs->trans("ThirdPartyEmail");
+			$transContactForInvoices = $langs->trans("ContactForInvoices");
+
+			$out .= '<h4>'.$langs->trans("Email").' '.$langs->trans("Sources").'</h4>';
+			$out .= '<div id="checkbox_ThirdPartyEmail">';
+			$out .= '<input type="checkbox" id="ThirdPartyEmail" name="ThirdPartyEmail" value="1"><label for="ThirdPartyEmail">'.$transThirdPartyEmail.'</label><br>';
+			$out .= '</div>';
+			$out .= '<br>';
+
+			$out .= '<div id="select_contactsrc">';
+			$out .= '<b><label for="select_contactsrc">'.$transContactForInvoices.'</label></b><br>';
+			$out .= '<select class="select" name="select_contactsrc[]" id="select_contactsrc" size="'.$size.'" multiple>';
+			foreach ($contacttypes as $code => $label) {
+				$out .= '    <option class="option" value="'.$code.'">'.$langs->trans($label).'</option>';
+			}
+			$out .= '</select>';
+			$out .= '</div>';
+			$out .= '<br>';
+
+			$out .= '<div id="showerrors">';
+			$out .= '<label for="showerrors">'.$langs->trans("ShowOnVCard", $langs->trans("errors")).'</label><br>';
+			$out .= '<select class="select" name="showerrors[]" id="showerrors" size="3" multiple>';
+			$out .= '    <option class="option" value="ThirdPartyEmail" selected>'.$transThirdPartyEmail.'</option>';
+			$out .= '    <option class="option" value="ContactForInvoices" selected>'.$transContactForInvoices.'</option>';
+			$out .= '</select>';
+			$out .= '</div>';
+		} else {
+			$out .= '<label for="select_mailsrc">'.$langs->trans("Email").' '.$langs->trans("Sources").'</label><br>';
+			$out .= '<select class="select" name="select_mailsrc[]" id="select_mailsrc" size="8" multiple>';
+			$out .= '    <option class="option" value="ThirdPartyEmail">'.$transThirdPartyEmail.'</option>';
+			$out .= '    <option class="option" value="ContactForInvoices">'.$transContactForInvoices.'</option>';
+			$out .= '</select>';
+		}
+
+		$out .= '<div id="massmail_selection_buttons_mailing"><br>';
+		$out .= '<input type="hidden" name="massaction" value="confirm_premassmail">';
+		$out .= '<!-- 3 buttons Add, Delete and Cancel -->';
+		$out .= '<input type="submit" class="butAction button-add small reposition" id="button_add_mailing" name="button_add_mailing" value="'.$langs->trans("Add").'">';
+		$out .= '<input type="submit" class="butActionDelete button-delete small reposition" id="button_delete_mailing" name="button_delete_mailing" value="'.$langs->trans("Delete").'">';
+		$out .= '<input type="submit" class="button button-cancel reposition" id="cancel" name="cancel" value="'.$langs->trans("Cancel").'" />';
+		$out .= '</div><br>';
+
+		if (!empty($page)) {
+			$out .= '</form>';
+		}
+
+		if (empty($nooutput)) {
+			print $out;
+			return '';
+		} else {
+			return $out;
+		}
 	}
 }

--- a/htdocs/core/class/html.formmailing.class.php
+++ b/htdocs/core/class/html.formmailing.class.php
@@ -136,6 +136,9 @@ class FormMailing extends Form
 		$out .= '<input type="checkbox" id="ignorenocontact" name="ignorenocontact" value="1"><label for="ignorenocontact">'.$langs->trans("EvenUnsubscribe").'</label><br>';
 		$out .= '<br>';
 
+		$transThirdPartyEmail = $langs->trans("ThirdPartyEmail");
+		$transContactForInvoices = $langs->trans("ContactForInvoices");
+
 		$out .= '<!-- select and options for '.$htmlname .' -->';
 		if ($htmlname == 'conferenceorboothattendee' ) {
 			$out .= '<label for="select_mailsrc">'.$langs->trans("Source").' '.$langs->trans("ListOf", $langs->trans("Email")).'</label>';
@@ -151,9 +154,6 @@ class FormMailing extends Form
 			$facturestatic = new Facture($this->db);
 			$contacttypes = $facturestatic->liste_type_contact('external', 'rowid', 1, 1) ?? array();
 			$size = (int) round(3 + (log(count($contacttypes)) > 0 ? log(count($contacttypes)) : 0));
-
-			$transThirdPartyEmail = $langs->trans("ThirdPartyEmail");
-			$transContactForInvoices = $langs->trans("ContactForInvoices");
 
 			$out .= '<h4>'.$langs->trans("Email").' '.$langs->trans("Sources").'</h4>';
 			$out .= '<div id="checkbox_ThirdPartyEmail">';

--- a/htdocs/core/class/html.formmailing.class.php
+++ b/htdocs/core/class/html.formmailing.class.php
@@ -79,7 +79,7 @@ class FormMailing extends Form
 	 */
 	public function formMultiSelectMassMailing($page, $htmlname, $title = '', $toplist = array(), $toptext = '', $endlist = array(), $endtext = '', $size = 16, $morecss = '', $nooutput = 0)
 	{
-		dol_syslog(__CLASS__.'::'.__METHOD__.'::', LOG_DEBUG);
+		dol_syslog(__METHOD__.'::', LOG_DEBUG);
 		global $langs;
 		$langs->load("mails");
 
@@ -104,7 +104,7 @@ class FormMailing extends Form
 			if ($fmresult) {
 				$out .= '    <option class="option" value="'.$mailingstatic->id.'">'.$mailingstatic->title.'</option>';
 			} else {
-				dol_syslog(__CLASS__.'::'.__METHOD__.'::fetching mailing with id='.$mailingid.' failed with result='.$fmresult, LOG_ERR);
+				dol_syslog(__METHOD__.'::fetching mailing with id='.$mailingid.' failed with result='.$fmresult, LOG_ERR);
 			}
 		}
 		$out .= '    <option class="option" value="" disabled>&mdash;&mdash;&mdash;</option>';
@@ -120,7 +120,7 @@ class FormMailing extends Form
 			if ($fmresult) {
 				$out .= '    <option class="option" value="'.$mailingstatic->id.'">'.$mailingstatic->title.'</option>';
 			} else {
-				dol_syslog(__CLASS__.'::'.__METHOD__.'::fetching mailing with id='.$mailingid.' failed with result='.$fmresult, LOG_ERR);
+				dol_syslog(__METHOD__.'::fetching mailing with id='.$mailingid.' failed with result='.$fmresult, LOG_ERR);
 			}
 		}
 		if (!empty($endtext)) {

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024		Ferran Marcet			<fmarcet@2byte.es>
+ * Copyright (C) 2026  		Jon Bendtsen            	<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,6 +49,7 @@
  * @var User $user
  *
  * @var string $action
+ * @var int $projectid
  * @var string $massaction
  * @var string $modelmail
  * @var string $sendto
@@ -72,6 +74,7 @@
 @phan-var-force string $modelmail
 @phan-var-force ?string $search_all
 @phan-var-force ?Task $taskstatic
+@phan-var-force int $projectid
 ';
 
 if (!empty($sall) || !empty($search_all)) {
@@ -372,6 +375,48 @@ if ($massaction == 'presend') {
 	}
 
 	print dol_get_fiche_end();
+}
+
+if ($massaction == 'premassmail') {
+	dol_syslog('massactions_pre.tpl.php::if massaction == premassmail', LOG_DEBUG);
+	require_once DOL_DOCUMENT_ROOT.'/core/class/html.formmailing.class.php';
+	$formmailing = new FormMailing($db);
+	require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
+	$mailingstatic = new Mailing($db);
+	require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
+	$projectstatic = new Project($db);
+
+	if (!isset($projectid)) {
+		$projectid = 0;
+	}
+	$fpresult = $projectstatic->fetch($projectid);
+	dol_syslog('fpresult='.$fpresult, LOG_DEBUG);
+	if ($fpresult > 0) {
+		$toptext = $projectstatic->title;
+		$toplist = $mailingstatic->fetchMassMailingIds($user, $projectid);
+		$endlist = $mailingstatic->fetchMassMailingIds($user, 0, $projectid);
+	} elseif ($projectid > 0) {
+		$toptext = $langs->trans("ProjectId").' '.$projectid.' '.$langs->trans("EMailings");
+		$toplist = $mailingstatic->fetchMassMailingIds($user, $projectid);
+		$endlist = $mailingstatic->fetchMassMailingIds($user, 0, $projectid);
+	} else {
+		$toptext = $langs->trans("ListOfEMailings");
+		$toplist = $mailingstatic->fetchMassMailingIds($user, 0);
+		$endlist = array();
+		dol_syslog('count(toplist)='.count($toplist), LOG_DEBUG);
+		dol_syslog('count(endlist)='.count($endlist), LOG_DEBUG);
+		dol_syslog('log(count(toplist))='.log(count($toplist)), LOG_DEBUG);
+		dol_syslog('log(count(endlist))='.log(count($endlist)), LOG_DEBUG);
+	}
+
+	$htmlname = $objecttmp->element ?? 'unknown';
+	$page = '';
+	$endtext = $langs->trans("Other").' '.$langs->trans("EMailings");
+	$size = (int) round(10 + ((log(count($toplist)) > 0 ? log(count($toplist)) : 0) + (log(count($endlist)) > 0 ? log(count($endlist)) : 0)));
+	$title = '<h4><label for="massmail_selection_choices_'.$htmlname.'">'.$toptext.':</label></h4>';
+	$formmailing->formMultiSelectMassMailing($page, $htmlname, $title, $toplist, $toptext, $endlist, $endtext, $size, 'width: 100%;');
+
+	print '<br>';
 }
 
 if ($massaction == 'edit_extrafields') {

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -404,7 +404,7 @@ if ($massaction == 'premassmail') {
 		$endlist = array();
 	}
 
-	$htmlname = $objecttmp->element ?? 'unknown';
+	$htmlname = isset($objecttmp->element) ? $objecttmp->element : 'unknownelement';
 	$page = '';
 	$endtext = $langs->trans("Other").' '.$langs->trans("EMailings");
 	$size = (int) round(10 + ((log(count($toplist)) > 0 ? log(count($toplist)) : 0) + (log(count($endlist)) > 0 ? log(count($endlist)) : 0)));

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -390,7 +390,6 @@ if ($massaction == 'premassmail') {
 		$projectid = 0;
 	}
 	$fpresult = $projectstatic->fetch($projectid);
-	dol_syslog('fpresult='.$fpresult, LOG_DEBUG);
 	if ($fpresult > 0) {
 		$toptext = $projectstatic->title;
 		$toplist = $mailingstatic->fetchMassMailingIds($user, $projectid);
@@ -403,10 +402,6 @@ if ($massaction == 'premassmail') {
 		$toptext = $langs->trans("ListOfEMailings");
 		$toplist = $mailingstatic->fetchMassMailingIds($user, 0);
 		$endlist = array();
-		dol_syslog('count(toplist)='.count($toplist), LOG_DEBUG);
-		dol_syslog('count(endlist)='.count($endlist), LOG_DEBUG);
-		dol_syslog('log(count(toplist))='.log(count($toplist)), LOG_DEBUG);
-		dol_syslog('log(count(endlist))='.log(count($endlist)), LOG_DEBUG);
 	}
 
 	$htmlname = $objecttmp->element ?? 'unknown';

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -277,7 +277,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 			}
 			$invoice_contact_list = array();
 			foreach ($select_contactsrc as $contact_code) {
-				$list_of_contacts = $invoicestatic->liste_contact(-1, 'external' , 0, $contact_code);
+				$list_of_contacts = $invoicestatic->liste_contact(-1, 'external', 0, $contact_code);
 				if (empty($list_of_contacts) && in_array("ContactForInvoices", $showerrors)) {
 					$invoice_type_contact = $invoicestatic->liste_type_contact('external', '', 1, 0, $contact_code);
 					$warn_message = $invoicestatic->getNomUrl().' &mdash; '.$langs->trans("ErrorRefNotFound", $invoice_type_contact[$contact_code]);
@@ -318,7 +318,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 							}
 							$whatchanged[$mailingid] = isset($whatchanged[$mailingid]) ? $whatchanged[$mailingid] + 1 : 1;
 							$info_mesgs[$mailingid][] = '&emsp;'.$invoicestatic->thirdparty->email;
-					} elseif ($thirdpartychangetomailing == 0) {
+						} elseif ($thirdpartychangetomailing == 0) {
 							$verified_mailings[] = $mailingid;
 							$fmresult = $mailingstatic->fetch($mailingid);
 							if ($fmresult) {
@@ -358,7 +358,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 								}
 								$whatchanged[$mailingid] = isset($whatchanged[$mailingid]) ? $whatchanged[$mailingid] + 1 : 1;
 								$info_mesgs[$mailingid][] = '&emsp;'.$contactstatic->email;
-						} elseif ($contactchangetomailing == 0) {
+							} elseif ($contactchangetomailing == 0) {
 								$verified_mailings[] = $mailingid;
 								$fmresult = $mailingstatic->fetch($mailingid);
 								if ($fmresult) {

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -253,8 +253,10 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 		setEventMessages($langs->trans("ThirdPartiesArea").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
 	}
 
+	require_once DOL_DOCUMENT_ROOT.'/comm/mailing/class/mailing.class.php';
 	require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 	$contactstatic = new Contact($db);
+	$mailingstatic = new Mailing($db);
 	$verified_toselect = array();
 	$verified_mailings = array();
 	$whatchanged = array();
@@ -311,17 +313,41 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 			foreach ($select_mailing as $mailingid) {
 				dol_syslog("product/stats/facture.php::mailingid=".$mailingid, LOG_DEBUG);
 				if ($thirdpartyemail > 0 && $fetchsociete) {
-					dol_syslog("product/stats/facture.php::if fetchsociete", LOG_DEBUG);
 					$thirdpartychangetomailing = 0; // to make sure isset is always true
 					if ($button_add_mailing) {
-						dol_syslog("product/stats/facture.php::if button_add_mailing", LOG_DEBUG);
 						$other = $langs->trans("ThirdParty").'@'.$langs->trans("CustomerInvoice").'='.$itemid;
 						$thirdpartychangetomailing = $invoicestatic->thirdparty->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
 					}
 					if ($button_delete_mailing) {
 						$thirdpartychangetomailing = $invoicestatic->thirdparty->deleteFromMassMailing($mailingid);
 					}
-					// we should record what changed as well as errors.
+					if ($button_add_mailing || $button_delete_mailing) {
+						if ($thirdpartychangetomailing > 0) {
+							if (isset($whatchanged[$mailingid])) {
+								$verified_mailings[] = $mailingid;
+							}
+							$whatchanged[$mailingid] = isset($whatchanged[$mailingid]) ? $whatchanged[$mailingid] + 1 : 1;
+							$info_mesgs[$mailingid][] = '&emsp;'.$invoicestatic->thirdparty->email;
+					} elseif ($thirdpartychangetomailing == 0) {
+							$verified_mailings[] = $mailingid;
+							$fmresult = $mailingstatic->fetch($mailingid);
+							if ($fmresult) {
+								$vmailing_title = $mailingstatic->title;
+							} else {
+								$vmailing_title = 'Mailing ID '.$mailingid;
+							}
+							if ($button_add_mailing && in_array("ThirdPartyEmail", $showerrors)) {
+								$info_warnings[$mailingid][] = '&emsp;'.$invoicestatic->thirdparty->error;
+							}
+						} elseif ($thirdpartychangetomailing == -6 && $ignorenocontact && in_array("ThirdPartyEmail", $showerrors)) {
+							$info_warnings[$mailingid][] = '&emsp;'.$invoicestatic->thirdparty->error;
+						} elseif (in_array("ThirdPartyEmail", $showerrors)) {
+							$info_errors[$mailingid][] = '&emsp;'.$invoicestatic->thirdparty->error;
+						}
+					} else {
+						dol_syslog('confirm_premassmail, but neither button_add_mailing nor button_delete_mailing', LOG_ERR);
+						setEventMessages($langs->trans("ErrorGlobalVariableUpdater2", "button_add_mailing or button_delete_mailing"), null, 'errors');
+					}
 				}
 				foreach ($verified_invoice_contact_list as $invoice_contact) {
 					$fetchcontact = $contactstatic->fetch($invoice_contact['id']);
@@ -334,8 +360,34 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 						if ($button_delete_mailing) {
 							$contactchangetomailing = $contactstatic->deleteFromMassMailing($mailingid);
 						}
-						dol_syslog("product/stats/facture.php::contactchangetomailing=".$contactchangetomailing.' for contact code='.$invoice_contact['code'].' and contact id='.$invoice_contact['id'], LOG_DEBUG);
-						// we should record what changed as well as errors.
+
+						if ($button_add_mailing || $button_delete_mailing) {
+							if ($contactchangetomailing > 0) {
+								if (isset($whatchanged[$mailingid])) {
+									$verified_mailings[] = $mailingid;
+								}
+								$whatchanged[$mailingid] = isset($whatchanged[$mailingid]) ? $whatchanged[$mailingid] + 1 : 1;
+								$info_mesgs[$mailingid][] = '&emsp;'.$contactstatic->email;
+						} elseif ($contactchangetomailing == 0) {
+								$verified_mailings[] = $mailingid;
+								$fmresult = $mailingstatic->fetch($mailingid);
+								if ($fmresult) {
+									$vmailing_title = $mailingstatic->title;
+								} else {
+									$vmailing_title = 'Mailing ID '.$mailingid;
+								}
+								if ($button_add_mailing && in_array("ContactForInvoices", $showerrors)) {
+									$info_warnings[$mailingid][] = '&emsp;'.$contactstatic->error;
+								}
+							} elseif ($contactchangetomailing == -6 && $ignorenocontact && in_array("ContactForInvoices", $showerrors)) {
+								$info_warnings[$mailingid][] = '&emsp;'.$contactstatic->error;
+							} elseif (in_array("ContactForInvoices", $showerrors)) {
+								$info_errors[$mailingid][] = '&emsp;'.$contactstatic->error;
+							}
+						} else {
+							dol_syslog('confirm_premassmail, but neither button_add_mailing nor button_delete_mailing', LOG_ERR);
+							setEventMessages($langs->trans("ErrorGlobalVariableUpdater2", "button_add_mailing or button_delete_mailing"), null, 'errors');
+						}
 					}
 				}
 			}
@@ -388,6 +440,12 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 			setEventMessages($actionmessage.' &mdash; '.$langs->trans("MailingArea").' &mdash; '.$vmailing_title, null, 'mesgs');
 		}
 	}
+
+	$total_changes = 0;
+	foreach ($select_mailing as $mailingid) {
+		$total_changes = $total_changes + $whatchanged[$mailingid];
+	}
+	setEventMessages($langs->trans("GrandTotal").' '.$langs->trans("RecordsModified", $total_changes), null, 'mesgs');
 
 	foreach ($verified_mailings as $mailingid) {
 		if ($mailingstatic->fetch($mailingid)) {

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -179,10 +179,10 @@ $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
+$permissiontoread = $user->hasRight("facture", "lire");
 if (empty($reshook)) {
 	$objectclass = 'Facture';
 	$objectlabel = 'Invoices';
-	$permissiontoread = $user->hasRight("facture", "lire");
 	$permissiontoadd = $user->hasRight("facture", "creer");
 	$permissiontodelete = $user->hasRight("facture", "supprimer");
 	$uploaddir = $conf->invoice->dir_output;
@@ -273,6 +273,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 		$fetchinvoiceresult = $invoicestatic->fetch($itemid);
 		if ($fetchinvoiceresult) {
 			$verified_toselect[] = $itemid;
+			$fetchsociete = null;
 			if ($thirdpartyemail > 0) {
 				$fetchsociete = $invoicestatic->fetch_thirdparty();
 				if (!$fetchsociete && in_array("ThirdPartyEmail", $showerrors)) {
@@ -351,7 +352,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 					if ($fetchcontact) {
 						$contactchangetomailing = 0; // to make sure isset is always true
 						if ($button_add_mailing) {
-							$other = $invoice_contact['label'].'@'.$langs->trans("CustomerInvoice").'='.$itemid;
+							$other = (string) $invoice_contact['label'].'@'.$langs->trans("CustomerInvoice").'='.$itemid;
 							$contactchangetomailing = $contactstatic->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
 						}
 						if ($button_delete_mailing) {
@@ -440,7 +441,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 
 	$total_changes = 0;
 	foreach ($select_mailing as $mailingid) {
-		$total_changes = $total_changes + $whatchanged[$mailingid];
+		$total_changes += $whatchanged[$mailingid];
 	}
 	setEventMessages($langs->trans("GrandTotal").' '.$langs->trans("RecordsModified", $total_changes), null, 'mesgs');
 

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -242,13 +242,15 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 	$select_contactsrc = GETPOST('select_contactsrc', 'array') ?? array(0);
 	$verbosereporting = GETPOSTINT('verbosereporting') ? GETPOSTINT('verbosereporting') : 0;
 	$thirdpartyemail = GETPOSTINT('ThirdPartyEmail') ? GETPOSTINT('ThirdPartyEmail') : 0;
-	dol_syslog("product/stats/facture.php::thirdpartyemail=".$thirdpartyemail, LOG_DEBUG);
 	$select_mailing = GETPOST('select_mailing', 'array:int') ?? array();
 	if (empty($select_mailing)) {
 		setEventMessages($langs->trans("ListOfEMailings").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
 	}
 	if (empty($toselect)) {
 		setEventMessages($langs->trans("Invoices").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
+	}
+	if (empty($select_contactsrc) && !$thirdpartyemail) {
+		setEventMessages($langs->trans("ThirdPartiesArea").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
 	}
 
 	require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -228,10 +228,10 @@ if (empty($reshook)) {
 $button_add_mailing = GETPOST('button_add_mailing', 'aZ09');
 $button_delete_mailing = GETPOST('button_delete_mailing', 'aZ09');
 if ($button_add_mailing && $button_delete_mailing) {
-    dol_syslog('Error: Both add and delete mailing buttons were pressed simultaneously.', LOG_ERR);
-    setEventMessages($langs->trans("Choose").' '.$langs->trans("Max").' 1 '.$langs->trans("Input"), null, 'errors');
-    header("Location: " . $_SERVER['HTTP_REFERER']);
-    exit;
+	dol_syslog('Error: Both add and delete mailing buttons were pressed simultaneously.', LOG_ERR);
+	setEventMessages($langs->trans("Choose").' '.$langs->trans("Max").' 1 '.$langs->trans("Input"), null, 'errors');
+	header("Location: " . $_SERVER['HTTP_REFERER']);
+	exit;
 }
 $permissiontomailing = $user->hasRight('mailing', 'write');
 if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -227,6 +227,12 @@ if (empty($reshook)) {
 // Massaction add/delete recipients to/from mass mailing
 $button_add_mailing = GETPOST('button_add_mailing', 'aZ09');
 $button_delete_mailing = GETPOST('button_delete_mailing', 'aZ09');
+if ($button_add_mailing && $button_delete_mailing) {
+    dol_syslog('Error: Both add and delete mailing buttons were pressed simultaneously.', LOG_ERR);
+    setEventMessages($langs->trans("Choose").' '.$langs->trans("Max").' 1 '.$langs->trans("Input"), null, 'errors');
+    header("Location: " . $_SERVER['HTTP_REFERER']);
+    exit;
+}
 $permissiontomailing = $user->hasRight('mailing', 'write');
 if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 	dol_syslog('User='.$user->id.' misses permissions to write mailings', LOG_WARNING);
@@ -284,6 +290,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 					setEventMessages($warn_message, null, 'warnings');
 				} elseif (!empty($list_of_contacts)) {
 					$invoice_contact_list = array_merge($invoice_contact_list, $list_of_contacts);
+				}
 			}
 			// fail once pr. invoice, not once pr. mailing pr. invoice
 			$verified_invoice_contact_list = array();

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -180,7 +180,6 @@ if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
 if (empty($reshook)) {
-	dol_syslog("product/stats/facture.php::if empty reshook", LOG_DEBUG);
 	$objectclass = 'Facture';
 	$objectlabel = 'Invoices';
 	$permissiontoread = $user->hasRight("facture", "lire");
@@ -221,7 +220,6 @@ if (empty($reshook)) {
 			exit;
 		}
 	} else {
-		dol_syslog("product/stats/facture.php::if empty reshook::else confirmmassaction presend", LOG_DEBUG);
 		include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
 	}
 }
@@ -285,17 +283,13 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 					$warn_message = $invoicestatic->getNomUrl().' &mdash; '.$langs->trans("ErrorRefNotFound", $invoice_type_contact[$contact_code]);
 					setEventMessages($warn_message, null, 'warnings');
 				} elseif (!empty($list_of_contacts)) {
-					dol_syslog("count(invoice_contact_list)=".count($invoice_contact_list), LOG_DEBUG);
 					$invoice_contact_list = array_merge($invoice_contact_list, $list_of_contacts);
-			        // Optional: Log total count
-					dol_syslog("Total contacts found so far: " . count($invoice_contact_list), LOG_DEBUG);				}
 			}
 			// fail once pr. invoice, not once pr. mailing pr. invoice
 			$verified_invoice_contact_list = array();
 			foreach ($invoice_contact_list as $contact_array) {
 				$fetchcontact = $contactstatic->fetch($contact_array['id']);
 				if ($fetchcontact) {
-					dol_syslog("count(verified_invoice_contact_list".count($verified_invoice_contact_list), LOG_DEBUG);
 					$verified_invoice_contact_list[] = $contact_array;
 					// we will still fail later if this contact does not have an email address
 				} else {
@@ -307,11 +301,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 				$error_message = $invoicestatic->getNomUrl().' &mdash; '.$langs->trans("ErrorRefNotFound", $langs->trans("SearchIntoContacts"));
 				setEventMessages($error_message, null, 'errors');
 			}
-			dol_syslog("count(invoice_contact_list)=".count($invoice_contact_list), LOG_DEBUG);
-			dol_syslog("count(verified_invoice_contact_list)=".count($verified_invoice_contact_list), LOG_DEBUG);
-			dol_syslog("product/stats/facture.php::count(select_mailing)=".count($select_mailing), LOG_DEBUG);
 			foreach ($select_mailing as $mailingid) {
-				dol_syslog("product/stats/facture.php::mailingid=".$mailingid, LOG_DEBUG);
 				if ($thirdpartyemail > 0 && $fetchsociete) {
 					$thirdpartychangetomailing = 0; // to make sure isset is always true
 					if ($button_add_mailing) {

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -43,7 +43,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/actions_changeselectedfields.inc.php';
 
 // Load translation files required by the page
-$langs->loadLangs(array('companies', 'bills', 'products', 'supplier_proposal'));
+$langs->loadLangs(array('companies', 'bills', 'products', 'supplier_proposal', 'mails'));
 
 $action = GETPOST('action', 'aZ');
 
@@ -143,7 +143,7 @@ if (GETPOST('cancel', 'alpha')) {
 	$action = 'list';
 	$massaction = '';
 }
-if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') {
+if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend' && $massaction != 'premassmail') {
 	$massaction = '';
 }
 $arrayfields = array(
@@ -162,10 +162,9 @@ $societestatic = new Societe($db);
 $form = new Form($db);
 $formother = new FormOther($db);
 
-
-
 $arrayofmassactions = array(
 	'presend' => img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
+	'premassmail' => img_picto('', 'mail-bulk', 'class="pictofixedwidth"').$langs->trans("EditMailing"),
 );
 $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
 $arrayofselected = is_array($toselect) ? $toselect : array();
@@ -181,6 +180,7 @@ if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
 if (empty($reshook)) {
+	dol_syslog("product/stats/facture.php::if empty reshook", LOG_DEBUG);
 	$objectclass = 'Facture';
 	$objectlabel = 'Invoices';
 	$permissiontoread = $user->hasRight("facture", "lire");
@@ -221,10 +221,157 @@ if (empty($reshook)) {
 			exit;
 		}
 	} else {
+		dol_syslog("product/stats/facture.php::if empty reshook::else confirmmassaction presend", LOG_DEBUG);
 		include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
 	}
 }
 
+// Massaction add/delete recipients to/from mass mailing
+$button_add_mailing = GETPOST('button_add_mailing', 'aZ09');
+$button_delete_mailing = GETPOST('button_delete_mailing', 'aZ09');
+$permissiontomailing = $user->hasRight('mailing', 'write');
+if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
+	dol_syslog('User='.$user->id.' misses permissions to write mailings', LOG_WARNING);
+	setEventMessages($langs->trans("NotEnoughPermissions").' &mdash; '.$langs->trans("EditMailing"), null, 'errors');
+	$massaction = '';
+} elseif ($massaction == 'confirm_premassmail' && $permissiontomailing && $permissiontoread) {
+	dol_syslog("product/stats/facture.php::if confirmmassaction presend && permissiontomailing && permissiontoread", LOG_DEBUG);
+	$langs->loadLangs(array("errors", "main", "mails", "companies"));
+	$ignorenocontact = GETPOSTINT('ignorenocontact') ? GETPOSTINT('ignorenocontact') : 0;
+	$showerrors = GETPOST('showerrors', 'array:string') ?? array('');
+	$select_contactsrc = GETPOST('select_contactsrc', 'array') ?? array(0);
+	$verbosereporting = GETPOSTINT('verbosereporting') ? GETPOSTINT('verbosereporting') : 0;
+	$thirdpartyemail = GETPOSTINT('ThirdPartyEmail') ? GETPOSTINT('ThirdPartyEmail') : 0;
+	dol_syslog("product/stats/facture.php::thirdpartyemail=".$thirdpartyemail, LOG_DEBUG);
+	dol_syslog("product/stats/facture.php::ignorenocontact=".$ignorenocontact, LOG_DEBUG);
+	$select_mailing = GETPOST('select_mailing', 'array:int') ?? array();
+	if (empty($select_mailing)) {
+		setEventMessages($langs->trans("ListOfEMailings").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
+	}
+	if (empty($toselect)) {
+		setEventMessages($langs->trans("Invoices").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
+	}
+
+	// Verify all invoices actually exist before actually inserting their thirdparty + any contacts, where successful insert verifies the invoice
+
+	require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+	$contactstatic = new Contact($db);
+	$verified_toselect = array();
+	$verified_mailings = array();
+	$whatchanged = array();
+	$info_mesgs = array();
+	$info_warnings = array();
+	$info_errors = array();
+	$changetomailing = null;
+	$source_type = $invoicestatic->element;
+	foreach ($toselect as $itemid) {
+		$fetchinvoiceresult = $invoicestatic->fetch($itemid);
+		if ($fetchinvoiceresult) {
+			$verified_toselect[] = $itemid;
+			if ($thirdpartyemail > 0) {
+				$fetchsociete = $invoicestatic->fetch_thirdparty();
+				if (!$fetchsociete) {
+					// TODO we handle if fetching societe once pr invoice.
+
+				}
+			}
+
+
+			// here we should if empty($list_of_contacts && in_array($showerrors, 'ContactForInvoices')) - report that there are no contacts for the given invoice
+			// we should also fetch each contact to make sure it is a good contact such that we don't fail once pr. mailing pr. invoice, but only once pr invoice.
+			dol_syslog("product/stats/facture.php::count(select_mailing)=".count($select_mailing), LOG_DEBUG);
+			foreach ($select_mailing as $mailingid) {
+				dol_syslog("product/stats/facture.php::mailingid=".$mailingid, LOG_DEBUG);
+				if ($thirdpartyemail > 0 && $fetchsociete) {
+					dol_syslog("product/stats/facture.php::if fetchsociete", LOG_DEBUG);
+					$thirdpartychangetomailing = 0; // to make sure isset is always true
+					if ($button_add_mailing) {
+						dol_syslog("product/stats/facture.php::if button_add_mailing", LOG_DEBUG);
+						$other = $langs->trans("ThirdParty").'@'.$langs->trans("CustomerInvoice").'='.$itemid;
+						$thirdpartychangetomailing = $invoicestatic->thirdparty->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
+					}
+					if ($button_delete_mailing) {
+						$thirdpartychangetomailing = $invoicestatic->thirdparty->deleteFromMassMailing($mailingid, $itemid); // adjust parameters later
+					}
+					// we should record what changed as well as errors.
+				}
+				foreach ($select_contactsrc as $contact_code) {
+					$list_of_contacts = $invoicestatic->liste_contact(-1, 'external' , 0, $contact_code);
+					dol_syslog("product/stats/facture.php::count(list_of_contacts)=".count($list_of_contacts), LOG_DEBUG);
+					foreach ($list_of_contacts as $contact_array) {
+						$fetchcontact = $contactstatic->fetch($contact_array['id']);
+						if ($fetchcontact) {
+							$contactchangetomailing = 0; // to make sure isset is always true
+							if ($button_add_mailing) {
+								$other = $contact_array['label'].'@'.$langs->trans("CustomerInvoice").'='.$itemid;
+								$contactchangetomailing = $contactstatic->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
+							}
+							if ($button_delete_mailing) {
+								$contactchangetomailing = $contactstatic->deleteFromMassMailing($mailingid, $itemid); // adjust parameters later
+							}
+							dol_syslog("product/stats/facture.php::contactchangetomailing=".$contactchangetomailing.' for contact code='.$contact_array['code'].' and contact id='.$contact_array['id'], LOG_DEBUG);
+							// we should record what changed as well as errors.
+						}
+					}
+				}
+			}
+		} else {
+			$error_message = 'source_type='.$source_type.' id='.$itemid;
+			dol_syslog('fetch failed for '.$error_message.' in array toselect on page product/stats/facture.php massaction confirm_premassmail', LOG_ERR);
+			setEventMessages($langs->trans("ErrorRefNotFound", $error_message), null, 'errors');
+			continue;
+		}
+	}
+
+	// 1. report errors first
+	foreach ($info_errors as $key => $value) {
+		$fmresult = $mailingstatic->fetch($key);
+		if ($fmresult) {
+			$vmailing_title = $mailingstatic->title;
+		} else {
+			$vmailing_title = 'Mailing ID '.$key;
+		}
+		setEventMessages($langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'errors');
+	}
+	// 2. report warnings
+	foreach ($info_warnings as $key => $value) {
+		$fmresult = $mailingstatic->fetch($key);
+		if ($fmresult) {
+			$vmailing_title = $mailingstatic->title;
+		} else {
+			$vmailing_title = 'Mailing ID '.$key;
+		}
+		setEventMessages($langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'warnings');
+	}
+	// 3. report success
+	foreach ($info_mesgs as $key => $value) {
+		$fmresult = $mailingstatic->fetch($key);
+		if ($fmresult) {
+			$vmailing_title = $mailingstatic->title;
+		} else {
+			$vmailing_title = 'Mailing ID '.$key;
+		}
+		$actionmessage = $langs->trans("Unknown").' '.$langs->trans("BulkActions").' '.$langs->trans("RecordsModified", count($value));
+		if ($button_add_mailing) {
+			$actionmessage = $langs->trans("XTargetsAdded", count($value));
+		}
+		if ($button_delete_mailing) {
+			$actionmessage = $langs->trans("RecordsDeleted", count($value));
+		}
+		if ($verbosereporting) {
+			setEventMessages($actionmessage.' &mdash; '.$langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'mesgs');
+		} else {
+			setEventMessages($actionmessage.' &mdash; '.$langs->trans("MailingArea").' &mdash; '.$vmailing_title, null, 'mesgs');
+		}
+	}
+
+	foreach ($verified_mailings as $mailingid) {
+		if ($mailingstatic->fetch($mailingid)) {
+			$mailingstatic->countNbOfTargets($mailingid);
+		}
+	}
+	dol_syslog("product/stats/facture.php::END confirmmassaction presend && permissiontomailing && permissiontoread", LOG_DEBUG);
+}
 
 /*
  * View
@@ -423,6 +570,11 @@ if ($id > 0 || !empty($ref)) {
 					$objecttmp = new Facture($db);
 					$trackid = 'inv'.$id;
 
+					include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
+				}
+				if ($massaction == 'premassmail' && !empty($arrayofselected)) {
+					dol_syslog('product/stats/facture.php::massaction == premassmail', LOG_DEBUG);
+					$objecttmp = new Facture($db);
 					include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
 				}
 

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -252,8 +252,6 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 		setEventMessages($langs->trans("Invoices").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
 	}
 
-	// Verify all invoices actually exist before actually inserting their thirdparty + any contacts, where successful insert verifies the invoice
-
 	require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 	$contactstatic = new Contact($db);
 	$verified_toselect = array();
@@ -271,12 +269,11 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 			if ($thirdpartyemail > 0) {
 				$fetchsociete = $invoicestatic->fetch_thirdparty();
 				if (!$fetchsociete) {
-					// TODO we handle if fetching societe once pr invoice.
-
+					dol_syslog('product/stats/facture.php::failed fetching societe of invoice='.$itemid, LOG_ERR);
+					$error_message = $langs->trans("CustomerInvoice").'='.$itemid.' &mdash; '.$langs->trans("ErrorRefNotFound", $langs->trans("ThirdParty"));
+					setEventMessages($error_message, null, 'errors');
 				}
 			}
-
-
 			// here we should if empty($list_of_contacts && in_array($showerrors, 'ContactForInvoices')) - report that there are no contacts for the given invoice
 			// we should also fetch each contact to make sure it is a good contact such that we don't fail once pr. mailing pr. invoice, but only once pr invoice.
 			dol_syslog("product/stats/facture.php::count(select_mailing)=".count($select_mailing), LOG_DEBUG);

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -291,7 +291,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 						$thirdpartychangetomailing = $invoicestatic->thirdparty->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
 					}
 					if ($button_delete_mailing) {
-						$thirdpartychangetomailing = $invoicestatic->thirdparty->deleteFromMassMailing($mailingid, $itemid); // adjust parameters later
+						$thirdpartychangetomailing = $invoicestatic->thirdparty->deleteFromMassMailing($mailingid);
 					}
 					// we should record what changed as well as errors.
 				}
@@ -307,7 +307,7 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 								$contactchangetomailing = $contactstatic->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
 							}
 							if ($button_delete_mailing) {
-								$contactchangetomailing = $contactstatic->deleteFromMassMailing($mailingid, $itemid); // adjust parameters later
+								$contactchangetomailing = $contactstatic->deleteFromMassMailing($mailingid);
 							}
 							dol_syslog("product/stats/facture.php::contactchangetomailing=".$contactchangetomailing.' for contact code='.$contact_array['code'].' and contact id='.$contact_array['id'], LOG_DEBUG);
 							// we should record what changed as well as errors.

--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -236,14 +236,13 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 	$massaction = '';
 } elseif ($massaction == 'confirm_premassmail' && $permissiontomailing && $permissiontoread) {
 	dol_syslog("product/stats/facture.php::if confirmmassaction presend && permissiontomailing && permissiontoread", LOG_DEBUG);
-	$langs->loadLangs(array("errors", "main", "mails", "companies"));
+	$langs->loadLangs(array("errors", "main", "mails", "companies", "margins"));
 	$ignorenocontact = GETPOSTINT('ignorenocontact') ? GETPOSTINT('ignorenocontact') : 0;
-	$showerrors = GETPOST('showerrors', 'array:string') ?? array('');
+	$showerrors = GETPOST('showerrors', 'array') ?? array('');
 	$select_contactsrc = GETPOST('select_contactsrc', 'array') ?? array(0);
 	$verbosereporting = GETPOSTINT('verbosereporting') ? GETPOSTINT('verbosereporting') : 0;
 	$thirdpartyemail = GETPOSTINT('ThirdPartyEmail') ? GETPOSTINT('ThirdPartyEmail') : 0;
 	dol_syslog("product/stats/facture.php::thirdpartyemail=".$thirdpartyemail, LOG_DEBUG);
-	dol_syslog("product/stats/facture.php::ignorenocontact=".$ignorenocontact, LOG_DEBUG);
 	$select_mailing = GETPOST('select_mailing', 'array:int') ?? array();
 	if (empty($select_mailing)) {
 		setEventMessages($langs->trans("ListOfEMailings").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
@@ -268,14 +267,44 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 			$verified_toselect[] = $itemid;
 			if ($thirdpartyemail > 0) {
 				$fetchsociete = $invoicestatic->fetch_thirdparty();
-				if (!$fetchsociete) {
+				if (!$fetchsociete && in_array("ThirdPartyEmail", $showerrors)) {
 					dol_syslog('product/stats/facture.php::failed fetching societe of invoice='.$itemid, LOG_ERR);
-					$error_message = $langs->trans("CustomerInvoice").'='.$itemid.' &mdash; '.$langs->trans("ErrorRefNotFound", $langs->trans("ThirdParty"));
+					$error_message = $langs->trans("CustomerInvoice").'='.$invoicestatic->ref.' &mdash; '.$langs->trans("ErrorRefNotFound", $langs->trans("ThirdParty"));
 					setEventMessages($error_message, null, 'errors');
 				}
 			}
-			// here we should if empty($list_of_contacts && in_array($showerrors, 'ContactForInvoices')) - report that there are no contacts for the given invoice
-			// we should also fetch each contact to make sure it is a good contact such that we don't fail once pr. mailing pr. invoice, but only once pr invoice.
+			$invoice_contact_list = array();
+			foreach ($select_contactsrc as $contact_code) {
+				$list_of_contacts = $invoicestatic->liste_contact(-1, 'external' , 0, $contact_code);
+				if (empty($list_of_contacts) && in_array("ContactForInvoices", $showerrors)) {
+					$invoice_type_contact = $invoicestatic->liste_type_contact('external', '', 1, 0, $contact_code);
+					$warn_message = $invoicestatic->getNomUrl().' &mdash; '.$langs->trans("ErrorRefNotFound", $invoice_type_contact[$contact_code]);
+					setEventMessages($warn_message, null, 'warnings');
+				} elseif (!empty($list_of_contacts)) {
+					dol_syslog("count(invoice_contact_list)=".count($invoice_contact_list), LOG_DEBUG);
+					$invoice_contact_list = array_merge($invoice_contact_list, $list_of_contacts);
+			        // Optional: Log total count
+					dol_syslog("Total contacts found so far: " . count($invoice_contact_list), LOG_DEBUG);				}
+			}
+			// fail once pr. invoice, not once pr. mailing pr. invoice
+			$verified_invoice_contact_list = array();
+			foreach ($invoice_contact_list as $contact_array) {
+				$fetchcontact = $contactstatic->fetch($contact_array['id']);
+				if ($fetchcontact) {
+					dol_syslog("count(verified_invoice_contact_list".count($verified_invoice_contact_list), LOG_DEBUG);
+					$verified_invoice_contact_list[] = $contact_array;
+					// we will still fail later if this contact does not have an email address
+				} else {
+					$warn_message = $invoicestatic->getNomUrl().' &mdash; '.$langs->trans("ErrorRefNotFound", $langs->trans("Contact").'='.$contact_array['id']);
+					setEventMessages($warn_message, null, 'warnings');
+				}
+			}
+			if (empty($verified_invoice_contact_list) && !empty($select_contactsrc) && in_array("ContactForInvoices", $showerrors)) {
+				$error_message = $invoicestatic->getNomUrl().' &mdash; '.$langs->trans("ErrorRefNotFound", $langs->trans("SearchIntoContacts"));
+				setEventMessages($error_message, null, 'errors');
+			}
+			dol_syslog("count(invoice_contact_list)=".count($invoice_contact_list), LOG_DEBUG);
+			dol_syslog("count(verified_invoice_contact_list)=".count($verified_invoice_contact_list), LOG_DEBUG);
 			dol_syslog("product/stats/facture.php::count(select_mailing)=".count($select_mailing), LOG_DEBUG);
 			foreach ($select_mailing as $mailingid) {
 				dol_syslog("product/stats/facture.php::mailingid=".$mailingid, LOG_DEBUG);
@@ -292,23 +321,19 @@ if ($massaction == 'confirm_premassmail' && !$permissiontomailing) {
 					}
 					// we should record what changed as well as errors.
 				}
-				foreach ($select_contactsrc as $contact_code) {
-					$list_of_contacts = $invoicestatic->liste_contact(-1, 'external' , 0, $contact_code);
-					dol_syslog("product/stats/facture.php::count(list_of_contacts)=".count($list_of_contacts), LOG_DEBUG);
-					foreach ($list_of_contacts as $contact_array) {
-						$fetchcontact = $contactstatic->fetch($contact_array['id']);
-						if ($fetchcontact) {
-							$contactchangetomailing = 0; // to make sure isset is always true
-							if ($button_add_mailing) {
-								$other = $contact_array['label'].'@'.$langs->trans("CustomerInvoice").'='.$itemid;
-								$contactchangetomailing = $contactstatic->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
-							}
-							if ($button_delete_mailing) {
-								$contactchangetomailing = $contactstatic->deleteFromMassMailing($mailingid);
-							}
-							dol_syslog("product/stats/facture.php::contactchangetomailing=".$contactchangetomailing.' for contact code='.$contact_array['code'].' and contact id='.$contact_array['id'], LOG_DEBUG);
-							// we should record what changed as well as errors.
+				foreach ($verified_invoice_contact_list as $invoice_contact) {
+					$fetchcontact = $contactstatic->fetch($invoice_contact['id']);
+					if ($fetchcontact) {
+						$contactchangetomailing = 0; // to make sure isset is always true
+						if ($button_add_mailing) {
+							$other = $invoice_contact['label'].'@'.$langs->trans("CustomerInvoice").'='.$itemid;
+							$contactchangetomailing = $contactstatic->addToMassMailing($mailingid, $itemid, $source_type, $other, $ignorenocontact);
 						}
+						if ($button_delete_mailing) {
+							$contactchangetomailing = $contactstatic->deleteFromMassMailing($mailingid);
+						}
+						dol_syslog("product/stats/facture.php::contactchangetomailing=".$contactchangetomailing.' for contact code='.$invoice_contact['code'].' and contact id='.$invoice_contact['id'], LOG_DEBUG);
+						// we should record what changed as well as errors.
 					}
 				}
 			}


### PR DESCRIPTION
# NEW #37747 From product Related invoices do massaction add to massmailing
This PR adds a new massaction on the list of invoices one gets when coming from a Product and selecting related items, then customer invoices.

Given invoices both have thirdparties and contacts which can have an email address, this PR had to be able to add both, and even select which kind of contact should be added to 1 or more mass mailings.

This PR allows for various kinds of verbose and/or error reporting, as well as one can force override to include email addresses which requested no contact.

This PR should close #37747.

This PR would probably conflict with #37984 until some merging and changes has been made. This PR is better than #37984, but other wise heavily inspired from #37984. I am prepared to fix those conflicts myself, because I kind of created them.