### PR TITLE
FIX autofill price with multicurrency on supplier doc (backport commit 391aca5)

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3692,7 +3692,7 @@ class Form
 					$optstart .= ' data-supplier-ref="' . dol_escape_htmltag($objp->ref_fourn) . '"';
 					if (isModEnabled('multicurrency')) {
 						$optstart .= ' data-multicurrency-code="' . dol_escape_htmltag($objp->multicurrency_code) . '"';
-						$optstart .= ' data-multicurrency-up="' . dol_escape_htmltag($objp->multicurrency_unitprice) . '"';
+						$optstart .= ' data-multicurrency-unitprice="' . dol_escape_htmltag(price2num($objp->multicurrency_unitprice)) . '"';	// the price with numeric international format
 					}
 				}
 				$optstart .= ' data-description="' . dol_escape_htmltag($objp->description, 0, 1) . '"';


### PR DESCRIPTION
FIX autofill price with multicurrency on supplier doc (backport commit 391aca5)
- when you have a supplier order in multicurrency
<img width="1137" height="135" alt="image" src="https://github.com/user-attachments/assets/ec4c3aee-a1f4-422a-91bf-6d2b45bb92a6" />

- you buy a product in the same currency as the supplier order
<img width="1712" height="95" alt="image" src="https://github.com/user-attachments/assets/dfa9208f-8341-4484-9869-fc6cc783c038" />

- you want to select this product in supplier order
<img width="2289" height="381" alt="image" src="https://github.com/user-attachments/assets/02c1ba0d-9ab1-4467-bc15-2872405cb9e5" />

**Before**
You got an "NaN" in multicurrency unit price field

**After**
You got hhe multicurrency unit price value
