### PR TITLE
Fix: #38011 wrong line seq when generating invoice from order

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1419,6 +1419,9 @@ class Facture extends CommonInvoice
 		$this->date = dol_now();
 		$this->source = 0;
 
+		// Avoid updating the row ranks
+		$this->context['createfromclone'] = 1;
+
 		$num = count($object->lines);
 		for ($i = 0; $i < $num; $i++) {
 			$line = new FactureLigne($this->db);


### PR DESCRIPTION
FIX #38011 wrong line seq when generating invoice from order

Considering through this fix that creating an invoice from an order is cloning its content (lines). No need to re-order lines.
This fix is related to PR (#37613 ). 
