### PR TITLE
FIX double transaction db begin

### DIFF
--- a/htdocs/societe/price.php
+++ b/htdocs/societe/price.php
@@ -561,7 +561,7 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES')) {
 			$nbtotalofrecords = $prodcustprice->fetchAll('', '', 0, 0, $filter);
 		}
 
-		$result = $prodcustprice->fetchAll($sortorder, $sortfield, $conf->liste_limit, $offset, $filter);
+		$result = $prodcustprice->fetchAll($sortorder, $sortfield, $limit, $offset, $filter);
 		if ($result < 0) {
 			setEventMessages($prodcustprice->error, $prodcustprice->errors, 'errors');
 		}

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1713,8 +1713,6 @@ class Ticket extends CommonObject
 
 			$this->status = Ticket::STATUS_READ;
 
-			$this->db->begin();
-
 			$sql = "UPDATE ".MAIN_DB_PREFIX."ticket";
 			$sql .= " SET fk_statut = ".((int) $this->status) .", date_read = '".$this->db->idate(dol_now())."'";
 			$sql .= " WHERE rowid = ".((int) $this->id);


### PR DESCRIPTION
Removed a redundant call to $this->db->begin() in the markAsRead method of the Ticket class. This extra call caused an imbalance in the transaction stack, preventing the data from being committed to the database and resulting in partial blank pages during redirection after creation.