### PR TITLE
FIX product price.php: preserve default_vat_code and tva_npr when aut…

### DIFF
--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -2765,9 +2765,9 @@ if ((!getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || $action == 'showlog_defau
 			// We add it to fix this if not (trouble with old versions)
 			// We emulate the change of the price from interface with the same value than the one into table llx_product
 			if (getDolGlobalString('PRODUIT_MULTIPRICES') || getDolGlobalString('PRODUIT_CUSTOMER_PRICES_AND_MULTIPRICES')) {
-				$ret = $object->updatePrice(($object->multiprices_base_type[1] == 'TTC' ? $object->multiprices_ttc[1] : $object->multiprices[1]), $object->multiprices_base_type[1], $user, (empty($object->multiprices_tva_tx[1]) ? 0 : $object->multiprices_tva_tx[1]), ($object->multiprices_base_type[1] == 'TTC' ? $object->multiprices_min_ttc[1] : $object->multiprices_min[1]), 1);
+				$ret = $object->updatePrice(($object->multiprices_base_type[1] == 'TTC' ? $object->multiprices_ttc[1] : $object->multiprices[1]), $object->multiprices_base_type[1], $user, (empty($object->multiprices_tva_tx[1]) ? 0 : $object->multiprices_tva_tx[1]), ($object->multiprices_base_type[1] == 'TTC' ? $object->multiprices_min_ttc[1] : $object->multiprices_min[1]), 1, 0, 0, 0, array(), $object->default_vat_code);
 			} else {
-				$ret = $object->updatePrice(($object->price_base_type == 'TTC' ? $object->price_ttc : $object->price), $object->price_base_type, $user, $object->tva_tx, ($object->price_base_type == 'TTC' ? $object->price_min_ttc : $object->price_min));
+				$ret = $object->updatePrice(($object->price_base_type == 'TTC' ? $object->price_ttc : $object->price), $object->price_base_type, $user, $object->tva_tx, ($object->price_base_type == 'TTC' ? $object->price_min_ttc : $object->price_min), 0, $object->tva_npr, 0, 0, array(), $object->default_vat_code);
 			}
 
 			if ($ret < 0) {


### PR DESCRIPTION
# FIX

preserve default_vat_code and tva_npr when auto-creating initial product_price row

When a product has no row in llx_product_price (typical for products imported in bulk where only llx_product was populated), price.php auto-creates an initial history line on first display of the price tab (branch starting at "We must have at least one initial line").

The two updatePrice() calls in this branch omitted parameter 11 (\$newdefaultvatcode) which defaults to ''. In Product::updatePrice() the SQL then writes default_vat_code = NULL in BOTH llx_product and the new llx_product_price row, silently wiping a correctly-stored VAT code on every first display.

Symptom: "ErrorBadValueForParamNotAString" rendered next to selling price/min selling price (because \$langs->trans(\$object->price_base_type) is called with NULL when the row is freshly created with empty fields), and default_vat_code persistently reset to NULL until the user manually re-saves through the form.

Fix: forward \$object->default_vat_code (and \$object->tva_npr for the non-multiprice branch) to updatePrice() so the auto-init preserves the product's VAT configuration.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*

