### PR TITLE
NEW massaction Clone eventattendees to event

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -1443,16 +1443,17 @@ abstract class CommonObject
 	/**
 	 *    Copy contact from one element to current
 	 *
-	 *    @param    CommonObject    $objFrom    Source element
-	 *    @param    'internal'|'external'	$source	Nature of contact ('internal' or 'external')
+	 *    @param    CommonObject    		$objFrom    Source element
+	 *    @param    'internal'|'external'	$source		Nature of contact ('internal' or 'external')
+	 *    @param	int<0,1>				$notrigger	0=launch triggers after, 1=disable triggers
 	 *    @return   int                         >0 if OK, <0 if KO
 	 */
-	public function copy_linked_contact($objFrom, $source = 'internal')
+	public function copy_linked_contact($objFrom, $source = 'internal', $notrigger = 0)
 	{
 		// phpcs:enable
 		$contacts = $objFrom->liste_contact(-1, $source);
 		foreach ($contacts as $contact) {
-			if ($this->add_contact($contact['id'], $contact['fk_c_type_contact'], $contact['source']) < 0) {
+			if ($this->add_contact($contact['id'], $contact['fk_c_type_contact'], $contact['source'], $notrigger) < 0) {
 				return -1;
 			}
 		}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5190,6 +5190,39 @@ abstract class CommonObject
 		}
 	}
 
+	/**
+	 *	fetch object link Relationtype By Values, not id
+	 *
+	 *  @param		int		$fk_source		source id of object we link from
+	 *  @param		string	$sourcetype		type of the source object
+	 *  @param		int		$fk_target		target id of object we link to
+	 *  @param		string	$targettype 	type of the target object
+	 *	@return 	int			        	Return integer <0 if KO, >0 if OK
+	 */
+	public function getRelationtypeByValues($fk_source, $sourcetype, $fk_target, $targettype)
+	{
+		$sql = "SELECT relationtype FROM";
+		$sql .= " ".MAIN_DB_PREFIX.'element_element';
+		$sql .= " WHERE fk_source=".((int) $fk_source);
+		$sql .= " AND sourcetype='".$this->db->escape($sourcetype)."'";
+		$sql .= " AND fk_target=".((int) $fk_target);
+		$sql .= " AND targettype='".$this->db->escape($targettype)."'";
+
+		dol_syslog(__METHOD__, LOG_DEBUG);
+		$result = $this->db->query($sql);
+		if ($result) {
+			$obj = $this->db->fetch_object($result);
+			if ($obj) {
+				return $obj->relationtype;
+			} else {
+				$this->error = $this->db->error();
+				return null;
+			}
+		} else {
+			$this->error = $this->db->error();
+			return null;
+		}
+	}
 
 	/**
 	 * 	Get special code of a line

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -11592,7 +11592,7 @@ abstract class CommonObject
 	 *	@param	User	$user			Object user that modify
 	 *  @param	int		$status			New status to set (often a constant like self::STATUS_XXX)
 	 *  @param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
-	 *  @param  string  $triggercode    Trigger code to use
+	 *  @param  string  $triggercode    Trigger code to use, 'auto' will make it try to find the right triggercode to use based on the status to change to.
 	 *	@return	int						Return integer <0 if KO, >0 if OK
 	 *  @see setStatut()
 	 */
@@ -11602,6 +11602,10 @@ abstract class CommonObject
 
 		$this->db->begin();
 
+		if ($triggercode == 'auto' && isset($this->list_possible_triggercode)) {
+			$triggercode = isset($this->list_possible_triggercode[$status]) ? $this->list_possible_triggercode[$status] : '';
+			dol_syslog(get_class($this).' change to status='.$status.' uses triggercode='.$triggercode, LOG_DEBUG);
+		}
 		$statusfield = 'status';
 		if (in_array($this->element, array('don', 'donation', 'shipping', 'project_task'))) {
 			$statusfield = 'fk_statut';

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5197,7 +5197,7 @@ abstract class CommonObject
 	 *  @param		string	$sourcetype		type of the source object
 	 *  @param		int		$fk_target		target id of object we link to
 	 *  @param		string	$targettype 	type of the target object
-	 *	@return 	int			        	Return integer <0 if KO, >0 if OK
+	 *	@return 	string|null			    Return integer <0 if KO, >0 if OK
 	 */
 	public function getRelationtypeByValues($fk_source, $sourcetype, $fk_target, $targettype)
 	{

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -10655,6 +10655,7 @@ class Form
 
 			$nboftypesoutput = 0;
 
+			print '<!-- foreach linkedObjects -->';
 			foreach ($object->linkedObjects as $objecttype => $objects) {
 				$tplpath = $element = $subelement = $objecttype;
 

--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -976,6 +976,7 @@ class FormProjets extends Form
 		$out .= '</div>';
 
 		$out .= '<br>';
+		$out .= '<input type="checkbox" id="verbosereporting" name="verbosereporting" value="1"><label for="verbosereporting">'.$langs->trans("Show").' '.$langs->trans("ListOf", $langs->trans("CloneOf", $langs->trans("Attendee"))).'</label><br>';
 		$out .= '<div id="oldobject_status">';
 		$out .= '<label for="oldobject_status"><h4>'.$langs->trans("Source").' &mdash; '.$langs->trans("SetToStatus").'</h4></label>';
 		$out .= '<select class="select" name="oldobject_status" id="oldobject_status" size="6">';
@@ -1001,6 +1002,7 @@ class FormProjets extends Form
 		$actionname = $htmlname;
 		$out .= '<div id="massmail_selection_buttons_'.$htmlname.'"><br>';
 		$out .= '<input type="hidden" name="massaction" value="confirm_preclone">';
+		$out .= '<input type="checkbox" id="notrigger" name="notrigger" value="1" checked><label for="notrigger">'.$langs->trans("NoTrigger").' '.$langs->trans("CloneOf", $langs->trans("Attendee")).'</label><br><br>';
 		$out .= '<!-- 2 buttons Add and Cancel -->';
 		$out .= '<input type="submit" class="butAction button-add small reposition" id="button_clone_attendee" name="button_clone_attendee" value="'.$langs->trans("Clone").'">';
 		$out .= '<input type="submit" class="button button-cancel reposition" id="cancel" name="cancel" value="'.$langs->trans("Cancel").'" />';

--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -1002,7 +1002,8 @@ class FormProjets extends Form
 		$actionname = $htmlname;
 		$out .= '<div id="massmail_selection_buttons_'.$htmlname.'"><br>';
 		$out .= '<input type="hidden" name="massaction" value="confirm_preclone">';
-		$out .= '<input type="checkbox" id="notrigger" name="notrigger" value="1" checked><label for="notrigger">'.$langs->trans("NoTrigger").' '.$langs->trans("CloneOf", $langs->trans("Attendee")).'</label><br><br>';
+		$out .= '<input type="checkbox" id="notrigger" name="notrigger" value="1" checked><label for="notrigger">'.$langs->trans("NoTrigger").' '.$langs->trans("CloneOf", $langs->trans("Attendee")).'</label><br>';
+		$out .= '<input type="checkbox" id="objlink" name="objlink" value="1" checked><label for="objlink">'.$langs->trans("Create").' '.$langs->trans("LinkedObject").'</label><br><br>';
 		$out .= '<!-- 2 buttons Add and Cancel -->';
 		$out .= '<input type="submit" class="butAction button-add small reposition" id="button_clone_attendee" name="button_clone_attendee" value="'.$langs->trans("Clone").'">';
 		$out .= '<input type="submit" class="button button-cancel reposition" id="cancel" name="cancel" value="'.$langs->trans("Cancel").'" />';

--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -935,6 +935,90 @@ class FormProjets extends Form
 	}
 
 	/**
+	 * Output a form with Multi Selection of event organisation 4 cloning
+	 *
+	 * @param 	string 		$page 		Page - if empty no form tags are printed, else they are
+	 * @param	string		$htmlname	Name of HTML field
+	 * @param 	string 		$title 		Text above the multi select form., default is '' and not shown, could be a <h4>...</h4>
+	 * @param	int[] 	$status_list 	List of event organisations
+	 * @param	int[] 		$toplist 	List of event organisations
+	 * @param 	string 		$toptext 	Text in top/main optgroup (optional) - default is '' and not shown
+	 * @param	int 		$size 		How high the table should be in lines, default is 8
+	 * @param	string 		$morecss 	More css
+	 * @param	int			$nooutput 	No print output. Return it only.
+	 *
+	 * @return 	string 					HTML
+	 */
+	public function formMultiSelectEventOrg4Clone($page, $htmlname, $title = '', $status_list = array(), $toplist = array(), $toptext = '', $size = 8, $morecss = '', $nooutput = 0)
+	{
+		dol_syslog(__METHOD__.'::', LOG_DEBUG);
+		global $langs;
+		$langs->load("mails");
+
+		$out = '';
+		if (!empty($page)) {
+			$out .= '<form action="'.$page.'">';
+		}
+		if (!empty($title)) {
+			$out .= $title;
+		}
+
+		$out .= '<div id="select_'.$htmlname.'">';
+		$out .= '<select class="select" name="select_'.$htmlname.'[]" id="select_'.$htmlname.'" multiple size="'.$size.'" style="'.$morecss.'">';
+
+		foreach ($toplist as $key => $value) {
+            $project_id = $value["rowid"];
+            $project_title = $value["title"];
+		    $out .= '    <option class="option" value="'.$project_id.'">'.$project_title.'</option>';
+		}
+
+		$out .= '</select>';
+		$out .= '</div>';
+
+		$out .= '<br>';
+		$out .= '<div id="oldobject_status">';
+		$out .= '<label for="oldobject_status"><h4>'.$langs->trans("Source").' &mdash; '.$langs->trans("SetToStatus").'</h4></label>';
+		$out .= '<select class="select" name="oldobject_status" id="oldobject_status" size="6">';
+		$out .= '    <option class="option" value="-1" selected>'.$langs->trans("IsBefore").'</option>';
+		$out .= '    <option class="option" value="" disabled>&mdash;&mdash;&mdash;</option>';
+		foreach ($status_list as $key => $value) {
+		    $out .= '    <option class="option" value="'.$key.'">'.$value.'</option>';
+		}
+		$out .= '</select>';
+		$out .= '</div><br>';
+
+		$out .= '<div id="newobject_status">';
+		$out .= '<label for="newobject_status"><h4>'.$langs->trans("Clone").' &mdash; '.$langs->trans("SetToStatus").'</h4></label>';
+		$out .= '<select class="select" name="newobject_status" id="newobject_status" size="6">';
+		$out .= '    <option class="option" value="-1" selected>'.$langs->trans("Copy").'</option>';
+		$out .= '    <option class="option" value="" disabled>&mdash;&mdash;&mdash;</option>';
+		foreach ($status_list as $key => $value) {
+		    $out .= '    <option class="option" value="'.$key.'">'.$value.'</option>';
+		}
+		$out .= '</select>';
+		$out .= '</div>';
+
+		$actionname = $htmlname;
+		$out .= '<div id="massmail_selection_buttons_'.$htmlname.'"><br>';
+		$out .= '<input type="hidden" name="massaction" value="confirm_preclone">';
+		$out .= '<!-- 2 buttons Add and Cancel -->';
+		$out .= '<input type="submit" class="butAction button-add small reposition" id="button_clone_'.$actionname.'" name="button_clone_'.$actionname.'" value="'.$langs->trans("Clone").'">';
+		$out .= '<input type="submit" class="button button-cancel reposition" id="cancel" name="cancel" value="'.$langs->trans("Cancel").'" />';
+		$out .= '</div><br>';
+
+		if (!empty($page)) {
+			$out .= '</form>';
+		}
+
+		if (empty($nooutput)) {
+			print $out;
+			return '';
+		} else {
+			return $out;
+		}
+	}
+
+	/**
 	 *  Output html select to select opportunity status
 	 *
 	 *  @param	string $page       		Page

--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -1002,7 +1002,7 @@ class FormProjets extends Form
 		$out .= '<div id="massmail_selection_buttons_'.$htmlname.'"><br>';
 		$out .= '<input type="hidden" name="massaction" value="confirm_preclone">';
 		$out .= '<!-- 2 buttons Add and Cancel -->';
-		$out .= '<input type="submit" class="butAction button-add small reposition" id="button_clone_'.$actionname.'" name="button_clone_'.$actionname.'" value="'.$langs->trans("Clone").'">';
+		$out .= '<input type="submit" class="butAction button-add small reposition" id="button_clone_attendee" name="button_clone_attendee" value="'.$langs->trans("Clone").'">';
 		$out .= '<input type="submit" class="button button-cancel reposition" id="cancel" name="cancel" value="'.$langs->trans("Cancel").'" />';
 		$out .= '</div><br>';
 

--- a/htdocs/core/class/html.formprojet.class.php
+++ b/htdocs/core/class/html.formprojet.class.php
@@ -967,9 +967,9 @@ class FormProjets extends Form
 		$out .= '<select class="select" name="select_'.$htmlname.'[]" id="select_'.$htmlname.'" multiple size="'.$size.'" style="'.$morecss.'">';
 
 		foreach ($toplist as $key => $value) {
-            $project_id = $value["rowid"];
-            $project_title = $value["title"];
-		    $out .= '    <option class="option" value="'.$project_id.'">'.$project_title.'</option>';
+			$project_id = $value["rowid"];
+			$project_title = $value["title"];
+			$out .= '    <option class="option" value="'.$project_id.'">'.$project_title.'</option>';
 		}
 
 		$out .= '</select>';
@@ -983,7 +983,7 @@ class FormProjets extends Form
 		$out .= '    <option class="option" value="-1" selected>'.$langs->trans("IsBefore").'</option>';
 		$out .= '    <option class="option" value="" disabled>&mdash;&mdash;&mdash;</option>';
 		foreach ($status_list as $key => $value) {
-		    $out .= '    <option class="option" value="'.$key.'">'.$value.'</option>';
+			$out .= '    <option class="option" value="'.$key.'">'.$value.'</option>';
 		}
 		$out .= '</select>';
 		$out .= '</div><br>';
@@ -994,7 +994,7 @@ class FormProjets extends Form
 		$out .= '    <option class="option" value="-1" selected>'.$langs->trans("Copy").'</option>';
 		$out .= '    <option class="option" value="" disabled>&mdash;&mdash;&mdash;</option>';
 		foreach ($status_list as $key => $value) {
-		    $out .= '    <option class="option" value="'.$key.'">'.$value.'</option>';
+			$out .= '    <option class="option" value="'.$key.'">'.$value.'</option>';
 		}
 		$out .= '</select>';
 		$out .= '</div>';

--- a/htdocs/core/class/objectlink.class.php
+++ b/htdocs/core/class/objectlink.class.php
@@ -232,6 +232,7 @@ class ObjectLink extends CommonObject
 	 */
 	public function create($user, $fk_source, $sourcetype, $fk_target, $targettype, $relationtype = null, $notrigger = 0)
 	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
 		global $conf, $langs;
 		$error = 0;
 
@@ -280,8 +281,8 @@ class ObjectLink extends CommonObject
 		} else {
 			$sql .= " (fk_source, sourcetype, fk_target, targettype )";
 		}
-		$sql .= " VALUES (".((int) $this->fk_source).", '".$this->db->escape($sourcetype)."', ";
-		$sql .= ((int) $this->fk_target).", '".$this->db->escape($targettype)."'";
+		$sql .= " VALUES (".((int) $fk_source).", '".$this->db->escape($sourcetype)."', ";
+		$sql .= ((int) $fk_target).", '".$this->db->escape($targettype)."'";
 		if ($relationtype) {
 			$sql .= ", '".$this->db->escape($relationtype)."'";
 		}
@@ -310,9 +311,16 @@ class ObjectLink extends CommonObject
 	 */
 	private function _makeobject($objectid, $objecttype)
 	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
 		if ($objecttype == 'adherent') {
 			require_once DOL_DOCUMENT_ROOT.'/adherents/class/adherent.class.php';
 			$newobject = new Adherent($this->db);
+			$result = $newobject->fetch($objectid);
+			return $result;
+		}
+		if ($objecttype == 'conferenceorboothattendee') {
+			require_once DOL_DOCUMENT_ROOT.'/eventorganization/class/conferenceorboothattendee.class.php';
+			$newobject = new ConferenceOrBoothAttendee($this->db);
 			$result = $newobject->fetch($objectid);
 			return $result;
 		}

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -50,6 +50,7 @@
  * @var string $action
  * @var string $massaction
  * @var string $modelmail
+ * @var string $projectid
  * @var string $sendto
  * @var string $topicmail
  * @var string $trackid

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -402,7 +402,7 @@ if ($massaction == 'preclone') {
 	foreach ($objecttmp->list_possible_status as $statusid) {
 		$status_list[$statusid] = $objecttmp->LibStatut($statusid, 1);
 	}
-	$htmlname = 'attendee';
+	$htmlname = 'eventorg';
 	$page = '';
 	$size = (int) round(3 + log(count($project_list)));
 	$toptext = $langs->trans("EventOrganization").' &mdash; '.$langs->trans("ExtrafieldCheckBoxFromList");

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -374,6 +374,44 @@ if ($massaction == 'presend') {
 	print dol_get_fiche_end();
 }
 
+if ($massaction == 'preclone') {
+	dol_syslog('massactions_pre.tpl.php::if massaction == preclone', LOG_DEBUG);
+	$langs->loadLangs(array("eventorganization", "admin", "projects"));
+	require_once DOL_DOCUMENT_ROOT.'/core/class/html.formprojet.class.php';
+	$formprojet = new FormProjets($db);
+	require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
+	$projectstatic = new Project($db);
+	if (!isset($projectid)) {
+		$projectid = 0;
+	}
+	if (isset($projectstatic->date_start_event)) {
+		$fromdate = $projectstatic->date_start_event;
+	} else {
+		$fpresult = $projectstatic->fetch($projectid);
+		if ($fpresult) {
+			$fromdate = $projectstatic->date_start_event;
+		} else {
+			setEventMessages($langs->trans("ErrorRefNotFound", $langs->trans("Project")), null, 'errors');
+			dol_syslog('massaction_pre.tpl.php::failed fetching project='.$projectid, LOG_ERR);
+			$fromdate = 0;
+		}
+	}
+
+	$project_list = $projectstatic->fetchEventOrgIds($user, 1, $fromdate, 1);
+	$status_list = array();
+	foreach ($objecttmp->list_possible_status as $statusid) {
+		$status_list[$statusid] = $objecttmp->LibStatut($statusid, 1);
+	}
+	$htmlname = 'attendee';
+	$page = '';
+	$size = (int) round(3 + log(count($project_list)));
+	$toptext = $langs->trans("EventOrganization").' &mdash; '.$langs->trans("ExtrafieldCheckBoxFromList");
+	$title = '<h4><label for="eventOrg_selection_choices_'.$htmlname.'">'.$toptext.':</label></h4>';
+	$formprojet->formMultiSelectEventOrg4Clone($page, $htmlname, $title, $status_list, $project_list, $toptext, $size, 'width: 100%;');
+
+	print '<br>';
+}
+
 if ($massaction == 'edit_extrafields') {
 	require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 	$elementtype = $objecttmp->element;

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -50,7 +50,7 @@
  * @var string $action
  * @var string $massaction
  * @var string $modelmail
- * @var string $projectid
+ * @var int $projectid
  * @var string $sendto
  * @var string $topicmail
  * @var string $trackid
@@ -66,6 +66,7 @@
 @phan-var-force int[] $toselect
 @phan-var-force ?string $uploaddir
 @phan-var-force int<0,1> $withmaindocfilemail
+@phan-var-force int $projectid
 @phan-var-force string $sendto
 @phan-var-force string $massaction
 @phan-var-force int[] $arrayofselected

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -63,6 +63,10 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 */
 	public $list_possible_status = [self::STATUS_DRAFT, self::STATUS_VALIDATED, self::STATUS_USED, self::STATUS_CANCELED];
 
+	/**
+	 * @var array<int, string> list of possible triggercode for this object
+	 */
+	public $list_possible_triggercode = [self::STATUS_DRAFT => 'CONFERENCEORBOOTHATTENDEE_UNVALIDATE', self::STATUS_VALIDATED => 'CONFERENCEORBOOTHATTENDEE_VALIDATE', self::STATUS_USED => 'CONFERENCEORBOOTHATTENDEE_USED', self::STATUS_CANCELED => 'CONFERENCEORBOOTHATTENDEE_CANCEL'];
 
 	/**
 	 *  'type' field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter]]', 'sellist:TableName:LabelFieldName[:KeyFieldName[:KeyFieldParent[:Filter]]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'text:none', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
@@ -322,9 +326,10 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 * @param  	int 	$fromid     Id of object to clone
 	 * @param	int 	$notrigger	0=launch triggers after, 1=disable triggers
 	 * @param	int 	$nolink		0=make link between source and clone, 1=do not link
+	 * @param	array<string, mixed>	$changes	Default empty array else array[field] = value, naturally not id/rowid, but this could be used to create the clone in a different fk_project: $changes["fk_project"] = $newprojectid
 	 * @return ConferenceOrBoothAttendee|int
 	 */
-	public function createFromClone(User $user, $fromid, $notrigger = 0, $nolink = 0)
+	public function createFromClone(User $user, $fromid, $notrigger = 0, $nolink = 0, $changes = array())
 	{
 		global $langs, $extrafields;
 		$error = 0;
@@ -344,6 +349,24 @@ class ConferenceOrBoothAttendee extends CommonObject
 		// get lines so they will be clone
 		//foreach($this->lines as $line)
 		//	$line->fetch_optionals();
+
+		// handle changes to fields
+		foreach ($changes as $key => $value) {
+			if ($key == "fields") {
+				dol_syslog('this->fields MUST NOT BE CHANGED', LOG_ERR);
+				$this->error = 'this->fields MUST NOT BE CHANGED';
+				return -2;
+			} elseif (array_key_exists((string) $key, $this->fields)) {
+				dol_syslog('key='.$key.' changed from '.$object->$key, LOG_DEBUG);
+				$object->$key = $value;
+				dol_syslog('key='.$key.' changed to '.$value, LOG_DEBUG);
+			} else {
+				$error++;
+				dol_syslog('key='.$key.' was not found in $this->fields', LOG_ERR);
+				$this->error = 'key='.$key.' was not found in $this->fields';
+				return -3;
+			}
+		}
 
 		// Reset some properties
 		unset($object->id);

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -321,9 +321,10 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 * @param  	User 	$user      	User that creates
 	 * @param  	int 	$fromid     Id of object to clone
 	 * @param	int 	$notrigger	0=launch triggers after, 1=disable triggers
+	 * @param	int 	$nolink		0=make link between source and clone, 1=do not link
 	 * @return 	mixed 				New object created, <0 if KO
 	 */
-	public function createFromClone(User $user, $fromid, $notrigger = 0)
+	public function createFromClone(User $user, $fromid, $notrigger = 0, $nolink = 0)
 	{
 		global $langs, $extrafields;
 		$error = 0;
@@ -399,6 +400,20 @@ class ConferenceOrBoothAttendee extends CommonObject
 		// End
 		if (!$error) {
 			$this->db->commit();
+
+			require_once DOL_DOCUMENT_ROOT.'/core/class/objectlink.class.php';
+			$staticobjectlink = new ObjectLink($this->db);
+			if (!$nolink) {
+				$linkresult = $staticobjectlink->create($user, $this->id, $this->element, $object->id, $object->element, 'clone', $notrigger);
+				if ($linkresult) {
+					return $object;
+				} else {
+					dol_syslog('Failed to objectlink clone + source='.$this->id.' '.$staticobjectlink->error, LOG_ERR);
+					$this->db->rollback();
+					$this->error = $staticobjectlink->error;
+					return -1;
+				}
+			}
 			return $object;
 		} else {
 			$this->db->rollback();

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -59,7 +59,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	const STATUS_CANCELED = 9;
 
 	/**
-	 * @var array[int] list of possible statuses for this object
+	 * @var array<int, int> list of possible statuses for this object
 	 */
 	public $list_possible_status = [self::STATUS_DRAFT, self::STATUS_VALIDATED, self::STATUS_USED, self::STATUS_CANCELED];
 

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -322,7 +322,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 * @param  	int 	$fromid     Id of object to clone
 	 * @param	int 	$notrigger	0=launch triggers after, 1=disable triggers
 	 * @param	int 	$nolink		0=make link between source and clone, 1=do not link
-	 * @return 	mixed 				New object created, <0 if KO
+	 * @return ConferenceOrBoothAttendee|int
 	 */
 	public function createFromClone(User $user, $fromid, $notrigger = 0, $nolink = 0)
 	{

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -320,9 +320,10 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *
 	 * @param  	User 	$user      	User that creates
 	 * @param  	int 	$fromid     Id of object to clone
+	 * @param	int 	$notrigger	0=launch triggers after, 1=disable triggers
 	 * @return 	mixed 				New object created, <0 if KO
 	 */
-	public function createFromClone(User $user, $fromid)
+	public function createFromClone(User $user, $fromid, $notrigger = 0)
 	{
 		global $langs, $extrafields;
 		$error = 0;
@@ -368,18 +369,18 @@ class ConferenceOrBoothAttendee extends CommonObject
 
 		// Create clone
 		$object->context['createfromclone'] = 'createfromclone';
-		$result = $object->createCommon($user);
+		$result = $object->createCommon($user, $notrigger);
 		if ($result < 0) {
 			$error++;
 			$this->setErrorsFromObject($object);
 		} else {
 			$object->ref = (string) $object->id;
-			$result = $object->update($user);
+			$result = $object->update($user, $notrigger);
 		}
 
 		if (!$error) {
 			// copy internal contacts
-			if ($this->copy_linked_contact($object, 'internal') < 0) {
+			if ($this->copy_linked_contact($object, 'internal', $notrigger) < 0) {
 				$error++;
 			}
 		}
@@ -387,7 +388,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		if (!$error) {
 			// copy external contacts if same company
 			if (!empty($this->fk_soc) && $this->fk_soc == $object->socid) {
-				if ($this->copy_linked_contact($object, 'external') < 0) {
+				if ($this->copy_linked_contact($object, 'external', $notrigger) < 0) {
 					$error++;
 				}
 			}

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -59,6 +59,12 @@ class ConferenceOrBoothAttendee extends CommonObject
 	const STATUS_CANCELED = 9;
 
 	/**
+	 * @var array[int] list of possible statuses for this object
+	 */
+	public $list_possible_status = [self::STATUS_DRAFT, self::STATUS_VALIDATED, self::STATUS_USED, self::STATUS_CANCELED];
+
+
+	/**
 	 *  'type' field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter]]', 'sellist:TableName:LabelFieldName[:KeyFieldName[:KeyFieldParent[:Filter]]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'text:none', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
 	 *         Note: Filter can be a string like "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.nature:is:NULL)"
 	 *  'label' the translation key.

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -254,6 +254,8 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 	$oldobject_status_txt = ($oldobject_status_id < 0) ? ($langs->trans("IsBefore")) : $object->LibStatut($oldobject_status_id, 1);
 	$newobject_status_txt = ($newobject_status_id < 0) ? ($langs->trans("Copy").' '.$langs->trans("Source")) : $object->LibStatut($newobject_status_id, 1);
 	$notrigger = GETPOSTINT('notrigger') ? GETPOSTINT('notrigger') : 0;
+	$nolink = GETPOSTINT('objlink') ? 0 : 1;
+	dol_syslog("nolink=".$nolink, LOG_DEBUG);
 	$select_eventorg = GETPOST('select_eventorg', 'array:int') ?? array();
 	if (empty($select_eventorg)) {
 		setEventMessages($langs->trans("OrganizedEvent").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
@@ -281,7 +283,7 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 					$verified_eventorgs[] = $target_event;
 					$userHasProjectRights = $projectstatic->restrictedProjectArea($user, 'write');
 					if ($userHasProjectRights) {
-						$attendeeclone = $attendeestatic->createFromClone($user, $attendeeid, $notrigger);
+						$attendeeclone = $attendeestatic->createFromClone($user, $attendeeid, $notrigger, $nolink);
 						if (is_object($attendeeclone)) {
 							// basic clone successful, let's report that
 							$whatchanged[$target_event] = isset($whatchanged[$target_event]) ? $whatchanged[$target_event] + 1 : 1;

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -204,7 +204,7 @@ if (GETPOST('cancel', 'alpha')) {
 	$action = 'list';
 	$massaction = '';
 }
-if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') {
+if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend' && $massaction != 'preclone' && $massaction != 'confirm_preclone') {
 	$massaction = '';
 }
 
@@ -829,11 +829,12 @@ $arrayofmassactions = array(
 	//'generate_doc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("ReGeneratePDF"),
 	//'builddoc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("PDFMerge"),
 	'presend' => img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
+	'preclone' => img_picto('', 'clone', 'class="pictofixedwidth"').$langs->trans("Clone").' '.$langs->trans("Attendees"),
 );
 if (!empty($permissiontodelete)) {
 	$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 }
-if (GETPOSTINT('nomassaction') || in_array($massaction, array('presend', 'predelete'))) {
+if (GETPOSTINT('nomassaction') || in_array($massaction, array('presend', 'preclone', 'predelete'))) {
 	$arrayofmassactions = array();
 }
 $massactionbutton = $form->selectMassAction('', $arrayofmassactions);

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -286,6 +286,8 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 					if ($userHasProjectRights) {
 						$attendeeclone = $attendeestatic->createFromClone($user, $attendeeid, $notrigger, $nolink);
 						if (is_object($attendeeclone)) {
+							// @phan-suppress-next-line PhanTypeMismatchReturn
+							/** @var ConferenceOrBoothAttendee $attendeeclone */
 							// basic clone successful, let's report that
 							$whatchanged[$target_event] = isset($whatchanged[$target_event]) ? $whatchanged[$target_event] + 1 : 1;
 

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -284,27 +284,28 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 					$verified_eventorgs[] = $target_event;
 					$userHasProjectRights = $projectstatic->restrictedProjectArea($user, 'write');
 					if ($userHasProjectRights) {
-						$attendeeclone = $attendeestatic->createFromClone($user, $attendeeid, $notrigger, $nolink);
+						// copied 2 next lines from the single clone in htdocs/eventorganization/conferenceorboothattendee_card.php
+						// We clone object to avoid to denaturate loaded object when setting some properties for clone or if createFromClone modifies the object.
+						$objectutil = dol_clone($attendeestatic, 1);
+						// we REALLY want to trigger creation with the correct project
+						$changes = array();
+						$changes["fk_project"] = $target_event;
+						$attendeeclone = $objectutil->createFromClone($user, $attendeeid, $notrigger, $nolink, $changes);
 						if (is_object($attendeeclone)) {
 							// @phan-suppress-next-line PhanTypeMismatchReturn
 							/** @var ConferenceOrBoothAttendee $attendeeclone */
 							// basic clone successful, let's report that
 							$whatchanged[$target_event] = isset($whatchanged[$target_event]) ? $whatchanged[$target_event] + 1 : 1;
 
-							// update clone with new project and possible new status as well
-							$cloneprojectresult = (int) $attendeeclone->setProject($target_event, $notrigger);
-							if (!$cloneprojectresult) {
-								$warn_message = $langs->trans("Clone").' '.((string) $attendeeclone->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetProject").' = <i>'.$projectstatic->getNomUrl().'</i>';
-								$info_warnings[$target_event][] = '&emsp;'.$warn_message;
-							}
+							// possible update clone with new status
 							if ($newobject_status_id != -1) {
-								$clonestatusresult = (int) $attendeeclone->setStatusCommon($user, $newobject_status_id, $notrigger);
+								$clonestatusresult = (int) $attendeeclone->setStatusCommon($user, $newobject_status_id, $notrigger, 'auto');
 								if (!$clonestatusresult) {
 									$warn_message = $langs->trans("Clone").' '.((string) $attendeeclone->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
 									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
 								}
 							} else {
-								$clonestatusresult = (int) $attendeeclone->setStatusCommon($user, $attendeestatic->status, $notrigger);
+								$clonestatusresult = (int) $attendeeclone->setStatusCommon($user, $attendeestatic->status, $notrigger, 'auto');
 								if (!$clonestatusresult) {
 									$warn_message = $langs->trans("Clone").' '.((string) $attendeeclone->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
 									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
@@ -314,7 +315,7 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 							// possible update old status
 							$sourcestatusresult = 0;
 							if ($oldobject_status_id != -1) {
-								$sourcestatusresult = (int) $attendeestatic->setStatusCommon($user, $oldobject_status_id, $notrigger);
+								$sourcestatusresult = (int) $attendeestatic->setStatusCommon($user, $oldobject_status_id, $notrigger, 'auto');
 								if (!$sourcestatusresult) {
 									$warn_message = $langs->trans("Source").' '.((string) $attendeestatic->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$oldobject_status_txt.'</i>';
 									$info_warnings[$target_event][] = '&emsp;'.$warn_message;

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -266,6 +266,7 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 
 	// Verify all eventattendees actually exist before actually inserting them, where successful insert verifies the mailing
 	$attendeestatic = new ConferenceOrBoothAttendee($db);
+	$attendeeclone = new ConferenceOrBoothAttendee($db);
 	$verified_attendees = array();
 	$verified_eventorgs = array();
 	$whatchanged = array();

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -325,7 +325,7 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 							// we should also try creating a link between the cloned objects
 
 							// all okay
-							if ($cloneprojectresult > 0 && $clonestatusresult >= 0 && $sourcestatusresult >= 0) {
+							if ($clonestatusresult >= 0 && $sourcestatusresult >= 0) {
 								$info_mesgs[$target_event][] = '&emsp;'.$langs->trans("NewObject", $langs->trans("Attendee")).' '.$attendeeclone->getNomUrl(1).' &mdash; '.$langs->trans("CloneOf", $attendeestatic->firstname.' '.$attendeestatic->lastname.' '.$attendeestatic->getNomUrl(1));
 							}
 						} elseif ($attendeeclone == -1) {

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -290,21 +290,21 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 							$whatchanged[$target_event] = isset($whatchanged[$target_event]) ? $whatchanged[$target_event] + 1 : 1;
 
 							// update clone with new project and possible new status as well
-							$cloneprojectresult = $attendeeclone->setProject($target_event, $notrigger);
+							$cloneprojectresult = (int) $attendeeclone->setProject($target_event, $notrigger);
 							if (!$cloneprojectresult) {
-								$warn_message = $langs->trans("Clone").' '.$attendeeclone->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetProject").' = <i>'.$projectstatic->getNomUrl().'</i>';
+								$warn_message = $langs->trans("Clone").' '.((string) $attendeeclone->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetProject").' = <i>'.$projectstatic->getNomUrl().'</i>';
 								$info_warnings[$target_event][] = '&emsp;'.$warn_message;
 							}
 							if ($newobject_status_id != -1) {
-								$clonestatusresult = $attendeeclone->setStatusCommon($user, $newobject_status_id, $notrigger);
+								$clonestatusresult = (int) $attendeeclone->setStatusCommon($user, $newobject_status_id, $notrigger);
 								if (!$clonestatusresult) {
-									$warn_message = $langs->trans("Clone").' '.$attendeeclone->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
+									$warn_message = $langs->trans("Clone").' '.((string) $attendeeclone->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
 									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
 								}
 							} else {
-								$clonestatusresult = $attendeeclone->setStatusCommon($user, $attendeestatic->status, $notrigger);
+								$clonestatusresult = (int) $attendeeclone->setStatusCommon($user, $attendeestatic->status, $notrigger);
 								if (!$clonestatusresult) {
-									$warn_message = $langs->trans("Clone").' '.$attendeeclone->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
+									$warn_message = $langs->trans("Clone").' '.((string) $attendeeclone->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
 									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
 								}
 							}
@@ -312,9 +312,9 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 							// possible update old status
 							$sourcestatusresult = 0;
 							if ($oldobject_status_id != -1) {
-								$sourcestatusresult = $attendeestatic->setStatusCommon($user, $oldobject_status_id, $notrigger);
+								$sourcestatusresult = (int) $attendeestatic->setStatusCommon($user, $oldobject_status_id, $notrigger);
 								if (!$sourcestatusresult) {
-									$warn_message = $langs->trans("Source").' '.$attendeestatic->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$oldobject_status_txt.'</i>';
+									$warn_message = $langs->trans("Source").' '.((string) $attendeestatic->getNomUrl()).' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$oldobject_status_txt.'</i>';
 									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
 								}
 							}

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -243,7 +243,126 @@ if (empty($reshook)) {
 	include DOL_DOCUMENT_ROOT.'/core/actions_massactions.inc.php';
 }
 
+// Massaction add/delete recipients to/from mass mailing
+$button_clone_attendee = GETPOST('button_clone_attendee', 'aZ09');
+if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissiontoadd) {
+	$langs->loadLangs(array("errors", "main", "mails", "companies"));
 
+	$oldobject_status = GETPOSTINT('oldobject_status') ? GETPOSTINT('oldobject_status') : -1; // default is not to change old attendee status
+	$newobject_status = GETPOSTINT('newobject_status') ? GETPOSTINT('newobject_status') : 0;  // default for new cloned attendee is draft
+	$notrigger = GETPOSTINT('notrigger') ? GETPOSTINT('notrigger') : 1;
+
+	$select_eventorg = GETPOST('select_eventorg', 'array:int') ?? array();
+	if (empty($select_eventorg)) {
+		setEventMessages($langs->trans("OrganizedEvent").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
+	}
+	if (empty($toselect)) {
+		setEventMessages($langs->trans("Attendees").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
+	}
+
+	// Verify all eventattendees actually exist before actually inserting them, where successful insert verifies the mailing
+	$attendeestatic = new ConferenceOrBoothAttendee($db);
+	$verified_attendees = array();
+	$verified_eventorgs = array();
+	$whatchanged = array();
+	$info_mesgs = array();
+	$info_warnings = array();
+	$info_errors = array();
+	$changetomailing = null;
+	$notrigger = 1;
+	foreach ($toselect as $attendeeid) {
+		dol_syslog('eventorganization/conferenceorboothattendee_list::foreach attendeeid='.$attendeeid, LOG_DEBUG);
+		$faresult = $attendeestatic->fetch($attendeeid);
+		if ($faresult) {
+			$verified_attendees[] = $attendeeid;
+			foreach ($select_eventorg as $target_event) {
+				dol_syslog('eventorganization/conferenceorboothattendee_list::foreach target_event='.$target_event, LOG_DEBUG);
+				$pfresult = $projectstatic->fetch($target_event);
+				if ($pfresult) {
+					$userHasProjectRights = $projectstatic->restrictedProjectArea($user, 'write');
+					if ($userHasProjectRights) {
+						$attendeeclone = $attendeestatic->createFromClone($user, $attendeeid);
+						if (is_object($attendeeclone)) {
+							$attendeeclone->fk_project = $target_event;
+							if ($newobject_status != -1) {
+								$attendeeclone->status = $newobject_status;
+							}
+							$cloneresult = $attendeeclone->update($user, $notrigger);
+							$sourceresult = 0; // so it is always something
+							if ($oldobject_status != -1) {
+								$attendeestatic->status = $oldobject_status;
+								$sourceresult = $attendeeclone->update($user, $notrigger);
+							}
+							// we should record the changes
+						} elseif ($attendeeclone == -1) {
+							$cloneresult = -1;
+						} else {
+							// okay something is really wrong with cloning, we should log and report that
+						}
+					} else {
+						// this is bad, user does not have access rights to this project
+					}
+				} else {
+					// okay, fetching the project failed
+				}
+			}
+		} else {
+			dol_syslog('fetch failed for attendee id='.$attendeeid.' in array toselect on page eventorganization/conferenceorboothattendee_list.php massaction confirm_preclone', LOG_ERR);
+			setEventMessages($langs->trans("ErrorRefNotFound", "attendeeid=".$attendeeid), null, 'errors');
+			continue;
+		}
+	}
+
+	// 1. report errors first
+	foreach ($info_errors as $key => $value) {
+		$fmresult = $mailingstatic->fetch($key);
+		if ($fmresult) {
+			$vmailing_title = $mailingstatic->title;
+		} else {
+			$vmailing_title = 'Mailing ID '.$key;
+		}
+		setEventMessages($langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'errors');
+	}
+	// 2. report warnings
+	foreach ($info_warnings as $key => $value) {
+		$fmresult = $mailingstatic->fetch($key);
+		if ($fmresult) {
+			$vmailing_title = $mailingstatic->title;
+		} else {
+			$vmailing_title = 'Mailing ID '.$key;
+		}
+		setEventMessages($langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'warnings');
+	}
+	// 3. report success
+	foreach ($info_mesgs as $key => $value) {
+		$fmresult = $mailingstatic->fetch($key);
+		if ($fmresult) {
+			$vmailing_title = $mailingstatic->title;
+		} else {
+			$vmailing_title = 'Mailing ID '.$key;
+		}
+		$actionmessage = $langs->trans("Unknown").' '.$langs->trans("BulkActions").' '.$langs->trans("RecordsModified", count($value));
+		if ($button_add_mailing) {
+			$actionmessage = $langs->trans("XTargetsAdded", count($value));
+		}
+		if ($button_delete_mailing) {
+			$actionmessage = $langs->trans("RecordsDeleted", count($value));
+		}
+		if ($verbosereporting) {
+			setEventMessages($actionmessage.' &mdash; '.$langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'mesgs');
+		} else {
+			setEventMessages($actionmessage.' &mdash; '.$langs->trans("MailingArea").' &mdash; '.$vmailing_title, null, 'mesgs');
+		}
+	}
+
+	$total_changes = 0;
+	foreach ($select_mailing as $mailingid) {
+		$total_changes += $whatchanged[$mailingid];
+	}
+	setEventMessages($langs->trans("GrandTotal").' '.$langs->trans("RecordsModified", $total_changes), null, 'mesgs');
+
+	dol_syslog("eventorganization/conferenceorboothattendee_list::END confirmmassaction confirm_preclone && permissiontoadd", LOG_DEBUG);
+}
 
 /*
  * View

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -246,12 +246,14 @@ if (empty($reshook)) {
 // Massaction add/delete recipients to/from mass mailing
 $button_clone_attendee = GETPOST('button_clone_attendee', 'aZ09');
 if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissiontoadd) {
-	$langs->loadLangs(array("errors", "main", "mails", "companies"));
+	$langs->loadLangs(array("errors", "main", "mails", "companies", "accountancy"));
 
-	$oldobject_status = GETPOSTINT('oldobject_status') ? GETPOSTINT('oldobject_status') : -1; // default is not to change old attendee status
-	$newobject_status = GETPOSTINT('newobject_status') ? GETPOSTINT('newobject_status') : 0;  // default for new cloned attendee is draft
-	$notrigger = GETPOSTINT('notrigger') ? GETPOSTINT('notrigger') : 1;
-
+	$verbosereporting = GETPOSTINT('verbosereporting') ? GETPOSTINT('verbosereporting') : 0;
+	$oldobject_status_id = GETPOSTINT('oldobject_status') ? GETPOSTINT('oldobject_status') : -1; // default is not to change old attendee status
+	$newobject_status_id = GETPOSTINT('newobject_status') ? GETPOSTINT('newobject_status') : 0;  // default for new cloned attendee is draft
+	$oldobject_status_txt = ($oldobject_status_id < 0) ? ($langs->trans("IsBefore")) : $object->LibStatut($oldobject_status_id, 1);
+	$newobject_status_txt = ($newobject_status_id < 0) ? ($langs->trans("Copy").' '.$langs->trans("Source")) : $object->LibStatut($newobject_status_id, 1);
+	$notrigger = GETPOSTINT('notrigger') ? GETPOSTINT('notrigger') : 0;
 	$select_eventorg = GETPOST('select_eventorg', 'array:int') ?? array();
 	if (empty($select_eventorg)) {
 		setEventMessages($langs->trans("OrganizedEvent").' &mdash; '.$langs->trans("NoRecordSelected"), null, 'warnings');
@@ -269,41 +271,75 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 	$info_warnings = array();
 	$info_errors = array();
 	$changetomailing = null;
-	$notrigger = 1;
 	foreach ($toselect as $attendeeid) {
-		dol_syslog('eventorganization/conferenceorboothattendee_list::foreach attendeeid='.$attendeeid, LOG_DEBUG);
 		$faresult = $attendeestatic->fetch($attendeeid);
 		if ($faresult) {
 			$verified_attendees[] = $attendeeid;
 			foreach ($select_eventorg as $target_event) {
-				dol_syslog('eventorganization/conferenceorboothattendee_list::foreach target_event='.$target_event, LOG_DEBUG);
 				$pfresult = $projectstatic->fetch($target_event);
 				if ($pfresult) {
+					$verified_eventorgs[] = $target_event;
 					$userHasProjectRights = $projectstatic->restrictedProjectArea($user, 'write');
 					if ($userHasProjectRights) {
-						$attendeeclone = $attendeestatic->createFromClone($user, $attendeeid);
+						$attendeeclone = $attendeestatic->createFromClone($user, $attendeeid, $notrigger);
 						if (is_object($attendeeclone)) {
-							$attendeeclone->fk_project = $target_event;
-							if ($newobject_status != -1) {
-								$attendeeclone->status = $newobject_status;
+							// basic clone successful, let's report that
+							$whatchanged[$target_event] = isset($whatchanged[$target_event]) ? $whatchanged[$target_event] + 1 : 1;
+
+							// update clone with new project and possible new status as well
+							$cloneprojectresult = $attendeeclone->setProject($target_event, $notrigger);
+							if (!$cloneprojectresult) {
+								$warn_message = $langs->trans("Clone").' '.$attendeeclone->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetProject").' = <i>'.$projectstatic->getNomUrl().'</i>';
+								$info_warnings[$target_event][] = '&emsp;'.$warn_message;
 							}
-							$cloneresult = $attendeeclone->update($user, $notrigger);
-							$sourceresult = 0; // so it is always something
-							if ($oldobject_status != -1) {
-								$attendeestatic->status = $oldobject_status;
-								$sourceresult = $attendeeclone->update($user, $notrigger);
+							if ($newobject_status_id != -1) {
+								$clonestatusresult = $attendeeclone->setStatusCommon($user, $newobject_status_id, $notrigger);
+								if (!$clonestatusresult) {
+									$warn_message = $langs->trans("Clone").' '.$attendeeclone->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
+									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
+								}
+							} else {
+								$clonestatusresult = $attendeeclone->setStatusCommon($user, $attendeestatic->status, $notrigger);
+								if (!$clonestatusresult) {
+									$warn_message = $langs->trans("Clone").' '.$attendeeclone->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$newobject_status_txt.'</i>';
+									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
+								}
 							}
-							// we should record the changes
+
+							// possible update old status
+							$sourcestatusresult = 0;
+							if ($oldobject_status_id != -1) {
+								$sourcestatusresult = $attendeestatic->setStatusCommon($user, $oldobject_status_id, $notrigger);
+								if (!$sourcestatusresult) {
+									$warn_message = $langs->trans("Source").' '.$attendeestatic->getNomUrl().' '.$langs->trans("ResultKo").' '.$langs->trans("SetToStatus").'= <i>'.$oldobject_status_txt.'</i>';
+									$info_warnings[$target_event][] = '&emsp;'.$warn_message;
+								}
+							}
+
+							// we should also try creating a link between the cloned objects
+
+							// all okay
+							if ($cloneprojectresult > 0 && $clonestatusresult >= 0 && $sourcestatusresult >= 0) {
+								$info_mesgs[$target_event][] = '&emsp;'.$langs->trans("NewObject", $langs->trans("Attendee")).' '.$attendeeclone->getNomUrl(1).' &mdash; '.$langs->trans("CloneOf", $attendeestatic->firstname.' '.$attendeestatic->lastname.' '.$attendeestatic->getNomUrl(1));
+							}
 						} elseif ($attendeeclone == -1) {
-							$cloneresult = -1;
+							$error_message = $langs->trans("ResultKo").' '.$langs->trans("ConfirmMassCloneToOneProject", $target_event).' '.$langs->trans("Attendee").'='.$attendeeid;
+							$info_errors[$target_event][] = '&emsp;'.$error_message;
 						} else {
-							// okay something is really wrong with cloning, we should log and report that
+							dol_syslog('Unknown error cloning attendeeid='.$attendeeid.' to target project='.$target_event.' in array select_eventorg on page eventorganization/conferenceorboothattendee_list.php massaction confirm_preclone', LOG_ERR);
+							$error_message = $langs->trans("ConfirmMassCloneToOneProject", $target_event).' '.$langs->trans("Attendee").'='.$attendeeid;
+							setEventMessages($langs->trans("ErrorUnknown"), [$error_message], 'errors');
+							continue;
 						}
 					} else {
-						// this is bad, user does not have access rights to this project
+						dol_syslog('User='.$user->id.' does not have write access to id='.$target_event.' in array select_eventorg on page eventorganization/conferenceorboothattendee_list.php massaction confirm_preclone', LOG_ERR);
+						setEventMessages($langs->trans("ErrorForbidden", "project id=".$target_event), null, 'errors');
+						continue;
 					}
 				} else {
-					// okay, fetching the project failed
+					dol_syslog('fetch failed for project id='.$target_event.' in array select_eventorg on page eventorganization/conferenceorboothattendee_list.php massaction confirm_preclone', LOG_ERR);
+					setEventMessages($langs->trans("ErrorRefNotFound", "project id=".$target_event), null, 'errors');
+					continue;
 				}
 			}
 		} else {
@@ -315,49 +351,44 @@ if ($massaction == 'confirm_preclone' && $button_clone_attendee && $permissionto
 
 	// 1. report errors first
 	foreach ($info_errors as $key => $value) {
-		$fmresult = $mailingstatic->fetch($key);
-		if ($fmresult) {
-			$vmailing_title = $mailingstatic->title;
+		$fpresult = $projectstatic->fetch($key);
+		if ($fpresult) {
+			$vmailing_title = $projectstatic->title;
 		} else {
 			$vmailing_title = 'Mailing ID '.$key;
 		}
-		setEventMessages($langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'errors');
+		setEventMessages($langs->trans("Errors").' '.$langs->trans("OrganizedEvent").' &mdash; '.$vmailing_title, $value, 'errors');
 	}
 	// 2. report warnings
 	foreach ($info_warnings as $key => $value) {
-		$fmresult = $mailingstatic->fetch($key);
-		if ($fmresult) {
-			$vmailing_title = $mailingstatic->title;
+		$fpresult = $projectstatic->fetch($key);
+		if ($fpresult) {
+			$vmailing_title = $projectstatic->title;
 		} else {
 			$vmailing_title = 'Mailing ID '.$key;
 		}
-		setEventMessages($langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'warnings');
+		setEventMessages($langs->trans("Warnings").' '.$langs->trans("OrganizedEvent").' &mdash; '.$vmailing_title, $value, 'warnings');
 	}
 	// 3. report success
 	foreach ($info_mesgs as $key => $value) {
-		$fmresult = $mailingstatic->fetch($key);
-		if ($fmresult) {
-			$vmailing_title = $mailingstatic->title;
+		$fpresult = $projectstatic->fetch($key);
+		if ($fpresult) {
+			$vmailing_title = $projectstatic->title;
 		} else {
 			$vmailing_title = 'Mailing ID '.$key;
 		}
 		$actionmessage = $langs->trans("Unknown").' '.$langs->trans("BulkActions").' '.$langs->trans("RecordsModified", count($value));
-		if ($button_add_mailing) {
-			$actionmessage = $langs->trans("XTargetsAdded", count($value));
-		}
-		if ($button_delete_mailing) {
-			$actionmessage = $langs->trans("RecordsDeleted", count($value));
-		}
+		$actionmessage = $langs->trans("XTargetsAdded", count($value));
 		if ($verbosereporting) {
-			setEventMessages($actionmessage.' &mdash; '.$langs->trans("MailingArea").' &mdash; '.$vmailing_title, $value, 'mesgs');
+			setEventMessages($actionmessage.' &mdash; '.$langs->trans("OrganizedEvent").' &mdash; '.$vmailing_title, $value, 'mesgs');
 		} else {
-			setEventMessages($actionmessage.' &mdash; '.$langs->trans("MailingArea").' &mdash; '.$vmailing_title, null, 'mesgs');
+			setEventMessages($actionmessage.' &mdash; '.$langs->trans("OrganizedEvent").' &mdash; '.$vmailing_title, null, 'mesgs');
 		}
 	}
 
 	$total_changes = 0;
-	foreach ($select_mailing as $mailingid) {
-		$total_changes += $whatchanged[$mailingid];
+	foreach ($select_eventorg as $target_event) {
+		$total_changes += $whatchanged[$target_event];
 	}
 	setEventMessages($langs->trans("GrandTotal").' '.$langs->trans("RecordsModified", $total_changes), null, 'mesgs');
 

--- a/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
@@ -47,6 +47,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	echo '<td>'.$objectlink->getNomUrl(1).'</td>';
 	echo '<!-- relationtype should be here -->';
 	$relationtype = '';
+	$translation= '';
 	if ($object->id < $objectlink->id) {
 		$relationtype = $objectlink->getRelationtypeByValues($object->id, $object->element, $objectlink->id, $objectlink->element);
 		if ($relationtype == 'clone') {

--- a/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
@@ -74,7 +74,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	if (get_class($objectlink) == 'ConferenceOrBoothAttendee') {
 		print dol_print_date($objectlink->date_subscription);
 	} else {
-		print dol_print_date($objectlink->date);
+		print dol_print_date($objectlink->date_creation);
 	}
 	print '</td>';
 	echo '<td class="right">';

--- a/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
@@ -38,16 +38,39 @@ $langs = $GLOBALS['langs'];
 $linkedObjectBlock = $GLOBALS['linkedObjectBlock'];
 '@phan-var-force CommonObject[] $linkedObjectBlock';
 /** @var CommonObject[] $linkedObjectBlock */
-$langs->load("eventorganization");
+$langs->loadLangs(array("eventorganization", "main", "accountancy"));
 
 $total = 0;
 foreach ($linkedObjectBlock as $key => $objectlink) {
 	echo '<tr class="oddeven">';
 	echo '<td>' . $langs->trans(get_class($objectlink)) . '</td>';
 	echo '<td>'.$objectlink->getNomUrl(1).'</td>';
-	echo '<td class="center">';
-	if (get_class($objectlink) == 'ConferenceOrBooth') {
-		print  dol_trunc($objectlink->label, 20);
+	echo '<!-- relationtype should be here -->';
+	$relationtype = '';
+	if ($object->id < $objectlink->id) {
+		$relationtype = $objectlink->getRelationtypeByValues($object->id, $object->element, $objectlink->id, $objectlink->element);
+		if ($relationtype == 'clone') {
+			$translation = $langs->trans("Clone");
+		} else {
+			$translation = $relationtype;
+		}
+	} elseif ($object->id > $objectlink->id) {
+		$relationtype = $objectlink->getRelationtypeByValues($objectlink->id, $objectlink->element, $object->id, $object->element);
+		if ($relationtype == 'clone') {
+			$translation = $langs->trans("Source");
+		} else {
+			$translation = $relationtype;
+		}
+	}
+	if ($relationtype == 'clone') {
+		echo '<td class="left">';
+		echo $translation;
+	} else {
+		dol_syslog("not clone relationtype=".$relationtype, LOG_DEBUG);
+		echo '<td class="center">';
+		if (get_class($objectlink) == 'ConferenceOrBoothAttendee') {
+			print  dol_trunc($objectlink->label, 20);
+		}
 	}
 	print '</td>';
 	echo '<td class="center">';

--- a/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
+++ b/htdocs/eventorganization/tpl/linkedobjectblock.tpl.php
@@ -45,6 +45,7 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 	echo '<tr class="oddeven">';
 	echo '<td>' . $langs->trans(get_class($objectlink)) . '</td>';
 	echo '<td>'.$objectlink->getNomUrl(1).'</td>';
+	echo '<td class="left">';
 	echo '<!-- relationtype should be here -->';
 	$relationtype = '';
 	$translation= '';
@@ -64,21 +65,16 @@ foreach ($linkedObjectBlock as $key => $objectlink) {
 		}
 	}
 	if ($relationtype == 'clone') {
-		echo '<td class="left">';
 		echo $translation;
 	} else {
-		dol_syslog("not clone relationtype=".$relationtype, LOG_DEBUG);
-		echo '<td class="center">';
-		if (get_class($objectlink) == 'ConferenceOrBoothAttendee') {
-			print  dol_trunc($objectlink->label, 20);
-		}
+		print $objectlink->getFullName($langs, 0, -1, 20);
 	}
 	print '</td>';
 	echo '<td class="center">';
 	if (get_class($objectlink) == 'ConferenceOrBoothAttendee') {
 		print dol_print_date($objectlink->date_subscription);
 	} else {
-		print dol_print_date($objectlink->datep);
+		print dol_print_date($objectlink->date);
 	}
 	print '</td>';
 	echo '<td class="right">';

--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -2117,7 +2117,7 @@ class Project extends CommonObject
 	 * @param	int			$showmin 		event organization project with status below this value will not be shown. Default is 0 (draft)
 	 * @param	int			$showmax 		event organization project with status above this value will not be shown. Default is 1 (validated)
 	 *
-	 * @return	int|array{rowid:int, ref:string, label:string, date:string, date_end_event:string, location:string, max_attendees:int, public:int, fk_statut:int}		-1 if KO, else OK either [] for nothing found or a list of id's
+	 * @return int|list<int>|list<array{rowid:int, ref:string, title:string, date_start_event:string, date_end_event:string, location:string, max_attendees:int, public:int, fk_statut:int}>
 	 */
 	public function fetchEventOrgIds($user, $timeline = 1, $fromdate = 0, $mode = 0, $limit = 0, $offset = 0, $showmin = 0, $showmax = 1)
 	{

--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -2106,6 +2106,86 @@ class Project extends CommonObject
 	}
 
 	/**
+	 * Load id of event organization projects
+	 *
+	 * @param	User		$user			Object user to evaluate for project permissions
+	 * @param	int			$timeline		-1 only show past events, 0 show both past and future events, 1 (default) only show future events.
+	 * @param	int			$fromdate		0 (default) means now, -1 means read $this->date_start_event, any number higher than 0 will be used as date_start_event
+	 * @param	int			$mode			0 means just rowid, 1 means rowid, ref, title, date_start_event, date_end_event, location, max_attendees, public, fk_statut
+	 * @param	int			$limit        	limit
+	 * @param	int			$offset       	Offset
+	 * @param	int			$showmin 		event organization project with status below this value will not be shown. Default is 0 (draft)
+	 * @param	int			$showmax 		event organization project with status above this value will not be shown. Default is 1 (validated)
+	 *
+	 * @return	int|array{rowid:int, ref:string, label:string, date:string, date_end_event:string, location:string, max_attendees:int, public:int, fk_statut:int}		-1 if KO, else OK either [] for nothing found or a list of id's
+	 */
+	public function fetchEventOrgIds($user, $timeline = 1, $fromdate = 0, $mode = 0, $limit = 0, $offset = 0, $showmin = 0, $showmax = 1)
+	{
+		dol_syslog(__METHOD__, LOG_DEBUG);
+
+		$records = array();
+
+		if ($mode) {
+			$sql = 'SELECT rowid, ref, title, date_start_event, date_end_event, location, max_attendees, public, fk_statut';
+		} else {
+			$sql = 'SELECT rowid';
+		}
+		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element.' as t';
+		if (isset($this->ismultientitymanaged) && $this->ismultientitymanaged == 1) {
+			$sql .= ' WHERE t.entity IN ('.getEntity($this->element).')';
+		} else {
+			$sql .= ' WHERE 1 = 1';
+		}
+		$sql .= ' AND usage_organize_event = 1';
+		$sql .= ' AND fk_statut >= '.(int) $showmin;
+		$sql .= ' AND fk_statut <= '.(int) $showmax;
+
+		if ($fromdate == -1) {
+			$date_start_event = (isset($this->date_start_event)) ? ($this->date_start_event) : dol_now();
+		} elseif ($fromdate == 0) {
+			$date_start_event = dol_now();
+		} else {
+			$date_start_event = $fromdate;
+		}
+		if ($timeline < 0 ) {
+			$sql .= ' AND date_start_event < '.(int) $date_start_event;
+		} elseif ($timeline > 0) {
+			$sql .= ' AND date_start_event > '.(int) $date_start_event;
+		}
+
+		$sql .= ' ORDER BY date_start_event ASC';
+
+		if (!empty($limit)) {
+			$sql .= $this->db->plimit($limit, $offset);
+		}
+
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$num = $this->db->num_rows($resql);
+			$i = 0;
+			while ($i < ($limit ? min($limit, $num) : $num)) {
+				$obj = $this->db->fetch_object($resql);
+
+				if ($mode == 0 ) {
+					$records[] = $obj->rowid;
+				} elseif ($mode == 1) {
+					$element = array();
+					$records[] = (array) $obj;
+				}
+				$i++;
+			}
+			$this->db->free($resql);
+
+			return $records;
+		} else {
+			$this->errors[] = 'Error '.$this->db->lasterror();
+			dol_syslog(__METHOD__.' '.implode(',', $this->errors), LOG_ERR);
+
+			return -1;
+		}
+	}
+
+	/**
 	 *  Create an intervention document on disk using template defined into PROJECT_ADDON_PDF
 	 *
 	 *  @param	string		$modele			Force template to use ('' by default)


### PR DESCRIPTION
# NEW #37954 massaction Clone eventattendees to event
This PR adds a new massaction to clone eventattendees from one event to 1 or more other event(s). During cloning you can independently change status of both new attendee object and old attendee object - though only to the same for all event attendees and the same in all the receiving events. The default value is to keep the old status when creating the new event attendee, and not change the old event attendee status.

This even works if you select a list of event attendees with mixed status, the new event attendee objects by default get the same as the old, even if other event attendees in the selection has a different status.

This PR be default has selected a checkbox that adds an object link between the source and the clone, and when looking at the card of these event attendees, it even shows the translated text for either source or clone, even depending on which direction you look at the links.

Triggers can be disabled, and that is the default value since this is a massaction.

This massaction cloning could be used for registrations on a waiting lists that you transfer to next event.

This PR would almost close #37954, as it does not handle single object cloning.