### PR TITLE
Fix - clear resPrint after reading selectForFormsListUrl hook value

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -9500,6 +9500,7 @@ class Form
 			$reshook = $hookmanager->executeHooks('selectForFormsListUrl', $parameters, $objecttmp, $action);
 			if (!empty($reshook)) {
 				$urloption = $hookmanager->resPrint;
+                $hookmanager->resPrint = '';
 			}
 
 			// Activate the auto complete using ajax call.

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -9500,7 +9500,7 @@ class Form
 			$reshook = $hookmanager->executeHooks('selectForFormsListUrl', $parameters, $objecttmp, $action);
 			if (!empty($reshook)) {
 				$urloption = $hookmanager->resPrint;
-                $hookmanager->resPrint = '';
+				$hookmanager->resPrint = '';
 			}
 
 			// Activate the auto complete using ajax call.


### PR DESCRIPTION
# FIX|Fix - clear resPrint after reading selectForFormsListUrl hook value

When a module uses the `selectForFormsListUrl` hook to modify the AJAX URL of an autocomplete field, the hook communicates its return value through `$hookmanager->resPrint`. The core reads this value correctly to build the AJAX URL, but never clears it afterwards.

Later in the same execution cycle, `showOptionals()` in `CommonObject` unconditionally appends `$hookmanager->resPrint` to its output after the extrafields loop (line 9604). Since `resPrint` still holds the URL params string left by the last `selectForFormsListUrl` call, those params get appended to the HTML output and appear as raw visible text on the page.     
                                                                                                                                                                                                                                           
Adding `$hookmanager->resPrint = '';` immediately after the core reads the
value clears it before `showOptionals` can pick it up as stale content.

  **How to reproduce:**                                                                                                                                                                                                                          
1. Create a custom module that implements the `selectForFormsListUrl` hook and returns 1 with a non-empty 
`$this->resprints`
3. Add a `link` type extrafield on any object that uses `showOptionals` targeting a class whose `*_USE_SEARCH_TO_SELECT` constant is enabled
4. Open the create or edit form of that object
5. Raw URL parameter text appears as visible text at the top of the extrafields section