### PR TITLE
FIX - Normalize empty values for extrafield types mapping to INT columns                                                                                                                                                           

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6696,10 +6696,17 @@ abstract class CommonObject
 
 				switch ($attributeType) {
 					case 'int':
+					case 'duration':
+					case 'stars':
 						if (!is_numeric($value) && $value != '') {
 							$this->errors[] = $langs->trans("ExtraFieldHasWrongValue", $attributeLabel);
 							return -1;
-						} elseif ($value == '') {
+						} elseif ($value === '' || $value === false || $value === null) {
+							$new_array_options[$key] = null;
+						}
+						break;
+					case 'boolean':
+						if ($value === '' || $value === false || $value === null) {
 							$new_array_options[$key] = null;
 						}
 						break;
@@ -6790,6 +6797,10 @@ abstract class CommonObject
 						$new_array_options[$key] = $this->db->idate($this->array_options[$key], 'gmt');
 						break;
 					case 'link':
+						if ($value === '' || $value === false || $value === null) {
+							$new_array_options[$key] = null;
+							break;
+						}
 						$param_list = array_keys($attributeParam['options']);
 						// 0 : ObjectName
 						// 1 : classPath


### PR DESCRIPTION
# FIX - Normalize empty values for extrafield types mapping to INT columns                                                                                                                                                           
                                                                                                                                                                                                                                    
  insertExtraFields() only normalizes '' → null for int, price and double types. However, several other extrafield types map to an INT column at the DB level (see extrafields.class.php):
                                                                                                                                                                                                                                    
  - boolean → INT(1)                                        
  - link → INT(11)                                                                                                                                                                                                                  
  - duration → INT(11)                                      
  - stars → INT                                                                                                                                                                                                                     
   
  None of these had a branch in the switch normalizing empty values. The SQL builder fallback ($value != '') uses loose comparison, which lets false, 0 and whitespace strings slip through and reach the INSERT as raw '',         
  triggering MySQL strict mode error 1366 Incorrect integer value: ''.
                                                                                                                                                                                                                                    
  This is what we hit in production: a trigger populated array_options['options_security_main_instance_unique_id'] from a JSON payload via a simple isset() check, without filtering '' or false. The field is typed boolean (INT(1)
   in DB), so neither the switch nor the SQL fallback normalized it, and the INSERT crashed.
                                                                                                                                                                                                                                    
  Changes:                                                  
  - Group int, duration, stars under the same branch (same INT mapping, same validation).
  - Add a dedicated boolean case forcing null on empty/false/null.                                                                                                                                                                  
  - Short-circuit the link case on empty/false/null before attempting to fetch the linked object.
  - Use strict comparisons (===) for '', false, null instead of the loose == '' that let false through.                                                                                                                             
                                                                                                                                                                                                                                    
  updateExtraField() already handles boolean and link correctly — this aligns insertExtraFields() with that behavior.     