### PR TITLE
New #38051: Hook for calculating number of working days in a date range

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2018-2024 Charlene Benke       <charlene@patas-monkey.com>
  * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024      Frédéric France      <frederic.france@free.fr>
+ * Copyright (C) 2026      Joachim Küter        <git-jk@bloxera.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1323,12 +1324,16 @@ function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
  *	@param		int			$lastday            We include last day, 0: no, 1:yes
  *  @param		int			$halfday			Tag to define half day when holiday start and end
  *  @param      string|int	$countryCodeOrId    Country Code or Id (company country code if not defined)
+ *  @param      int         $user_id            User id. When > 0, the 'numOpenDay' hook fires after the standard
+ *                                              calculation so modules can adjust the result for that user
+ *                                              (e.g. employees with fewer than 5 fixed working days, bridge days,
+ *                                              fixed half-days). Default 0 keeps the standard behavior unchanged.
  *	@return    	float|string					Number of days or hours or string if error
  *  @seealso num_between_day(), num_public_holiday()
  */
-function num_open_day($timestampStart, $timestampEnd, $inhour = 0, $lastday = 0, $halfday = 0, $countryCodeOrId = '')
+function num_open_day($timestampStart, $timestampEnd, $inhour = 0, $lastday = 0, $halfday = 0, $countryCodeOrId = '', $user_id = 0)
 {
-	global $langs, $mysoc;
+	global $langs, $mysoc, $hookmanager;
 
 	if (empty($countryCodeOrId) || $countryCodeOrId < 0) {
 		$countryCodeOrId = $mysoc->country_code;
@@ -1343,6 +1348,8 @@ function num_open_day($timestampStart, $timestampEnd, $inhour = 0, $lastday = 0,
 	if (!is_int($timestampEnd) && !is_float($timestampEnd)) {
 		return 'ErrorBadParameter_num_open_day';
 	}
+
+	$nbOpenDay = 0; // expressed in days; inhour conversion happens at the end
 
 	if ($timestampStart < $timestampEnd) {
 		// --- 1. Calculate Gross Working Days ---
@@ -1370,31 +1377,46 @@ function num_open_day($timestampStart, $timestampEnd, $inhour = 0, $lastday = 0,
 		if (($halfday == 1 || $halfday == 2) && date('Y-m-d', $timestampStart) != date('Y-m-d', $timestampEnd) && $isEndDayWorking) {
 			$nbOpenDay -= 0.5;
 		}
-
-		// --- 3. Return Final Value ---
-		if ($inhour == 1) {
-			return (int) ($nbOpenDay * 24);  // Can be half a day, which is still int hours
-		}
-
-		return $nbOpenDay;
 	} elseif ($timestampStart == $timestampEnd) {
-		$numholidays = 0;
+		$isSingleDayHoliday = false;
 		if ($lastday) {
 			$numholidays = num_public_holiday($timestampStart, $timestampEnd, $countryCodeOrId, $lastday);
 			if ($numholidays == 1) {
-				return 0;
+				$isSingleDayHoliday = true;
 			}
 		}
-
-		$nbOpenDay = $lastday;
-
-		if ($inhour == 1) {
-			$nbOpenDay *= 24;
+		if (!$isSingleDayHoliday) {
+			$nbOpenDay = $lastday - 0.5 * abs((int) $halfday);
 		}
-		return $nbOpenDay - (($inhour == 1 ? 12 : 0.5) * abs($halfday));
 	} else {
 		return $langs->trans("Error");
 	}
+
+	// --- 3. Allow modules to adjust the result based on the user (e.g. per-employee
+	// individual workdays, bridge days, fixed half-days). Only fires when caller
+	// opts in by passing a non-zero $user_id, so existing call sites are unaffected.
+	if ($user_id > 0 && is_object($hookmanager)) {
+		$parameters = array(
+			'timestampStart'  => $timestampStart,
+			'timestampEnd'    => $timestampEnd,
+			'inhour'          => $inhour,
+			'lastday'         => $lastday,
+			'halfday'         => $halfday,
+			'countryCodeOrId' => $countryCodeOrId,
+			'user_id'         => $user_id,
+			'nbOpenDay'       => $nbOpenDay,
+		);
+		$action = '';
+		$reshook = $hookmanager->executeHooks('numOpenDay', $parameters, $hookmanager, $action);
+		if ($reshook > 0 && isset($hookmanager->resArray['nbOpenDay'])) {
+			$nbOpenDay = $hookmanager->resArray['nbOpenDay'];
+		}
+	}
+
+	if ($inhour == 1) {
+		return (int) ($nbOpenDay * 24);
+	}
+	return $nbOpenDay;
 }
 
 

--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -263,7 +263,7 @@ if (empty($reshook)) {
 		$tmpUser->fetch($fuserid);
 
 		// If there is no Business Days within request
-		$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, $tmpUser->country_id);
+		$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, $tmpUser->country_id, $tmpUser->id);
 		if ($nbopenedday < 0.5) {
 			setEventMessages($langs->trans("ErrorDureeCP"), null, 'errors'); // No working day
 			$error++;
@@ -408,7 +408,7 @@ if (empty($reshook)) {
 				$tmpUser->fetch($fuserid);
 
 				// If there is no Business Days within request
-				$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, $tmpUser->country_id);
+				$nbopenedday = num_open_day($date_debut_gmt, $date_fin_gmt, 0, 1, $halfday, $tmpUser->country_id, $tmpUser->id);
 				if ($nbopenedday < 0.5) {
 					setEventMessages($langs->trans('ErrorDureeCP'), null, 'warnings');
 					$error++;
@@ -542,7 +542,7 @@ if (empty($reshook)) {
 					$tmpUser = new User($db);
 					$tmpUser->fetch($object->fk_user);
 
-					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $tmpUser->country_id);
+					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $tmpUser->country_id, $object->fk_user);
 
 					if ($nbopenedday > $object->getCPforUser($object->fk_user, $object->fk_type)) {
 						$message .= "<p>".$langs->transnoentities("HolidaysToValidateAlertSolde")."</p>\n";
@@ -657,7 +657,7 @@ if (empty($reshook)) {
 				$tmpUser->fetch($object->fk_user);
 
 				// Calculate number of days consumed
-				$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $tmpUser->country_id);
+				$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $tmpUser->country_id, $object->fk_user);
 				$soldeActuel = $object->getCpforUser($object->fk_user, $object->fk_type);
 				$newSolde = ($soldeActuel - $nbopenedday);
 				$label = $object->ref.' - '.$langs->transnoentitiesnoconv("HolidayConsumption");
@@ -903,7 +903,7 @@ if (empty($reshook)) {
 				$tmpUser->fetch($object->fk_user);
 
 				// Calculate number of days consumed
-				$nbopenedday = num_open_day($startDate, $endDate, 0, 1, $object->halfday, $tmpUser->country_id);
+				$nbopenedday = num_open_day($startDate, $endDate, 0, 1, $object->halfday, $tmpUser->country_id, $object->fk_user);
 
 				$soldeActuel = $object->getCpforUser($object->fk_user, $object->fk_type);
 				$newSolde = ($soldeActuel + $nbopenedday);
@@ -1442,7 +1442,7 @@ if ((empty($id) && empty($ref)) || $action == 'create' || $action == 'add') {
 				print $form->textwithpicto($langs->trans('NbUseDaysCP'), $htmlhelp);
 				print '</td>';
 				print '<td>';
-				print num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, (int) $object->halfday, $userRequest->country_id);
+				print num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, (int) $object->halfday, $userRequest->country_id, $object->fk_user);
 				print '</td>';
 				print '</tr>';
 

--- a/htdocs/holiday/card_group.php
+++ b/htdocs/holiday/card_group.php
@@ -761,7 +761,7 @@ function sendMail($id, $cancreate, $now, $autoValidation)
 
 				// option to notify the validator if the balance is less than the request
 				if (!getDolGlobalString('HOLIDAY_HIDE_APPROVER_ABOUT_NEGATIVE_BALANCE')) {
-					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $expediteur->country_id);
+					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $expediteur->country_id, $object->fk_user);
 
 					if ($nbopenedday > $object->getCPforUser($object->fk_user, $object->fk_type)) {
 						$message .= "<p>".$langs->transnoentities("HolidaysToValidateAlertSolde")."</p>\n";

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -777,7 +777,7 @@ class Holiday extends CommonObject
 
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
-			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1, 0, '', $this->fk_user);
 
 			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
@@ -901,7 +901,7 @@ class Holiday extends CommonObject
 
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
-			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1, 0, '', $this->fk_user);
 
 			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
@@ -1030,7 +1030,7 @@ class Holiday extends CommonObject
 
 		if ($checkBalance > 0 && $this->statut != self::STATUS_DRAFT && $this->statut != self::STATUS_CANCELED) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
-			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1, 0, '', $this->fk_user);
 
 			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
@@ -1766,7 +1766,7 @@ class Holiday extends CommonObject
 							$endDate = $endOfMonth;
 						}
 
-						$nbDaysToDeduct = (int) num_open_day($startDate, $endDate, 0, 1, $obj['halfday'], $obj['country_id']);
+						$nbDaysToDeduct = (int) num_open_day($startDate, $endDate, 0, 1, $obj['halfday'], $obj['country_id'], $obj['fk_user']);
 
 						if ($nbDaysToDeduct <= 0) {
 							continue;
@@ -2741,7 +2741,7 @@ class Holiday extends CommonObject
 					"type" => $arraytypeleaves[$obj->fk_type],
 					"date_start" => dol_print_date($date_start_inmonth, 'day') . ' <span class="opacitymedium">('.$outputlangs->trans($listhalfday[$starthalfdayinmonth]).')</span>',
 					"date_end" => dol_print_date($date_end_inmonth, 'day') . ' <span class="opacitymedium">('.$outputlangs->trans($listhalfday[$endhalfdayinmonth]).')</span>',
-					"used_days" => num_open_day($date_start_inmonth, $date_end_inmonth, 0, 1, $halfdayinmonth, $tmpuser->country_id)
+					"used_days" => num_open_day($date_start_inmonth, $date_end_inmonth, 0, 1, $halfdayinmonth, $tmpuser->country_id, $obj->fk_user)
 				);
 			}
 		}

--- a/htdocs/holiday/document.php
+++ b/htdocs/holiday/document.php
@@ -228,7 +228,7 @@ if ($object->id) {
 	}
 	print $form->textwithpicto($langs->trans('NbUseDaysCP'), $htmlhelp);
 	print '</td>';
-	print '<td>'.num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $userRequest->country_id).'</td>';
+	print '<td>'.num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday, $userRequest->country_id, $object->fk_user).'</td>';
 	print '</tr>';
 
 	if ($object->status == Holiday::STATUS_REFUSED) {

--- a/htdocs/holiday/list.php
+++ b/htdocs/holiday/list.php
@@ -877,7 +877,7 @@ if ($id && !$user->hasRight('holiday', 'readall') && !in_array($id, $childids)) 
 		$starthalfday = ($obj->halfday == -1 || $obj->halfday == 2) ? 'afternoon' : 'morning';
 		$endhalfday = ($obj->halfday == 1 || $obj->halfday == 2) ? 'morning' : 'afternoon';
 
-		$nbopenedday = num_open_day($db->jdate($obj->date_debut, 1), $db->jdate($obj->date_fin, 1), 0, 1, $obj->halfday, $userstatic->country_id);	// user jdate(..., 1) because num_open_day need UTC dates
+		$nbopenedday = num_open_day($db->jdate($obj->date_debut, 1), $db->jdate($obj->date_fin, 1), 0, 1, $obj->halfday, $userstatic->country_id, $obj->fk_user);	// user jdate(..., 1) because num_open_day need UTC dates
 		$totalduration += $nbopenedday;
 
 		if ($mode == 'kanban') {

--- a/htdocs/holiday/month_report.php
+++ b/htdocs/holiday/month_report.php
@@ -458,7 +458,7 @@ if ($num == 0) {
 		}
 
 		if (!empty($arrayfields['used_days']['checked'])) {
-			print '<td class="right">'.num_open_day($date_start, $date_end, 0, 1, $obj->halfday, $tmpuser->country_id).'</td>';
+			print '<td class="right">'.num_open_day($date_start, $date_end, 0, 1, $obj->halfday, $tmpuser->country_id, $obj->fk_user).'</td>';
 		}
 
 		if (!empty($arrayfields['date_start_month']['checked'])) {
@@ -474,7 +474,7 @@ if ($num == 0) {
 		}
 
 		if (!empty($arrayfields['used_days_month']['checked'])) {
-			print '<td class="right">'.num_open_day($date_start_inmonth, $date_end_inmonth, 0, 1, $halfdayinmonth, $tmpuser->country_id).'</td>';
+			print '<td class="right">'.num_open_day($date_start_inmonth, $date_end_inmonth, 0, 1, $halfdayinmonth, $tmpuser->country_id, $obj->fk_user).'</td>';
 		}
 		if (!empty($arrayfields['cp.description']['checked'])) {
 			print '<td class="maxwidth300 small">';


### PR DESCRIPTION
Adds an optional $user_id parameter to num_open_day() and adds a numOpenDay hook after the standard calculation when it's set. Default 0 keeps existing behaviour identical.
                                                                                                                                                                                                                                                                                              
Modules can adjust the standard result for the user by registering on the numOpenDay hook and writing $hookmanager->resArray['nbOpenDay'] = ... ; return 1;

Holiday module call sites in card.php, list.php, month_report.php, document.php, card_group.php and holiday.class.php now pass fk_user as the new last argument so the hook fires there. Group-request form intentionally left at default since there's no single user context. Actual holidays will get created later in a loop per user with the hook called with the user's id.
