### PR TITLE
FIX Wrong margin calculation for supplier proposals and orders in project overview

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -979,7 +979,10 @@ foreach ($listofreferent as $key => $value) {
 			// Calculate margin
 			if ($margin) {
 				if ($margin === 'add') {
-					$total_revenue_ht += $total_ht;
+					if ($tablename != 'commande_fournisseur' && $tablename != 'supplier_proposal') {
+						// Exclude these objects from total revenue calculation because of sign change above
+						$total_revenue_ht += $total_ht;
+					}
 				}
 
 				if ($margin === "minus") {	// Revert sign


### PR DESCRIPTION
# FIX Wrong margin calculation for supplier proposals and orders in project overview
If supplier proposals or orders are selected for inclusion in a project's margin, the calculation was wrong because of the sign reversal on line 965.
In the following examples, both customer orders and supplier orders are included in the profit margin calculation by adding `'margin' => 'add'` to the `$listofreferent` array.
Without the fix, the profit margin is wrong (100%) because the value of both `$total_revenue_ht` and `$balance_ht` end up being set to 20:
<img width="2004" height="714" alt="image" src="https://github.com/user-attachments/assets/a01cab46-7a46-4751-bd99-02644ad11cea" />
With the fix, the profit margin is right (25%) because `$total_revenue_ht` is correctly set to 80:
<img width="1004" height="358" alt="screenshot 2026-05-02 à 18 48 48" src="https://github.com/user-attachments/assets/22e30213-bc1f-4d4d-bb68-74b4fb17326d" />