### PR TITLE
Update html.formwebportal.class.php

### DIFF
--- a/htdocs/webportal/class/html.formwebportal.class.php
+++ b/htdocs/webportal/class/html.formwebportal.class.php
@@ -1608,7 +1608,7 @@ class FormWebPortal extends Form
 	 * @return string																	HTML code to output photo
 	 * @see getImagePublicURLOfObject()
 	 */
-	public static function showphoto($modulepart, $object, $width = 100, $height = 0, $caneditfield = 0, $cssclass = 'photowithmargin', $imagesize = '', $addlinktofullsize = 1, $cache = 0, $forcecapture = '', $noexternsourceoverwrite = 0)
+	public static function showphoto($modulepart, $object, $width = 100, $height = 0, $caneditfield = 0, $cssclass = 'photowithmargin', $imagesize = '', $addlinktofullsize = 1, $cache = 0, $forcecapture = '', $noexternsourceoverwrite = 0, $usesharelinkifavailable = 0)
 	{
 		$out = parent::showphoto($modulepart, $object, $width, $height, $caneditfield, $cssclass, $imagesize, $addlinktofullsize, $cache, $forcecapture, $noexternsourceoverwrite);
 		$out = self::convertAllLink($out);


### PR DESCRIPTION
Missing section in the original line of public static function - $usesharelinkifavailable = 0

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


FIX #37552 Webportal Proposal/orders/invoices - links not working
Applying this PR will make links in the webportal to Proposal/orders/invoices work again.

When third party user log in to the web portal account and trays to reach some of the records under his account (invoices, orders or proposals) it gets Internal Error 500
Adding a missing part of the line 1611 - $usesharelinkifavailable = 0