### PR TITLE
Fix: reset fk_code_ventilation on invoice clone

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1359,6 +1359,9 @@ class Facture extends CommonInvoice
 			}
 
 			$object->lines[$i]->ref_ext = ''; // Do not clone ref_ext
+
+			// Do not clone accountancy ventilation: a cloned invoice must reappear in "to dispatch" list
+			$object->lines[$i]->fk_code_ventilation = 0;
 		}
 
 		// Create clone


### PR DESCRIPTION
# FIX - Reset fk_code_ventilation on invoice clone

When cloning an invoice that was already dispatched in accounting, the new invoice copied each line's fk_code_ventilation from the in "Accounting > Dispatch > Invoices to dispatch". 

Fix: reset fk_code_ventilation = 0 on each line inside Facture::createFromClone(), right before $object->create() forwards the value to addline(). One field is enough — it's the only accountancy column on llx_facturedet, and the "dispatched" status is derived from the lines

