### PR TITLE
FIX : draft invoice paid when add absolute discount == remain to pay

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -674,6 +674,15 @@ if (empty($reshook)) {
 				$error++;
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
+
+			if (!$error) {
+				if ($object->status == Facture::STATUS_VALIDATED) {
+					$newremaintopay = $object->getRemainToPay(0);
+					if ($newremaintopay == 0) {
+						$object->setPaid($user);
+					}
+				}
+			}
 		}
 		// We use the credit note to reduce remain to pay
 		if (GETPOSTINT("remise_id_for_payment") > 0) {

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -674,13 +674,6 @@ if (empty($reshook)) {
 				$error++;
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
-
-			if (!$error) {
-				$newremaintopay = $object->getRemainToPay(0);
-				if ($newremaintopay == 0) {
-					$object->setPaid($user);
-				}
-			}
 		}
 		// We use the credit note to reduce remain to pay
 		if (GETPOSTINT("remise_id_for_payment") > 0) {


### PR DESCRIPTION
Hello,

I created a new invoice with the status **DRAFT**.

Then, I added an absolute discount equal to the remaining amount to pay on the invoice.

This automatically changed the invoice status to **Paid** by calling the `setPaid` function.

As a result, I now have some invoices with references like `PROVXX` marked as **Paid**, even though they are still draft invoices.