### PR TITLE
FIX: scope file picker click to the just-shown attach-new-file form

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1407,7 +1407,7 @@ class FormFile
 			// Show title of list of existing files
 			$morehtmlright = '';
 			if (!empty($moreoptions['showhideaddbutton']) && $conf->use_javascript_ajax) {
-				$tmpurlforbutton = 'javascript:console.log("open add file form");jQuery(".divattachnewfile").toggle(); if (!jQuery(".divattachnewfile").is(":hidden")) { jQuery("input[type=\'file\']").click();}void(0);';
+				$tmpurlforbutton = 'javascript:console.log("open add file form");jQuery(".divattachnewfile").toggle(); if (!jQuery(".divattachnewfile").is(":hidden")) { jQuery(".divattachnewfile input[type=\'file\']").first().click();}void(0);';	// scope file picker click to the just-shown form to avoid triggering native file dialog twice when other input[type=file] exist on the page
 				$morehtmlright .= dolGetButtonTitle($langs->trans('New'), '', 'fa fa-plus-circle', $tmpurlforbutton, '', $permtoeditline);
 			}
 


### PR DESCRIPTION
In FormFile::list_of_documents(), when the user clicks the "+ New" button to reveal the upload form (showhideaddbutton), the JS handler triggers jQuery("input[type='file']").click(). This selector matches every <input type="file"> on the page, opening the OS file picker once per match. Users with multiple file inputs in the DOM (e.g. another hidden upload form, an editor's media browser, modules with their own attachers) have to dismiss the file dialog several times before being able to drag-drop or browse normally.

Fix: scope the selector to the form that was just shown:

- jQuery("input[type='file']").click();
+ jQuery(".divattachnewfile input[type='file']").first().click(); 

No regression on pages with a single .divattachnewfile. Reproduces on any *document.php tab where a hidden second <input type="file"> is present.

