### PR TITLE
NEW add possibility to anonymise user fullname

### DIFF
--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -129,6 +129,22 @@ trait CommonPeople
 		return dol_string_nohtmltag(dol_trunc($ret, $maxlen));
 	}
 
+	/**
+	 *	Return full name (civility+' '+name+' '+lastname) or anonymous string
+	 *
+	 *	@param	Translate	$langs			Language object for translation of civility (used only if option is 1)
+	 *	@param	int<0,1>	$option			0=No option, 1=Add civility
+	 * 	@param	int<-1,5>	$nameorder		-1=Auto, 0=Lastname+Firstname, 1=Firstname+Lastname, 2=Firstname, 3=Firstname if defined else lastname, 4=Lastname, 5=Lastname if defined else firstname
+	 * 	@param	int			$maxlen			Maximum length
+	 * 	@return	string						String with full name
+	 */
+	public function getAnonymisableFullName($langs, $option = 0, $nameorder = -1, $maxlen = 0)
+	{
+		if (getDolGlobalInt('MAIN_ANONYMIZE_USER_FULLNAME') == 1) {
+			return '***';
+		}
+		return $this->getFullName($langs, $option, $nameorder, $maxlen);
+	}
 
 	/**
 	 *    Return civility label of object

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -379,7 +379,7 @@ class pdf_sponge extends ModelePDFFactures
 				$pdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 				$pdf->SetSubject($outputlangs->transnoentities("PdfInvoiceTitle"));
 				$pdf->SetCreator("Dolibarr ".DOL_VERSION);
-				$pdf->SetAuthor($mysoc->name.($user->id > 0 ? ' - '.$outputlangs->convToOutputCharset($user->getFullName($outputlangs)) : ''));
+				$pdf->SetAuthor($mysoc->name.($user->id > 0 ? ' - '.$outputlangs->convToOutputCharset($user->getAnonymisableFullName($outputlangs)) : ''));
 				$pdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref)." ".$outputlangs->transnoentities("PdfInvoiceTitle")." ".$outputlangs->convToOutputCharset($object->thirdparty->name));
 				if (getDolGlobalString('MAIN_DISABLE_PDF_COMPRESSION')) {
 					$pdf->SetCompression(false);


### PR DESCRIPTION
# NEW add possibility to anonymise user fullname

PDFs generated by Dolibarr contain the user's personal data in the metadata. To comply with GDPR regulations, it must be possible to anonymize this data.

@eldy does this implementation, which includes a new dedicated function, work for you? If yes I will udpate all PDFs templates.


