### PR TITLE
Fix :  Quick memo share BTN

### DIFF
--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1660,6 +1660,10 @@ class Memo extends CommonObject
 		];
 		$jsConfVars = array_merge($defaultJsConfVars, $jsConfVars);
 
+		if (!empty($jsConfVars['elementType'])) {
+			$jsConfVars['shareBtnStatus'] = 1;
+		}
+
 		// LOAD Memo class
 		print '<link rel="stylesheet" type="text/css" href="'.dol_buildpath('quickmemo/css/memo.css', 1) . '">'."\n";
 		print '<link rel="stylesheet" type="text/css" href="'.dol_buildpath('quickmemo/css/memo-dialog.css', 1) . '">'."\n";

--- a/htdocs/quickmemo/js/QuickMemo.js
+++ b/htdocs/quickmemo/js/QuickMemo.js
@@ -24,6 +24,7 @@ class QuickMemo {
 			elementType: '',
 			context: '',
 			token: '',
+			shareBtnStatus: 0,
 			colors: ['#fff8a6', '#ffd6d6', '#d6ffd9', '#d6e6ff', '#f3d6ff', '#ffffff', '#f5f5f5'],
 			publicFontAIcon: 'far fa-eye',
 			privateFontAIcon: 'far fa-eye-slash',
@@ -522,7 +523,9 @@ class QuickMemo {
 		// Append buttons based on permissions
 		if (this.param.userWriteRight) {
 			actions.appendChild(btnPrivate);
-			actions.appendChild(btnShare);
+			if(this.param.shareBtnStatus > 0) {
+				actions.appendChild(btnShare);
+			}
 			actions.appendChild(colorInput);
 			actions.appendChild(btnCreateModel);
 		}


### PR DESCRIPTION
# Fix 
The "Share" feature on the home page is not useful, since sharing makes more sense on individual cards or detail pages related to a specific item (element).