### PR TITLE
NEW Show count of "commerce" documents on Thirdparty card

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -763,6 +763,7 @@ if ($object->id > 0) {
 
 	if (isModEnabled("propal") && $user->hasRight('propal', 'lire')) {
 		// Box proposals
+		$nbProposals = $object->getNbOfCommerce('propal');
 		$tmp = $object->getOutstandingProposals();
 		$outstandingOpened = $tmp['opened'];
 		$outstandingTotal = $tmp['total_ht'];
@@ -774,7 +775,8 @@ if ($object->id > 0) {
 			$boxstat .= '<a href="'.$link.'" class="boxstatsindicator thumbstat nobold nounderline">';
 		}
 		$boxstat .= '<div class="boxstats" title="'.dol_escape_htmltag($text).'">';
-		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.'</span></span><br>';
+		// $boxstat .= '<span class="badge marginleftonlyshort">'.$nbProposals.'</span>';
+		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.' <small>('.$nbProposals.')</small></span></span><br>';
 		$boxstat .= '<span class="boxstatsindicator">'.price($outstandingTotal, 1, $langs, 1, -1, -1, $conf->currency).'</span>';
 		$boxstat .= '</div>';
 		if ($link) {
@@ -784,6 +786,7 @@ if ($object->id > 0) {
 
 	if (isModEnabled('order') && $user->hasRight('commande', 'lire')) {
 		// Box orders
+		$nbOrders = $object->getNbOfCommerce('commande');
 		$tmp = $object->getOutstandingOrders();
 		$outstandingOpened = $tmp['opened'];
 		$outstandingTotal = $tmp['total_ht'];
@@ -795,7 +798,8 @@ if ($object->id > 0) {
 			$boxstat .= '<a href="'.$link.'" class="boxstatsindicator thumbstat nobold nounderline">';
 		}
 		$boxstat .= '<div class="boxstats" title="'.dol_escape_htmltag($text).'">';
-		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.'</span></span><br>';
+		// $boxstat .= '<span class="badge marginleftonlyshort">'.$nbOrders.'</span>';
+		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.' <small>('.$nbOrders.')</small></span></span><br>';
 		$boxstat .= '<span class="boxstatsindicator">'.price($outstandingTotal, 1, $langs, 1, -1, -1, $conf->currency).'</span>';
 		$boxstat .= '</div>';
 		if ($link) {
@@ -805,6 +809,7 @@ if ($object->id > 0) {
 
 	if (isModEnabled('invoice') && $user->hasRight('facture', 'lire')) {
 		// Box invoices
+		$nbInvoices = $object->getNbOfCommerce('facture');
 		$tmp = $object->getOutstandingBills('customer', 0);
 		$outstandingOpened = $tmp['opened'];
 		$outstandingTotal = $tmp['total_ht'];
@@ -817,7 +822,8 @@ if ($object->id > 0) {
 			$boxstat .= '<a href="'.$link.'" class="boxstatsindicator thumbstat nobold nounderline">';
 		}
 		$boxstat .= '<div class="boxstats" title="'.dol_escape_htmltag($text).'">';
-		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.'</span></span><br>';
+		// $boxstat .= '<span class="badge marginleftonlyshort">'.$nbInvoices.'</span>';
+		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.' <small>('.$nbInvoices.')</small></span></span><br>';
 		$boxstat .= '<span class="boxstatsindicator">'.price($outstandingTotal, 1, $langs, 1, -1, -1, $conf->currency).'</span>';
 		$boxstat .= '</div>';
 		if ($link) {

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2023-2025  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Jon Bendtsen        <jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -127,6 +128,49 @@ trait CommonPeople
 		$ret .= dolGetFirstLastname($firstname, $lastname, $nameorder);
 
 		return dol_string_nohtmltag(dol_trunc($ret, $maxlen));
+	}
+
+	/**
+	 *  Return number of "Commerce" (Proposal, Order, Invoice) belonging to this CommonPeople (most likely Thirdparty)
+	 *  Not checking if user has permission, because the webpage that shows these numbers should do that checking
+	 *
+	 *  @param	string	$commerceType	The type of commerce object to look at: Proposal, Order, Invoice
+	 *  @return	int     				-1 when error, 0 or more = Number of "Commerce" Objects
+	 */
+	public function getNbOfCommerce($commerceType)
+	{
+		if ($commerceType == "propal") {
+			$table_element = 'propal';
+		} elseif ($commerceType == "commande") {
+			$table_element = 'commande';
+		} elseif ($commerceType == "facture") {
+			$table_element = 'facture';
+		} elseif ($commerceType == 'supplier_proposal') {
+			$table_element = 'supplier_proposal';
+		} elseif ($commerceType == 'supplier_proposal') {
+			$table_element = 'commande_fournisseur';
+		} elseif ($commerceType == 'invoice_supplier') {
+			$table_element = 'facture_fourn';
+		} else {
+			dol_syslog("Don't know which table_element to use for commerceType=".$commerceType, LOG_ERR);
+			return -1;
+		}
+
+		$sql = "SELECT count(*) as nb";
+		$sql .= " FROM ".MAIN_DB_PREFIX.$table_element;
+		$sql .= " WHERE fk_soc = ".(int) $this->id;
+
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$obj = $this->db->fetch_object($resql);
+			$nb = (int) $obj->nb;
+
+			$this->db->free($resql);
+			return $nb;
+		} else {
+			$this->error = $this->db->error();
+			return -1;
+		}
 	}
 
 	/**

--- a/htdocs/core/class/commonpeople.class.php
+++ b/htdocs/core/class/commonpeople.class.php
@@ -147,7 +147,7 @@ trait CommonPeople
 			$table_element = 'facture';
 		} elseif ($commerceType == 'supplier_proposal') {
 			$table_element = 'supplier_proposal';
-		} elseif ($commerceType == 'supplier_proposal') {
+		} elseif ($commerceType == 'order_supplier') {
 			$table_element = 'commande_fournisseur';
 		} elseif ($commerceType == 'invoice_supplier') {
 			$table_element = 'facture_fourn';

--- a/htdocs/fourn/card.php
+++ b/htdocs/fourn/card.php
@@ -497,6 +497,7 @@ if ($object->id > 0) {
 
 	if (isModEnabled('supplier_proposal')) {
 		// Box proposals
+		$nbProposals = $object->getNbOfCommerce('supplier_proposal');
 		$tmp = $object->getOutstandingProposals('supplier');
 		$outstandingOpened = $tmp['opened'];
 		$outstandingTotal = $tmp['total_ht'];
@@ -508,7 +509,7 @@ if ($object->id > 0) {
 			$boxstat .= '<a href="'.$link.'" class="boxstatsindicator thumbstat nobold nounderline">';
 		}
 		$boxstat .= '<div class="boxstats" title="'.dol_escape_htmltag($text).'">';
-		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.'</span></span><br>';
+		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.' <small>('.$nbProposals.')</small></span></span><br>';
 		$boxstat .= '<span class="boxstatsindicator">'.price($outstandingTotal, 1, $langs, 1, -1, -1, $conf->currency).'</span>';
 		$boxstat .= '</div>';
 		if ($link) {
@@ -518,6 +519,7 @@ if ($object->id > 0) {
 
 	if (isModEnabled("supplier_order")) {
 		// Box proposals
+		$nbOrders = $object->getNbOfCommerce('order_supplier');
 		$tmp = $object->getOutstandingOrders('supplier');
 		$outstandingOpened = $tmp['opened'];
 		$outstandingTotal = $tmp['total_ht'];
@@ -529,7 +531,7 @@ if ($object->id > 0) {
 			$boxstat .= '<a href="'.$link.'" class="boxstatsindicator thumbstat nobold nounderline">';
 		}
 		$boxstat .= '<div class="boxstats" title="'.dol_escape_htmltag($text).'">';
-		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.'</span></span><br>';
+		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.' <small>('.$nbOrders.')</small></span></span><br>';
 		$boxstat .= '<span class="boxstatsindicator">'.price($outstandingTotal, 1, $langs, 1, -1, -1, $conf->currency).'</span>';
 		$boxstat .= '</div>';
 		if ($link) {
@@ -539,6 +541,7 @@ if ($object->id > 0) {
 
 	if (isModEnabled("supplier_invoice") && ($user->hasRight('fournisseur', 'facture', 'lire') || $user->hasRight('supplier_invoice', 'read'))) {
 		$warn = '';
+		$nbInvoices = $object->getNbOfCommerce('invoice_supplier');
 		$tmp = $object->getOutstandingBills('supplier');
 		$outstandingOpened = $tmp['opened'];
 		$outstandingTotal = $tmp['total_ht'];
@@ -551,7 +554,7 @@ if ($object->id > 0) {
 			$boxstat .= '<a href="'.$link.'" class="boxstatsindicator thumbstat nobold nounderline">';
 		}
 		$boxstat .= '<div class="boxstats" title="'.dol_escape_htmltag($text).'">';
-		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.'</span></span><br>';
+		$boxstat .= '<span class="boxstatstext">'.img_object("", $icon).' <span>'.$text.' <small>('.$nbInvoices.')</small></span></span><br>';
 		$boxstat .= '<span class="boxstatsindicator">'.price($outstandingTotal, 1, $langs, 1, -1, -1, $conf->currency).'</span>';
 		$boxstat .= '</div>';
 		if ($link) {


### PR DESCRIPTION
# NEW #32924 Show count of "commerce" documents on Thirdparty card
Applying this pr will show a little number next to the Poposal, Order, Invoice in their little boxes with the total amount for each type.

I tried getting a badge look, but failed, so I settled on (123...) in <small>

You can see them on these pages:

### Customer `/comm/card.php`
<img width="369" height="73" alt="customer_count" src="https://github.com/user-attachments/assets/3373eedd-5887-4b2d-abcc-3c7f516a2e6d" />

### Vendor `/fourn/card.php`
<img width="361" height="74" alt="vendor_count" src="https://github.com/user-attachments/assets/3f7615d4-05f6-4a13-9be2-4a80ec59db3a" />

I did not put it on the outstanding/unpaid invoices

Applying this PR would close #32924