### PR TITLE
FIX #38146 Honor tpl override on supplier contacts

### DIFF
--- a/htdocs/fourn/commande/contact.php
+++ b/htdocs/fourn/commande/contact.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2017      Ferran Marcet       	 <fmarcet@2byte.es>
  * Copyright (C) 2023      Christian Foellmann  <christian@foellmann.de>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026       Serhii Bondarenko       <serhiilabs@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -187,8 +188,14 @@ if ($id > 0 || !empty($ref)) {
 
 		print dol_get_fiche_end();
 
-		// Contacts lines
-		include DOL_DOCUMENT_ROOT.'/core/tpl/contacts.tpl.php';
+		// Contacts lines (modules that overwrite templates must declare this into descriptor)
+		$dirtpls = array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
+		foreach ($dirtpls as $reldir) {
+			$res = @include dol_buildpath($reldir.'/contacts.tpl.php');
+			if ($res) {
+				break;
+			}
+		}
 	} else {
 		// Contact not found
 		print "ErrorRecordNotFound";

--- a/htdocs/fourn/facture/contact.php
+++ b/htdocs/fourn/facture/contact.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2017		Ferran Marcet       	<fmarcet@2byte.es>
  * Copyright (C) 2021-2024  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2023       Christian Foellmann  <christian@foellmann.de>
+ * Copyright (C) 2026       Serhii Bondarenko    <serhiilabs@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -269,8 +270,14 @@ if ($id > 0 || !empty($ref)) {
 		//print '<div class="clearboth"></div>';
 		//print '<br>';
 
-		// Contacts lines
-		include DOL_DOCUMENT_ROOT.'/core/tpl/contacts.tpl.php';
+		// Contacts lines (modules that overwrite templates must declare this into descriptor)
+		$dirtpls = array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
+		foreach ($dirtpls as $reldir) {
+			$res = @include dol_buildpath($reldir.'/contacts.tpl.php');
+			if ($res) {
+				break;
+			}
+		}
 	} else {
 		print "ErrorRecordNotFound";
 	}

--- a/htdocs/supplier_proposal/contact.php
+++ b/htdocs/supplier_proposal/contact.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2023		Christian Foellmann			<christian@foellmann.de>
  * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026       Serhii Bondarenko       <serhiilabs@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -189,8 +190,14 @@ if ($id > 0 || !empty($ref)) {
 
 		print dol_get_fiche_end();
 
-		// Contacts lines
-		include DOL_DOCUMENT_ROOT.'/core/tpl/contacts.tpl.php';
+		// Contacts lines (modules that overwrite templates must declare this into descriptor)
+		$dirtpls = array_merge($conf->modules_parts['tpl'], array('/core/tpl'));
+		foreach ($dirtpls as $reldir) {
+			$res = @include dol_buildpath($reldir.'/contacts.tpl.php');
+			if ($res) {
+				break;
+			}
+		}
 	} else {
 		// Contact not found
 		print "ErrorRecordNotFound";


### PR DESCRIPTION
Fixes #38146.

Three supplier-side contact tabs hardcode `include DOL_DOCUMENT_ROOT.'/core/tpl/contacts.tpl.php'`, which silently ignores any `module_parts['tpl']` override registered by a third-party module:

- `htdocs/fourn/commande/contact.php`
- `htdocs/fourn/facture/contact.php`
- `htdocs/supplier_proposal/contact.php`

The customer-side `contact.php` files (`htdocs/commande`, `htdocs/comm/propal`, `htdocs/compta/facture`, `htdocs/expedition`) already iterate over `array_merge($conf->modules_parts['tpl'], array('/core/tpl'))` and resolve each candidate via `dol_buildpath()`. So a module that ships its own `contacts.tpl.php` overrides the customer tabs correctly but silently fails on the supplier ones.

This PR copies the loop verbatim from `htdocs/commande/contact.php` into the three supplier files (same indentation, same branch). When no module registered an override the loop reduces to a single iteration loading `/core/tpl/contacts.tpl.php`, so vanilla installs are byte-for-byte unchanged.

Targeting `21.0` per CONTRIBUTING.md (N - 2). The reporter mentions the bug is also present in 19.0.4 and 23.0.2.

### Tested

- `php -l` clean on the three modified files.
- The new block is byte-identical to the loop already in use on `htdocs/commande/contact.php` (this branch).
- Runtime verification with a real override module - please confirm in review, I don't have a local install with such a module set up.
