### PR TITLE
cron: load rights for method job user context

### DIFF
--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1269,7 +1269,7 @@ class Cronjob extends CommonObject
 	public function run_jobs(string $userlogin)
 	{
 		// phpcs:enable
-		global $langs, $conf, $hookmanager;
+		global $langs, $conf, $hookmanager, $user;
 
 		$hookmanager->initHooks(array('cron'));
 
@@ -1310,11 +1310,7 @@ class Cronjob extends CommonObject
 			}
 		}
 
-		$user->getrights();
-
-		// Method-based cron jobs rely on the global user context for permission checks.
-		// Ensure the fetched cron user is also the execution user for called code.
-		$GLOBALS['user'] = $user;
+		$user->loadRights();
 
 		dol_syslog(get_class($this)."::run_jobs jobtype=".$this->jobtype." userlogin=".$userlogin, LOG_DEBUG);
 

--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1310,6 +1310,12 @@ class Cronjob extends CommonObject
 			}
 		}
 
+		$user->getrights();
+
+		// Method-based cron jobs rely on the global user context for permission checks.
+		// Ensure the fetched cron user is also the execution user for called code.
+		$GLOBALS['user'] = $user;
+
 		dol_syslog(get_class($this)."::run_jobs jobtype=".$this->jobtype." userlogin=".$userlogin, LOG_DEBUG);
 
 		// Increase limit of time. Works only if we are not in safe mode


### PR DESCRIPTION
# FIX|Fix # method cron jobs did not load execution user rights

Method-based scheduled jobs fetch the configured execution user in `Cronjob::run_jobs()`, but they do not load that user's rights before calling the target method.

Some cron-executed business flows rely on the execution user context and `hasRight()` checks during the called method. In this case, recurring customer invoice generation could create the draft invoice but failed during validation with `Permission denied` when run from cron, even though the scheduled job had a valid admin user configured.

This change fixes the cron runner by:
- loading rights for the fetched cron user with `getrights()`
- exposing that fetched user as the global execution user for the called method

This ensures method-based cron jobs run with the same effective user permissions as the configured cron user, which restores expected behavior for flows such as recurring invoice validation.
