### PR TITLE
Fix: MRP REST API `produceAndConsumeAll` uses price=0 for all stock movements

### DIFF
--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -429,6 +429,18 @@ class Mos extends DolibarrApi
 
 							$stockmove->setOrigin($this->mo->element, $this->mo->id);
 
+							// Compute unit cost: cost_price has priority, then pmp, then min supplier price
+							$unitcost = price2num(!empty($tmpproduct->cost_price) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+							if (empty($unitcost)) {
+								require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
+								$productFournisseur = new ProductFournisseur($this->db);
+								if ($productFournisseur->find_min_price_product_fournisseur($value["objectid"], $qtytoprocess) > 0) {
+									$unitcost = $productFournisseur->fourn_unitprice;
+								} else {
+									$unitcost = 0;
+								}
+							}
+
 							if ($arrayname == 'arraytoconsume') {
 								$moline = new MoLine($this->db);
 								$moline->fk_mo = $this->mo->id;
@@ -449,6 +461,8 @@ class Mos extends DolibarrApi
 								}
 								$idstockmove = $stockmove->livraison(DolibarrApiAccess::$user, $value["objectid"], $value["fk_warehouse"], $qtytoprocess, 0, $labelmovement, dol_now(), '', '', (string) $tmpproduct->status_batch, $id_product_batch, $codemovement);
 							} else {
+								// For produced lines, compute total manufacturing cost from consumed lines
+								$mfgcost = (float) price2num($unitcost);
 								$moline = new MoLine($this->db);
 								$moline->fk_mo = $this->mo->id;
 								$moline->position = $pos;
@@ -466,7 +480,7 @@ class Mos extends DolibarrApi
 									$error++;
 									throw new RestException(500, $moline->error);
 								}
-								$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $value["objectid"], $value["fk_warehouse"], $qtytoprocess, 0, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
+								$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $value["objectid"], $value["fk_warehouse"], $qtytoprocess, $mfgcost, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
 							}
 							if ($idstockmove < 0) {
 								$error++;
@@ -530,10 +544,20 @@ class Mos extends DolibarrApi
 						}
 						$idstockmove = 0;
 						if (!$error && $line->fk_warehouse > 0) {
-							// Record stock movement
+							// Record stock movement — use cost_price, fallback pmp, fallback min supplier price
 							$id_product_batch = 0;
 							$stockmove->origin_type = 'mo';
 							$stockmove->origin_id = $this->mo->id;
+							$unitcost = price2num(!empty($tmpproduct->cost_price) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+							if (empty($unitcost)) {
+								require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
+								$productFournisseur = new ProductFournisseur($this->db);
+								if ($productFournisseur->find_min_price_product_fournisseur($line->fk_product, $qtytoprocess) > 0) {
+									$unitcost = $productFournisseur->fourn_unitprice;
+								} else {
+									$unitcost = 0;
+								}
+							}
 							if ($qtytoprocess >= 0) {
 								$idstockmove = $stockmove->livraison(DolibarrApiAccess::$user, $line->fk_product, (int) $line->fk_warehouse, $qtytoprocess, 0, $labelmovement, dol_now(), '', '', (string) $tmpproduct->status_batch, $id_product_batch, $codemovement);
 							} else {
@@ -590,12 +614,30 @@ class Mos extends DolibarrApi
 						}
 						$idstockmove = 0;
 						if (!$error && $line->fk_warehouse > 0) {
-							// Record stock movement
+							// Record stock movement — manufacturing cost = sum of consumed MPs (cost_price/pmp)
 							$id_product_batch = 0;
 							$stockmove->origin_type = 'mo';
 							$stockmove->origin_id = $this->mo->id;
+							// Compute manufacturing cost = sum(qty * cost_price/pmp) of toconsume lines
+							$bomcostupdated = 0;
+							foreach ($this->mo->lines as $consumedline) {
+								if ($consumedline->role == 'toconsume') {
+									$cp = new Product($this->db);
+									$cp->fetch($consumedline->fk_product);
+									$cc = price2num(!empty($cp->cost_price) ? $cp->cost_price : $cp->pmp);
+									if (empty($cc)) {
+										require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
+										$pf = new ProductFournisseur($this->db);
+										if ($pf->find_min_price_product_fournisseur($consumedline->fk_product, $consumedline->qty) > 0) {
+											$cc = $pf->fourn_unitprice;
+										}
+									}
+									$bomcostupdated += price2num(($consumedline->qty * $cc) / ($this->mo->qty > 0 ? $this->mo->qty : 1), 'MU');
+								}
+							}
+							$mfgcost = (float) price2num($bomcostupdated, 'MU');
 							if ($qtytoprocess >= 0) {
-								$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $line->fk_product, (int) $line->fk_warehouse, $qtytoprocess, 0, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
+								$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $line->fk_product, (int) $line->fk_warehouse, $qtytoprocess, $mfgcost, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
 							} else {
 								$idstockmove = $stockmove->livraison(DolibarrApiAccess::$user, $line->fk_product, (int) $line->fk_warehouse, $qtytoprocess, 0, $labelmovement, dol_now(), '', '', (string) $tmpproduct->status_batch, $id_product_batch, $codemovement);
 							}
@@ -819,11 +861,22 @@ class Mos extends DolibarrApi
 					$id_product_batch = 0;
 					$stockmove->origin_type = 'mo';
 					$stockmove->origin_id = $this->mo->id;
+					// Compute unit cost for consumption: cost_price fallback pmp fallback min supplier
+					$unitcost = price2num(!empty($tmpproduct->cost_price) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+					if (empty($unitcost)) {
+						require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
+						$productFournisseur = new ProductFournisseur($this->db);
+						if ($productFournisseur->find_min_price_product_fournisseur($molinetoprocess->fk_product, $qtytoprocess) > 0) {
+							$unitcost = $productFournisseur->fourn_unitprice;
+						} else {
+							$unitcost = 0;
+						}
+					}
 					if ($arrayname == "arraytoconsume") {
 						if ($qtytoprocess >= 0) {
 							$idstockmove = $stockmove->livraison(DolibarrApiAccess::$user, $molinetoprocess->fk_product, $fk_warehousetoprocess, $qtytoprocess, 0, $labelmovement, dol_now(), '', '', (string) $tmpproduct->status_batch, $id_product_batch, $codemovement);
 						} else {
-							$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $molinetoprocess->fk_product, $fk_warehousetoprocess, $qtytoprocess, 0, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
+							$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $molinetoprocess->fk_product, $fk_warehousetoprocess, $qtytoprocess, $unitcost, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
 						}
 					} else {
 						if ($qtytoprocess >= 0) {


### PR DESCRIPTION
# Fix: MRP REST API `produceAndConsumeAll` uses price=0 for all stock movements

## Summary

The `POST /mos/{id}/produceandconsumeall` REST API endpoint (and `consumeAndProduceLine`) hardcoded `price=0` in all calls to `MouvementStock::livraison()` and `MouvementStock::reception()`, regardless of the product's actual purchase cost.

As a result, **all manufacturing orders closed via the REST API leave `pmp=0`** on every produced product, making cost tracking unusable for any workflow that automates MO closing through the API.

## Root cause

In `htdocs/mrp/class/api_mos.class.php`, all stock movement calls were:
```php
$idstockmove = $stockmove->livraison(..., 0, ...);  // price hardcoded to 0
$idstockmove = $stockmove->reception(..., 0, ...);  // price hardcoded to 0
```

The web UI equivalent (`htdocs/mrp/mo_production.php`) already implements the correct fallback chain:
```php
$costprice = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
if (empty($costprice)) {
    // fallback to min supplier price
}
```

The REST API simply never received this logic.

## Fix

Apply the same priority chain used by the web UI to all three affected code paths in `api_mos.class.php`:

**For consumed products (livraison — stock out):**
```php
$unitcost = price2num(!empty($tmpproduct->cost_price) ? $tmpproduct->cost_price : $tmpproduct->pmp);
if (empty($unitcost)) {
    // find_min_price_product_fournisseur fallback
}
$stockmove->livraison(..., $unitcost, ...);
```

**For produced products (reception — stock in):**
```php
// Sum cost of all toconsume lines to get manufacturing cost
$bomcostupdated = 0;
foreach ($this->mo->lines as $consumedline) {
    if ($consumedline->role == 'toconsume') {
        $cc = price2num(!empty($cp->cost_price) ? $cp->cost_price : $cp->pmp);
        $bomcostupdated += ($consumedline->qty * $cc) / $this->mo->qty;
    }
}
$stockmove->reception(..., $mfgcost, ...);
```

## Affected methods

| Method | Path affected | Change |
|--------|--------------|--------|
| `produceAndConsumeAll()` | explicit `arraytoconsume`/`arraytoproduce` | `0` → `$unitcost` / `$mfgcost` |
| `produceAndConsumeAll()` | existing MO lines (`toconsume` loop) | `0` → `$unitcost` |
| `produceAndConsumeAll()` | existing MO lines (`toproduce` loop) | `0` → `$mfgcost` (computed from toconsume) |
| `consumeAndProduceLine()` | `arraytoconsume` path | `0` → `$unitcost` |

## How to reproduce

1. Create products with non-zero `pmp` (via purchase receipts) but no `cost_price`
2. Create and validate a MO consuming those products
3. Close the MO via `POST /mos/{id}/produceandconsumeall`
4. Check `GET /stockmovements/{id}` for the generated movements → `price: 0.00`
5. Check `GET /products/{produced_id}` → `pmp: 0`

Expected: `price` equals the product's `cost_price` or `pmp` at time of closing.

## Impact

Any application automating MO closure via the REST API (e.g. brewery management, food production, manufacturing ERP integrations) will see correct cost propagation after this fix. The `pmp` of produced/intermediate goods will be updated correctly by Dolibarr's stock movement triggers.

## Testing

Tested with a multi-stage brewing workflow:
- OF1: raw materials →  intermediate product
- OF2: intermediate product + raw materials additions → intermediate products  
- OF-COND: intermediate products → finished products

**Before fix:** all stock movements `price=0`, all intermediate `pmp=0`  
**After fix:** stock movements carry actual unit costs, `pmp` propagates correctly through the production chain

## Notes

- `cost_price` (manually set standard cost) takes priority over `pmp` (weighted average from purchases), matching the web UI behavior
- If both are zero, falls back to minimum supplier price via `find_min_price_product_fournisseur()`
- No behavior change when `cost_price` and `pmp` are both 0 (price remains 0, no regression)
- The `pricetoproduce` field already present in `consumeAndProduceLine()` for produced lines is preserved and takes priority when explicitly provided