### PR TITLE
Fix git commit template path in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -93,11 +93,11 @@ Use clear commit messages with the following structure:
 LONGDESC
 ```
 
-We provide a [.gitmessage](/.gitmessage) file to help you fit the template.
+We provide a [/dev/setup/git/gitmessage](/dev/setup/git/gitmessage) file to help you fit the template.
 
 You can add it to your git configuration using:
 ```
-git config --local commit.template .gitmessage
+git config --local commit.template ./dev/setup/git/gitmessage
 ```
 
 where


### PR DESCRIPTION
Updated the path for the git commit template file in CONTRIBUTING.md that was moved in https://github.com/Dolibarr/dolibarr/commit/706b9f47d8976bb7190e223a558f42b00def6332
