### PR TITLE
NEW replace Event Attendee with another Event Attendee

### DIFF
--- a/htdocs/core/modules/modEventOrganization.class.php
+++ b/htdocs/core/modules/modEventOrganization.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2021		Florian Henry			<florian.henry@scopen.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2026		Jon Bendtsen			<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/modules/modEventOrganization.class.php
+++ b/htdocs/core/modules/modEventOrganization.class.php
@@ -536,6 +536,21 @@ class modEventOrganization extends DolibarrModules
 			dolibarr_set_const($this->db, 'EVENTORGANIZATION_TEMPLATE_EMAIL_AFT_SUBS_EVENT', $template->id, 'chaine', 0, '', $conf->entity);
 		}
 
+		$sql_triggers = array(
+			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', 'Attendee Replaced (Source)', 'Triggered when an attendee is replaced by another.', 'conferenceorboothattendee', 2461)",
+			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT', 'Attendee Replaced (Target)', 'Triggered when an attendee becomes a replacement.', 'conferenceorboothattendee', 2462)",
+			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET', 'Attendee Replacement Reset (Source)', 'Triggered when a replacement is undone for the source.', 'conferenceorboothattendee', 2463)",
+			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', 'Attendee Replacement Reset (Target)', 'Triggered when a replacement is undone for the target.', 'conferenceorboothattendee', 2464)",
+		);
+
+		foreach ($sql_triggers as $sql) {
+			$resql = $this->_db->query($sql);
+			if (!$resql) {
+				// Log error but don't necessarily fail the whole activation if it's just a duplicate
+				dol_syslog("Error inserting trigger: " . $this->_db->lasterror(), LOG_ERR);
+			}
+		}
+
 		return $init;
 	}
 

--- a/htdocs/core/modules/modEventOrganization.class.php
+++ b/htdocs/core/modules/modEventOrganization.class.php
@@ -544,10 +544,10 @@ class modEventOrganization extends DolibarrModules
 		);
 
 		foreach ($sql_triggers as $sql) {
-			$resql = $this->_db->query($sql);
+			$resql = $this->db->query($sql);
 			if (!$resql) {
 				// Log error but don't necessarily fail the whole activation if it's just a duplicate
-				dol_syslog("Error inserting trigger: " . $this->_db->lasterror(), LOG_ERR);
+				dol_syslog("Error inserting trigger: " . $this->db->lasterror(), LOG_ERR);
 			}
 		}
 

--- a/htdocs/core/modules/modEventOrganization.class.php
+++ b/htdocs/core/modules/modEventOrganization.class.php
@@ -537,10 +537,10 @@ class modEventOrganization extends DolibarrModules
 		}
 
 		$sql_triggers = array(
-			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', 'Attendee Replaced (Source)', 'Triggered when an attendee is replaced by another.', 'conferenceorboothattendee', 2461)",
-			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT', 'Attendee Replaced (Target)', 'Triggered when an attendee becomes a replacement.', 'conferenceorboothattendee', 2462)",
-			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET', 'Attendee Replacement Reset (Source)', 'Triggered when a replacement is undone for the source.', 'conferenceorboothattendee', 2463)",
-			"INSERT IGNORE INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', 'Attendee Replacement Reset (Target)', 'Triggered when a replacement is undone for the target.', 'conferenceorboothattendee', 2464)",
+			"INSERT INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', 'Attendee Replaced (Source)', 'Triggered when an attendee is replaced by another.', 'conferenceorboothattendee', 2461)",
+			"INSERT INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT', 'Attendee Replaced (Target)', 'Triggered when an attendee becomes a replacement.', 'conferenceorboothattendee', 2462)",
+			"INSERT INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET', 'Attendee Replacement Reset (Source)', 'Triggered when a replacement is undone for the source.', 'conferenceorboothattendee', 2463)",
+			"INSERT INTO ".MAIN_DB_PREFIX."c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', 'Attendee Replacement Reset (Target)', 'Triggered when a replacement is undone for the target.', 'conferenceorboothattendee', 2464)",
 		);
 
 		foreach ($sql_triggers as $sql) {

--- a/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
+++ b/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2021		Florian Henry		<florian.henry@scopen.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		Jon Bendtsen			<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
+++ b/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
@@ -192,7 +192,7 @@ class InterfaceEventOrganization extends DolibarrTriggers
 			$actioncomm->datef       = dol_now();
 			$actioncomm->durationp   = 0;
 			$actioncomm->percentage  = -1;
-			$actioncomm->socid       = (property_exists($object, 'fk_soc') ? $object->fk_soc : 0);
+			$actioncomm->socid       = (property_exists($object, 'fk_soc') ? $object->fk_soc : 0); // @phan-suppress-current-line PhanUndeclaredProperty
 			$actioncomm->contact_id  = 0;
 			$actioncomm->authorid    = $user->id;
 			$actioncomm->userownerid = $user->id;

--- a/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
+++ b/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
@@ -126,6 +126,86 @@ class InterfaceEventOrganization extends DolibarrTriggers
 				}
 			}
 		}
+
+		// Switch to handle specific triggers
+		$langs->loadLangs(array("agenda", "other", "eventorganization"));
+		switch ($action) {
+			case 'CONFERENCEORBOOTHATTENDEE_REPLACED_SRC':
+				$transKey = "AttendeeReplacedBy";
+				// Get replacement name from context (passed from replaceMeWithAttendee)
+				$replacementName = $object->context['replacement_name'] ?? $langs->trans("Unknown");
+				if (empty($object->actionmsg2)) {
+					$object->actionmsg2 = $langs->transnoentities($transKey, $object->getFullName($langs), $replacementName);
+				}
+				if (empty($object->actionmsg)) {
+					$object->actionmsg = $langs->transnoentities($transKey, $object->getFullName($langs), $replacementName);
+				}
+				break;
+
+			case 'CONFERENCEORBOOTHATTENDEE_REPLACED_TGT':
+				$transKey = "AttendeeBecameReplacementFor";
+				// Get the name of the person being replaced (Source)
+				$sourceName = $object->context['source_name'] ?? $langs->trans("Unknown");
+				if (empty($object->actionmsg2)) {
+					$object->actionmsg2 = $langs->transnoentities($transKey, $object->getFullName($langs), $sourceName);
+				}
+				if (empty($object->actionmsg)) {
+					$object->actionmsg = $langs->transnoentities($transKey, $object->getFullName($langs), $sourceName);
+				}
+				break;
+
+			case 'CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET':
+				$transKey = "AttendeeReplacementSourceReset";
+				if (empty($object->actionmsg2)) {
+					$object->actionmsg2 = $langs->transnoentities($transKey, $object->getFullName($langs));
+				}
+				if (empty($object->actionmsg)) {
+					$object->actionmsg = $langs->transnoentities($transKey, $object->getFullName($langs));
+				}
+				break;
+
+			case 'CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET':
+				$transKey = "AttendeeReplacementTargetReset";
+				if (empty($object->actionmsg2)) {
+					$object->actionmsg2 = $langs->transnoentities($transKey, $object->getFullName($langs));
+				}
+				if (empty($object->actionmsg)) {
+					$object->actionmsg = $langs->transnoentities($transKey, $object->getFullName($langs));
+				}
+				break;
+
+			default:
+				// If the action is not one of ours, do nothing
+				return 0;
+		}
+
+		if (!empty($object->actionmsg2)) {
+			require_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
+			$actioncomm = new ActionComm($this->db);
+			$actioncomm->type_code   = 'AC_OTH_AUTO';
+			$actioncomm->code        = 'AC_'.$action;
+			$actioncomm->label       = $object->actionmsg2;
+			$actioncomm->note_private = $object->actionmsg;
+			$actioncomm->fk_project  = (property_exists($object, 'fk_project') ? $object->fk_project : 0);
+			$actioncomm->datep       = dol_now();
+			$actioncomm->datef       = dol_now();
+			$actioncomm->durationp   = 0;
+			$actioncomm->percentage  = -1;
+			$actioncomm->socid       = (property_exists($object, 'fk_soc') ? $object->fk_soc : 0);
+			$actioncomm->contact_id  = 0;
+			$actioncomm->authorid    = $user->id;
+			$actioncomm->userownerid = $user->id;
+			$actioncomm->fk_element  = $object->id;
+			$actioncomm->elementtype = 'conferenceorboothattendee';
+
+			$ret = $actioncomm->create($user);
+			if ($ret < 0) {
+				$this->error = "Failed to create agenda event: " . $actioncomm->error;
+				$this->errors = $actioncomm->errors;
+				return -1;
+			}
+		}
+
 		return 0;
 	}
 }

--- a/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
+++ b/htdocs/core/triggers/interface_50_modEventOrganization_EventOrganization.class.php
@@ -197,7 +197,7 @@ class InterfaceEventOrganization extends DolibarrTriggers
 			$actioncomm->authorid    = $user->id;
 			$actioncomm->userownerid = $user->id;
 			$actioncomm->fk_element  = $object->id;
-			$actioncomm->elementtype = 'conferenceorboothattendee';
+			$actioncomm->elementtype = $object->element . '@' . $object->module;
 
 			$ret = $actioncomm->create($user);
 			if ($ret < 0) {

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -113,7 +113,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		'model_pdf' => array('type' => 'varchar(255)', 'label' => 'Model pdf', 'enabled' => 1, 'position' => 1010, 'notnull' => -1, 'visible' => 0,),
 		'ip' => array('type' => 'varchar(250)', 'label' => 'IPAddress', 'enabled' => 1, 'position' => 900, 'notnull' => -1, 'visible' => -2,),
 		'status' => array('type' => 'smallint', 'label' => 'Status', 'enabled' => 1, 'position' => 1000, 'default' => '0', 'notnull' => 1, 'visible' => 1, 'index' => 1, 'arrayofkeyval' => array('0' => 'Draft', '1' => 'Registered', '5' => 'ShowedUp', '9' => 'Canceled', '13' => 'Replaced'),),
-		'fk_replace' => array('type' => 'integer:ConferenceOrBoothAttendee:eventorganization/class/conferenceorboothattendee.class.php', 'label' => 'ReplacementAttendee', 'enabled' => 1, 'position' => 66, 'notnull' => -1, 'visible' => 1, 'index' => 1, 'help' => "ReplaceThisAttendeeWithAnother", 'css' => 'maxwidth500 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
+		'fk_replacement' => array('type' => 'integer:ConferenceOrBoothAttendee:eventorganization/class/conferenceorboothattendee.class.php', 'label' => 'ReplacementAttendee', 'enabled' => 1, 'position' => 66, 'notnull' => -1, 'visible' => 1, 'index' => 1, 'help' => "ReplaceThisAttendeeWithAnother", 'css' => 'maxwidth500 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
 	);
 	/**
 	 * @var int

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -196,9 +196,9 @@ class ConferenceOrBoothAttendee extends CommonObject
 	public $status;
 
 	/**
-	 * @var int
+	 * @var int|null
 	 */
-	public $fk_replacement;
+	public $fk_replacement = null;
 	// END MODULEBUILDER PROPERTIES
 
 

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -57,6 +57,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	const STATUS_VALIDATED = 1;
 	const STATUS_USED = 5;					// was present, presence confirmed, no more entrances can be done using this ticket
 	const STATUS_CANCELED = 9;
+	const STATUS_REPLACED = 13;				// This event attendee has been replaced with a different event Attendee which should be recorded in field fk_replacement
 
 	/**
 	 *  'type' field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter]]', 'sellist:TableName:LabelFieldName[:KeyFieldName[:KeyFieldParent[:Filter]]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'text:none', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
@@ -111,7 +112,8 @@ class ConferenceOrBoothAttendee extends CommonObject
 		'import_key' => array('type' => 'varchar(14)', 'label' => 'ImportId', 'enabled' => 1, 'position' => 1000, 'notnull' => -1, 'visible' => -2,),
 		'model_pdf' => array('type' => 'varchar(255)', 'label' => 'Model pdf', 'enabled' => 1, 'position' => 1010, 'notnull' => -1, 'visible' => 0,),
 		'ip' => array('type' => 'varchar(250)', 'label' => 'IPAddress', 'enabled' => 1, 'position' => 900, 'notnull' => -1, 'visible' => -2,),
-		'status' => array('type' => 'smallint', 'label' => 'Status', 'enabled' => 1, 'position' => 1000, 'default' => '0', 'notnull' => 1, 'visible' => 1, 'index' => 1, 'arrayofkeyval' => array('0' => 'Draft', '1' => 'Registered', '5' => 'ShowedUp', '9' => 'Canceled'),),
+		'status' => array('type' => 'smallint', 'label' => 'Status', 'enabled' => 1, 'position' => 1000, 'default' => '0', 'notnull' => 1, 'visible' => 1, 'index' => 1, 'arrayofkeyval' => array('0' => 'Draft', '1' => 'Registered', '5' => 'ShowedUp', '9' => 'Canceled', '13' => 'Replaced'),),
+		'fk_replace' => array('type' => 'integer:ConferenceOrBoothAttendee:eventorganization/class/conferenceorboothattendee.class.php', 'label' => 'ReplacementAttendee', 'enabled' => 1, 'position' => 66, 'notnull' => -1, 'visible' => 1, 'index' => 1, 'help' => "ReplaceThisAttendeeWithAnother", 'css' => 'maxwidth500 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
 	);
 	/**
 	 * @var int
@@ -187,6 +189,11 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 * @var ?int
 	 */
 	public $status;
+
+	/**
+	 * @var int
+	 */
+	public $fk_replacement;
 	// END MODULEBUILDER PROPERTIES
 
 
@@ -767,6 +774,72 @@ class ConferenceOrBoothAttendee extends CommonObject
 		}
 
 		return $this->setStatusCommon($user, self::STATUS_VALIDATED, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REOPEN');
+	}
+
+	/**
+	 *	replace "me" with another ConferenceOrBoothAttendee
+	 *
+	 *	@param	User	$user			Object user that modify
+	 *	@param	ConferenceOrBoothAttendee	$fk_replacement			The event attendee that replaces "me"
+	 *	@param	int		$status_fk_replacement		The new status of fk_replacement, default is STATUS_VALIDATED
+	 *	@param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
+	 *	@return	int						Return integer <0 if KO, 0=Nothing done, >0 if OK
+	 */
+	public function replaceWith($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $notrigger = 0)
+	{
+		// Protection
+		$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
+		if (!in_array($this->status, $allowed_statuses)) {
+			$error_text = 'Can not replace eventattendee=' . $this->id . '. Current status=' . $this->status . ' is not allowed (must be STATUS_VALIDATED or STATUS_DRAFT)';
+			dol_syslog($error_text, LOG_ERR);
+			$this->error = $error_text;
+			return -1;
+		}
+		if ($fk_replacement->id == $this->id) {
+			$error_text = 'Can not replace an attendee with itself';
+			dol_syslog($error_text, LOG_ERR);
+			$this->error = $error_text;
+			return -2;
+		}
+
+
+		$this->db->begin();
+		try {
+			// Original
+			$this->fk_replacement = $fk_replacement->id;
+			$this->status = self::STATUS_REPLACED;
+			$originalReplace = $this->update($user, 1); // we do our own trigger
+			if ($originalReplace < 0) {
+				throw new Exception("Update original failed: " . $this->error);
+			}
+
+			// call triggers
+			if (!$notrigger) {
+				$result = $this->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED', $user);
+				if ($result < 0) {
+					throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED failed: " . $this->error);
+				}
+			}
+
+
+			// Replacement
+			$replacementStatus = $fk_replacement->setStatusCommon($user, $status_fk_replacement, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REPLACING');
+			if ($replacementStatus < 0) {
+				throw new Exception("Update replacement status failed: " . $fk_replacement->error);
+			}
+
+			$this->db->commit();
+			return 1;
+
+		} catch (Exception $e) {
+			// 5. Rollback
+			// If we are here, the transaction is likely already rolled back
+			// if update() threw an exception that caused a DB error.
+			// But to be safe, we call rollback.
+			$this->db->rollback();
+			$this->error = $e->getMessage();
+			return -1;
+		}
 	}
 
 	/**

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -797,12 +797,17 @@ class ConferenceOrBoothAttendee extends CommonObject
 	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $status_source = self::STATUS_REPLACED, $notrigger = 0, $force_fk_replacement = 0)
 	{
 		// Protection
-		$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
-		if (!in_array($this->status, $allowed_statuses)) {
-			$error_text = 'Can not replace eventattendee=' . $this->id . '. Current status=' . $this->LibStatut($this->status) . ' is not allowed (must be '.$this->LibStatut(self::STATUS_VALIDATED).' or '.$this->LibStatut(self::STATUS_DRAFT);
-			dol_syslog($error_text, LOG_ERR);
-			$this->error = $error_text;
-			return -1;
+		if (!is_null($fk_replacement)) {
+			$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
+			if (!in_array($this->status, $allowed_statuses)) {
+				$allowed_labels = array_map(function($s) {
+					return $this->LibStatut($s);
+				}, $allowed_statuses);
+				$error_text = 'Can not replace eventattendee=' . $this->id . '. Current status=' . $this->LibStatut($this->status) . ' is not allowed (must be ' . implode(' or ', $allowed_labels) . ')';
+				dol_syslog($error_text, LOG_ERR);
+				$this->error = $error_text;
+				return -1;
+			}
 		}
 		if (!is_null($fk_replacement) && $fk_replacement->id == $this->id) {
 			$error_text = 'Can not replace an attendee with itself';

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -786,7 +786,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *	@param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
 	 *	@return	int						Return integer <0 if KO, 0=Nothing done, >0 if OK
 	 */
-	public function replaceWith($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $notrigger = 0)
+	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $notrigger = 0)
 	{
 		// Protection
 		$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -850,9 +850,12 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  @param  int     $notooltip                  1=Disable tooltip
 	 *  @param  string  $morecss                    Add more css on link
 	 *  @param  int     $save_lastsearch_value      -1=Auto, 0=No save of lastsearch_values when clicking, 1=Save lastsearch_values whenclicking
+	 *  @param  array   $labelparts                 Array of parts to build the visible label.
+	 *                                              Can contain field names (e.g. 'firstname') or static strings (e.g. ' - ').
+	 *                                              If empty/null, defaults to $this->ref.
 	 *  @return	string                              String with URL
 	 */
-	public function getNomUrl($withpicto = 0, $option = '', $notooltip = 0, $morecss = '', $save_lastsearch_value = -1)
+	public function getNomUrl($withpicto = 0, $option = '', $notooltip = 0, $morecss = '', $save_lastsearch_value = -1, $labelparts = null)
 	{
 		global $conf, $langs, $hookmanager;
 
@@ -956,7 +959,30 @@ class ConferenceOrBoothAttendee extends CommonObject
 		}
 
 		if ($withpicto != 2) {
-			$result .= $this->ref;
+			// Build the visible label from $labelparts array
+			$display_text = '';
+			if (!empty($labelparts) && is_array($labelparts)) {
+				foreach ($labelparts as $part) {
+					if (property_exists($this, $part)) {
+						$val = $this->$part;
+						// Format specific types
+						if ($part == 'date_subscription' && !empty($val)) {
+							$val = dol_print_date($val, 'dayhour');
+						} elseif ($part == 'amount' && !empty($val)) {
+							$val = price($val);
+						}
+						$display_text .= $val;
+					} else {
+						// Static string (separator, space, etc.)
+						$display_text .= $part;
+					}
+				}
+			}
+			// Fallback to ref if no parts provided or result is empty
+			if (empty($display_text)) {
+				$display_text = $this->ref;
+			}
+			$result .= dol_escape_htmltag($display_text);
 		}
 
 		$result .= $linkend;
@@ -964,7 +990,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 
 		global $action, $hookmanager;
 		$hookmanager->initHooks(array('conferenceorboothattendeedao'));
-		$parameters = array('id' => $this->id, 'getnomurl' => &$result);
+		$parameters = array('id' => $this->id, 'getnomurl' => &$result, 'labelparts' => $labelparts);
 		$reshook = $hookmanager->executeHooks('getNomUrl', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 		if ($reshook > 0) {
 			$result = $hookmanager->resPrint;
@@ -973,6 +999,41 @@ class ConferenceOrBoothAttendee extends CommonObject
 		}
 
 		return $result;
+	}
+
+	/**
+	 *  Return a string to display a field value (overridden to show Name for 'fk_replacement')
+	 *
+	 *  @param  array   $val      Array of properties of field to show
+	 *  @param  string  $key      Key of attribute
+	 *  @param  mixed   $value    Preselected value to show
+	 *  @param  string  $moreparam    To add more parameters on html tag
+	 *  @param  string  $keysuffix    Prefix string to add into name and id of field
+	 *  @param  string  $keyprefix    Suffix string to add into name and id of field
+	 *  @param  mixed   $morecss      Value for CSS to use
+	 *  @return string
+	 */
+	public function showOutputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = '')
+	{
+		global $langs;
+
+		if ($key == 'fk_replacement' && !empty($value)) {
+			$replacement = new ConferenceOrBoothAttendee($this->db);
+			$result = $replacement->fetch((int) $value);
+
+			if ($result > 0) {
+				// Define the label structure: "Firstname Lastname"
+				// You can easily change this to ["ref", " - ", "firstname", " ", "lastname"]
+				$label_config = array('firstname', ' ', 'lastname');
+
+				return $replacement->getNomUrl(1, '', 0, '', -1, $label_config);
+			}
+
+			$langs->loadLangs(array("eventorganization", "errors"));
+			return '<span class="opacitymedium">'.$langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")).'</span>';
+		}
+
+		return parent::showOutputField($val, $key, $value, $moreparam, $keysuffix, $keyprefix, $morecss);
 	}
 
 	/**

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -788,15 +788,16 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *	@param	User	$user			Object user that modify
 	 *	@param	ConferenceOrBoothAttendee	$fk_replacement			The event attendee that replaces "me"
 	 *	@param	int		$status_fk_replacement		The new status of fk_replacement, default is STATUS_VALIDATED
+	 *	@param	int		$status_source				The new status of "me", default is STATUS_REPLACED
 	 *	@param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
 	 *	@return	int						Return integer <0 if KO, 0=Nothing done, >0 if OK
 	 */
-	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $notrigger = 0)
+	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $status_source = self::STATUS_REPLACED, $notrigger = 0)
 	{
 		// Protection
 		$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
 		if (!in_array($this->status, $allowed_statuses)) {
-			$error_text = 'Can not replace eventattendee=' . $this->id . '. Current status=' . $this->status . ' is not allowed (must be STATUS_VALIDATED or STATUS_DRAFT)';
+			$error_text = 'Can not replace eventattendee=' . $this->id . '. Current status=' . $this->LibStatut($this->status) . ' is not allowed (must be '.$this->LibStatut(self::STATUS_VALIDATED).' or '.$this->LibStatut(self::STATUS_DRAFT);
 			dol_syslog($error_text, LOG_ERR);
 			$this->error = $error_text;
 			return -1;
@@ -807,13 +808,25 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$this->error = $error_text;
 			return -2;
 		}
+		if (!in_array($status_fk_replacement, $this->list_possible_status)) {
+			$error_text = 'Invalid status_fk_replacement='.$status_fk_replacement;
+			dol_syslog($error_text, LOG_ERR);
+			$this->error = $error_text;
+			return -3;
+		}
+		if (!in_array($status_source, $this->list_possible_status)) {
+			$error_text = 'Invalid status_source='.$status_source;
+			dol_syslog($error_text, LOG_ERR);
+			$this->error = $error_text;
+			return -4;
+		}
 
 
 		$this->db->begin();
 		try {
 			// Original
 			$this->fk_replacement = $fk_replacement->id;
-			$this->status = self::STATUS_REPLACED;
+			$this->status = $status_source;
 			$originalReplace = $this->update($user, 1); // we do our own trigger
 			if ($originalReplace < 0) {
 				throw new Exception("Update original failed: " . $this->error);

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -118,7 +118,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		'model_pdf' => array('type' => 'varchar(255)', 'label' => 'Model pdf', 'enabled' => 1, 'position' => 1010, 'notnull' => -1, 'visible' => 0,),
 		'ip' => array('type' => 'varchar(250)', 'label' => 'IPAddress', 'enabled' => 1, 'position' => 900, 'notnull' => -1, 'visible' => -2,),
 		'status' => array('type' => 'smallint', 'label' => 'Status', 'enabled' => 1, 'position' => 1000, 'default' => '0', 'notnull' => 1, 'visible' => 1, 'index' => 1, 'arrayofkeyval' => array('0' => 'Draft', '1' => 'Registered', '5' => 'ShowedUp', '9' => 'Canceled', '13' => 'Replaced'),),
-		'fk_replacement' => array('type' => 'integer:ConferenceOrBoothAttendee:eventorganization/class/conferenceorboothattendee.class.php', 'label' => 'ReplacementAttendee', 'enabled' => 1, 'position' => 66, 'notnull' => -1, 'visible' => 1, 'index' => 1, 'help' => "ReplaceThisAttendeeWithAnother", 'css' => 'maxwidth500 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
+		'fk_replacement' => array('type' => 'integer:ConferenceOrBoothAttendee:eventorganization/class/conferenceorboothattendee.class.php', 'label' => 'ReplacementAttendee', 'enabled' => 1, 'position' => 66, 'notnull' => -1, 'visible' => 1, 'noteditable' => 1, 'index' => 1, 'help' => "ReplaceThisAttendeeWithAnother", 'css' => 'maxwidth500 widthcentpercentminusxx', 'csslist' => 'tdoverflowmax150'),
 	);
 	/**
 	 * @var int

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -1103,15 +1103,18 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  @param  string  $keysuffix    Prefix string to add into name and id of field
 	 *  @param  string  $keyprefix    Suffix string to add into name and id of field
 	 *  @param  mixed   $morecss      Value for CSS to use
+	 *  @param  array   $labelparts                 Array of parts to build the visible label.
+	 *                                              Can contain field names (e.g. 'firstname') or static strings (e.g. ' - ').
+	 *                                              If empty/null, defaults to $this->ref.
+	 *
 	 *  @return string
 	 */
-	public function showOutputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = '')
+	public function showOutputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = '', $labelparts = array('firstname', ' ', 'lastname', ' (#', 'id', ')'))
 	{
 		global $langs;
 
 		if ($key == 'fk_replacement') {
 			$html = '';
-			$label_config = array('firstname', ' ', 'lastname');
 
 			// 1. Get the reverse chain (people I replaced / who came before me)
 			$replacedByChain = $this->getReplacedByChain();
@@ -1140,14 +1143,14 @@ class ConferenceOrBoothAttendee extends CommonObject
 				$reversedChain = array_reverse($replacedByChain);
 				foreach ($reversedChain as $person) {
 					if (!empty($html)) $html .= ' &rarr; ';
-					$html .= $person->getNomUrl(1, '', 0, '', -1, $label_config);
+					$html .= $person->getNomUrl(1, '', 0, '', -1, $labelparts);
 				}
 			}
 
 			// Add "Me"
 			if (!empty($html)) $html .= ' &rarr; ';
 
-			$meLabel = '&nbsp;'.$langs->transnoentitiesnoconv("Me").'&nbsp;';
+			$meLabel = $langs->transnoentitiesnoconv("This");
 			// Generate link: No picto, Rich Tooltip, Text = "Me"
 			$html .= $this->getNomUrl(0, '', 0, 'badge badge-primary', -1, array($meLabel));
 
@@ -1156,7 +1159,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 			foreach ($forwardChain as $person) {
 				$html .= ' &rarr; ';
 				if ($person !== null) {
-					$html .= $person->getNomUrl(1, '', 0, '', -1, $label_config);
+					$html .= $person->getNomUrl(1, '', 0, '', -1, $labelparts);
 				} else {
 					$html .= '<span class="opacitymedium">' . $langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")) . '</span>';
 				}

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -899,24 +899,23 @@ class ConferenceOrBoothAttendee extends CommonObject
 					}
 
 					if ($oldReplacementAttendee !== null) {
+						$oldReplacementAttendee->context['source_name'] = $this->getFullName($langs);
 						$oldUpdateResult = $oldReplacementAttendee->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', $user);
 						if ($oldUpdateResult < 0) {
 							throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET failed: " . $oldReplacementAttendee->error);
 						}
 					}
 				} else {
+					$this->context['replacement_name'] = $fk_replacement->getFullName($langs);
 					$result = $this->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', $user);
 					if ($result < 0) {
 						throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED_SRC failed: " . $this->error);
 					}
-				}
-			}
-
-			// Replacement
-			if (!is_null($fk_replacement)) {
-				$replacementStatus = $fk_replacement->setStatusCommon($user, $status_fk_replacement, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REPLACED_TGT');
-				if ($replacementStatus < 0) {
-					throw new Exception("Update replacement status failed: " . $fk_replacement->error);
+					$fk_replacement->context['source_name'] = $this->getFullName($langs);
+					$replacementStatus = $fk_replacement->setStatusCommon($user, $status_fk_replacement, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REPLACED_TGT');
+					if ($replacementStatus < 0) {
+						throw new Exception("Update replacement status failed: " . $fk_replacement->error);
+					}
 				}
 			}
 

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -862,9 +862,9 @@ class ConferenceOrBoothAttendee extends CommonObject
 
 		$this->db->begin();
 		try {
+			$oldReplacementAttendee = null;
 			// Original
 			if (is_null($fk_replacement)) {
-				$oldReplacementAttendee = null;
 				$any_old_fk_replacement = $this->fk_replacement;
 				if ($any_old_fk_replacement > 0) {
 					$oldReplacementAttendee = new ConferenceOrBoothAttendee($this->db);

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -847,7 +847,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$oldFetch = $oldReplacementAttendee->fetch($this->fk_replacement);
 			if ($oldFetch > 0) {
 				if (!empty($oldReplacementAttendee->fk_replacement)) {
-					$error_text = 'Cannot undo replacement for attendee ' . $this->id . '. ' .'The current replacement (ID: ' . $oldReplacementAttendee->id . ') is itself replaced by attendee (ID: ' .$oldReplacementAttendee->fk_replacement . '). ' .'Please undo the replacement for attendee ' . $oldReplacementAttendee->id . ' first.';
+					$error_text = 'Cannot undo replacement for attendee ' . $this->id . '. The current replacement (ID: ' . $oldReplacementAttendee->id . ') is itself replaced by attendee (ID: ' . $oldReplacementAttendee->fk_replacement . '). Please undo the replacement for attendee ' . $oldReplacementAttendee->id . ' first.';
 					dol_syslog($error_text, LOG_WARNING);
 					$this->error = $error_text;
 					return -7;

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -807,7 +807,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		if (!is_null($fk_replacement)) {
 			$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
 			if (!$force_fk_replacement && !in_array($this->status, $allowed_statuses)) {
-				$allowed_labels = array_map(function ($s) {
+				$allowed_labels = array_map(function (int $s) {
 					return $this->LibStatut($s);
 				}, $allowed_statuses);
 				$error_text = 'Can not replace eventattendee=' . $this->id . '. Current status=' . $this->LibStatut($this->status) . ' is not allowed (must be ' . implode(' or ', $allowed_labels) . ')';

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -1003,7 +1003,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	}
 
 	/**
-	 *  Return a string to display a field value (overridden to show Name for 'fk_replacement')
+	 *  Return a string to display a field value (overridden to show Name and Chain for 'fk_replacement')
 	 *
 	 *  @param  array   $val      Array of properties of field to show
 	 *  @param  string  $key      Key of attribute
@@ -1018,47 +1018,61 @@ class ConferenceOrBoothAttendee extends CommonObject
 	{
 		global $langs;
 
-if ($key == 'fk_replacement' && !empty($value)) {
-	$replacement = new ConferenceOrBoothAttendee($this->db);
-	$result = $replacement->fetch((int) $value);
+		if ($key == 'fk_replacement') {
+			$html = '';
+			$label_config = array('firstname', ' ', 'lastname');
 
-	// Handle the 'fk_replacement' field: Show "Me" -> Replacement -> Next...
-	if ($key == 'fk_replacement' && !empty($value)) {
-		$html = '';
-		$label_config = array('firstname', ' ', 'lastname');
+			// 1. Get the reverse chain (people I replaced / who came before me)
+			$replacedByChain = $this->getReplacedByChain();
 
-		// 1. Add "Me" as a link to the current object
-		$html .= $this->getNomUrl(1, '', 0, '', -1, array($langs->transnoentitiesnoconv("Me")));
-
-		// 2. Load the immediate replacement
-		$replacement = new ConferenceOrBoothAttendee($this->db);
-		$result = $replacement->fetch((int) $value);
-
-		if ($result > 0) {
-			// Add arrow and the replacement
-			$html .= ' &rarr; ' . $replacement->getNomUrl(1, '', 0, '', -1, $label_config);
-
-			// 3. Get the rest of the chain (forward traversal from the replacement)
-			$chain = $replacement->getReplacementChain();
-
-			// 4. Append subsequent replacements
-			if (!empty($chain)) {
-				foreach ($chain as $person) {
-					$html .= ' &rarr; ' . $person->getNomUrl(1, '', 0, '', -1, $label_config);
+			// 2. Get the forward chain (people who replaced me / who came after me)
+			$forwardChain = array();
+			if (!empty($value)) {
+				$replacement = new ConferenceOrBoothAttendee($this->db);
+				if ($replacement->fetch((int) $value) > 0) {
+					$forwardChain[] = $replacement;
+					$forwardChain = array_merge($forwardChain, $replacement->getReplacementChain());
+				} else {
+					$langs->loadLangs(array("eventorganization", "errors"));
+					$forwardChain[] = null; // Marker for broken link
 				}
 			}
-		} else {
-			// Error: The referenced replacement record was not found
-			$langs->loadLangs(array("eventorganization", "errors"));
-			$html .= ' &rarr; <span class="opacitymedium">' . $langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")) . '</span>';
+
+			// 3. If neither chain exists, show nothing
+			if (empty($replacedByChain) && empty($forwardChain)) {
+				return '';
+			}
+
+			// 4. Build the display: [Reversed Past] → Me → [Future]
+			// Reverse the backward chain so oldest is first
+			if (!empty($replacedByChain)) {
+				$reversedChain = array_reverse($replacedByChain);
+				foreach ($reversedChain as $person) {
+					if (!empty($html)) $html .= ' &rarr; ';
+					$html .= $person->getNomUrl(1, '', 0, '', -1, $label_config);
+				}
+			}
+
+			// Add "Me"
+			if (!empty($html)) $html .= ' &rarr; ';
+
+			$meLabel = '&nbsp;'.$langs->transnoentitiesnoconv("Me").'&nbsp;';
+			// Generate link: No picto, Rich Tooltip, Text = "Me"
+			$html .= $this->getNomUrl(0, '', 0, 'badge badge-primary', -1, array($meLabel));
+
+
+			// Add forward chain
+			foreach ($forwardChain as $person) {
+				$html .= ' &rarr; ';
+				if ($person !== null) {
+					$html .= $person->getNomUrl(1, '', 0, '', -1, $label_config);
+				} else {
+					$html .= '<span class="opacitymedium">' . $langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")) . '</span>';
+				}
+			}
+
+			return $html;
 		}
-
-		return $html;
-	}
-
-    $langs->loadLangs(array("eventorganization", "errors"));
-    return '<span class="opacitymedium">'.$langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")).'</span>';
-}
 
 		return parent::showOutputField($val, $key, $value, $moreparam, $keysuffix, $keyprefix, $morecss);
 	}
@@ -1100,49 +1114,46 @@ if ($key == 'fk_replacement' && !empty($value)) {
 	}
 
 	/**
-	 *  Get the full replacement chain leading to this attendee.
-	 *  Traverses backwards: Finds who I replaced, then who they replaced, etc.
-	 *  Includes protection against circular loops.
+	 *  Get the chain of people I replaced (Backward traversal).
+	 *  Example: If Sarah replaced Camilla, who replaced Alice.
+	 *  Calling $sarah->getReplacedChain() returns [Camilla, Alice].
 	 *
-	 *  @param  array   $visitedIds   Internal parameter to track visited IDs (do not pass from outside)
 	 *  @return array   Array of ConferenceOrBoothAttendee objects
 	 */
-	public function getReplacedByChain($visitedIds = array())
+	public function getReplacedByChain()
 	{
-		// Initialize visited list if this is the first call
-		if (empty($visitedIds)) {
-			$visitedIds = array();
-		}
-
-		// 1. Check for Circular Loop
-		if (in_array($this->id, $visitedIds)) {
-			// Circular loop detected!
-			dol_syslog("Circular replacement loop detected for attendee ID " . $this->id, LOG_WARNING);
-			return array(); // Return empty chain to break the loop
-		}
-
-		$visitedIds[] = $this->id;
 		$chain = array();
+		$currentObj = $this;
+		$visitedIds = array($this->id);
 
-		$sql = "SELECT rowid FROM " . $this->db->prefix() . "eventorganization_conferenceorboothattendee";
-		$sql .= " WHERE fk_replacement = " . ((int) $this->id);
+		// Traverse backward: Find who has fk_replacement = MY_ID
+		while (true) {
+			// Find the record where fk_replacement = currentObj->id
+			$sql = "SELECT rowid FROM " . $this->db->prefix() . "eventorganization_conferenceorboothattendee";
+			$sql .= " WHERE fk_replacement = " . ((int) $currentObj->id);
 
-		$resql = $this->db->query($sql);
-		if (!$resql) return array();
+			$resql = $this->db->query($sql);
+			if (!$resql) break;
 
-		$obj = $this->db->fetch_object($resql);
-		if (!$obj) return array(); // I am not a replacement for anyone
+			$obj = $this->db->fetch_object($resql);
+			if (!$obj) break; // No one replaced this person
 
-		$replacedObj = new ConferenceOrBoothAttendee($this->db);
-		if ($replacedObj->fetch($obj->rowid) <= 0) return array();
+			// Loop protection
+			if (in_array($obj->rowid, $visitedIds)) {
+				dol_syslog("Circular loop detected in replaced chain at ID " . $obj->rowid, LOG_WARNING);
+				break;
+			}
+			$visitedIds[] = $obj->rowid;
 
-		$chain[] = $replacedObj;
-
-		// Recursively find who THEY replaced, passing the updated visited list
-		$subChain = $replacedObj->getReplacedByChain($visitedIds);
-
-		// Merge the rest of the chain
-		$chain = array_merge($chain, $subChain);
+			// Fetch the person who replaced the current one
+			$replacer = new ConferenceOrBoothAttendee($this->db);
+			if ($replacer->fetch($obj->rowid) > 0) {
+				$chain[] = $replacer;
+				$currentObj = $replacer; // Move backward
+			} else {
+				break;
+			}
+		}
 
 		return $chain;
 	}

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2017	Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2024-2025  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Jon Bendtsen	    <jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -1097,7 +1097,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	/**
 	 *  Return a string to display a field value (overridden to show Name and Chain for 'fk_replacement')
 	 *
-	 *  @param  array   $val      Array of properties of field to show
+	 *  @param array{type:string,label:string,enabled:int<0,2>|string,position:int,notnull?:int,visible:int<-6,6>,noteditable?:int,default?:int|string,index?:int,foreignkey?:string,searchall?:int,isameasure?:int,css?:string,csslist?:string,cssview?:string,help?:string,showoncombobox?:int,disabled?:int,arrayofkeyval?:array<int|string,string>,comment?:string,validate?:int,required?:int,picto?:string}	$val	Array of properties of field to show
 	 *  @param  string  $key      Key of attribute
 	 *  @param  mixed   $value    Preselected value to show
 	 *  @param  string  $moreparam    To add more parameters on html tag

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -805,7 +805,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		if (!is_null($fk_replacement)) {
 			$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
 			if (!$force_fk_replacement && !in_array($this->status, $allowed_statuses)) {
-				$allowed_labels = array_map(function($s) {
+				$allowed_labels = array_map(function ($s) {
 					return $this->LibStatut($s);
 				}, $allowed_statuses);
 				$error_text = 'Can not replace eventattendee=' . $this->id . '. Current status=' . $this->LibStatut($this->status) . ' is not allowed (must be ' . implode(' or ', $allowed_labels) . ')';
@@ -832,16 +832,16 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$this->error = $error_text;
 			return -4;
 		}
-	    if (!$force_fk_replacement && !empty($this->fk_replacement) && !is_null($fk_replacement) && $this->fk_replacement != $fk_replacement->id) {
+		if (!$force_fk_replacement && !empty($this->fk_replacement) && !is_null($fk_replacement) && $this->fk_replacement != $fk_replacement->id) {
 			$error_text = 'Attendee ' . $this->id . ' already has a replacement (ID: ' . $this->fk_replacement . '). Use force_fk_replacement=1 to override.';
 			dol_syslog($error_text, LOG_WARNING);
 			$this->error = $error_text;
 			return -5;
 		}
 		if (is_null($fk_replacement) && empty($this->fk_replacement)) {
-            $this->error = "No replacement to undo.";
-            return -6;
-        }
+			$this->error = "No replacement to undo.";
+			return -6;
+		}
 		if (is_null($fk_replacement) && $this->fk_replacement > 0) {
 			$oldReplacementAttendee = new ConferenceOrBoothAttendee($this->db);
 			$oldFetch = $oldReplacementAttendee->fetch($this->fk_replacement);
@@ -926,7 +926,6 @@ class ConferenceOrBoothAttendee extends CommonObject
 
 			$this->db->commit();
 			return 1;
-
 		} catch (Exception $e) {
 			// 5. Rollback
 			// If we are here, the transaction is likely already rolled back

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -943,7 +943,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  @param  int     $notooltip                  1=Disable tooltip
 	 *  @param  string  $morecss                    Add more css on link
 	 *  @param  int     $save_lastsearch_value      -1=Auto, 0=No save of lastsearch_values when clicking, 1=Save lastsearch_values whenclicking
-	 *  @param  array<string>   $labelparts                 Array of parts to build the visible label.
+	 *  @param  array<string>   $labelparts         Array of parts to build the visible label.
 	 *                                              Can contain field names (e.g. 'firstname') or static strings (e.g. ' - ').
 	 *                                              If empty/null, defaults to $this->ref.
 	 *  @return	string                              String with URL
@@ -1104,9 +1104,9 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  @param  string  $keysuffix    Prefix string to add into name and id of field
 	 *  @param  string  $keyprefix    Suffix string to add into name and id of field
 	 *  @param  mixed   $morecss      Value for CSS to use
-	 *  @param  array<string>   $labelparts                 Array of parts to build the visible label.
-	 *                                              Can contain field names (e.g. 'firstname') or static strings (e.g. ' - ').
-	 *                                              If empty/null, defaults to $this->ref.
+	 *  @param  array<string>   $labelparts		Array of parts to build the visible label.
+	 *                                    		Can contain field names (e.g. 'firstname') or static strings (e.g. ' - ').
+	 *                                          If empty/null, defaults to $this->ref.
 	 *
 	 *  @return string
 	 */

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -797,9 +797,14 @@ class ConferenceOrBoothAttendee extends CommonObject
 	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $status_source = self::STATUS_REPLACED, $notrigger = 0, $force_fk_replacement = 0)
 	{
 		// Protection
+		if (!is_null($fk_replacement) && isset($this->fk_replacement) && $this->fk_replacement == $fk_replacement->id) {
+			// User selected the SAME replacement that is already set
+			$this->error = "No change made: The replacement is already set to this attendee.";
+			return 0; // Return 0 (Nothing done) instead of error
+		}
 		if (!is_null($fk_replacement)) {
 			$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
-			if (!in_array($this->status, $allowed_statuses)) {
+			if (!$force_fk_replacement && !in_array($this->status, $allowed_statuses)) {
 				$allowed_labels = array_map(function($s) {
 					return $this->LibStatut($s);
 				}, $allowed_statuses);

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -783,16 +783,18 @@ class ConferenceOrBoothAttendee extends CommonObject
 	}
 
 	/**
-	 *	replace "me" with another ConferenceOrBoothAttendee
+	 *	replace "me" with another ConferenceOrBoothAttendee + reset any existing replacement
 	 *
-	 *	@param	User	$user			Object user that modify
-	 *	@param	ConferenceOrBoothAttendee	$fk_replacement			The event attendee that replaces "me"
+	 *	@param	User	$user						User that modify
+	 *	@param	ConferenceOrBoothAttendee|null	$fk_replacement		The event attendee that replaces "me". If NULL, this function will UNDO the current replacement (clear link, reset to STATUS_VALIDATED original and STATUS_DRAFT on any currently $this->fk_replacement attendee)
 	 *	@param	int		$status_fk_replacement		The new status of fk_replacement, default is STATUS_VALIDATED
 	 *	@param	int		$status_source				The new status of "me", default is STATUS_REPLACED
-	 *	@param	int		$notrigger		1=Does not execute triggers, 0=Execute triggers
+	 *	@param	int		$notrigger					1=Does not execute triggers, 0=Execute triggers
+	 *	@param	int		$force_fk_replacement		0 (default) do not overwrite fk_replacement if it has a sane value, 1  overwrite fk_replacement regardless of the existing value of fk_replacement
+	 *
 	 *	@return	int						Return integer <0 if KO, 0=Nothing done, >0 if OK
 	 */
-	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $status_source = self::STATUS_REPLACED, $notrigger = 0)
+	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $status_source = self::STATUS_REPLACED, $notrigger = 0, $force_fk_replacement = 0)
 	{
 		// Protection
 		$allowed_statuses = array(self::STATUS_VALIDATED, self::STATUS_DRAFT);
@@ -802,7 +804,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$this->error = $error_text;
 			return -1;
 		}
-		if ($fk_replacement->id == $this->id) {
+		if (!is_null($fk_replacement) && $fk_replacement->id == $this->id) {
 			$error_text = 'Can not replace an attendee with itself';
 			dol_syslog($error_text, LOG_ERR);
 			$this->error = $error_text;
@@ -820,31 +822,75 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$this->error = $error_text;
 			return -4;
 		}
-
+	    if (!$force_fk_replacement && !empty($this->fk_replacement) && !is_null($fk_replacement) && $this->fk_replacement != $fk_replacement->id) {
+			$error_text = 'Attendee ' . $this->id . ' already has a replacement (ID: ' . $this->fk_replacement . '). Use force_fk_replacement=1 to override.';
+			dol_syslog($error_text, LOG_WARNING);
+			$this->error = $error_text;
+			return -5;
+		}
+		if (is_null($fk_replacement) && empty($this->fk_replacement)) {
+            $this->error = "No replacement to undo.";
+            return -6;
+        }
 
 		$this->db->begin();
 		try {
 			// Original
-			$this->fk_replacement = $fk_replacement->id;
-			$this->status = $status_source;
+			if (is_null($fk_replacement)) {
+				$oldReplacementAttendee = null;
+				$any_old_fk_replacement = $this->fk_replacement;
+				if ($any_old_fk_replacement > 0) {
+					$oldReplacementAttendee = new ConferenceOrBoothAttendee($this->db);
+					$oldFetch = $oldReplacementAttendee->fetch($any_old_fk_replacement);
+					if ($oldFetch > 0) {
+						$oldReplacementAttendee->status = self::STATUS_DRAFT;
+						$oldStatusDraft = $oldReplacementAttendee->update($user, 1); // we do our own trigger
+						if ($oldStatusDraft < 0) {
+							throw new Exception("Update oldReplacementAttendee=".$any_old_fk_replacement."failed: " . $oldReplacementAttendee->error);
+						}
+					} else {
+						throw new Exception("Fetch oldReplacementAttendee failed: " . $oldReplacementAttendee->error);
+					}
+				}
+				$this->fk_replacement = null;
+				$this->status = self::STATUS_VALIDATED;
+			} else {
+				$this->fk_replacement = $fk_replacement->id;
+				$this->status = $status_source;
+			}
 			$originalReplace = $this->update($user, 1); // we do our own trigger
 			if ($originalReplace < 0) {
-				throw new Exception("Update original failed: " . $this->error);
+				throw new Exception("Update original attendee=".$this->id." failed: " . $this->error);
 			}
 
 			// call triggers
 			if (!$notrigger) {
-				$result = $this->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED', $user);
-				if ($result < 0) {
-					throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED failed: " . $this->error);
+				if (is_null($fk_replacement)) {
+					$result = $this->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET', $user);
+					if ($result < 0) {
+						throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET failed: " . $this->error);
+					}
+
+					if ($oldReplacementAttendee !== null) {
+						$oldUpdateResult = $oldReplacementAttendee->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', $user);
+						if ($oldUpdateResult < 0) {
+							throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET failed: " . $oldReplacementAttendee->error);
+						}
+					}
+				} else {
+					$result = $this->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED', $user);
+					if ($result < 0) {
+						throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED failed: " . $this->error);
+					}
 				}
 			}
 
-
 			// Replacement
-			$replacementStatus = $fk_replacement->setStatusCommon($user, $status_fk_replacement, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REPLACING');
-			if ($replacementStatus < 0) {
-				throw new Exception("Update replacement status failed: " . $fk_replacement->error);
+			if (!is_null($fk_replacement)) {
+				$replacementStatus = $fk_replacement->setStatusCommon($user, $status_fk_replacement, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REPLACING');
+				if ($replacementStatus < 0) {
+					throw new Exception("Update replacement status failed: " . $fk_replacement->error);
+				}
 			}
 
 			$this->db->commit();

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -847,10 +847,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$oldFetch = $oldReplacementAttendee->fetch($this->fk_replacement);
 			if ($oldFetch > 0) {
 				if (!empty($oldReplacementAttendee->fk_replacement)) {
-					$error_text = 'Cannot undo replacement for attendee ' . $this->id . '. ' .
-								'The current replacement (ID: ' . $oldReplacementAttendee->id . ') is itself replaced by attendee (ID: ' .
-								$oldReplacementAttendee->fk_replacement . '). ' .
-								'Please undo the replacement for attendee ' . $oldReplacementAttendee->id . ' first.';
+					$error_text = 'Cannot undo replacement for attendee ' . $this->id . '. ' .'The current replacement (ID: ' . $oldReplacementAttendee->id . ') is itself replaced by attendee (ID: ' .$oldReplacementAttendee->fk_replacement . '). ' .'Please undo the replacement for attendee ' . $oldReplacementAttendee->id . ' first.';
 					dol_syslog($error_text, LOG_WARNING);
 					$this->error = $error_text;
 					return -7;

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -1109,7 +1109,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *
 	 *  @return string
 	 */
-	public function showOutputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = '', $labelparts = array('firstname', ' ', 'lastname', ' (#', 'id', ')'))
+	public function showOutputField($val, $key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = '', $labelparts = array('firstname', ' ', 'lastname', ' #', 'id'))
 	{
 		global $langs;
 

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -796,6 +796,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 */
 	public function replaceMeWithAttendee($user, $fk_replacement, $status_fk_replacement = self::STATUS_VALIDATED, $status_source = self::STATUS_REPLACED, $notrigger = 0, $force_fk_replacement = 0)
 	{
+		global $langs;
 		// Protection
 		if (!is_null($fk_replacement) && isset($this->fk_replacement) && $this->fk_replacement == $fk_replacement->id) {
 			// User selected the SAME replacement that is already set
@@ -881,7 +882,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 						throw new Exception("Fetch oldReplacementAttendee failed: " . $oldReplacementAttendee->error);
 					}
 				}
-				$this->fk_replacement = null;
+				$this->fk_replacement = 0;
 				$this->status = self::STATUS_VALIDATED;
 			} else {
 				$this->fk_replacement = $fk_replacement->id;
@@ -942,7 +943,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  @param  int     $notooltip                  1=Disable tooltip
 	 *  @param  string  $morecss                    Add more css on link
 	 *  @param  int     $save_lastsearch_value      -1=Auto, 0=No save of lastsearch_values when clicking, 1=Save lastsearch_values whenclicking
-	 *  @param  array   $labelparts                 Array of parts to build the visible label.
+	 *  @param  array<string>   $labelparts                 Array of parts to build the visible label.
 	 *                                              Can contain field names (e.g. 'firstname') or static strings (e.g. ' - ').
 	 *                                              If empty/null, defaults to $this->ref.
 	 *  @return	string                              String with URL
@@ -1103,7 +1104,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  @param  string  $keysuffix    Prefix string to add into name and id of field
 	 *  @param  string  $keyprefix    Suffix string to add into name and id of field
 	 *  @param  mixed   $morecss      Value for CSS to use
-	 *  @param  array   $labelparts                 Array of parts to build the visible label.
+	 *  @param  array<string>   $labelparts                 Array of parts to build the visible label.
 	 *                                              Can contain field names (e.g. 'firstname') or static strings (e.g. ' - ').
 	 *                                              If empty/null, defaults to $this->ref.
 	 *
@@ -1177,7 +1178,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  Example: If Alice (1) was replaced by Camilla (5), who was replaced by Sarah (2).
 	 *  Calling $alice->getReplacementChain() returns [Camilla, Sarah].
 	 *
-	 *  @return array   Array of ConferenceOrBoothAttendee objects
+	 *  @return array<ConferenceOrBoothAttendee>   Array of ConferenceOrBoothAttendee objects
 	 */
 	public function getReplacementChain()
 	{
@@ -1212,7 +1213,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 *  Example: If Sarah replaced Camilla, who replaced Alice.
 	 *  Calling $sarah->getReplacedChain() returns [Camilla, Alice].
 	 *
-	 *  @return array   Array of ConferenceOrBoothAttendee objects
+	 *  @return array<ConferenceOrBoothAttendee>   Array of ConferenceOrBoothAttendee objects
 	 */
 	public function getReplacedByChain()
 	{

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -837,6 +837,24 @@ class ConferenceOrBoothAttendee extends CommonObject
             $this->error = "No replacement to undo.";
             return -6;
         }
+		if (is_null($fk_replacement) && $this->fk_replacement > 0) {
+			$oldReplacementAttendee = new ConferenceOrBoothAttendee($this->db);
+			$oldFetch = $oldReplacementAttendee->fetch($this->fk_replacement);
+			if ($oldFetch > 0) {
+				if (!empty($oldReplacementAttendee->fk_replacement)) {
+					$error_text = 'Cannot undo replacement for attendee ' . $this->id . '. ' .
+								'The current replacement (ID: ' . $oldReplacementAttendee->id . ') is itself replaced by attendee (ID: ' .
+								$oldReplacementAttendee->fk_replacement . '). ' .
+								'Please undo the replacement for attendee ' . $oldReplacementAttendee->id . ' first.';
+					dol_syslog($error_text, LOG_WARNING);
+					$this->error = $error_text;
+					return -7;
+				}
+			} elseif ($oldFetch < 0) {
+				$this->error = "Fetch oldReplacementAttendee failed: " . $oldReplacementAttendee->error;
+				return -8;
+			}
+		}
 
 		$this->db->begin();
 		try {
@@ -848,10 +866,14 @@ class ConferenceOrBoothAttendee extends CommonObject
 					$oldReplacementAttendee = new ConferenceOrBoothAttendee($this->db);
 					$oldFetch = $oldReplacementAttendee->fetch($any_old_fk_replacement);
 					if ($oldFetch > 0) {
+						if (!empty($oldReplacementAttendee->fk_replacement)) {
+							throw new Exception("Race condition: The replacement (ID: " . $oldReplacementAttendee->id . ") has been replaced by another attendee since the check.");
+						}
+
 						$oldReplacementAttendee->status = self::STATUS_DRAFT;
-						$oldStatusDraft = $oldReplacementAttendee->update($user, 1); // we do our own trigger
+						$oldStatusDraft = $oldReplacementAttendee->update($user, 1);
 						if ($oldStatusDraft < 0) {
-							throw new Exception("Update oldReplacementAttendee=".$any_old_fk_replacement."failed: " . $oldReplacementAttendee->error);
+							throw new Exception("Update oldReplacementAttendee=" . $any_old_fk_replacement . " failed: " . $oldReplacementAttendee->error);
 						}
 					} else {
 						throw new Exception("Fetch oldReplacementAttendee failed: " . $oldReplacementAttendee->error);

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -349,6 +349,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		unset($object->fk_user_creat);
 		unset($object->user_creation_id);
 		unset($object->import_key);
+		unset($object->fk_replacement);
 
 		// Clear fields
 		$object->ref = "(PROV)";

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -60,6 +60,11 @@ class ConferenceOrBoothAttendee extends CommonObject
 	const STATUS_REPLACED = 13;				// This event attendee has been replaced with a different event Attendee which should be recorded in field fk_replacement
 
 	/**
+	 * @var array<int, int> list of possible statuses for this object
+	 */
+	public $list_possible_status = [self::STATUS_DRAFT, self::STATUS_VALIDATED, self::STATUS_USED, self::STATUS_CANCELED, self::STATUS_REPLACED];
+
+	/**
 	 *  'type' field format ('integer', 'integer:ObjectClass:PathToClass[:AddCreateButtonOrNot[:Filter]]', 'sellist:TableName:LabelFieldName[:KeyFieldName[:KeyFieldParent[:Filter]]]', 'varchar(x)', 'double(24,8)', 'real', 'price', 'text', 'text:none', 'html', 'date', 'datetime', 'timestamp', 'duration', 'mail', 'phone', 'url', 'password')
 	 *         Note: Filter can be a string like "(t.ref:like:'SO-%') or (t.date_creation:<:'20160101') or (t.nature:is:NULL)"
 	 *  'label' the translation key.

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -1078,10 +1078,12 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$this->labelStatus[self::STATUS_VALIDATED] = $langs->trans('Registered');
 			$this->labelStatus[self::STATUS_USED] = $langs->trans('ShowedUp');
 			$this->labelStatus[self::STATUS_CANCELED] = $langs->trans('Disabled');
+			$this->labelStatus[self::STATUS_REPLACED] = $langs->trans('Replaced');
 			$this->labelStatusShort[self::STATUS_DRAFT] = $langs->trans('Draft');
 			$this->labelStatusShort[self::STATUS_VALIDATED] = $langs->trans('Registered');
 			$this->labelStatusShort[self::STATUS_USED] = $langs->trans('ShowedUp');
 			$this->labelStatusShort[self::STATUS_CANCELED] = $langs->trans('Disabled');
+			$this->labelStatusShort[self::STATUS_REPLACED] = $langs->trans('Replaced');
 		}
 
 		$labelStatus = $this->labelStatus[$status];
@@ -1092,7 +1094,10 @@ class ConferenceOrBoothAttendee extends CommonObject
 			$statusType = 'status2';
 		}
 		if ($status == self::STATUS_CANCELED) {
-			$statusType = 'status9';
+			$statusType = 'status8';
+		}
+		if ($status == self::STATUS_REPLACED) {
+			$statusType = 'status1';
 		}
 
 		if ($status == self::STATUS_VALIDATED && $this->date_subscription && $this->amount) {

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -1018,23 +1018,133 @@ class ConferenceOrBoothAttendee extends CommonObject
 	{
 		global $langs;
 
-		if ($key == 'fk_replacement' && !empty($value)) {
-			$replacement = new ConferenceOrBoothAttendee($this->db);
-			$result = $replacement->fetch((int) $value);
+if ($key == 'fk_replacement' && !empty($value)) {
+	$replacement = new ConferenceOrBoothAttendee($this->db);
+	$result = $replacement->fetch((int) $value);
 
-			if ($result > 0) {
-				// Define the label structure: "Firstname Lastname"
-				// You can easily change this to ["ref", " - ", "firstname", " ", "lastname"]
-				$label_config = array('firstname', ' ', 'lastname');
+	// Handle the 'fk_replacement' field: Show "Me" -> Replacement -> Next...
+	if ($key == 'fk_replacement' && !empty($value)) {
+		$html = '';
+		$label_config = array('firstname', ' ', 'lastname');
 
-				return $replacement->getNomUrl(1, '', 0, '', -1, $label_config);
+		// 1. Add "Me" as a link to the current object
+		$html .= $this->getNomUrl(1, '', 0, '', -1, array($langs->transnoentitiesnoconv("Me")));
+
+		// 2. Load the immediate replacement
+		$replacement = new ConferenceOrBoothAttendee($this->db);
+		$result = $replacement->fetch((int) $value);
+
+		if ($result > 0) {
+			// Add arrow and the replacement
+			$html .= ' &rarr; ' . $replacement->getNomUrl(1, '', 0, '', -1, $label_config);
+
+			// 3. Get the rest of the chain (forward traversal from the replacement)
+			$chain = $replacement->getReplacementChain();
+
+			// 4. Append subsequent replacements
+			if (!empty($chain)) {
+				foreach ($chain as $person) {
+					$html .= ' &rarr; ' . $person->getNomUrl(1, '', 0, '', -1, $label_config);
+				}
 			}
-
+		} else {
+			// Error: The referenced replacement record was not found
 			$langs->loadLangs(array("eventorganization", "errors"));
-			return '<span class="opacitymedium">'.$langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")).'</span>';
+			$html .= ' &rarr; <span class="opacitymedium">' . $langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")) . '</span>';
 		}
 
+		return $html;
+	}
+
+    $langs->loadLangs(array("eventorganization", "errors"));
+    return '<span class="opacitymedium">'.$langs->trans("ErrorRefNotFound", $langs->trans("ConferenceOrBoothAttendee")).'</span>';
+}
+
 		return parent::showOutputField($val, $key, $value, $moreparam, $keysuffix, $keyprefix, $morecss);
+	}
+
+	/**
+	 *  Get the full replacement chain starting from this attendee.
+	 *  Traverses FORWARD: Finds who replaced this attendee, then who replaced them, etc.
+	 *  Example: If Alice (1) was replaced by Camilla (5), who was replaced by Sarah (2).
+	 *  Calling $alice->getReplacementChain() returns [Camilla, Sarah].
+	 *
+	 *  @return array   Array of ConferenceOrBoothAttendee objects
+	 */
+	public function getReplacementChain()
+	{
+		$chain = array();
+		$currentObj = $this;
+		$visitedIds = array($this->id);
+
+		// Traverse forward: Follow fk_replacement links
+		while (!empty($currentObj->fk_replacement)) {
+			// Loop protection
+			if (in_array($currentObj->fk_replacement, $visitedIds)) {
+				dol_syslog("Circular replacement loop detected at ID " . $currentObj->fk_replacement, LOG_WARNING);
+				break;
+			}
+			$visitedIds[] = $currentObj->fk_replacement;
+
+			// Fetch the next person
+			$nextObj = new ConferenceOrBoothAttendee($this->db);
+			if ($nextObj->fetch((int) $currentObj->fk_replacement) > 0) {
+				$chain[] = $nextObj;
+				$currentObj = $nextObj;
+			} else {
+				break;
+			}
+		}
+
+		return $chain;
+	}
+
+	/**
+	 *  Get the full replacement chain leading to this attendee.
+	 *  Traverses backwards: Finds who I replaced, then who they replaced, etc.
+	 *  Includes protection against circular loops.
+	 *
+	 *  @param  array   $visitedIds   Internal parameter to track visited IDs (do not pass from outside)
+	 *  @return array   Array of ConferenceOrBoothAttendee objects
+	 */
+	public function getReplacedByChain($visitedIds = array())
+	{
+		// Initialize visited list if this is the first call
+		if (empty($visitedIds)) {
+			$visitedIds = array();
+		}
+
+		// 1. Check for Circular Loop
+		if (in_array($this->id, $visitedIds)) {
+			// Circular loop detected!
+			dol_syslog("Circular replacement loop detected for attendee ID " . $this->id, LOG_WARNING);
+			return array(); // Return empty chain to break the loop
+		}
+
+		$visitedIds[] = $this->id;
+		$chain = array();
+
+		$sql = "SELECT rowid FROM " . $this->db->prefix() . "eventorganization_conferenceorboothattendee";
+		$sql .= " WHERE fk_replacement = " . ((int) $this->id);
+
+		$resql = $this->db->query($sql);
+		if (!$resql) return array();
+
+		$obj = $this->db->fetch_object($resql);
+		if (!$obj) return array(); // I am not a replacement for anyone
+
+		$replacedObj = new ConferenceOrBoothAttendee($this->db);
+		if ($replacedObj->fetch($obj->rowid) <= 0) return array();
+
+		$chain[] = $replacedObj;
+
+		// Recursively find who THEY replaced, passing the updated visited list
+		$subChain = $replacedObj->getReplacedByChain($visitedIds);
+
+		// Merge the rest of the chain
+		$chain = array_merge($chain, $subChain);
+
+		return $chain;
 	}
 
 	/**

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -905,16 +905,16 @@ class ConferenceOrBoothAttendee extends CommonObject
 						}
 					}
 				} else {
-					$result = $this->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED', $user);
+					$result = $this->call_trigger('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', $user);
 					if ($result < 0) {
-						throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED failed: " . $this->error);
+						throw new Exception("Trigger CONFERENCEORBOOTHATTENDEE_REPLACED_SRC failed: " . $this->error);
 					}
 				}
 			}
 
 			// Replacement
 			if (!is_null($fk_replacement)) {
-				$replacementStatus = $fk_replacement->setStatusCommon($user, $status_fk_replacement, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REPLACING');
+				$replacementStatus = $fk_replacement->setStatusCommon($user, $status_fk_replacement, $notrigger, 'CONFERENCEORBOOTHATTENDEE_REPLACED_TGT');
 				if ($replacementStatus < 0) {
 					throw new Exception("Update replacement status failed: " . $fk_replacement->error);
 				}

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -621,11 +621,16 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			// Create an array for form
 			$formquestion = array();
 
+			$current_fk_replacement = $attendeestatic->fk_replacement ?? 0;
 			$filter = '((t.fk_project:=:' . ((int) $attendeestatic->fk_project) . ') AND (t.status:IN:[' . $attendeestatic::STATUS_VALIDATED . ',' . $attendeestatic::STATUS_DRAFT . ']) AND (t.rowid:!=:' . ((int) $id) . '))';
 			$attendee_list = $attendeestatic->fetchAll('', '', 0, 0, $filter);
 			$reformat_list = array();
 			foreach ($attendee_list as $attendee) {
-				$reformat_list[$attendee->id] = $attendee->getFullName($langs, 0, -1, 0);
+				if ($current_fk_replacement == $attendee->id) {
+					$reformat_list[$attendee->id] = '✓ '.$attendee->getFullName($langs, 0, -1, 0);
+				} else {
+					$reformat_list[$attendee->id] = $attendee->getFullName($langs, 0, -1, 0);
+				}
 			}
 
 			// 655360? well, 640k is enough for everybody :-D and if I used -1 then it would show very fain where as with 655360 the text is clearly seen, and I can not use 0, because that is draft :-(
@@ -680,7 +685,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					'label'    => $select_replace_attendee,
 					'type'     => 'select',
 					'values'   => (array) $reformat_list,
-					'default'  => -2,
+					'default'  => $current_fk_replacement,
 				];
 				$oldstatus_selection_list = [
 					'name'     => 'oldobject_status',
@@ -764,7 +769,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			$autotrigger = GETPOST('autotrigger', 'alpha') ? GETPOST('autotrigger', 'alpha') : null;
 			$notrigger = ($autotrigger == 'on') ? 0 : 1;
 
-			if ($select_replace_attendee > 0) {
+			if (isset($attendeesource->fk_replacement) && $attendeesource->fk_replacement == $select_replace_attendee) {
+				$fetchReplace = 0;
+			} elseif ($select_replace_attendee > 0) {
 				$attendeereplace = new ConferenceOrBoothAttendee($db);
 				$fetchReplace = $attendeereplace->fetch($select_replace_attendee);
 			} else {
@@ -790,7 +797,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					$force_fk_replacement = 0;
 				}
 				$replaceResult = $attendeesource->replaceMeWithAttendee($user, $attendeereplace, $newobject_status_id, $oldobject_status_id, $notrigger, $force_fk_replacement);
-			} else {
+			} elseif ($fetchReplace < 0) {
 				setEventMessages($langs->trans("ErrorObjectNotFound", $langs->trans("ReplacementAttendee")), null, 'errors');
 			}
 
@@ -808,6 +815,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				exit;
 				// header() method does not work, it gives this error
 				// PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/html/main.inc.php:2098)
+			} elseif ($replaceResult == 0) {
+				// No Change: Show Info message
+				$langs->loadLangs(array("eventorganization"));
+				setEventMessages($langs->trans("NoChangeMade"), null, 'mesgs'); // Add this key
+				// Redirect back
+				$url = htmlspecialchars($_SERVER['PHP_SELF']) . '?id=' . $id;
+				echo '<meta http-equiv="refresh" content="0;url=' . $url . '">';
+				exit;
 			} else {
 				// Map error codes to numbered translation keys
 				$transKeys = array(

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -610,8 +610,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		$formquestion = array();
 		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToClone'), $langs->trans('ConfirmCloneAsk', $object->ref), 'confirm_clone', $formquestion, 'yes', 1);
 	}
-	// Replace confirmation
-	if ($action == 'replace') {
+	// Replace or undo replace confirmation popup
+	if ($action == 'replace' || $action == 'undoreplace') {
 		$langs->loadLangs(array("productbatch", "eventorganization", "admin", "bills", "main"));
 		$fetchme = $attendeestatic->fetch($id);
 		if ($fetchme) {
@@ -624,7 +624,6 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			foreach ($attendee_list as $attendee) {
 				$reformat_list[$attendee->id] = $attendee->getFullName($langs, 0, -1, 0);
 			}
-			$reformat_list['none'] = '--- '.$langs->trans("None").' ---';
 
 			// 655360? well, 640k is enough for everybody :-D and if I used -1 then it would show very fain where as with 655360 the text is clearly seen, and I can not use 0, because that is draft :-(
 			$source_status_list = array();
@@ -649,35 +648,54 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			 *   inputko?: int
 			 * }>
 			 */
-			$formquestion = [
-				// 1. Single-select: Replacement Attendee
-				[
+			if ($action == 'replace') {
+				$attendee_selection_list = [
 					'name'     => 'select_replace_attendee',
 					'label'    => $select_replace_attendee,
 					'type'     => 'select',
 					'values'   => (array) $reformat_list,
-					'default'  => 'none'
-				],
-
-				// 2. Single-select: Source Status after replacement
-				[
+					'default'  => '-1'
+				];
+				$oldstatus_selection_list = [
 					'name'     => 'oldobject_status',
 					'label'    => $langs->trans("Source").' &ndash; '.$langs->trans("SetToStatus"),
 					'type'     => 'select',
 					'values'   => (array) $source_status_list,
 					'default'  => 13,
-				],
-
-				// 3. Single-select: Replacement Status after replacing
-				[
+				];
+				$newstatus_selection_list = [
 					'name'     => 'newobject_status',
 					'label'    => $langs->trans("ToReplace").' &ndash; '.$langs->trans("SetToStatus"),
 					'type'     => 'select',
 					'values'   => (array) $replace_status_list,
 					'default'  => 1,
-				],
+				];
+			} else {
+				$reformat_list[-2] = '--- '.$langs->trans("None").' ---';
+				$attendee_selection_list = [
+					'name'     => 'select_replace_attendee',
+					'label'    => $select_replace_attendee,
+					'type'     => 'select',
+					'values'   => (array) $reformat_list,
+					'default'  => -2,
+				];
+				$oldstatus_selection_list = [
+					'name'     => 'oldobject_status',
+					'label'    => $langs->trans("Source").' &ndash; '.$langs->trans("SetToStatus"),
+					'type'     => 'select',
+					'values'   => (array) $source_status_list,
+					'default'  => 1,
+				];
+				$newstatus_selection_list = [
+					'name'     => 'newobject_status',
+					'label'    => $langs->trans("ToReplace").' &ndash; '.$langs->trans("SetToStatus"),
+					'type'     => 'select',
+					'values'   => (array) $replace_status_list,
+					'default'  => 0,
+				];
+			}
 
-				// 4. Checkbox: Auto trigger replace of Source
+			$formquestion = [$attendee_selection_list, $oldstatus_selection_list, $newstatus_selection_list,
 				[
 					'name'    => 'autotrigger',
 					'label'   => $langs->trans("AutomaticTrigger"),
@@ -697,18 +715,17 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		}
 	}
 
-	// Action clone object
-	$val = GETPOST('select_replace_attendee');
-	$select_replace_attendee = ($val === 'none') ? -1 : (int) $val;
-	if ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && $select_replace_attendee < 1) {
+	// Action replace object
+	$select_replace_attendee = GETPOSTINT('select_replace_attendee');
+	if ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && $select_replace_attendee == -1) {
 		$langs->loadLangs(array("eventorganization", "errors"));
 		setEventMessages($langs->trans("ErrorGlobalVariableUpdater2", $langs->trans("Attendee")), null, 'errors');
-	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && $select_replace_attendee > 0 && $id == $select_replace_attendee) {
+	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && $id > 0 && $id == $select_replace_attendee) {
 		$langs->loadLangs(array("eventorganization", "admin"));
 		dol_syslog('Aborted - Attempt to replace attendee='.(int) $id.' with itself!', LOG_WARNING);
 		setEventMessages($langs->trans("Attendee").' '.$langs->trans("ReplacedBy").' '.$langs->trans("Attendee"), $langs->trans("IgnoreDuplicateRecords"), 'errors');
-	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && $select_replace_attendee > 0) {
-		$langs->loadLangs(array("eventorganization", "errors", "blockedlog", "bills"));
+	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && ($select_replace_attendee > 0 || $select_replace_attendee == -2)) {
+		$langs->loadLangs(array("eventorganization", "errors", "blockedlog", "bills", "main"));
 		// can not reuse attendeestatic because I modify it
 		$attendeesource = new ConferenceOrBoothAttendee($db);
 		if ($id > 0) {
@@ -735,6 +752,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			dol_syslog('User='.$user->id.' has no write access to project='.$attendeesource->fk_project, LOG_WARNING);
 			setEventMessages($langs->trans("Project").': '.$langs->trans("ErrorForbidden2"), null, 'errors');
 		} else {
+			$label_config = array('firstname', ' ', 'lastname');
 			$oldobject_status_id = GETPOSTINT('oldobject_status');
 			$newobject_status_id = GETPOSTINT('newobject_status');
 			$oldobject_status_id = (is_null($oldobject_status_id) || is_numeric($oldobject_status_id)) ? (int) $oldobject_status_id : (int) 13; // default is set the old objects status to 13 (replaced)
@@ -743,26 +761,52 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			$autotrigger = GETPOST('autotrigger', 'alpha') ? GETPOST('autotrigger', 'alpha') : null;
 			$notrigger = ($autotrigger == 'on') ? 0 : 1;
 
-			$attendeereplace = new ConferenceOrBoothAttendee($db);
-			$fetchReplace = $attendeereplace->fetch($select_replace_attendee);
-			if ($fetchReplace) {
-				$replaceResult = $attendeesource->replaceMeWithAttendee($user, $attendeereplace, $newobject_status_id, $oldobject_status_id, $notrigger);
-				if ($replaceResult > 0) {
-					dol_syslog('Replacing attendee='.$id.' with attendee='.$select_replace_attendee, LOG_INFO);
-					$label_config = array('firstname', ' ', 'lastname');
-					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("ReplacedBy").' '.$attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config);
-					setEventMessages($info_message, null, 'mesgs');
-					$url = htmlspecialchars($_SERVER['PHP_SELF']) . '?id=' . $id;
-					echo '<meta http-equiv="refresh" content="0;url=' . $url . '">';
-					echo '<p>Redirecting to <a href="' . $url . '">new page</a>...</p>';
-					exit;
-					// header() method does not work, it gives this error
-					// PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/html/main.inc.php:2098)
-				}  else {
-					setEventMessages($attendeesource->error, null, 'errors');
+			if ($select_replace_attendee > 0) {
+				$attendeereplace = new ConferenceOrBoothAttendee($db);
+				$fetchReplace = $attendeereplace->fetch($select_replace_attendee);
+			} else {
+				$fetchReplace = null;
+			}
+
+			$replaceResult = null;
+			if (is_null($fetchReplace)) {
+				$replaceResult = $attendeesource->replaceMeWithAttendee($user, null, 0, 0, 0, 0);
+			} elseif ($fetchReplace > 0) {
+				$any_existing_fk_replacement = $attendeesource->fk_replacement;
+				$check_any_existing_fk_replacement = 0;
+				if ($any_existing_fk_replacement > 0) {
+					$tempObj = new ConferenceOrBoothAttendee($db);
+					$check_any_existing_fk_replacement = $tempObj->fetch($any_existing_fk_replacement);
 				}
+				if ($check_any_existing_fk_replacement > 0) {
+					$force_fk_replacement = 1;
+					dol_syslog('Source attendee='.$id.' already had fk_replacement='.$any_existing_fk_replacement.' now replaced with new value='.$select_replace_attendee, LOG_WARNING);
+					$warn_message = $langs->trans("Warning").': '.$langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("OldValue", $tempObj->getNomUrl(1, '', 0, '', -1, $label_config)).' '.$langs->trans("ReplacedBy").' '.$attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config);
+					setEventMessages($warn_message, null, 'warnings');
+				} else {
+					$force_fk_replacement = 0;
+				}
+				$replaceResult = $attendeesource->replaceMeWithAttendee($user, $attendeereplace, $newobject_status_id, $oldobject_status_id, $notrigger, $force_fk_replacement);
 			} else {
 				setEventMessages($langs->trans("ErrorObjectNotFound", $langs->trans("InvoiceReplacementShort").' '.$langs->trans("Attendee")), null, 'errors');
+			}
+
+			if ($replaceResult > 0) {
+				dol_syslog('Replacing attendee='.$id.' with attendee='.$select_replace_attendee, LOG_INFO);
+				if ($select_replace_attendee == -2) {
+					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("Reset").' '.$langs->trans("ReplacedBy");
+				} else {
+					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("ReplacedBy").' '.$attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config);
+				}
+				setEventMessages($info_message, null, 'mesgs');
+				$url = htmlspecialchars($_SERVER['PHP_SELF']) . '?id=' . $id;
+				echo '<meta http-equiv="refresh" content="0;url=' . $url . '">';
+				echo '<p>Redirecting to <a href="' . $url . '">new page</a>...</p>';
+				exit;
+				// header() method does not work, it gives this error
+				// PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/html/main.inc.php:2098)
+			}  else {
+				setEventMessages($attendeesource->error, null, 'errors');
 			}
 		}
 	}

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -496,7 +496,7 @@ if (!empty($withproject)) {
 
 // Part to create an attendee
 if ($action == 'create' && $confOrBooth === null) {
-	$object->fk_replacement = null;
+	$object->fk_replacement = 0;
 	unset($object->fields['fk_replacement']);
 	// because else some preset data showed up in create form? and we don't want it here anyway
 	print load_fiche_titre($langs->trans("NewObject", $langs->transnoentitiesnoconv("ConferenceOrBoothAttendee")), '', 'object_'.$object->picto);

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -752,7 +752,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			dol_syslog('User='.$user->id.' has no write access to project='.$attendeesource->fk_project, LOG_WARNING);
 			setEventMessages($langs->trans("Project").': '.$langs->trans("ErrorForbidden2"), null, 'errors');
 		} else {
-			$label_config = array('firstname', ' ', 'lastname');
+			$label_config = array('firstname', ' ', 'lastname', ' (#', 'id', ')');
 			$oldobject_status_id = GETPOSTINT('oldobject_status');
 			$newobject_status_id = GETPOSTINT('newobject_status');
 			$oldobject_status_id = (is_null($oldobject_status_id) || is_numeric($oldobject_status_id)) ? (int) $oldobject_status_id : (int) 13; // default is set the old objects status to 13 (replaced)

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -624,6 +624,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			foreach ($attendee_list as $attendee) {
 				$reformat_list[$attendee->id] = $attendee->getFullName($langs, 0, -1, 0);
 			}
+			$reformat_list['none'] = '--- '.$langs->trans("None").' ---';
 
 			// 655360? well, 640k is enough for everybody :-D and if I used -1 then it would show very fain where as with 655360 the text is clearly seen, and I can not use 0, because that is draft :-(
 			$source_status_list = array();
@@ -655,6 +656,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					'label'    => $select_replace_attendee,
 					'type'     => 'select',
 					'values'   => (array) $reformat_list,
+					'default'  => 'none'
 				],
 
 				// 2. Single-select: Source Status after replacement
@@ -696,7 +698,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	}
 
 	// Action clone object
-	$select_replace_attendee = GETPOSTINT('select_replace_attendee');
+	$val = GETPOST('select_replace_attendee');
+	$select_replace_attendee = ($val === 'none') ? -1 : (int) $val;
 	if ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && $select_replace_attendee < 1) {
 		$langs->loadLangs(array("eventorganization", "errors"));
 		setEventMessages($langs->trans("ErrorGlobalVariableUpdater2", $langs->trans("Attendee")), null, 'errors');
@@ -832,8 +835,11 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// Replace
 			$langs->loadLangs(array("productbatch"));
-			print dolGetButtonAction('', $langs->trans('ToReplace'), 'replace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=replace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
-
+			if (empty($object->fk_replacement)) {
+				print dolGetButtonAction('', $langs->trans('ToReplace'), 'replace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=replace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
+			} else {
+				print dolGetButtonAction('', $langs->trans("Undo").' '.$langs->trans('ToReplace'), 'undoreplace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=undoreplace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
+			}
 			// Delete (need delete permission, or if draft, just need create/modify permission)
 			print dolGetButtonAction('', $langs->trans('Delete'), 'delete', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=delete&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontodelete || ($object->status == $object::STATUS_DRAFT && $permissiontoadd));
 		}

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -885,7 +885,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			if (empty($object->fk_replacement)) {
 				print dolGetButtonAction('', $langs->trans('ToReplace'), 'replace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=replace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
 			} else {
-				print dolGetButtonAction('', $langs->trans("Undo").' '.$langs->trans('ToReplace'), 'undoreplace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=undoreplace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
+				print dolGetButtonAction('', $langs->trans("EditReplacement").' '.$langs->trans('ToReplace'), 'undoreplace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=undoreplace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
 			}
 			// Delete (need delete permission, or if draft, just need create/modify permission)
 			print dolGetButtonAction('', $langs->trans('Delete'), 'delete', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=delete&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontodelete || ($object->status == $object::STATUS_DRAFT && $permissiontoadd));

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -646,15 +646,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			}
 			$select_replace_attendee = $langs->trans("SelectOneReplacementAttendee");
 			/**
-			 * @var array<array{
-			 *   name: string,
-			 *   label: string,
-			 *   type: 'select'|'checkbox',
-			 *   values?: array<int|string, string>,
-			 *   default?: string|int,
-			 *   value?: int,
-			 *   inputko?: int
-			 * }>
+			 * @var array<array{name: string, label: string, type: 'select'|'checkbox', values?: array<int|string, string>, default?: string|int, value?: int, inputko?: int}> $formquestion
 			 */
 			if ($action == 'replace') {
 				$attendee_selection_list = [
@@ -767,10 +759,11 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			$autotrigger = GETPOST('autotrigger', 'alpha') ? GETPOST('autotrigger', 'alpha') : null;
 			$notrigger = ($autotrigger == 'on') ? 0 : 1;
 
+			$attendeereplace = new ConferenceOrBoothAttendee($db);
+			$tempObj = new ConferenceOrBoothAttendee($db);
 			if (isset($attendeesource->fk_replacement) && $attendeesource->fk_replacement == $select_replace_attendee) {
 				$fetchReplace = 0;
 			} elseif ($select_replace_attendee > 0) {
-				$attendeereplace = new ConferenceOrBoothAttendee($db);
 				$fetchReplace = $attendeereplace->fetch($select_replace_attendee);
 			} else {
 				$fetchReplace = null;
@@ -783,7 +776,6 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				$any_existing_fk_replacement = $attendeesource->fk_replacement;
 				$check_any_existing_fk_replacement = 0;
 				if ($any_existing_fk_replacement > 0) {
-					$tempObj = new ConferenceOrBoothAttendee($db);
 					$check_any_existing_fk_replacement = $tempObj->fetch($any_existing_fk_replacement);
 				}
 				if ($check_any_existing_fk_replacement > 0) {

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -718,8 +718,6 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			// Our keys (-1, 1, 5) are valid for the runtime logic but violate the strict 'string[]' type hint.
 			/** @phan-suppress-next-line PhanTypeMismatchArgument */
 			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToReplace'), $langs->trans('ConfirmReplaceAsk', $attendeestatic->getFullName($langs, 0, -1, 0)), 'confirm_replace_attendee', $formquestion, 'yes', 1);
-		} else {
-		// we should show a popup
 		}
 	}
 

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -726,7 +726,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && $id > 0 && $id == $select_replace_attendee) {
 		$langs->loadLangs(array("eventorganization", "admin"));
 		dol_syslog('Aborted - Attempt to replace attendee='.(int) $id.' with itself!', LOG_WARNING);
-		setEventMessages($langs->trans("SelfReplacement"), null, 'errors');
+		setEventMessages($langs->trans("ErrorCannotReplaceSelf2"), null, 'errors');
 	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && ($select_replace_attendee > 0 || $select_replace_attendee == -2)) {
 		$langs->loadLangs(array("eventorganization", "errors", "blockedlog", "bills", "main"));
 		// can not reuse attendeestatic because I modify it

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -676,6 +676,10 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			// Clone
 			print dolGetButtonAction('', $langs->trans('ToClone'), 'clone', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=clone&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
 
+			// Replace
+			$langs->loadLangs(array("productbatch"));
+			print dolGetButtonAction('', $langs->trans('ToReplace'), 'replace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=replace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
+
 			// Delete (need delete permission, or if draft, just need create/modify permission)
 			print dolGetButtonAction('', $langs->trans('Delete'), 'delete', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=delete&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontodelete || ($object->status == $object::STATUS_DRAFT && $permissiontoadd));
 		}

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -645,6 +645,20 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 	include DOL_DOCUMENT_ROOT.'/core/tpl/commonfields_view.tpl.php';
 
+    $chain = $object->getReplacementChain();
+	print '<!-- getReplacementChain -->';
+    if (!empty($chain)) {
+        print '<tr><td class="titlefield">Replaces Chain:</td><td>';
+        // Re-use your showOutputField logic or print directly
+        $html = '';
+        foreach ($chain as $index => $person) {
+            if ($index > 0) $html .= ' &rarr; ';
+            $html .= $person->getNomUrl(1, '', 0, '', -1, array('firstname', ' ', 'lastname'));
+        }
+        print $html;
+        print '</td></tr>';
+    }
+
 	// Other attributes. Fields from hook formObjectOptions and Extrafields.
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_view.tpl.php';
 

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -496,6 +496,9 @@ if (!empty($withproject)) {
 
 // Part to create an attendee
 if ($action == 'create' && $confOrBooth === null) {
+	$object->fk_replacement = null;
+	unset($object->fields['fk_replacement']);
+	// because else some preset data showed up in create form? and we don't want it here anyway
 	print load_fiche_titre($langs->trans("NewObject", $langs->transnoentitiesnoconv("ConferenceOrBoothAttendee")), '', 'object_'.$object->picto);
 
 

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -645,20 +645,6 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 	include DOL_DOCUMENT_ROOT.'/core/tpl/commonfields_view.tpl.php';
 
-    $chain = $object->getReplacementChain();
-	print '<!-- getReplacementChain -->';
-    if (!empty($chain)) {
-        print '<tr><td class="titlefield">Replaces Chain:</td><td>';
-        // Re-use your showOutputField logic or print directly
-        $html = '';
-        foreach ($chain as $index => $person) {
-            if ($index > 0) $html .= ' &rarr; ';
-            $html .= $person->getNomUrl(1, '', 0, '', -1, array('firstname', ' ', 'lastname'));
-        }
-        print $html;
-        print '</td></tr>';
-    }
-
 	// Other attributes. Fields from hook formObjectOptions and Extrafields.
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_view.tpl.php';
 

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -609,6 +609,101 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		$formquestion = array();
 		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToClone'), $langs->trans('ConfirmCloneAsk', $object->ref), 'confirm_clone', $formquestion, 'yes', 1);
 	}
+	// Replace confirmation
+	if ($action == 'replace') {
+		$langs->loadLangs(array("productbatch", "eventorganization", "admin", "bills", "main"));
+		$attendeestatic = new ConferenceOrBoothAttendee($db);
+		$fetchme = $attendeestatic->fetch($id);
+		if ($fetchme) {
+			// Create an array for form
+			$formquestion = array();
+
+			$filter = '((t.fk_project:=:' . ((int) $attendeestatic->fk_project) . ') AND (t.status:IN:[' . $attendeestatic::STATUS_VALIDATED . ',' . $attendeestatic::STATUS_DRAFT . ']) AND (t.rowid:!=:' . ((int) $id) . '))';
+			$attendee_list = $attendeestatic->fetchAll('', '', 0, 0, $filter);
+			$reformat_list = array();
+			foreach ($attendee_list as $attendee) {
+				$reformat_list[$attendee->id] = $attendee->getFullName($langs, 0, -1, 0);
+			}
+
+			// 655360? well, 640k is enough for everybody :-D and if I used -1 then it would show very fain where as with 655360 the text is clearly seen, and I can not use 0, because that is draft :-(
+			$source_status_list = array();
+			$source_status_list[655360] = $langs->trans("IsBefore");
+			foreach ($attendeestatic->list_possible_status as $statusid) {
+				$source_status_list[(int) $statusid] = $attendeestatic->LibStatut($statusid, 1);
+			}
+			$replace_status_list = array();
+			$replace_status_list[655360] = $langs->trans("Copy");
+			foreach ($attendeestatic->list_possible_status as $statusid) {
+				$replace_status_list[(int) $statusid] = $attendeestatic->LibStatut($statusid, 1);
+			}
+			$select_replace_attendee = $langs->trans("Select").' '.$langs->trans("InvoiceReplacementShort").' '.$langs->trans("ConferenceOrBoothAttendee");
+			/**
+			 * @var array<array{
+			 *   name: string,
+			 *   label: string,
+			 *   type: 'select'|'checkbox',
+			 *   values?: array<int|string, string>,
+			 *   default?: string|int,
+			 *   value?: int,
+			 *   inputko?: int
+			 * }>
+			 */
+			$formquestion = [
+				// 1. Single-select: Replacement Attendee
+				[
+					'name'     => 'select_replace_attendee',
+					'label'    => $select_replace_attendee,
+					'type'     => 'select',
+					'values'   => (array) $reformat_list,
+				],
+
+				// 2. Single-select: Source Status after replacement
+				[
+					'name'     => 'oldobject_status',
+					'label'    => $langs->trans("Source").' &ndash; '.$langs->trans("SetToStatus"),
+					'type'     => 'select',
+					'values'   => (array) $source_status_list,
+					'default'  => 13,
+				],
+
+				// 3. Single-select: Replacement Status after replacing
+				[
+					'name'     => 'newobject_status',
+					'label'    => $langs->trans("ToReplace").' &ndash; '.$langs->trans("SetToStatus"),
+					'type'     => 'select',
+					'values'   => (array) $replace_status_list,
+					'default'  => 1,
+				],
+
+				// 4. Checkbox: Auto trigger replace of Source
+				[
+					'name'    => 'autotrigger_source',
+					'label'   => $langs->trans("Source").' &ndash; '.$langs->trans("AutomaticTrigger"),
+					'type'    => 'checkbox',
+					'value'   => 1,
+					'default' => 1,
+					'inputko' => 1,
+				],
+
+				// 5. Checkbox: Auto trigger replace of replace
+				[
+					'name'    => 'autotrigger_replace',
+					'label'   => $langs->trans("ToReplace").' &ndash; '.$langs->trans("AutomaticTrigger"),
+					'type'    => 'checkbox',
+					'value'   => 1,
+					'default' => 1,
+					'inputko' => 1,
+				]
+			];
+
+			// Reason: The function expects 'string[]' (indexed 0,1,2), but Dolibarr requires associative arrays (Key=>Label) for selects.
+			// Our keys (-1, 1, 5) are valid for the runtime logic but violate the strict 'string[]' type hint.
+			/** @phan-suppress-next-line PhanTypeMismatchArgument */
+			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToReplace'), $langs->trans('ConfirmCloneAsk', $attendeestatic->getFullName($langs, 0, -1, 0)), 'confirm_replace_attendee', $formquestion, 'yes', 1);
+		} else {
+		// we should show a popup
+		}
+	}
 
 	// Call Hook formConfirm
 	$parameters = array('formConfirm' => $formconfirm, 'lineid' => $lineid);

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -2,7 +2,8 @@
 /* Copyright (C) 2017		Laurent Destailleur			<eldy@users.sourceforge.net>
  * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2025  Frédéric France         	<frederic.france@free.fr>
+ * Copyright (C) 2026       Jon Bendtsen	         	<jon.bendtsen.github@jonb.dk>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -70,6 +70,7 @@ $withproject = 1;
 
 // Initialize a technical objects
 $object = new ConferenceOrBoothAttendee($db);
+$attendeestatic = new ConferenceOrBoothAttendee($db);
 $extrafields = new ExtraFields($db);
 $projectstatic = new Project($db);
 $diroutputmassaction = $conf->eventorganization->dir_output.'/temp/massgeneration/'.$user->id;
@@ -612,7 +613,6 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	// Replace confirmation
 	if ($action == 'replace') {
 		$langs->loadLangs(array("productbatch", "eventorganization", "admin", "bills", "main"));
-		$attendeestatic = new ConferenceOrBoothAttendee($db);
 		$fetchme = $attendeestatic->fetch($id);
 		if ($fetchme) {
 			// Create an array for form
@@ -677,18 +677,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 				// 4. Checkbox: Auto trigger replace of Source
 				[
-					'name'    => 'autotrigger_source',
-					'label'   => $langs->trans("Source").' &ndash; '.$langs->trans("AutomaticTrigger"),
-					'type'    => 'checkbox',
-					'value'   => 1,
-					'default' => 1,
-					'inputko' => 1,
-				],
-
-				// 5. Checkbox: Auto trigger replace of replace
-				[
-					'name'    => 'autotrigger_replace',
-					'label'   => $langs->trans("ToReplace").' &ndash; '.$langs->trans("AutomaticTrigger"),
+					'name'    => 'autotrigger',
+					'label'   => $langs->trans("AutomaticTrigger"),
 					'type'    => 'checkbox',
 					'value'   => 1,
 					'default' => 1,
@@ -702,6 +692,75 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToReplace'), $langs->trans('ConfirmCloneAsk', $attendeestatic->getFullName($langs, 0, -1, 0)), 'confirm_replace_attendee', $formquestion, 'yes', 1);
 		} else {
 		// we should show a popup
+		}
+	}
+
+	// Action clone object
+	$select_replace_attendee = GETPOSTINT('select_replace_attendee');
+	if ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && $select_replace_attendee < 1) {
+		$langs->loadLangs(array("eventorganization", "errors"));
+		setEventMessages($langs->trans("ErrorGlobalVariableUpdater2", $langs->trans("Attendee")), null, 'errors');
+	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && $select_replace_attendee > 0 && $id == $select_replace_attendee) {
+		$langs->loadLangs(array("eventorganization", "admin"));
+		dol_syslog('Aborted - Attempt to replace attendee='.(int) $id.' with itself!', LOG_WARNING);
+		setEventMessages($langs->trans("Attendee").' '.$langs->trans("ReplacedBy").' '.$langs->trans("Attendee"), $langs->trans("IgnoreDuplicateRecords"), 'errors');
+	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && $select_replace_attendee > 0) {
+		$langs->loadLangs(array("eventorganization", "errors", "blockedlog", "bills"));
+		// can not reuse attendeestatic because I modify it
+		$attendeesource = new ConferenceOrBoothAttendee($db);
+		if ($id > 0) {
+			$fetchme = $attendeesource->fetch($id);
+		} else {
+			dol_syslog('Attendee='.(int) $id.' not found', LOG_WARNING);
+			setEventMessages($langs->trans("ErrorObjectNotFound", $langs->trans("Attendee")), null, 'errors');
+			$fetchme = 0;
+		}
+		if ($fetchme > 0 && $attendeesource->fk_project > 0) {
+			$fetchproject = $projectstatic->fetch($attendeesource->fk_project);
+		} else {
+			dol_syslog('fk_project='.(string) $attendeesource->fk_project.' on attendee='.(int) $id.' not found', LOG_WARNING);
+			setEventMessages($langs->trans("ErrorObjectNotFound", $langs->trans("ProjectRef")), null, 'errors');
+			$fetchproject = 0;
+		}
+		if ($fetchproject > 0) {
+			$userHasProjectRights = $projectstatic->restrictedProjectArea($user, 'write');
+		} else {
+			$userHasProjectRights = null;
+		}
+
+		if ($userHasProjectRights < 1) {
+			dol_syslog('User='.$user->id.' has no write access to project='.$attendeesource->fk_project, LOG_WARNING);
+			setEventMessages($langs->trans("Project").': '.$langs->trans("ErrorForbidden2"), null, 'errors');
+		} else {
+			$oldobject_status_id = GETPOSTINT('oldobject_status');
+			$newobject_status_id = GETPOSTINT('newobject_status');
+			$oldobject_status_id = (is_null($oldobject_status_id) || is_numeric($oldobject_status_id)) ? (int) $oldobject_status_id : (int) 13; // default is set the old objects status to 13 (replaced)
+			$newobject_status_id = (is_null($newobject_status_id) || is_numeric($newobject_status_id)) ? (int) $newobject_status_id : (int) 1;  // default for new replaced attendee to 1 (registered)
+
+			$autotrigger = GETPOST('autotrigger', 'alpha') ? GETPOST('autotrigger', 'alpha') : null;
+			$notrigger = ($autotrigger == 'on') ? 0 : 1;
+
+			$attendeereplace = new ConferenceOrBoothAttendee($db);
+			$fetchReplace = $attendeereplace->fetch($select_replace_attendee);
+			if ($fetchReplace) {
+				$replaceResult = $attendeesource->replaceMeWithAttendee($user, $attendeereplace, $newobject_status_id, $oldobject_status_id, $notrigger);
+				if ($replaceResult > 0) {
+					dol_syslog('Replacing attendee='.$id.' with attendee='.$select_replace_attendee, LOG_INFO);
+					$label_config = array('firstname', ' ', 'lastname');
+					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("ReplacedBy").' '.$attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config);
+					setEventMessages($info_message, null, 'mesgs');
+					$url = htmlspecialchars($_SERVER['PHP_SELF']) . '?id=' . $id;
+					echo '<meta http-equiv="refresh" content="0;url=' . $url . '">';
+					echo '<p>Redirecting to <a href="' . $url . '">new page</a>...</p>';
+					exit;
+					// header() method does not work, it gives this error
+					// PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/html/main.inc.php:2098)
+				}  else {
+					setEventMessages($attendeesource->error, null, 'errors');
+				}
+			} else {
+				setEventMessages($langs->trans("ErrorObjectNotFound", $langs->trans("InvoiceReplacementShort").' '.$langs->trans("Attendee")), null, 'errors');
+			}
 		}
 	}
 

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -794,7 +794,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			if ($replaceResult > 0) {
 				dol_syslog('Replacing attendee='.$id.' with attendee='.$select_replace_attendee, LOG_INFO);
 				if ($select_replace_attendee == -2) {
-					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("Reset").' '.$langs->trans("ReplacedBy");
+					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).': '.$langs->trans("Reset").' '.$langs->trans("ReplacedBy");
 				} else {
 					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("ReplacedBy").' '.$attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config);
 				}

--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -613,7 +613,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		$formquestion = array();
 		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToClone'), $langs->trans('ConfirmCloneAsk', $object->ref), 'confirm_clone', $formquestion, 'yes', 1);
 	}
-	// Replace or undo replace confirmation popup
+	// popup to confirmation Set replace or edit replace
 	if ($action == 'replace' || $action == 'undoreplace') {
 		$langs->loadLangs(array("productbatch", "eventorganization", "admin", "bills", "main"));
 		$fetchme = $attendeestatic->fetch($id);
@@ -630,16 +630,16 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 			// 655360? well, 640k is enough for everybody :-D and if I used -1 then it would show very fain where as with 655360 the text is clearly seen, and I can not use 0, because that is draft :-(
 			$source_status_list = array();
-			$source_status_list[655360] = $langs->trans("IsBefore");
+			$source_status_list[655360] = $langs->trans("Unchanged");
 			foreach ($attendeestatic->list_possible_status as $statusid) {
 				$source_status_list[(int) $statusid] = $attendeestatic->LibStatut($statusid, 1);
 			}
 			$replace_status_list = array();
-			$replace_status_list[655360] = $langs->trans("Copy");
+			$replace_status_list[655360] = $langs->trans("CopyOriginal");
 			foreach ($attendeestatic->list_possible_status as $statusid) {
 				$replace_status_list[(int) $statusid] = $attendeestatic->LibStatut($statusid, 1);
 			}
-			$select_replace_attendee = $langs->trans("Select").' '.$langs->trans("InvoiceReplacementShort").' '.$langs->trans("ConferenceOrBoothAttendee");
+			$select_replace_attendee = $langs->trans("SelectOneReplacementAttendee");
 			/**
 			 * @var array<array{
 			 *   name: string,
@@ -661,14 +661,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				];
 				$oldstatus_selection_list = [
 					'name'     => 'oldobject_status',
-					'label'    => $langs->trans("Source").' &ndash; '.$langs->trans("SetToStatus"),
+					'label'    => $langs->trans("OriginalAttendee").' &ndash; '.$langs->trans("SetToStatus"),
 					'type'     => 'select',
 					'values'   => (array) $source_status_list,
 					'default'  => 13,
 				];
 				$newstatus_selection_list = [
 					'name'     => 'newobject_status',
-					'label'    => $langs->trans("ToReplace").' &ndash; '.$langs->trans("SetToStatus"),
+					'label'    => $langs->trans("ReplacementAttendee").' &ndash; '.$langs->trans("SetToStatus"),
 					'type'     => 'select',
 					'values'   => (array) $replace_status_list,
 					'default'  => 1,
@@ -684,14 +684,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				];
 				$oldstatus_selection_list = [
 					'name'     => 'oldobject_status',
-					'label'    => $langs->trans("Source").' &ndash; '.$langs->trans("SetToStatus"),
+					'label'    => $langs->trans("OriginalAttendee").' &ndash; '.$langs->trans("SetToStatus"),
 					'type'     => 'select',
 					'values'   => (array) $source_status_list,
 					'default'  => 1,
 				];
 				$newstatus_selection_list = [
 					'name'     => 'newobject_status',
-					'label'    => $langs->trans("ToReplace").' &ndash; '.$langs->trans("SetToStatus"),
+					'label'    => $langs->trans("ReplacementAttendee").' &ndash; '.$langs->trans("SetToStatus"),
 					'type'     => 'select',
 					'values'   => (array) $replace_status_list,
 					'default'  => 0,
@@ -712,7 +712,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			// Reason: The function expects 'string[]' (indexed 0,1,2), but Dolibarr requires associative arrays (Key=>Label) for selects.
 			// Our keys (-1, 1, 5) are valid for the runtime logic but violate the strict 'string[]' type hint.
 			/** @phan-suppress-next-line PhanTypeMismatchArgument */
-			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToReplace'), $langs->trans('ConfirmCloneAsk', $attendeestatic->getFullName($langs, 0, -1, 0)), 'confirm_replace_attendee', $formquestion, 'yes', 1);
+			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToReplace'), $langs->trans('ConfirmReplaceAsk', $attendeestatic->getFullName($langs, 0, -1, 0)), 'confirm_replace_attendee', $formquestion, 'yes', 1);
 		} else {
 		// we should show a popup
 		}
@@ -722,11 +722,11 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	$select_replace_attendee = GETPOSTINT('select_replace_attendee');
 	if ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && $select_replace_attendee == -1) {
 		$langs->loadLangs(array("eventorganization", "errors"));
-		setEventMessages($langs->trans("ErrorGlobalVariableUpdater2", $langs->trans("Attendee")), null, 'errors');
+		setEventMessages($langs->trans("NoReplacementAttendeeSelected"), null, 'errors');
 	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && $id > 0 && $id == $select_replace_attendee) {
 		$langs->loadLangs(array("eventorganization", "admin"));
 		dol_syslog('Aborted - Attempt to replace attendee='.(int) $id.' with itself!', LOG_WARNING);
-		setEventMessages($langs->trans("Attendee").' '.$langs->trans("ReplacedBy").' '.$langs->trans("Attendee"), $langs->trans("IgnoreDuplicateRecords"), 'errors');
+		setEventMessages($langs->trans("SelfReplacement"), null, 'errors');
 	} elseif ($action == 'confirm_replace_attendee' && $confirm == 'yes' && !empty($permissiontoadd) && ($select_replace_attendee > 0 || $select_replace_attendee == -2)) {
 		$langs->loadLangs(array("eventorganization", "errors", "blockedlog", "bills", "main"));
 		// can not reuse attendeestatic because I modify it
@@ -753,7 +753,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 		if ($userHasProjectRights < 1) {
 			dol_syslog('User='.$user->id.' has no write access to project='.$attendeesource->fk_project, LOG_WARNING);
-			setEventMessages($langs->trans("Project").': '.$langs->trans("ErrorForbidden2"), null, 'errors');
+			setEventMessages($langs->trans("NoProjectWritePermission"), null, 'errors');
 		} else {
 			$label_config = array('firstname', ' ', 'lastname', ' (#', 'id', ')');
 			$oldobject_status_id = GETPOSTINT('oldobject_status');
@@ -784,22 +784,22 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				if ($check_any_existing_fk_replacement > 0) {
 					$force_fk_replacement = 1;
 					dol_syslog('Source attendee='.$id.' already had fk_replacement='.$any_existing_fk_replacement.' now replaced with new value='.$select_replace_attendee, LOG_WARNING);
-					$warn_message = $langs->trans("Warning").': '.$langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("OldValue", $tempObj->getNomUrl(1, '', 0, '', -1, $label_config)).' '.$langs->trans("ReplacedBy").' '.$attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config);
+					$warn_message = $langs->trans("ExistingAttendeeReplacementTarget", $attendeesource->getNomUrl(1, '', 0, '', -1, $label_config), $tempObj->getNomUrl(1, '', 0, '', -1, $label_config), $attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config));
 					setEventMessages($warn_message, null, 'warnings');
 				} else {
 					$force_fk_replacement = 0;
 				}
 				$replaceResult = $attendeesource->replaceMeWithAttendee($user, $attendeereplace, $newobject_status_id, $oldobject_status_id, $notrigger, $force_fk_replacement);
 			} else {
-				setEventMessages($langs->trans("ErrorObjectNotFound", $langs->trans("InvoiceReplacementShort").' '.$langs->trans("Attendee")), null, 'errors');
+				setEventMessages($langs->trans("ErrorObjectNotFound", $langs->trans("ReplacementAttendee")), null, 'errors');
 			}
 
 			if ($replaceResult > 0) {
 				dol_syslog('Replacing attendee='.$id.' with attendee='.$select_replace_attendee, LOG_INFO);
 				if ($select_replace_attendee == -2) {
-					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).': '.$langs->trans("Reset").' '.$langs->trans("ReplacedBy");
+					$info_message = $langs->trans("AttendeeReplacementSourceReset", $attendeesource->getNomUrl(1, '', 0, '', -1, $label_config));
 				} else {
-					$info_message = $langs->trans("Attendee").' '.$attendeesource->getNomUrl(1, '', 0, '', -1, $label_config).' '.$langs->trans("ReplacedBy").' '.$attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config);
+					$info_message = $langs->trans("AttendeeReplacedBy", $attendeesource->getNomUrl(1, '', 0, '', -1, $label_config), $attendeereplace->getNomUrl(1, '', 0, '', -1, $label_config));
 				}
 				setEventMessages($info_message, null, 'mesgs');
 				$url = htmlspecialchars($_SERVER['PHP_SELF']) . '?id=' . $id;
@@ -808,8 +808,28 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 				exit;
 				// header() method does not work, it gives this error
 				// PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/html/main.inc.php:2098)
-			}  else {
-				setEventMessages($attendeesource->error, null, 'errors');
+			} else {
+				// Map error codes to numbered translation keys
+				$transKeys = array(
+					-1 => 'ErrorStatusNotAllowed1',
+					-2 => 'ErrorCannotReplaceSelf2',
+					-3 => 'ErrorInvalidStatusReplacement3',
+					-4 => 'ErrorInvalidStatusSource4',
+					-5 => 'ErrorAlreadyHasReplacement5',
+					-6 => 'ErrorNothingToUndo6',
+					-7 => 'ErrorChainNotEmpty7',
+					-8 => 'ErrorFetchFailed8'
+				);
+
+				if (isset($transKeys[$replaceResult])) {
+					$error_msg = $langs->trans($transKeys[$replaceResult]);
+				} else {
+					// Fallback for unknown error codes using core Dolibarr error key
+					// Format: "Unknown error '%s'" where %s is the code
+					$error_msg = $langs->trans("ErrorPriceExpressionUnknown", $replaceResult);
+				}
+
+				setEventMessages($error_msg, null, 'errors');
 			}
 		}
 	}
@@ -885,7 +905,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 			if (empty($object->fk_replacement)) {
 				print dolGetButtonAction('', $langs->trans('ToReplace'), 'replace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=replace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
 			} else {
-				print dolGetButtonAction('', $langs->trans("EditReplacement").' '.$langs->trans('ToReplace'), 'undoreplace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=undoreplace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
+				print dolGetButtonAction('', $langs->trans("EditReplacement"), 'undoreplace', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=undoreplace&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontoadd);
 			}
 			// Delete (need delete permission, or if draft, just need create/modify permission)
 			print dolGetButtonAction('', $langs->trans('Delete'), 'delete', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=delete&token='.newToken().(!empty($projectstatic->id) ? '&fk_project='.$projectstatic->id : ''), '', $permissiontodelete || ($object->status == $object::STATUS_DRAFT && $permissiontoadd));

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -1113,7 +1113,7 @@ while ($i < $imaxinloop) {
 					}
 					print $object->getNomUrl(1, $optionLink);
 				} else {
-					$label_config = array('firstname', ' (#', 'id', ')');
+					$label_config = array('firstname', ' #', 'id');
 					print $object->showOutputField($val, $key, (string) $object->$key, '', '', '', '', $label_config);
 				}
 				print '</td>';

--- a/htdocs/eventorganization/conferenceorboothattendee_list.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_list.php
@@ -1113,7 +1113,8 @@ while ($i < $imaxinloop) {
 					}
 					print $object->getNomUrl(1, $optionLink);
 				} else {
-					print $object->showOutputField($val, $key, (string) $object->$key, '');
+					$label_config = array('firstname', ' (#', 'id', ')');
+					print $object->showOutputField($val, $key, (string) $object->$key, '', '', '', '', $label_config);
 				}
 				print '</td>';
 				if (!$i) {

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -530,6 +530,5 @@ ALTER TABLE llx_product_warehouse_properties ADD INDEX idx_product_warehouse_pro
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_product FOREIGN KEY (fk_product) REFERENCES llx_product (rowid);
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_entrepot FOREIGN KEY (fk_entrepot) REFERENCES llx_entrepot (rowid);
 
-ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD COLUMN fk_replacement integer DEFAULT NULL;
-
+ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD COLUMN fk_replacement integer DEFAULT NULL, ADD UNIQUE INDEX uk_fk_replacement (fk_replacement);
 -- end of migration

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -532,9 +532,9 @@ ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse
 
 ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD COLUMN fk_replacement integer DEFAULT NULL, ADD UNIQUE INDEX uk_fk_replacement (fk_replacement);
 -- Event Organization: Replacement Triggers
-INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', 'Attendee Replaced (Source)', 'Triggered when an attendee is replaced by another.', 'conferenceorboothattendee', 2461);
-INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT', 'Attendee Replaced (Target)', 'Triggered when an attendee becomes a replacement.', 'conferenceorboothattendee', 2462);
-INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET', 'Attendee Replacement Reset (Source)', 'Triggered when a replacement is undone for the source.', 'conferenceorboothattendee', 2463);
-INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', 'Attendee Replacement Reset (Target)', 'Triggered when a replacement is undone for the target.', 'conferenceorboothattendee', 2464);
+INSERT INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', 'Attendee Replaced (Source)', 'Triggered when an attendee is replaced by another.', 'conferenceorboothattendee', 2461);
+INSERT INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT', 'Attendee Replaced (Target)', 'Triggered when an attendee becomes a replacement.', 'conferenceorboothattendee', 2462);
+INSERT INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET', 'Attendee Replacement Reset (Source)', 'Triggered when a replacement is undone for the source.', 'conferenceorboothattendee', 2463);
+INSERT INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', 'Attendee Replacement Reset (Target)', 'Triggered when a replacement is undone for the target.', 'conferenceorboothattendee', 2464);
 
 -- end of migration

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -531,4 +531,10 @@ ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_entrepot FOREIGN KEY (fk_entrepot) REFERENCES llx_entrepot (rowid);
 
 ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD COLUMN fk_replacement integer DEFAULT NULL, ADD UNIQUE INDEX uk_fk_replacement (fk_replacement);
+-- Event Organization: Replacement Triggers
+INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC', 'Attendee Replaced (Source)', 'Triggered when an attendee is replaced by another.', 'conferenceorboothattendee', 2461);
+INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT', 'Attendee Replaced (Target)', 'Triggered when an attendee becomes a replacement.', 'conferenceorboothattendee', 2462);
+INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET', 'Attendee Replacement Reset (Source)', 'Triggered when a replacement is undone for the source.', 'conferenceorboothattendee', 2463);
+INSERT IGNORE INTO llx_c_action_trigger (code, label, description, elementtype, rang) VALUES ('CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET', 'Attendee Replacement Reset (Target)', 'Triggered when a replacement is undone for the target.', 'conferenceorboothattendee', 2464);
+
 -- end of migration

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -530,4 +530,6 @@ ALTER TABLE llx_product_warehouse_properties ADD INDEX idx_product_warehouse_pro
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_product FOREIGN KEY (fk_product) REFERENCES llx_product (rowid);
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_entrepot FOREIGN KEY (fk_entrepot) REFERENCES llx_entrepot (rowid);
 
+ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD COLUMN fk_replacement integer DEFAULT NULL;
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.key.sql
+++ b/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.key.sql
@@ -26,3 +26,4 @@ ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD INDEX idx_evento
 -- Note if we add the entity, we want the ref numbering rule per entity, so we must add entity in constraint.
 ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD UNIQUE INDEX uk_eventorganization_confboothattendee (ref);
 ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD UNIQUE INDEX uk_eventorganization_conferenceorboothattendee(fk_project, email, fk_actioncomm);
+ALTER TABLE llx_eventorganization_conferenceorboothattendee ADD UNIQUE INDEX uk_fk_replacement (fk_replacement);

--- a/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.sql
+++ b/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.sql
@@ -38,6 +38,7 @@ CREATE TABLE llx_eventorganization_conferenceorboothattendee(
 	ip varchar(250),              --ip used to create record (for public submission page)
 	import_key varchar(14),
 	model_pdf varchar(255),
-	status smallint NOT NULL
+	status smallint NOT NULL,
+	fk_replacement integer NULL
 	-- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;

--- a/htdocs/langs/en_US/eventorganization.lang
+++ b/htdocs/langs/en_US/eventorganization.lang
@@ -91,11 +91,32 @@ EvntOrgConfirmed = Confirmed
 EvntOrgNotQualified = Not Qualified
 EvntOrgDone = Done
 EvntOrgCancelled = Canceled
+# Replacement
+ConfirmReplaceAsk=Are you sure you want to replace the attendee <b>%s</b>?
+SelectOneReplacementAttendee=Select 1 replacement attendee
+OriginalAttendee=Original attendee
+ReplacementAttendee=Replacement attendee
+NoReplacementAttendeeSelected=No replacement attendee selected
+SelfReplacement=You can not replace an attendee with itself, make different selection
+CopyOriginal=Copy original
+Unchanged=Unchanged
+Replaced=Replaced
+This=This
+# Replacement Errors
+ErrorStatusNotAllowed1=Cannot replace attendee, current attendee status prevents replacement.
+ErrorCannotReplaceSelf2=Cannot replace an attendee with itself.
+ErrorInvalidStatusReplacement3=Invalid status for the replacement attendee.
+ErrorInvalidStatusSource4=Unknown new status for the source attendee, aborting.
+ErrorAlreadyHasReplacement5=Attendee already has a replacement.
+ErrorNothingToUndo6=No replacement to undo.
+ErrorChainNotEmpty7=Cannot undo replacement. The current replacement is itself replaced. Please undo the downstream replacement first.
+ErrorFetchFailed8=Failed to fetch replacement attendee data.
 # Agenda
 AttendeeReplacedBy=Attendee %s replaced by %s
 AttendeeBecameReplacementFor=Attendee %s became replacement for %s
-AttendeeReplacementSourceReset=Replacement attendee for %s reset
+AttendeeReplacementSourceReset=Undid replacement for %s
 AttendeeReplacementTargetReset=%s is no longer a replacement attendee
+ExistingAttendeeReplacementTarget=Warning: %s original replacement %s was changed to %s
 # Other
 SuggestForm = Suggestion page
 SuggestOrVoteForConfOrBooth = Page for suggestion or vote
@@ -170,3 +191,4 @@ Confirmed=Confirmed
 NotSelected=Not selected
 TheLinkIsAvailableOnTheProjectEventCard=The links to suggest or vote for a conference or apply for a booth is provided into the page of the project/event
 ShowedUp=Showed up
+NoProjectWritePermission=User has no write permission to this project

--- a/htdocs/langs/en_US/eventorganization.lang
+++ b/htdocs/langs/en_US/eventorganization.lang
@@ -97,6 +97,7 @@ SelectOneReplacementAttendee=Select 1 replacement attendee
 OriginalAttendee=Original attendee
 ReplacementAttendee=Replacement attendee
 NoReplacementAttendeeSelected=No replacement attendee selected
+NoChangeMade=No change was made. The replacement remains the same.
 CopyOriginal=Copy original
 Unchanged=Unchanged
 Replaced=Replaced

--- a/htdocs/langs/en_US/eventorganization.lang
+++ b/htdocs/langs/en_US/eventorganization.lang
@@ -91,9 +91,15 @@ EvntOrgConfirmed = Confirmed
 EvntOrgNotQualified = Not Qualified
 EvntOrgDone = Done
 EvntOrgCancelled = Canceled
+# Agenda
+AttendeeReplacedBy=Attendee %s replaced by %s
+AttendeeBecameReplacementFor=Attendee %s became replacement for %s
+AttendeeReplacementSourceReset=Replacement attendee for %s reset
+AttendeeReplacementTargetReset=%s is no longer a replacement attendee
 # Other
 SuggestForm = Suggestion page
 SuggestOrVoteForConfOrBooth = Page for suggestion or vote
+EditReplacement=Edit Replacement
 EvntOrgRegistrationHelpMessage = Here, you can vote for a conference or suggest a new one for the event. You can also apply to have a booth during the event.
 EvntOrgRegistrationConfHelpMessage = Here, you can suggest a new conference to animate during the event.
 EvntOrgRegistrationBoothHelpMessage = Here, you can apply to have a booth during the event.

--- a/htdocs/langs/en_US/eventorganization.lang
+++ b/htdocs/langs/en_US/eventorganization.lang
@@ -97,7 +97,6 @@ SelectOneReplacementAttendee=Select 1 replacement attendee
 OriginalAttendee=Original attendee
 ReplacementAttendee=Replacement attendee
 NoReplacementAttendeeSelected=No replacement attendee selected
-SelfReplacement=You can not replace an attendee with itself, make different selection
 CopyOriginal=Copy original
 Unchanged=Unchanged
 Replaced=Replaced


### PR DESCRIPTION
# NEW #38127 replace Event Attendee with another Event Attendee
Applying this PR will make it possible to replace 1 event attendee with another event attendee.

A popup asking you to confirm allows selecting an attendee - where list does not include the attendee to be replaced.
Same popup can be used to undo a replacement if it was done wrongly or by mistake.

This popup has automatic triggering enabled, but user can disable it.

The user can independently select the new status for both the original and/or the replacement with some sane defaults.

No dangling fk_replacements should be possible.

Replacement chains are possible, and whereever the currently viewed attendee is, to make it more clear to the user, the word `This` is used and it has a different color.
Same replacement chain shows up in lists, though here only the first name is shown to make it shorter. To accommodate for similar or identical names the rowid is also shown.

Changes are logged in the agenda. The last 10 agenda events for an attendee is not shown like on eg. orders, because showing this is a general change which is not specific to attendee replacement.

### Technical Changes
Database Schema
New Column: fk_replacement (integer, nullable) in llx_eventorganization_conferenceorboothattendee.
New Index: Unique index uk_fk_replacement to ensure an attendee can only be a replacement for one person at a time.
New Status: STATUS_REPLACED (13) to track replaced attendees.

### Triggers & Events
New Triggers:
CONFERENCEORBOOTHATTENDEE_REPLACED_SRC
CONFERENCEORBOOTHATTENDEE_REPLACED_TGT
CONFERENCEORBOOTHATTENDEE_REPLACED_SRC_RESET
CONFERENCEORBOOTHATTENDEE_REPLACED_TGT_RESET


### Translation Keys Added
Errors: ErrorReplaceStatusNotAllowed, ErrorReplaceSelf, ErrorReplaceChainNotEmpty, etc.
Agenda: AttendeeReplacedBy, AttendeeBecameReplacementFor, AttendeeReplacementSourceReset.
UI: EditReplacement, ToReplace, This, Replaced.


This PR should close #38127

## Screenshots

### First replacement
<img width="547" height="275" alt="image" src="https://github.com/user-attachments/assets/f0e5024d-8c2b-4865-ba04-f2559edb1ae9" />

### Replacement chain on attendee card
<img width="692" height="576" alt="image" src="https://github.com/user-attachments/assets/465f4f7a-f9ba-4b5e-902c-d5739c89f26c" />

### Replacement chain in list of attendees, just the replacement column
<img width="228" height="327" alt="image" src="https://github.com/user-attachments/assets/477dd5b5-7af4-4f4a-bc5a-a7e788e0b589" />

### Re-editing the replacement
<img width="544" height="275" alt="image" src="https://github.com/user-attachments/assets/881dc199-6499-4c69-8e82-0ff58146329c" />

<img width="612" height="300" alt="image" src="https://github.com/user-attachments/assets/493d794c-e8e4-4dcc-8601-8f55bb1434a0" />

### Agenda view on project
<img width="598" height="769" alt="image" src="https://github.com/user-attachments/assets/ecf279d1-4896-4485-afa2-748bd95051f2" />




