### PR TITLE
NEW show last 10 events on conference attendee card

### DIFF
--- a/htdocs/eventorganization/conferenceorboothattendee_card.php
+++ b/htdocs/eventorganization/conferenceorboothattendee_card.php
@@ -716,6 +716,18 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 		print '</div><div class="fichehalfright">';
 
+		$MAXEVENT = 10;
+
+		$morehtmlcenter = '<div class="nowraponall">';
+		$morehtmlcenter .= dolGetButtonTitle($langs->trans('FullConversation'), '', 'fa fa-comments imgforviewmode', DOL_URL_ROOT.'/societe/messaging.php?socid='.$object->id);
+		$morehtmlcenter .= dolGetButtonTitle($langs->trans('FullList'), '', 'fa fa-bars imgforviewmode', DOL_URL_ROOT.'/societe/agenda.php?socid='.$object->id);
+		$morehtmlcenter .= '</div>';
+
+		// List of actions on element
+		include_once DOL_DOCUMENT_ROOT.'/core/class/html.formactions.class.php';
+		$formactions = new FormActions($db);
+		$somethingshown = $formactions->showactions($object, 'conferenceorboothattendee', 0, 1, '', $MAXEVENT, '', $morehtmlcenter); // Show all action for attendee
+
 		print '</div></div>';
 	}
 


### PR DESCRIPTION
# NEW #38165 show last 10 events on conference attendee card
Applying this PR will show the last 10 events for a given conference attendee when viewing it on a conference attendee card.

This PR would close #38165.

PR is almost direct copy from thirdparty card.

## Screenshot

This screenshot is from Dolibarr installation which was used to develop #38164, thus it shows Attendee replacement which is not yet in Dolibarr.

<img width="723" height="435" alt="image" src="https://github.com/user-attachments/assets/a37e32c7-805e-4afa-b4a7-29f05e4c5e21" />
