### PR TITLE
FIX: Allow editing quantity to produce on MO while in draft status

### DIFF
--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -268,6 +268,46 @@ if (empty($reshook)) {
 	}
 
 
+	// Allow editing qty while MO is still in draft status.
+	// IMPORTANT: this handler MUST run BEFORE actions_addupdatedelete.inc.php,
+	// which has a generic 'set<key>' matcher that would intercept 'setqty' and
+	// call $object->fetch() + update() without setting $object->oldQty, so
+	// Mo::updateProduction() would skip the line scaling (its condition is
+	// !empty($this->oldQty)).
+	if ($action == 'setqty' && $permissiontoadd && $object->status == Mo::STATUS_DRAFT) {
+		$newqty = GETPOSTFLOAT('qty');
+		if ($newqty > 0) {
+			$object->oldQty = (float) $object->qty;
+			$object->qty = $newqty;
+			$res = $object->update($user);
+			if ($res > 0) {
+				// Enforce invariant: the 'toproduce' line for the MO's main product
+				// must equal the MO qty. Mo::updateProduction() scales by ratio
+				// (newQty/oldQty) which can drift if the line state was already
+				// inconsistent (e.g. legacy data from before this patch). Realign
+				// the main product line, leaving sub-products and frozen lines
+				// untouched.
+				$object->fetchLines();
+				foreach ($object->lines as $line) {
+					if ($line->role === 'toproduce'
+						&& (int) $line->fk_product === (int) $object->fk_product
+						&& empty($line->qty_frozen)
+						&& (float) $line->qty != (float) $object->qty) {
+						$line->qty = (float) $object->qty;
+						$line->update($user);
+					}
+				}
+				setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+			} else {
+				setEventMessages($object->error, $object->errors, 'errors');
+			}
+		} else {
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->trans("Qty")), null, 'errors');
+		}
+		header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id);
+		exit;
+	}
+
 	// Actions cancel, add, update, update_extras, confirm_validate, confirm_delete, confirm_deleteline, confirm_clone, confirm_close, confirm_setdraft, confirm_reopen
 	include DOL_DOCUMENT_ROOT.'/core/actions_addupdatedelete.inc.php';
 
@@ -684,6 +724,18 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	$keyforbreak = 'fk_warehouse';
 	unset($object->fields['fk_project']);
 	unset($object->fields['fk_soc']);
+	// Allow inline edit of qty while MO is in draft status.
+	// Note: editfieldval() does not handle type 'real' (no <input> rendered, only
+	// Save/Cancel buttons appear). So we override the type to 'numeric' only when
+	// the user has actually clicked the edit pencil (action=editqty). This keeps
+	// the read-mode rendering (price() format) untouched.
+	if ($object->status == Mo::STATUS_DRAFT && $permissiontoadd && isset($object->fields['qty'])) {
+		$object->fields['qty']['alwayseditable'] = 1;
+		if ($action == 'editqty') {
+			$object->fields['qty']['type'] = 'numeric';
+		}
+	}
+
 	include DOL_DOCUMENT_ROOT.'/core/tpl/commonfields_view.tpl.php';
 
 	// Other attributes

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -163,6 +163,46 @@ if (empty($reshook)) {
 		}
 	}
 
+	// Allow editing qty while MO is still in draft status.
+	// IMPORTANT: this handler MUST run BEFORE actions_addupdatedelete.inc.php,
+	// which has a generic 'set<key>' matcher that would intercept 'setqty' and
+	// call $object->fetch() + update() without setting $object->oldQty, so
+	// Mo::updateProduction() would skip the line scaling (its condition is
+	// !empty($this->oldQty)).
+	if ($action == 'setqty' && $permissiontoadd && $object->status == Mo::STATUS_DRAFT) {
+		$newqty = GETPOSTFLOAT('qty');
+		if ($newqty > 0) {
+			$object->oldQty = (float) $object->qty;
+			$object->qty = $newqty;
+			$res = $object->update($user);
+			if ($res > 0) {
+				// Enforce invariant: the 'toproduce' line for the MO's main product
+				// must equal the MO qty. Mo::updateProduction() scales by ratio
+				// (newQty/oldQty) which can drift if the line state was already
+				// inconsistent (e.g. legacy data from before this patch). Realign
+				// the main product line, leaving sub-products and frozen lines
+				// untouched.
+				$object->fetchLines();
+				foreach ($object->lines as $line) {
+					if ($line->role === 'toproduce'
+						&& (int) $line->fk_product === (int) $object->fk_product
+						&& empty($line->qty_frozen)
+						&& (float) $line->qty != (float) $object->qty) {
+						$line->qty = (float) $object->qty;
+						$line->update($user);
+					}
+				}
+				setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+			} else {
+				setEventMessages($object->error, $object->errors, 'errors');
+			}
+		} else {
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->trans("Qty")), null, 'errors');
+		}
+		header("Location: ".$_SERVER["PHP_SELF"]."?id=".$object->id);
+		exit;
+	}
+
 	// Actions cancel, add, update, delete or clone
 	include DOL_DOCUMENT_ROOT.'/core/actions_addupdatedelete.inc.php';
 
@@ -714,6 +754,18 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	$keyforbreak = 'fk_warehouse';
 	unset($object->fields['fk_project']);
 	unset($object->fields['fk_soc']);
+	// Allow inline edit of qty while MO is in draft status.
+	// Note: editfieldval() does not handle type 'real' (no <input> rendered, only
+	// Save/Cancel buttons appear). So we override the type to 'numeric' only when
+	// the user has actually clicked the edit pencil (action=editqty). This keeps
+	// the read-mode rendering (price() format) untouched.
+	if ($object->status == Mo::STATUS_DRAFT && $permissiontoadd && isset($object->fields['qty'])) {
+		$object->fields['qty']['alwayseditable'] = 1;
+		if ($action == 'editqty') {
+			$object->fields['qty']['type'] = 'numeric';
+		}
+	}
+
 	include DOL_DOCUMENT_ROOT.'/core/tpl/commonfields_view.tpl.php';
 
 	// Other attributes


### PR DESCRIPTION
## FIX: Allow editing quantity to produce on MO while in draft status

### Description

Currently on the MO card (`htdocs/mrp/mo_card.php`) and the MO production view (`htdocs/mrp/mo_production.php`), the field **"Quantity to produce"** (`qty`) is displayed read-only — there is no edit pencil — even when the MO is still in DRAFT status. The only way to fix a wrong quantity entered at MO creation is to delete the MO and recreate it, which is inconvenient when the user has already set up the project, third party, BOM, warehouse, etc.

This PR adds an inline edit pencil next to "Quantity to produce" **only while the MO is in DRAFT status**, using the existing Dolibarr `alwayseditable` mechanism of `commonfields_view.tpl.php`, plus a small custom handler placed at the right position in the action chain.

### Behavior

- **Status = DRAFT**: pencil shown → click → inline input → save updates `llx_mrp_mo.qty`, scales the `toconsume`/`toproduce` lines (`llx_mrp_production`) proportionally to the new quantity via `Mo::update()` → `Mo::updateProduction()`, and realigns the main product `toproduce` line to match the MO qty exactly.
- **Status ≠ DRAFT** (validated, in progress, produced, cancelled): no pencil, field stays read-only as before. A server-side check on `Mo::STATUS_DRAFT` in the `setqty` action handler prevents any modification through a forged request.

### Changes

Two files modified — the MO card is rendered in two distinct pages that both include `commonfields_view.tpl.php`:

- `htdocs/mrp/mo_card.php` (main MO view tab)
- `htdocs/mrp/mo_production.php` (consumption/production view tab)

The same two changes are applied to each file:

1. New `setqty` action handler placed **before** the include of `actions_addupdatedelete.inc.php` (see "Why before the generic include" below). The handler:
   - Checks permission and `STATUS_DRAFT`
   - Validates `qty > 0`
   - Sets `$object->oldQty` then `$object->qty = $newqty`
   - Calls `$object->update($user)` which internally calls `Mo::updateProduction()` to scale BOM lines proportionally
   - Realigns the main product `toproduce` line to match the MO qty exactly
   - Redirects back to the card with a `RecordSaved` message

2. Just before `include commonfields_view.tpl.php`: sets `$object->fields['qty']['alwayseditable'] = 1` when the MO is in DRAFT and the user has write permission. When the user has actually clicked the pencil (`action=editqty`), the type is temporarily overridden from `real` to `numeric` so the form renders correctly (see "Note on real vs numeric" below).

### Why the handler must run before `actions_addupdatedelete.inc.php`

The shared file `htdocs/core/actions_addupdatedelete.inc.php` (line 402) contains a generic regex matcher for `set<key>` actions:

```php
if (preg_match('/^set(\w+)$/', $action, $reg) && GETPOSTINT('id') > 0 && !empty($permissiontoadd)) {
    $object->fetch(GETPOSTINT('id'));
    $object->$keyforfield = GETPOST($keyforfield);
    $result = $object->update($user);
    $action = 'view';
}
```

If our `setqty` handler runs after this include, the generic matcher intercepts the action first. It calls `$object->fetch()` which wipes any prior `oldQty` setup, then `$object->update($user)` without `oldQty`. The condition `!empty($this->oldQty)` in `Mo::updateProduction()` (line 890 of `mo.class.php`) then evaluates to false, so the line scaling loop is skipped entirely. The MO header qty is updated, but `llx_mrp_production.qty` stays at the old value — silent inconsistency.

Placing our handler before the generic include, with `header() + exit;` at the end, ensures we catch the `setqty` action with the correct `oldQty` set first.

### Invariant enforcement

After calling `Mo::update()` (which scales lines proportionally via `updateProduction()`), the handler explicitly re-aligns the `toproduce` line of the MO's main product to match the MO qty exactly. This guards against:

- Legacy data where the line state was already inconsistent with the MO qty (e.g. records created before this fix where only the header was updated).
- Floating-point drift from successive ratio scaling.

The realignment is restricted to (a) `role = 'toproduce'`, (b) the main product (`fk_product` match), and (c) non-frozen lines, so BOM sub-product ratios and frozen lines are preserved.

### Note on `real` vs `numeric` type

The `qty` field is declared with `type=real` in `mo.class.php`, but `Form::editfieldval()` in `html.form.class.php` only handles `string|integer|numeric|amount|checkbox|text|...` — it does NOT have a branch for `real`, so the inline edit form renders empty (only Save/Cancel buttons, no input). To avoid touching shared core code, the patch temporarily overrides the type to `numeric` only when `action=editqty`, leaving the read-mode rendering (via `price()`) untouched. A cleaner long-term fix would be to add a `real` branch in `editfieldval()`, but that's out of scope for this minimal PR.

### Known unrelated issue (out of scope)

During testing, a pre-existing bug was observed in `Mo::processBOM()` 
(line 814 of `mo.class.php`): for BOM lines with `qty_frozen=1`, the 
quantity is hardcoded to `1` instead of `$line->qty`. This affects MO 
creation from a BOM containing frozen lines, regardless of this patch. 
The bug is present in both `23.0` and `develop` branches and should be 
addressed separately.

The `setqty` handler in this PR correctly preserves the (incorrect) 
value of frozen lines during MO qty edits — it does not introduce or 
amplify the issue.

### Testing

- [x] Create a new MO in DRAFT without BOM → pencil appears next to "Quantity to produce"
- [x] Change qty from 1 to 100 → both `llx_mrp_mo.qty` and `llx_mrp_production.qty` updated to 100
- [x] Successive edits (100 → 20.5 → 20) → all consistent in DB
- [x] Create a MO with a BOM (MP1=2 + MP2=0.05 per unit, output qty=1) at qty=2 → MP1=4, MP2=0.1 → edit MO qty to 10 → MP1=20, MP2=0.5 (proportional scaling preserved)
- [x] Legacy inconsistent state simulation: force `llx_mrp_mo.qty=500` and `llx_mrp_production.qty=1`, edit qty via pencil to 100 → both aligned to 100 (invariant enforcement)
- [x] Pencil also appears on the "Production" tab (mo_production.php)
- [x] PHP lint OK on both files
- [x] Validated MO → no pencil shown, field read-only
- [x] Forged `?action=setqty&qty=999` on validated MO → rejected by status check

### Related

Reported in French community as a usability issue: when a user creates an MO with the wrong qty (e.g. forgot to update from the default 1), there is currently no way to fix it without deleting the MO.