### PR TITLE
FIX: Mo::processBOM() ignores qty value for qty_frozen BOM lines

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -811,7 +811,7 @@ class Mo extends CommonObject
 
 		$quantity /= $bom->qty;
 		foreach ($bom->lines as $line) {
-			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : 1;
+			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : $line->qty;;
 
 			$tmpproduct = new Product($this->db);
 			$tmpproduct->fetch($line->fk_product);


### PR DESCRIPTION
## FIX: Mo::processBOM() ignores qty value for qty_frozen BOM lines

Fixes #38177

### Description

When creating a Manufacturing Order from a Bill of Materials, lines marked 
as `qty_frozen` had their consumption quantity hardcoded to `1`, regardless 
of the `qty` value defined on the BOM line itself.

In `Mo::processBOM()` (`htdocs/mrp/class/mo.class.php` line 814):

```php
$quantity_line = !$line->qty_frozen
    ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1)
    : 1;   // ← always 1, ignores BOM value
```

This is inconsistent with the documented semantics of `qty_frozen`: 
**"frozen"** should mean **"do NOT scale with MO qty"**, not **"force to 1"**.
The line's BOM-defined `qty` should be used as-is.

### Example

- BOM `BOM2605-0008`: output 1 unit, requires **10 kg** of malt with `qty_frozen=1`
- Create MO from this BOM at qty=1: the consumption line for malt is created 
  with `qty=1` kg instead of the expected `qty=10` kg.

### Fix

Use `$line->qty` instead of the hardcoded `1`:

```diff
-$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : 1;
+$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : $line->qty;
```

### Testing

- [x] BOM with `qty_frozen=1` line at qty=10: creating an MO at any qty 
  results in the consumption line being set to 10 (as expected).
- [x] BOM without `qty_frozen` lines: behavior unchanged (proportional scaling 
  via `$line->qty * $quantity / efficiency`).
- [x] BOM with mixed lines (some frozen, some not): only the non-frozen ones 
  scale with MO qty, the frozen ones keep their BOM value.
- [x] PHP lint OK.

### Affects

This bug is present in both `23.0` and `develop` branches. PR submitted 
against `23.0`; if accepted, the same one-line change should be ported 
to `develop`.