### PR TITLE
NEW configurable PROJECT_TASK_USER_DEFAULT_NOBODY

### DIFF
--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -836,13 +836,19 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	// Assigned to
 	print '<tr><td>'.$langs->trans("AffectedTo").'</td><td>';
 	print img_picto('', 'user', 'class="pictofixedwidth"');
+	$preselect = '-4';
+	$show_empty = 0;
+	if (getDolGlobalString("PROJECT_TASK_DEFAULT_NOBODY")) {
+		$preselect = '-1';
+		$show_empty = $langs->trans('Nobody');
+	}
 	if (is_array($contactsofproject) && count($contactsofproject)) {
-		print $form->select_dolusers('-4', 'userid', 0, null, 0, '', $contactsofproject, '0', 0, 0, '(statut:=:1)', 4, '', 'maxwidth500 widthcentpercentminusx');
+		print $form->select_dolusers($preselect, 'userid', $show_empty, null, 0, '', $contactsofproject, '0', 0, 0, '(statut:=:1)', 4, '', 'maxwidth500 widthcentpercentminusx');
 	} else {
 		if ((isset($projectid) && $projectid > 0) || $object->id > 0) {
 			print '<span class="opacitymedium">'.$langs->trans("NoUserAssignedToTheProject").'</span>';
 		} else {
-			print $form->select_dolusers('-4', 'userid', 0, null, 0, '', '', '0', 0, 0, '(statut:=:1)', 4, '', 'maxwidth500 widthcentpercentminusx');
+			print $form->select_dolusers($preselect, 'userid', $show_empty, null, 0, '', '', '0', 0, 0, '(statut:=:1)', 4, '', 'maxwidth500 widthcentpercentminusx');
 		}
 	}
 	print '</td></tr>';


### PR DESCRIPTION
# NEW configurable PROJECT_TASK_USER_DEFAULT_NOBODY
Applying this PR will make it possible for Dolibarr admins to configure their project setup such that tasks starts unassigned

This is a partial fix of #38187

<img width="786" height="156" alt="image" src="https://github.com/user-attachments/assets/71acbec6-c852-4803-9ebb-f79c75bbf8ae" />

