### PR TITLE
NEW UIUX Category - Add category type in create form

### DIFF
--- a/htdocs/categories/card.php
+++ b/htdocs/categories/card.php
@@ -1,12 +1,13 @@
 <?php
-/* Copyright (C) 2005		Matthieu Valleton	<mv@seeschloss.org>
- * Copyright (C) 2006-2021	Laurent Destailleur	<eldy@users.sourceforge.net>
- * Copyright (C) 2005-2014	Regis Houssin		<regis.houssin@inodbox.com>
- * Copyright (C) 2007		Patrick Raguin		<patrick.raguin@gmail.com>
- * Copyright (C) 2013		Florian Henry		<florian.henry@open-concept.pro>
- * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
- * Copyright (C) 2020-2026  Frédéric France     <frederic.france@free.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2005       Matthieu Valleton           <mv@seeschloss.org>
+ * Copyright (C) 2006-2021  Laurent Destailleur         <eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2014  Regis Houssin               <regis.houssin@inodbox.com>
+ * Copyright (C) 2007       Patrick Raguin              <patrick.raguin@gmail.com>
+ * Copyright (C) 2013       Florian Henry               <florian.henry@open-concept.pro>
+ * Copyright (C) 2015       Raphaël Doursenaud          <rdoursenaud@gpcsolutions.fr>
+ * Copyright (C) 2020-2026  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024       MDW                         <mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Alexandre Spangaro          <alexandre@inovea-conseil.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -257,7 +258,13 @@ if ($user->hasRight('categorie', 'creer')) {
 			print '<input type="hidden" name="catorigin" value="'.$catorigin.'">';
 		}
 
-		print load_fiche_titre($langs->trans("CreateCat"), '', 'category');
+		$title = $langs->trans("CreateCat");
+
+		if (!empty($type) && !empty(Categorie::$MAP_TYPE_TITLE_AREA[$type])) {
+			$title .= ' - '.$langs->trans(Categorie::$MAP_TYPE_TITLE_AREA[$type]);
+		}
+
+		print load_fiche_titre($title, '', 'category');
 
 		print dol_get_fiche_head();
 

--- a/htdocs/categories/card.php
+++ b/htdocs/categories/card.php
@@ -258,17 +258,26 @@ if ($user->hasRight('categorie', 'creer')) {
 			print '<input type="hidden" name="catorigin" value="'.$catorigin.'">';
 		}
 
-		$title = $langs->trans("CreateCat");
-
-		if (!empty($type) && !empty(Categorie::$MAP_TYPE_TITLE_AREA[$type])) {
-			$title .= ' - '.$langs->trans(Categorie::$MAP_TYPE_TITLE_AREA[$type]);
-		}
-
-		print load_fiche_titre($title, '', 'category');
+		print load_fiche_titre($langs->trans("CreateCat"), '', 'category');
 
 		print dol_get_fiche_head();
 
 		print '<table class="border centpercent">';
+
+		// Type
+		$typeLabel = '';
+		if (!empty($type) && !empty(Categorie::$MAP_TYPE_TITLE_AREA[$type])) {
+			$typeLabel = $langs->trans(Categorie::$MAP_TYPE_TITLE_AREA[$type]);
+		}
+
+		if (!empty($typeLabel)) {
+			print '<tr>';
+			print '<td class="titlefieldcreate">'.$langs->trans("Type").'</td>';
+			print '<td>'.$typeLabel;
+			print '<input type="hidden" name="type" value="'.dol_escape_htmltag($type).'">';
+			print '</td>';
+			print '</tr>';
+		}
 
 		// Ref
 		print '<tr>';


### PR DESCRIPTION
When you create a category and open the creation form, it’s not clear on the screen what type of category you’re creating. I suggest adding this information to the form as a fixed label for a better comprehension.

### Before

<img width="1251" height="595" alt="image" src="https://github.com/user-attachments/assets/d7378f17-8808-48db-aa8f-f1191051224d" />

### After

<img width="1251" height="595" alt="image" src="https://github.com/user-attachments/assets/a61e1102-543a-4758-8b81-daa57c894875" />