### PR TITLE
NEW Accountancy - Export Quadra - Add option to export thirdparty account only if not existing

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2015		Florian Henry				<florian.henry@open-concept.pro>
  * Copyright (C) 2015		Raphaël Doursenaud			<rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2016		Pierre-Henry Favre			<phf@atm-consulting.fr>
- * Copyright (C) 2016-2025	Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2016-2026	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2022		Lionel Vessiller			<lvessiller@open-dsi.fr>
  * Copyright (C) 2013-2017	Olivier Geffroy				<jeff@jeffinfo.com>
  * Copyright (C) 2017		Elarifr. Ari Elbaz			<github@accedinfo.com>
@@ -950,7 +950,15 @@ class AccountancyExport
 				}
 
 				$tab['filler2'] = str_repeat(' ', 110);
-				$tab['Maj'] = 2; // Partial update (alpha key, label, address, collectif, RIB)
+
+				// Field "Maj" (static position 1 char):
+				// blank = no update if account already exists
+				// 2 = partial update (alpha key, label, address, collectif, RIB)
+				if (getDolGlobalString('ACCOUNTING_EXPORT_QUADRATUS_DISABLE_THIRDPARTY_UPDATE')) {
+					$tab['Maj'] = ' ';
+				} else {
+					$tab['Maj'] = 2;
+				}
 
 				if ($line->doc_type == 'customer_invoice') {
 					$tab['type_compte'] = 'C';


### PR DESCRIPTION
Republish work of @fbagnol #36438 in a different form

This change adds a new constant for Quadratus export to avoid updating existing thirdparty accounts during export. When the constant ACCOUNTING_EXPORT_QUADRATUS_DISABLE_THIRDPARTY_UPDATE is enabled, the Maj field is left blank in thirdparty lines so Quadratus does not update existing accounts; when the option is disabled, the current default behavior is kept with Maj = 2 for partial update.

Why
Quadratus supports several behaviors for the “Mise à jour compte si existant” field, including blank for no update and 2 for partial update. This change allows users who want to create only missing thirdparty accounts, without modifying existing ones, to control that behavior through a dedicated Dolibarr constant.

<img width="1180" height="177" alt="image" src="https://github.com/user-attachments/assets/0afeb8f6-9b45-42cc-9932-3d0a79af14c1" />


