### PR TITLE
NEW possibility to list only task that are assigned, unassigned, internal, external

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2883,8 +2883,8 @@ class Form
 					$out .= '</option>';
 
 					$outarray[$userstatic->id] = $userstatic->getFullName($langs, $fullNameMode, -1, $maxlength) . $moreinfo;
-					$outarray2[$userstatic->id] = array(
-						'id' => $userstatic->id,
+					$outarray2[(int) $userstatic->id] = array(
+						'id' => (int) $userstatic->id,
 						'label' => $labeltoshow,
 						'labelhtml' => $labeltoshowhtml,
 						'color' => '',

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1366,70 +1366,47 @@ class Form
 	/**
 	 * Injects custom options (before/after) into a select list securely.
 	 *
-	 * @param array<int, string> $options        Associative array of [key => label]. Keys must be integers (typically negative for before/after options).
-	 * @param array<int|string>  $selected       Array of currently selected values.
-	 * @param int                $outputmode     0=HTML only, 1=Simple Array, 2=Detailed Array.
-	 * @param string             $out            Reference to the HTML output string (passed by ref for efficiency).
-	 * @param array<string, string>              $outarray       Reference to the simple output array.
-	 * @param array<string, array{id: string, label: string, labelhtml: string, color: string, picto: string}> $outarray2 Reference to the detailed output array.
+	 * @param array<int, string> $options
+	 * @param array<int|string>  $selected
+	 * @param int                $outputmode
+	 * @param string             $out
+	 * @param array<int, string> $outarray
+	 * @param array<int, array{id: int, label: string, labelhtml: string, color: string, picto: string}> $outarray2
 	 * @return void
 	 */
 	private function injectCustomOptionsSecure(array $options, array $selected, int $outputmode, string &$out, array &$outarray, array &$outarray2): void
 	{
-		// Early exit if no options to process
 		if (empty($options)) {
 			return;
 		}
 
-		// Sort keys numerically/alphabetically to ensure deterministic order
-		// ksort handles mixed keys safely
 		ksort($options);
 
-		foreach ($options as $rawKey => $rawLabel) {
-			// --- SECURITY: Sanitize Key ---
-			// Ensure key is a string to prevent type confusion in HTML value attribute
-			// and to ensure consistent comparison logic.
-			$safeKey = (string) $rawKey;
-
-			// --- SECURITY: Sanitize Label ---
-			// Escape HTML entities to prevent XSS in the label text
-			$safeLabel = dol_escape_htmltag($rawLabel);
-
-			// --- LOGIC: Determine Selection State ---
+		foreach ($options as $key => $label) {
+			$safeLabel = dol_escape_htmltag($label);
 			$isSelected = '';
 
-			// Only check selection if $selected is a non-empty array
 			if (!empty($selected)) {
-				// Use strict comparison for safety, but cast selected item to string for comparison
-				// to match our sanitized key type.
 				foreach ($selected as $selItem) {
-					if ((string) $selItem === $safeKey) {
+					if ((string) $selItem === (string) $key) {
 						$isSelected = ' selected';
 						break;
 					}
 				}
 			}
 
-			// --- OUTPUT: Generate Safe HTML ---
-			// Construct the option tag. The value attribute is the sanitized key.
-			// The inner text is the sanitized label.
-			$out .= '<option value="' . $safeKey . '"' . $isSelected . '>' . $safeLabel . '</option>' . "\n";
-
-			// --- OUTPUT: Populate Arrays (if requested) ---
+			$out .= '<option value="' . (string) $key . '"' . $isSelected . '>' . $safeLabel . '</option>' . "\n";
 			if ($outputmode === 2) {
-				// Detailed array mode
-				$outarray2[$safeKey] = [
-					'id'	  => $safeKey,
-					'label'   => $rawLabel, // Keep raw for internal logic if needed, but labelhtml is escaped
+				$outarray2[$key] = [
+					'id'      => $key,
+					'label'   => $label,
 					'labelhtml' => $safeLabel,
 					'color'   => '',
 					'picto'   => ''
 				];
 			} elseif ($outputmode === 1) {
-				// Simple array mode
-				$outarray[$safeKey] = $rawLabel;
+				$outarray[$key] = $label;
 			}
-			// If outputmode is 0, we only care about the HTML string ($out)
 		}
 	}
 
@@ -2564,7 +2541,7 @@ class Form
 	 * @param array<int,string>	$before 		Array of custom options to insert BEFORE the list of users. Keys must be negative integers (e.g. -5, -6) to avoid collision with real user IDs. Values are the labels.
 	 * @param array<int,string>	$after 			Array of custom options to insert AFTER the list of users. Keys must be negative integers. Values are the labels.
 	 * @return array<string|int, array{id: string|int, label: string, labelhtml: string, color: string, picto: string}>|string
-	* @see select_dolgroups()
+	 * @see select_dolgroups()
 	 */
 	public function select_dolusers($userselected = '', $htmlname = 'userid', $show_empty = 0, $exclude = null, $disabled = 0, $include = '', $enableonly = '', $force_entity = '', $maxlength = 0, $showstatus = 0, $morefilter = '', $showalso = 0, $enableonlytext = '', $morecss = '', $notdisabled = 0, $outputmode = 0, $multiple = false, $forcecombo = 0, $before = [], $after = [])
 	{
@@ -2884,13 +2861,13 @@ class Form
 					$out .= '</option>';
 
 					$outarray[$userstatic->id] = $userstatic->getFullName($langs, $fullNameMode, -1, $maxlength) . $moreinfo;
-					array_push($outarray2, array(
+					$outarray2[(int) $userstatic->id] = array(
 						'id' => (int) $userstatic->id,
 						'label' => $labeltoshow,
 						'labelhtml' => $labeltoshowhtml,
 						'color' => '',
 						'picto' => ''
-					));
+					);
 
 					$i++;
 				}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2540,7 +2540,7 @@ class Form
 	 * @param int<0,1> 			$forcecombo 	Force the component to be a simple combo box without ajax
 	 * @param array<int,string>	$before 		Array of custom options to insert BEFORE the list of users. Keys must be negative integers (e.g. -5, -6) to avoid collision with real user IDs. Values are the labels.
 	 * @param array<int,string>	$after 			Array of custom options to insert AFTER the list of users. Keys must be negative integers. Values are the labels.
-	 * @return array<string|int, array{id: string|int, label: string, labelhtml: string, color: string, picto: string}>|string
+	 * @return string|array<int,string|array{id:int,label:string,labelhtml:string,color:string,picto:string}>	HTML select string
 	 * @see select_dolgroups()
 	 */
 	public function select_dolusers($userselected = '', $htmlname = 'userid', $show_empty = 0, $exclude = null, $disabled = 0, $include = '', $enableonly = '', $force_entity = '', $maxlength = 0, $showstatus = 0, $morefilter = '', $showalso = 0, $enableonlytext = '', $morecss = '', $notdisabled = 0, $outputmode = 0, $multiple = false, $forcecombo = 0, $before = [], $after = [])
@@ -2896,18 +2896,7 @@ class Form
 		if ($outputmode == 2) {
 			return $outarray2;
 		} elseif ($outputmode) {
-			// Convert $outarray to the expected format
-			$convertedArray = [];
-			foreach ($outarray as $key => $value) {
-				$convertedArray[$key] = [
-					'id' => $key,
-					'label' => $value,
-					'labelhtml' => $value,
-					'color' => '',
-					'picto' => ''
-				];
-			}
-			return $convertedArray;
+			return $outarray;
 		}
 		return $out;
 	}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1366,7 +1366,7 @@ class Form
 	/**
 	 * Injects custom options (before/after) into a select list securely.
 	 *
-	 * @param array<string, string> $options        Associative array of [key => label]. Keys must be strings or castable to strings.
+	 * @param array<int, string> $options        Associative array of [key => label]. Keys must be integers (typically negative for before/after options).
 	 * @param array<int|string>     $selected       Array of currently selected values.
 	 * @param int                   $outputmode     0=HTML only, 1=Simple Array, 2=Detailed Array.
 	 * @param string                $out            Reference to the HTML output string (passed by ref for efficiency).
@@ -1399,7 +1399,7 @@ class Form
 			$isSelected = '';
 
 			// Only check selection if $selected is a non-empty array
-			if (!empty($selected) && is_array($selected)) {
+			if (!empty($selected)) {
 				// Use strict comparison for safety, but cast selected item to string for comparison
 				// to match our sanitized key type.
 				foreach ($selected as $selItem) {

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2896,9 +2896,19 @@ class Form
 		if ($outputmode == 2) {
 			return $outarray2;
 		} elseif ($outputmode) {
-			return $outarray;
+			// Convert $outarray to the expected format
+			$convertedArray = [];
+			foreach ($outarray as $key => $value) {
+				$convertedArray[$key] = [
+					'id' => $key,
+					'label' => $value,
+					'labelhtml' => $value,
+					'color' => '',
+					'picto' => ''
+				];
+			}
+			return $convertedArray;
 		}
-
 		return $out;
 	}
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1914,7 +1914,7 @@ class Form
 	 * @param int<0,1>			$showcode 		Show code in list
 	 * @return array<int,array{key:int,value:string,label:string,labelhtml:string}>|string            	HTML string with
 	 * @see select_company()
-	 * @phpstan-return ($outputmode is 1 ? array<int,array{key:int,value:string,label:string,labelhtml:string}> : string)
+	 * @phpstan-return ($outputmode is 1 ? array<int,array{id:int,label:string,labelhtml:string,color:string,picto:string}> : string)
 	 */
 	public function select_thirdparty_list($selected = '', $htmlname = 'socid', $filter = '', $showempty = '', $showtype = 0, $forcecombo = 0, $events = array(), $filterkey = '', $outputmode = 0, $limit = 0, $morecss = 'minwidth100', $moreparam = '', $multiple = false, $excludeids = array(), $showcode = 0)
 	{
@@ -2634,6 +2634,7 @@ class Form
 
 		$out = '';
 		$outarray = array();
+		/** @var array<int, array{id: int, label: string, labelhtml: string, color: string, picto: string}> $outarray2 */
 		$outarray2 = array();
 
 		// Do we want to show the label of entity into the combo list ?
@@ -2883,13 +2884,13 @@ class Form
 					$out .= '</option>';
 
 					$outarray[$userstatic->id] = $userstatic->getFullName($langs, $fullNameMode, -1, $maxlength) . $moreinfo;
-					$outarray2[(int) $userstatic->id] = array(
+					array_push($outarray2, array(
 						'id' => (int) $userstatic->id,
 						'label' => $labeltoshow,
 						'labelhtml' => $labeltoshowhtml,
 						'color' => '',
 						'picto' => ''
-					);
+					));
 
 					$i++;
 				}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1374,7 +1374,8 @@ class Form
 	 * @param array                 $outarray2      Reference to the detailed output array.
 	 * @return void
 	 */
-	private function injectCustomOptionsSecure(array $options, array $selected, int $outputmode, string &$out, array &$outarray, array &$outarray2): void {
+	private function injectCustomOptionsSecure(array $options, array $selected, int $outputmode, string &$out, array &$outarray, array &$outarray2): void
+	{
 		// Early exit if no options to process
 		if (empty($options)) {
 			return;
@@ -2909,8 +2910,8 @@ class Form
 		// 2. Inject $after options
 		$this->injectCustomOptionsSecure($after, $selected, $outputmode, $out, $outarray, $outarray2);
 
-        // Now close the tag
-        $out .= '</select>';
+		// Now close the tag
+		$out .= '</select>';
 
 		$this->num = $num;
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1367,11 +1367,11 @@ class Form
 	 * Injects custom options (before/after) into a select list securely.
 	 *
 	 * @param array<int, string> $options        Associative array of [key => label]. Keys must be integers (typically negative for before/after options).
-	 * @param array<int|string>     $selected       Array of currently selected values.
-	 * @param int                   $outputmode     0=HTML only, 1=Simple Array, 2=Detailed Array.
-	 * @param string                $out            Reference to the HTML output string (passed by ref for efficiency).
-	 * @param array                 $outarray       Reference to the simple output array.
-	 * @param array                 $outarray2      Reference to the detailed output array.
+	 * @param array<int|string>  $selected       Array of currently selected values.
+	 * @param int                $outputmode     0=HTML only, 1=Simple Array, 2=Detailed Array.
+	 * @param string             $out            Reference to the HTML output string (passed by ref for efficiency).
+	 * @param array<string, string>              $outarray       Reference to the simple output array.
+	 * @param array<string, array{id: string, label: string, labelhtml: string, color: string, picto: string}> $outarray2 Reference to the detailed output array.
 	 * @return void
 	 */
 	private function injectCustomOptionsSecure(array $options, array $selected, int $outputmode, string &$out, array &$outarray, array &$outarray2): void

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1914,7 +1914,7 @@ class Form
 	 * @param int<0,1>			$showcode 		Show code in list
 	 * @return array<int,array{key:int,value:string,label:string,labelhtml:string}>|string            	HTML string with
 	 * @see select_company()
-	 * @phpstan-return ($outputmode is 1 ? array<int,array{id:int,label:string,labelhtml:string,color:string,picto:string}> : string)
+	 * @phpstan-return ($outputmode is 1 ? array<int,array{key:int,value:string,label:string,labelhtml:string}> : string)
 	 */
 	public function select_thirdparty_list($selected = '', $htmlname = 'socid', $filter = '', $showempty = '', $showtype = 0, $forcecombo = 0, $events = array(), $filterkey = '', $outputmode = 0, $limit = 0, $morecss = 'minwidth100', $moreparam = '', $multiple = false, $excludeids = array(), $showcode = 0)
 	{
@@ -2563,8 +2563,8 @@ class Form
 	 * @param int<0,1> 			$forcecombo 	Force the component to be a simple combo box without ajax
 	 * @param array<int,string>	$before 		Array of custom options to insert BEFORE the list of users. Keys must be negative integers (e.g. -5, -6) to avoid collision with real user IDs. Values are the labels.
 	 * @param array<int,string>	$after 			Array of custom options to insert AFTER the list of users. Keys must be negative integers. Values are the labels.
-	 * @return string|array<int,string|array{id:int,label:string,labelhtml:string,color:string,picto:string}>	HTML select string
-	 * @see select_dolgroups()
+	 * @return array<string|int, array{id: string|int, label: string, labelhtml: string, color: string, picto: string}>|string
+	* @see select_dolgroups()
 	 */
 	public function select_dolusers($userselected = '', $htmlname = 'userid', $show_empty = 0, $exclude = null, $disabled = 0, $include = '', $enableonly = '', $force_entity = '', $maxlength = 0, $showstatus = 0, $morefilter = '', $showalso = 0, $enableonlytext = '', $morecss = '', $notdisabled = 0, $outputmode = 0, $multiple = false, $forcecombo = 0, $before = [], $after = [])
 	{

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1364,6 +1364,75 @@ class Form
 	}
 
 	/**
+	 * Injects custom options (before/after) into a select list securely.
+	 *
+	 * @param array<string, string> $options        Associative array of [key => label]. Keys must be strings or castable to strings.
+	 * @param array<int|string>     $selected       Array of currently selected values.
+	 * @param int                   $outputmode     0=HTML only, 1=Simple Array, 2=Detailed Array.
+	 * @param string                $out            Reference to the HTML output string (passed by ref for efficiency).
+	 * @param array                 $outarray       Reference to the simple output array.
+	 * @param array                 $outarray2      Reference to the detailed output array.
+	 * @return void
+	 */
+	private function injectCustomOptionsSecure(array $options, array $selected, int $outputmode, string &$out, array &$outarray, array &$outarray2): void {
+		// Early exit if no options to process
+		if (empty($options)) {
+			return;
+		}
+
+		// Sort keys numerically/alphabetically to ensure deterministic order
+		// ksort handles mixed keys safely
+		ksort($options);
+
+		foreach ($options as $rawKey => $rawLabel) {
+			// --- SECURITY: Sanitize Key ---
+			// Ensure key is a string to prevent type confusion in HTML value attribute
+			// and to ensure consistent comparison logic.
+			$safeKey = (string) $rawKey;
+
+			// --- SECURITY: Sanitize Label ---
+			// Escape HTML entities to prevent XSS in the label text
+			$safeLabel = dol_escape_htmltag($rawLabel);
+
+			// --- LOGIC: Determine Selection State ---
+			$isSelected = '';
+
+			// Only check selection if $selected is a non-empty array
+			if (!empty($selected) && is_array($selected)) {
+				// Use strict comparison for safety, but cast selected item to string for comparison
+				// to match our sanitized key type.
+				foreach ($selected as $selItem) {
+					if ((string) $selItem === $safeKey) {
+						$isSelected = ' selected';
+						break;
+					}
+				}
+			}
+
+			// --- OUTPUT: Generate Safe HTML ---
+			// Construct the option tag. The value attribute is the sanitized key.
+			// The inner text is the sanitized label.
+			$out .= '<option value="' . $safeKey . '"' . $isSelected . '>' . $safeLabel . '</option>' . "\n";
+
+			// --- OUTPUT: Populate Arrays (if requested) ---
+			if ($outputmode === 2) {
+				// Detailed array mode
+				$outarray2[$safeKey] = [
+					'id'	  => $safeKey,
+					'label'   => $rawLabel, // Keep raw for internal logic if needed, but labelhtml is escaped
+					'labelhtml' => $safeLabel,
+					'color'   => '',
+					'picto'   => ''
+				];
+			} elseif ($outputmode === 1) {
+				// Simple array mode
+				$outarray[$safeKey] = $rawLabel;
+			}
+			// If outputmode is 0, we only care about the HTML string ($out)
+		}
+	}
+
+	/**
 	 * Return inline JS for country-selector → phone code sync (output once per page).
 	 *
 	 * When the country select changes, fetches the phone code via AJAX and updates
@@ -2484,17 +2553,19 @@ class Form
 	 * @param int 				$maxlength 		Maximum length of string into list (0=no limit)
 	 * @param int<-1,1>			$showstatus 	0=show user status only if status is disabled, 1=always show user status into label, -1=never show user status
 	 * @param string 			$morefilter 	Add more filters into sql request (Example: '(employee:=:1)'). This value must not come from user input.
-	 * @param int<0,3> 			$showalso 		0=default list, 1=add also a value "Everybody" at beginning of list, 2=add also a value "My team" at beginning of list (if user has at least 1 people), 3=add also "Everybody" + "My Team"
+	 * @param int<0,4> 			$showalso 		0=default list, 1=add also a value "Everybody" at beginning of list, 2=add also a value "My team" at beginning of list (if user has at least 1 people), 3=add also "Everybody" + "My Team", 4=add also a value "All Project Contacts" at beginning of list
 	 * @param string 			$enableonlytext If option $enableonlytext is set, we use this text to explain into label why record is disabled. Not used if enableonly is empty.
 	 * @param string 			$morecss 		More css
 	 * @param int<0,1> 			$notdisabled 	Show only active users (note: this will also happen, whatever is this option, if USER_HIDE_INACTIVE_IN_COMBOBOX is on).
 	 * @param int<0,2>			$outputmode 	0=HTML select string, 1=Array, 2=Detailed array
 	 * @param bool 				$multiple 		add [] in the name of element and add 'multiple' attribute
 	 * @param int<0,1> 			$forcecombo 	Force the component to be a simple combo box without ajax
+	 * @param array<int,string>	$before 		Array of custom options to insert BEFORE the list of users. Keys must be negative integers (e.g. -5, -6) to avoid collision with real user IDs. Values are the labels.
+	 * @param array<int,string>	$after 			Array of custom options to insert AFTER the list of users. Keys must be negative integers. Values are the labels.
 	 * @return string|array<int,string|array{id:int,label:string,labelhtml:string,color:string,picto:string}>	HTML select string
 	 * @see select_dolgroups()
 	 */
-	public function select_dolusers($userselected = '', $htmlname = 'userid', $show_empty = 0, $exclude = null, $disabled = 0, $include = '', $enableonly = '', $force_entity = '', $maxlength = 0, $showstatus = 0, $morefilter = '', $showalso = 0, $enableonlytext = '', $morecss = '', $notdisabled = 0, $outputmode = 0, $multiple = false, $forcecombo = 0)
+	public function select_dolusers($userselected = '', $htmlname = 'userid', $show_empty = 0, $exclude = null, $disabled = 0, $include = '', $enableonly = '', $force_entity = '', $maxlength = 0, $showstatus = 0, $morefilter = '', $showalso = 0, $enableonlytext = '', $morecss = '', $notdisabled = 0, $outputmode = 0, $multiple = false, $forcecombo = 0, $before = [], $after = [])
 	{
 		// phpcs:enable
 		global $conf, $user, $langs, $hookmanager;
@@ -2642,13 +2713,16 @@ class Form
 
 		dol_syslog(get_class($this) . "::select_dolusers", LOG_DEBUG);
 
+		$out .= '<select class="flat' . ($morecss ? ' ' . $morecss : ' minwidth200') . '" id="' . $htmlname . '" name="' . $htmlname . ($multiple ? '[]' : '') . '" ' . ($multiple ? 'multiple' : '') . ' ' . ($disabled ? ' disabled' : '') . '>';
+		// 1. Inject $before options
+		$this->injectCustomOptionsSecure($before, $selected, $outputmode, $out, $outarray, $outarray2);
+
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$num = $this->db->num_rows($resql);
 			$i = 0;
 			if ($num) {
 				// do not use maxwidthonsmartphone by default. Set it by caller so auto size to 100% will work when not defined
-				$out .= '<select class="flat' . ($morecss ? ' ' . $morecss : ' minwidth200') . '" id="' . $htmlname . '" name="' . $htmlname . ($multiple ? '[]' : '') . '" ' . ($multiple ? 'multiple' : '') . ' ' . ($disabled ? ' disabled' : '') . '>';
 				if ($show_empty && !$multiple) {
 					$textforempty = ' ';
 					if (!empty($conf->use_javascript_ajax)) {
@@ -2822,7 +2896,6 @@ class Form
 				$out .= '<select class="flat" id="' . $htmlname . '" name="' . $htmlname . '" disabled>';
 				$out .= '<option value="">' . $langs->trans("None") . '</option>';
 			}
-			$out .= '</select>';
 
 			if ($num && !$forcecombo) {
 				// Enhance with select2
@@ -2832,6 +2905,12 @@ class Form
 		} else {
 			dol_print_error($this->db);
 		}
+
+		// 2. Inject $after options
+		$this->injectCustomOptionsSecure($after, $selected, $outputmode, $out, $outarray, $outarray2);
+
+        // Now close the tag
+        $out .= '</select>';
 
 		$this->num = $num;
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1366,12 +1366,12 @@ class Form
 	/**
 	 * Injects custom options (before/after) into a select list securely.
 	 *
-	 * @param array<int, string> $options
-	 * @param array<int|string>  $selected
-	 * @param int                $outputmode
-	 * @param string             $out
-	 * @param array<int, string> $outarray
-	 * @param array<int, array{id: int, label: string, labelhtml: string, color: string, picto: string}> $outarray2
+	 * @param array<int, string> $options        Associative array of custom options [key => label].
+	 * @param array<int|string>  $selected       Array of currently selected values.
+	 * @param int                $outputmode     Output mode: 0=HTML, 1=Simple Array, 2=Detailed Array.
+	 * @param string             $out            Reference to the HTML output string.
+	 * @param array<int, string> $outarray       Reference to the simple output array.
+	 * @param array<int, array{id: int, label: string, labelhtml: string, color: string, picto: string}> $outarray2 Reference to the detailed output array.
 	 * @return void
 	 */
 	private function injectCustomOptionsSecure(array $options, array $selected, int $outputmode, string &$out, array &$outarray, array &$outarray2): void

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -337,3 +337,6 @@ TaskHourlyRateUpdated=Task's hourly rate updated
 UpdateWithLastHourlyRate=Update all recorded time spent of each user with the last hourly rate of the user
 UpdateUndefinedWithLastHourlyRate=Update the time spent that has no hourly rate defined with the last hourly rate of the user
 EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
+Unassigned=Unassigned
+AssignedToInternalUsers=Assigned to internal users
+AssignedToExternalContacts=Assigned to external contacts

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -98,6 +98,7 @@ $search_progressdeclare = GETPOST('search_progressdeclare');
 $search_task_budget_amount = GETPOST('search_task_budget_amount');
 $search_task_billable = GETPOST('search_task_billable');
 $search_status = GETPOST('search_status');
+$search_assignment = GETPOST('search_assignment', 'alpha');
 
 $search_date_start_startmonth = GETPOSTINT('search_date_start_startmonth');
 $search_date_start_startyear = GETPOSTINT('search_date_start_startyear');
@@ -251,6 +252,7 @@ if (empty($reshook)) {
 		$search_task_budget_amount = '';
 		$search_task_billable = '';
 		$search_status = -1;
+		$search_assignment = '';
 		$toselect = array();
 		$search_array_options = array();
 		$search_date_start_startmonth = "";
@@ -337,6 +339,26 @@ if ($search_task_budget_amount) {
 }
 if ($search_task_billable && $search_task_billable != '-1') {
 	$morewherefilterarray[] = " t.billable = ".($search_task_billable == "yes" ? 1 : 0);
+}
+if (!empty($search_assignment)) {
+    $subq = "SELECT 1 FROM " . $db->prefix() . "element_contact ec "
+          . "INNER JOIN " . $db->prefix() . "c_type_contact tc ON ec.fk_c_type_contact = tc.rowid "
+          . "WHERE ec.element_id = t.rowid AND tc.element = 'project_task' AND tc.active = 1";
+
+    switch ($search_assignment) {
+        case 'assigned':
+            $morewherefilterarray[] = "EXISTS (" . $subq . ")";
+            break;
+        case 'unassigned':
+            $morewherefilterarray[] = "NOT EXISTS (" . $subq . ")";
+            break;
+        case 'assigned_internal':
+            $morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'internal')";
+            break;
+        case 'assigned_external':
+            $morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'external')";
+            break;
+    }
 }
 //var_dump($morewherefilterarray);
 
@@ -595,6 +617,9 @@ if ($id > 0 || !empty($ref)) {
 	}
 	if ($search_status) {
 		$param .= '&search_status='.urlencode((string) ($search_status));
+	}
+	if ($search_assignment) {
+		$param .= '&search_assignment='.urlencode($search_assignment);
 	}
 	if ($search_task_budget_amount) {
 		$param .= '&search_task_budget_amount='.urlencode($search_task_budget_amount);
@@ -949,6 +974,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 	//print_barre_liste($title, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, $linktotasks, $num, $totalnboflines, 'generic', 0, '', '', 0, 1);
 	print load_fiche_titre($title, $linktotasks.' &nbsp; '.$linktocreatetask, 'projecttask', 0, '', '', $massactionbutton);
+	print '<!-- load_fiche_titre -->';
 
 	$objecttmp = new Task($db);
 	$trackid = 'task'.$taskstatic->id;
@@ -979,6 +1005,19 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	$moreforfilter .= img_picto('', 'user', 'class="pictofixedwidth"');
 	$moreforfilter .= $form->select_dolusers($tmpuser->id > 0 ? $tmpuser->id : '', 'search_user_id', $langs->trans("TasksAssignedTo"), null, 0, '', '');
 	$moreforfilter .= '</div>';
+
+	// Assignment status filter
+	$moreforfilter .= '<div class="divsearchfield">';
+	$moreforfilter .= img_picto('', 'company', 'class="pictofixedwidth"');
+	$assignmentOptions = array(
+		'assigned'          => $langs->trans("Assigned"),
+		'unassigned'        => $langs->trans("Unassigned"),
+		'assigned_internal' => $langs->trans("AssignedToInternalUsers"),
+		'assigned_external' => $langs->trans("AssignedToExternalContacts"),
+	);
+	$moreforfilter .= $form->selectarray('search_assignment', $assignmentOptions, $search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
+	$moreforfilter .= '</div>';
+
 	if ($moreforfilter) {
 		print '<div class="liste_titre liste_titre_bydiv centpercent">';
 		print $moreforfilter;

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1254,7 +1254,21 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 	$nboftaskshown = 0;
 	if (count($tasksarray) > 0) {
-		// Show all lines in taskarray (recursive function to go down on tree)
+		if (!empty($search_assignment)) {
+			$existingIds = array();
+			foreach ($tasksarray as $task) {
+				$existingIds[$task->id] = true;
+			}
+
+			foreach ($tasksarray as $task) {
+				if ($task->fk_task_parent > 0) {
+					if (!isset($existingIds[$task->fk_task_parent])) {
+						$task->fk_task_parent = 0;
+					}
+				}
+			}
+		}
+
 		$j = 0;
 		$level = 0;
 		$nboftaskshown = projectLinesa($j, 0, $tasksarray, $level, '', 0, $tasksrole, (string) $object->id, 1, $object->id, '', ($object->usage_bill_time ? 1 : 0), $arrayfields, $arrayofselected);

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -341,25 +341,22 @@ if ($search_task_billable && $search_task_billable != '-1') {
 	$morewherefilterarray[] = " t.billable = ".($search_task_billable == "yes" ? 1 : 0);
 }
 if (!empty($search_assignment)) {
-    $subq = "SELECT 1 FROM " . $db->prefix() . "element_contact ec "
-          . "INNER JOIN " . $db->prefix() . "c_type_contact tc ON ec.fk_c_type_contact = tc.rowid "
-          . "WHERE ec.element_id = t.rowid "
-          . "AND tc.element = 'project_task'";
+	$subq = "SELECT 1 FROM " . $db->prefix() . "element_contact ec INNER JOIN " . $db->prefix() . "c_type_contact tc ON ec.fk_c_type_contact = tc.rowid WHERE ec.element_id = t.rowid AND tc.element = 'project_task'";
 
-    switch ($search_assignment) {
-        case 'assigned':
-            $morewherefilterarray[] = "EXISTS (" . $subq . ")";
-            break;
-        case 'unassigned':
-            $morewherefilterarray[] = "NOT EXISTS (" . $subq . ")";
-            break;
-        case 'assigned_internal':
-            $morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'internal')";
-            break;
-        case 'assigned_external':
-            $morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'external')";
-            break;
-    }
+	switch ($search_assignment) {
+		case 'assigned':
+			$morewherefilterarray[] = "EXISTS (" . $subq . ")";
+			break;
+		case 'unassigned':
+			$morewherefilterarray[] = "NOT EXISTS (" . $subq . ")";
+			break;
+		case 'assigned_internal':
+			$morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'internal')";
+			break;
+		case 'assigned_external':
+			$morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'external')";
+			break;
+	}
 }
 //var_dump($morewherefilterarray);
 

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1009,7 +1009,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 	// Assignment status filter
 	$moreforfilter .= '<div class="divsearchfield">';
-	$moreforfilter .= img_picto('', 'company', 'class="pictofixedwidth"');
+	$moreforfilter .= img_picto('', 'contact', 'class="pictofixedwidth"');
 	$assignmentOptions = array(
 		'assigned'          => $langs->trans("Assigned"),
 		'unassigned'        => $langs->trans("Unassigned"),

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1020,14 +1020,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	$moreforfilter = '';
 	$moreforfilter .= '<div class="divsearchfield">';
 	$moreforfilter .= img_picto('', 'user', 'class="pictofixedwidth"');
-
-	$moreforfilter .= $form->select_dolusers(
-		userselected: $tmpuser->id > 0 ? $tmpuser->id : '',
-		htmlname: 'search_user_id',
-		show_empty: $langs->trans("TasksAssignedTo"), // Placeholder
-		before: $assignmentOptions,                   // Your custom top options
-		showalso: 0                                   // Disable built-in "Everybody/My Team" to avoid clutter
-	);
+	$moreforfilter .= $form->select_dolusers(($tmpuser->id > 0 ? $tmpuser->id : ''), 'search_user_id', $langs->trans("TasksAssignedTo"), null, 0, '', '', '0', 0, 0, '', 0, '', '', 0, 0, false, 0, $assignmentOptions);
 	$moreforfilter .= '</div>';
 
 	if ($moreforfilter) {

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -344,16 +344,16 @@ if ($search_task_billable && $search_task_billable != '-1') {
 // Assignment filter: works from both $search_user_id and $search_assignment
 $assignmentFilter = 0;
 if (!empty($search_user_id) && $search_user_id < -1) {
-    $assignmentFilter = $search_user_id;
+	$assignmentFilter = $search_user_id;
 } elseif (!empty($search_assignment)) {
-    $assignmentFilter = (int) $search_assignment;
+	$assignmentFilter = (int) $search_assignment;
 }
 
 if ($assignmentFilter != 0) {
 	$subq = "SELECT 1 FROM " . $db->prefix() . "element_contact ec INNER JOIN " . $db->prefix() . "c_type_contact tc ON ec.fk_c_type_contact = tc.rowid WHERE ec.element_id = t.rowid AND tc.element = 'project_task'";
 
 	// this is ugly, find the variable called assignmentOptions and see the explanation for these numbers.
-	// we use these numbers because select_dolusers() want's to use integers and not strings.
+	// we use these numbers because select_dolusers() wants to use integers and not strings.
 	switch ($assignmentFilter) {
 		case -100:
 			$morewherefilterarray[] = "EXISTS (" . $subq . ")";

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -343,7 +343,8 @@ if ($search_task_billable && $search_task_billable != '-1') {
 if (!empty($search_assignment)) {
     $subq = "SELECT 1 FROM " . $db->prefix() . "element_contact ec "
           . "INNER JOIN " . $db->prefix() . "c_type_contact tc ON ec.fk_c_type_contact = tc.rowid "
-          . "WHERE ec.element_id = t.rowid AND tc.element = 'project_task' AND tc.active = 1";
+          . "WHERE ec.element_id = t.rowid "
+          . "AND tc.element = 'project_task'";
 
     switch ($search_assignment) {
         case 'assigned':

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1013,7 +1013,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		'assigned_internal' => $langs->trans("AssignedToInternalUsers"),
 		'assigned_external' => $langs->trans("AssignedToExternalContacts"),
 	);
-	$moreforfilter .= $form->selectarray('search_assignment', $assignmentOptions, $search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
+	$moreforfilter .= $form->selectarray('search_assignment', (array)$assignmentOptions, (string)$search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
 	$moreforfilter .= '</div>';
 
 	if ($moreforfilter) {
@@ -1147,7 +1147,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	if (!empty($arrayfields['c.assigned']['checked'])) {
 		print '<td class="liste_titre right">';
 		print '<!-- c.assigned -->';
-		print $form->selectarray('search_assignment', $assignmentOptions, $search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
+		print $form->selectarray('search_assignment', (array)$assignmentOptions, (string)$search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
 		print '</td>';
 	}
 

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -340,20 +340,31 @@ if ($search_task_budget_amount) {
 if ($search_task_billable && $search_task_billable != '-1') {
 	$morewherefilterarray[] = " t.billable = ".($search_task_billable == "yes" ? 1 : 0);
 }
-if (!empty($search_assignment)) {
+
+// Assignment filter: works from both $search_user_id and $search_assignment
+$assignmentFilter = 0;
+if (!empty($search_user_id) && $search_user_id < -1) {
+    $assignmentFilter = $search_user_id;
+} elseif (!empty($search_assignment)) {
+    $assignmentFilter = (int) $search_assignment;
+}
+
+if ($assignmentFilter != 0) {
 	$subq = "SELECT 1 FROM " . $db->prefix() . "element_contact ec INNER JOIN " . $db->prefix() . "c_type_contact tc ON ec.fk_c_type_contact = tc.rowid WHERE ec.element_id = t.rowid AND tc.element = 'project_task'";
 
-	switch ($search_assignment) {
-		case 'assigned':
+	// this is ugly, find the variable called assignmentOptions and see the explanation for these numbers.
+	// we use these numbers because select_dolusers() want's to use integers and not strings.
+	switch ($assignmentFilter) {
+		case -100:
 			$morewherefilterarray[] = "EXISTS (" . $subq . ")";
 			break;
-		case 'unassigned':
+		case -101:
 			$morewherefilterarray[] = "NOT EXISTS (" . $subq . ")";
 			break;
-		case 'assigned_internal':
+		case -102:
 			$morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'internal')";
 			break;
-		case 'assigned_external':
+		case -103:
 			$morewherefilterarray[] = "EXISTS (" . $subq . " AND tc.source = 'external')";
 			break;
 	}
@@ -997,23 +1008,26 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		include DOL_DOCUMENT_ROOT.'/core/tpl/ajaxrow.tpl.php';
 	}
 
+	// 1. Define custom options with safe negative keys
+	$assignmentOptions = array(
+		-100 => $langs->trans("Assigned"),
+		-101 => $langs->trans("Unassigned"),
+		-102 => $langs->trans("AssignedToInternalUsers"),
+		-103 => $langs->trans("AssignedToExternalContacts"),
+	);
+
 	// Filter on assigned users
 	$moreforfilter = '';
 	$moreforfilter .= '<div class="divsearchfield">';
 	$moreforfilter .= img_picto('', 'user', 'class="pictofixedwidth"');
-	$moreforfilter .= $form->select_dolusers($tmpuser->id > 0 ? $tmpuser->id : '', 'search_user_id', $langs->trans("TasksAssignedTo"), null, 0, '', '');
-	$moreforfilter .= '</div>';
 
-	// Assignment status filter
-	$moreforfilter .= '<div class="divsearchfield">';
-	$moreforfilter .= img_picto('', 'contact', 'class="pictofixedwidth"');
-	$assignmentOptions = array(
-		'assigned'          => $langs->trans("Assigned"),
-		'unassigned'        => $langs->trans("Unassigned"),
-		'assigned_internal' => $langs->trans("AssignedToInternalUsers"),
-		'assigned_external' => $langs->trans("AssignedToExternalContacts"),
+	$moreforfilter .= $form->select_dolusers(
+		userselected: $tmpuser->id > 0 ? $tmpuser->id : '',
+		htmlname: 'search_user_id',
+		show_empty: $langs->trans("TasksAssignedTo"), // Placeholder
+		before: $assignmentOptions,                   // Your custom top options
+		showalso: 0                                   // Disable built-in "Everybody/My Team" to avoid clutter
 	);
-	$moreforfilter .= $form->selectarray('search_assignment', (array) $assignmentOptions, (string) $search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
 	$moreforfilter .= '</div>';
 
 	if ($moreforfilter) {

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1013,7 +1013,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		'assigned_internal' => $langs->trans("AssignedToInternalUsers"),
 		'assigned_external' => $langs->trans("AssignedToExternalContacts"),
 	);
-	$moreforfilter .= $form->selectarray('search_assignment', (array)$assignmentOptions, (string)$search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
+	$moreforfilter .= $form->selectarray('search_assignment', (array) $assignmentOptions, (string) $search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
 	$moreforfilter .= '</div>';
 
 	if ($moreforfilter) {
@@ -1147,7 +1147,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	if (!empty($arrayfields['c.assigned']['checked'])) {
 		print '<td class="liste_titre right">';
 		print '<!-- c.assigned -->';
-		print $form->selectarray('search_assignment', (array)$assignmentOptions, (string)$search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
+		print $form->selectarray('search_assignment', (array) $assignmentOptions, (string) $search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
 		print '</td>';
 	}
 

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1149,6 +1149,8 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 	if (!empty($arrayfields['c.assigned']['checked'])) {
 		print '<td class="liste_titre right">';
+		print '<!-- c.assigned -->';
+		print $form->selectarray('search_assignment', $assignmentOptions, $search_assignment, 1, 0, 0, '', 0, 0, 0, '', 'maxwidth150');
 		print '</td>';
 	}
 


### PR DESCRIPTION
# NEW possibility to list only task that are assigned, unassigned, internal, external
Applying this PR would add (the same) dropdown selection 2 places on a list of tasks. 

1. Addition is right next to the current dropdown where one can select users
<img width="497" height="283" alt="image" src="https://github.com/user-attachments/assets/2351630b-425d-463a-b778-f023c0a07caf" />

2. Addition is above the Contact column
<img width="330" height="150" alt="image" src="https://github.com/user-attachments/assets/51d37d92-f1ab-4a9f-a314-31d7396b063d" />

The addition both places was a UX design choice. Obviously it makes sense to have it on top of the contact column, but it also makes sense to have it on the top, in location 1. because I envision that it will be used quite a lot AND we also want to be able to filter on this even if the contact column is not shown.

In the dropdown one can select between

- [x] Assigned = tasks which is assigned to someone
- [x] Unassigned = tasks which is not assigned to anyone
- [x] Internal = tasks which are assigned to internal users
- [x] External = tasks which are assigned to external contacts

This PR would also add those 4 translation strings.

This PR is related to PR #38195.

Applying both this PR and PR #38195 should close #38187.