### PR TITLE
New : Add ON DELETE SET NULL FK constraint for link-type extrafields

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -392,17 +392,36 @@ class ExtraFields
 			);
 
 			$result = $this->db->DDLAddField($this->db->prefix().$this->db->sanitize($table), $attrname, $field_desc);
-			if ($result > 0) {
+			if ($result > 0 || $this->db->lasterrno() == 'DB_ERROR_COLUMN_ALREADY_EXISTS') {
 				if ($unique) {
 					$sql = "ALTER TABLE ".$this->db->prefix().$this->db->sanitize($table)." ADD UNIQUE INDEX uk_".$this->db->sanitize($table)."_".$attrname." (".$attrname.")";
 					$resql = $this->db->query($sql, 1, 'dml');
 				}
-				return 1;
-			} else {
-				$this->error = $this->db->lasterror();
-				$this->errno = $this->db->lasterrno();
-				return -1;
+				// For 'link' type extrafields: add FK with ON DELETE SET NULL on the value column (only if column is nullable)
+				if ($type == 'link' && !$required && is_array($param) && !empty($param['options'])) {
+					$param_list = array_keys($param['options']);
+					$InfoFieldList = explode(':', $param_list[0]);
+					$linkclassname = $InfoFieldList[0];
+					$linkclasspath = !empty($InfoFieldList[1]) ? $InfoFieldList[1] : '';
+					if ($linkclassname && $linkclasspath) {
+						dol_include_once($linkclasspath);
+						if (class_exists($linkclassname)) {
+							$tmpobject = new $linkclassname($this->db);
+							if (!empty($tmpobject->table_element)) {
+								$link_constraint_name = substr('fk_'.$this->db->sanitize($table).'_'.$this->db->sanitize($attrname), 0, 64);
+								$sql = "ALTER TABLE ".$this->db->prefix().$this->db->sanitize($table)." ADD CONSTRAINT ".$link_constraint_name." FOREIGN KEY (".$this->db->sanitize($attrname).") REFERENCES ".$this->db->prefix().$this->db->sanitize($tmpobject->table_element)."(rowid) ON DELETE SET NULL";
+								$this->db->query($sql, 1, 'dml'); // Error ignored: constraint may already exist
+							}
+						}
+					}
+				}
+				if ($result > 0) {
+					return 1;
+				}
 			}
+			$this->error = $this->db->lasterror();
+			$this->errno = $this->db->lasterrno();
+			return -1;
 		} else {
 			return 0;
 		}


### PR DESCRIPTION
# NEW|New Automatic ON DELETE SET NULL FK constraint for link-type extrafields

When a `link`-type non-required extrafield is created, Dolibarr now automatically adds a database-level foreign key constraint (`ON DELETE SET NULL`) between the extrafield value column and the referenced object's primary key (`rowid`).

Previously, deleting a referenced object could leave orphaned references in the _extrafields table, where the stored ID no longer matched an existing record.

With this change, referential integrity is now enforced directly at the database level: when the referenced object is deleted, the corresponding extrafield value is automatically set to NULL, without requiring additional application logic.

  **Scope:**                                                                                                                                                                                                                                     
  - Applies only to `link`-type extrafields                                                                                                                                                                                                      
  - Applies only when the extrafield is not required (nullable column)
  - Works for both newly created columns and pre-existing ones                                                                                                                                                                                   
  - Constraint name is truncated to 64 characters to respect MySQL/MariaDB limits
  - FK errors are silenced when the constraint already exists