### PR TITLE
Fix undefined SUBTOTALS_SPECIAL_CODE

### DIFF
--- a/htdocs/subtotals/class/commonsubtotal.class.php
+++ b/htdocs/subtotals/class/commonsubtotal.class.php
@@ -19,10 +19,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  * or see https://www.gnu.org/
  */
-
+if (!defined('SUBTOTALS_SPECIAL_CODE')) {
+	define('SUBTOTALS_SPECIAL_CODE', 9);
+}
 
 /**
- *
  * Trait CommonSubtotal
  *
  * Add subtotals lines


### PR DESCRIPTION
## Fix
This fixes a fatal error during installation when the Subtotals module is loaded and `SUBTOTALS_SPECIAL_CODE` is not defined yet.
The constant is now defined in the common subtotal class before it is used by the module descriptor and other subtotal-related code.


