### PR TITLE
FIX - supplier order PDF language not using thirdparty default_lang

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1950,6 +1950,9 @@ if ($action == 'create') {
 	$result = $object->fetch($id, $ref);
 	$object->fetch_thirdparty();
 
+	$soc = new Societe($db);
+	$soc->fetch($object->socid);
+
 	$societe = $object->thirdparty;
 
 	$author = new User($db);
@@ -2794,7 +2797,7 @@ if ($action == 'create') {
 			$delallowed = $usercancreate;
 			$modelpdf = (!empty($object->model_pdf) ? $object->model_pdf : (!getDolGlobalString('COMMANDE_SUPPLIER_ADDON_PDF') ? '' : $conf->global->COMMANDE_SUPPLIER_ADDON_PDF));
 
-			print $formfile->showdocuments('commande_fournisseur', $objref, $filedir, $urlsource, $genallowed, $delallowed, $modelpdf, 1, 0, 0, 0, 0, '', '', '', $object->thirdparty->default_lang, '', $object);
+			print $formfile->showdocuments('commande_fournisseur', $objref, $filedir, $urlsource, $genallowed, $delallowed, $modelpdf, 1, 0, 0, 0, 0, '', '', '', $soc->default_lang, '', $object);
 			$somethingshown = $formfile->numoffiles;
 
 			// Show links to link elements


### PR DESCRIPTION
# FIX - supplier order PDF language not using thirdparty default_lang
In htdocs/fourn/commande/card.php, the showdocuments() call reads $object->thirdparty->default_lang directly, which can be null and falls back to the user's UI language (French) instead of the supplier's configured language, unlike commande/card.php, supplier_proposal/card.php and fourn/facture/card.php which all fetch a separate Societe and use $soc->default_lang. This PR aligns the supplier order card with that pattern, fixing both the Attempt to read property "default_lang" on null warning and the PDF being generated in the wrong language.

