### PR TITLE
Fix #38219: TakePos deleteline should not delete invoice when last li…

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -978,8 +978,6 @@ if (empty($reshook)) {
 		}
 
 		if (count($invoice->lines) == 0) {
-			$invoice->delete($user);
-
 			if (defined('INCLUDE_PHONEPAGE_FROM_PUBLIC_PAGE')) {
 				header("Location: ".DOL_URL_ROOT."/takepos/public/auto_order.php");
 			} else {


### PR DESCRIPTION
Fix #38219

When deleting the last line of a TakePos draft invoice, the code was removing the user attached to the invoice. This is confusing UX - the `New()` button already exists for starting a new session intentionally and it is not practical.