### PR TITLE
FIX: add missing update_extras action handler in user/card.php

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -164,6 +164,12 @@ if ($id > 0) {
 	$permissiontoeditpasswordandsend = ((($user->id == $id) && $user->hasRight("user", "self", "password")) || (($user->id != $id) && $user->hasRight("user", "user", "password")))&& (empty($user->socid) || $user->socid == $object->socid);
 }
 
+$permissiontoeditextra = $permissiontoedit;
+if (GETPOST('attribute', 'aZ09') && isset($extrafields->attributes[$object->table_element]['perms'][GETPOST('attribute', 'aZ09')])) {
+	// For action 'update_extras', is there a specific permission set for the attribute to update
+	$permissiontoeditextra = dol_eval((string) $extrafields->attributes[$object->table_element]['perms'][GETPOST('attribute', 'aZ09')]);
+}
+
 $passwordismodified = false;
 $ldap = null;
 
@@ -696,6 +702,31 @@ if (empty($reshook)) {
 					}
 				}
 			}
+		}
+	}
+
+	// Update extrafields
+	if ($action == 'update_extras' && $permissiontoeditextra) {
+		$object->oldcopy = dol_clone($object, 2);   // @phan-suppress-current-line PhanTypeMismatchProperty
+
+		$attribute_name = GETPOST('attribute', 'aZ09');
+
+		// Fill array 'array_options' with data from update form
+		$ret = $extrafields->setOptionalsFromPost(null, $object, $attribute_name);
+		if ($ret < 0) {
+			$error++;
+		}
+
+		if (!$error) {
+			$result = $object->updateExtraField($attribute_name, 'USER_MODIFY');
+			if ($result < 0) {
+				setEventMessages($object->error, $object->errors, 'errors');
+				$error++;
+			}
+		}
+
+		if ($error) {
+			$action = 'edit_extras';
 		}
 	}
 


### PR DESCRIPTION
# FIX Fix: extrafields not saved on user card
user/card.php was missing the update_extras action handler. When clicking the inline edit pencil on an extrafield of the user card and saving, the form posted action=update_extras but no code processed it, so the value was silently discarded and never written to the database. This affected all extrafields on the user card.
                                                                                                                                                                                                                                                
Added $permissiontoeditextra (with per-attribute permission support) and the if ($action == 'update_extras') block calling setOptionalsFromPost() + updateExtraField('USER_MODIFY'), mirroring the pattern already in place in contact/card.php and societe/card.php.