### PR TITLE
Fix Z-report missing sales when TakePos session spans multiple days

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -168,6 +168,20 @@ if ($invoiceid > 0) {
 	$ret = $invoice->fetch($invoiceid);
 } else {
 	$ret = $invoice->fetch(0, '(PROV-POS'.$takeposterminal.'-'.$place.')');
+	// If draft is from a previous day, update its date to today so the Z-report date is correct
+	if ($ret > 0 && $invoice->status == Facture::STATUS_DRAFT) {
+		include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+		$dolnowtzuserrel = dol_now('tzuserrel');
+		$monthuser = dol_print_date($dolnowtzuserrel, '%m', 'gmt');
+		$dayuser   = dol_print_date($dolnowtzuserrel, '%d', 'gmt');
+		$yearuser  = dol_print_date($dolnowtzuserrel, '%Y', 'gmt');
+		$dateinvoice = dol_mktime(0, 0, 0, (int) $monthuser, (int) $dayuser, (int) $yearuser, 'tzserver');
+		if ($invoice->date < $dateinvoice) {
+			$sql = "UPDATE ".MAIN_DB_PREFIX."facture SET datef = '".$db->idate($dateinvoice)."' WHERE rowid = ".((int) $invoice->id);
+			$db->query($sql);
+			$invoice->date = $dateinvoice;
+		}
+	}
 }
 if ($ret > 0) {
 	$placeid = $invoice->id;


### PR DESCRIPTION
Fix #38227

When a provisional invoice (PROV-POS<terminal>-<place>) is created on day N and the TakePos session is resumed on day N+1 without closing, the invoice retains its original datef.

The Z-report (compta/cashcontrol/report.php) filters invoices by datef using the cashcontrol closing date. If the invoice is validated and paid on day N+1, it does not appear in the cashcontrol for day N+1 because datef = N.

Fix:
When loading a provisional invoice, if datef is older than today, update it to the current day. This logic is placed in the else branch (provisional invoice path only) so it never runs when a specific invoice is loaded by ID.

Steps to reproduce:
1. Open a TakePos session on day N and add items to the cart (a provisional invoice is created with datef = N)
2. Do not close the session, let the day change to N+1 — or manually set datef to a past date on the provisional invoice row in 3. the database to simulate the scenario
4. Resume the TakePos session and validate the invoice with a payment
5. Open the Z-report (cashcontrol) for day N+1
6. The validated invoice does not appear - it is attributed to day N
