### PR TITLE
NEW Add maternity and paternity leave (disable/enable holiday module)

### DIFF
--- a/htdocs/core/modules/modHoliday.class.php
+++ b/htdocs/core/modules/modHoliday.class.php
@@ -386,7 +386,7 @@ class modHoliday extends DolibarrModules
 		);
 
 		foreach ($data_to_insert as $row) {
-			$sql_check = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."c_holiday_types WHERE code = '".$this->db->escape($row['code'])."' AND entity = ".$entity;
+			$sql_check = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."c_holiday_types WHERE code = '".$this->db->escape($row['code'])."' AND entity = ".(int) $entity;
 
 			$resql_check = $this->db->query($sql_check);
 			if ($resql_check) {

--- a/htdocs/core/modules/modHoliday.class.php
+++ b/htdocs/core/modules/modHoliday.class.php
@@ -363,7 +363,7 @@ class modHoliday extends DolibarrModules
 		}
 
 		$error = 0;
-		$entity = (int) getEntity('c_holiday_types');
+		$entity = getEntity('c_holiday_types');
 		$data_to_insert = array(
 			array(
 				'code'    => 'LEAVE_MATERNITY',
@@ -395,7 +395,7 @@ class modHoliday extends DolibarrModules
 
 				if ($nb == 0) {
 					$sql_insert = "INSERT INTO ".MAIN_DB_PREFIX."c_holiday_types (entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) ";
-					$sql_insert .= "VALUES (".$entity.", '".$this->db->escape($row['code'])."', '".$this->db->escape($row['label'])."', ".((int) $row['affect']).", ".((int) $row['delay']).", ".((int) $row['newbymonth']).", NULL, ".((int) $row['sortorder']).", ".((int) $row['active']).")";
+					$sql_insert .= "VALUES (".(int) $entity.", '".$this->db->escape($row['code'])."', '".$this->db->escape($row['label'])."', ".((int) $row['affect']).", ".((int) $row['delay']).", ".((int) $row['newbymonth']).", NULL, ".((int) $row['sortorder']).", ".((int) $row['active']).")";
 
 					$resql_insert = $this->db->query($sql_insert);
 

--- a/htdocs/core/modules/modHoliday.class.php
+++ b/htdocs/core/modules/modHoliday.class.php
@@ -362,56 +362,56 @@ class modHoliday extends DolibarrModules
 			return -1;
 		}
 
-    $error = 0;
-    $entity = (int) getEntity('c_holiday_types');
-    $data_to_insert = array(
-        array(
-            'code'    => 'LEAVE_MATERNITY',
-            'label'   => 'Maternity leave',
-            'affect'  => 0,
-            'delay'   => 0,
-            'newbymonth' => 0,
-            'sortorder' => 2,
-            'active'  => 1
-        ),
-        array(
-            'code'    => 'LEAVE_PATERNITY',
-            'label'   => 'Paternity leave',
-            'affect'  => 0,
-            'delay'   => 0,
-            'newbymonth' => 0,
-            'sortorder' => 2,
-            'active'  => 1
-        )
-    );
+	$error = 0;
+	$entity = (int) getEntity('c_holiday_types');
+	$data_to_insert = array(
+		array(
+			'code'    => 'LEAVE_MATERNITY',
+			'label'   => 'Maternity leave',
+			'affect'  => 0,
+			'delay'   => 0,
+			'newbymonth' => 0,
+			'sortorder' => 2,
+			'active'  => 1
+		),
+		array(
+			'code'    => 'LEAVE_PATERNITY',
+			'label'   => 'Paternity leave',
+			'affect'  => 0,
+			'delay'   => 0,
+			'newbymonth' => 0,
+			'sortorder' => 2,
+			'active'  => 1
+		)
+	);
 
-    foreach ($data_to_insert as $row) {
-        $sql_check = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."c_holiday_types WHERE code = '".$this->db->escape($row['code'])."' AND entity = ".$entity;
+	foreach ($data_to_insert as $row) {
+		$sql_check = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."c_holiday_types WHERE code = '".$this->db->escape($row['code'])."' AND entity = ".$entity;
 
-        $resql_check = $this->db->query($sql_check);
-        if ($resql_check) {
-            $obj = $this->db->fetch_object($resql_check);
-            $nb = (int) $obj->nb;
+		$resql_check = $this->db->query($sql_check);
+		if ($resql_check) {
+			$obj = $this->db->fetch_object($resql_check);
+			$nb = (int) $obj->nb;
 
-            if ($nb == 0) {
-                $sql_insert = "INSERT INTO ".MAIN_DB_PREFIX."c_holiday_types (entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) ";
-                $sql_insert .= "VALUES (".$entity.", '".$this->db->escape($row['code'])."', '".$this->db->escape($row['label'])."', ".((int) $row['affect']).", ".((int) $row['delay']).", ".((int) $row['newbymonth']).", NULL, ".((int) $row['sortorder']).", ".((int) $row['active']).")";
+			if ($nb == 0) {
+			    $sql_insert = "INSERT INTO ".MAIN_DB_PREFIX."c_holiday_types (entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) ";
+			    $sql_insert .= "VALUES (".$entity.", '".$this->db->escape($row['code'])."', '".$this->db->escape($row['label'])."', ".((int) $row['affect']).", ".((int) $row['delay']).", ".((int) $row['newbymonth']).", NULL, ".((int) $row['sortorder']).", ".((int) $row['active']).")";
 
-                $resql_insert = $this->db->query($sql_insert);
+			    $resql_insert = $this->db->query($sql_insert);
 
-                if ($resql_insert) {
+			    if ($resql_insert) {
 					dol_syslog("modHoliday::init Adding holiday type into " . MAIN_DB_PREFIX . "c_holiday_types: code=" . $row['code'] . ", label=" . $row['label'], LOG_INFO);
 				} else {
-                    $error++;
-                    $this->error = $langs->trans("ErrorSQL", $this->db->error());
-                }
-            }
-        } else {
-            $error++;
-            $this->error = $langs->trans("ErrorRefNotFound", $row['code']);
-        }
-    }
+			        $error++;
+			        $this->error = $langs->trans("ErrorSQL", $this->db->error());
+			    }
+			}
+		} else {
+			$error++;
+			$this->error = $langs->trans("ErrorRefNotFound", $row['code']);
+		}
+	}
 
-    return ($error > 0) ? 0 : 1;
+	return ($error > 0) ? 0 : 1;
 	}
 }

--- a/htdocs/core/modules/modHoliday.class.php
+++ b/htdocs/core/modules/modHoliday.class.php
@@ -362,56 +362,56 @@ class modHoliday extends DolibarrModules
 			return -1;
 		}
 
-	$error = 0;
-	$entity = (int) getEntity('c_holiday_types');
-	$data_to_insert = array(
-		array(
-			'code'    => 'LEAVE_MATERNITY',
-			'label'   => 'Maternity leave',
-			'affect'  => 0,
-			'delay'   => 0,
-			'newbymonth' => 0,
-			'sortorder' => 2,
-			'active'  => 1
-		),
-		array(
-			'code'    => 'LEAVE_PATERNITY',
-			'label'   => 'Paternity leave',
-			'affect'  => 0,
-			'delay'   => 0,
-			'newbymonth' => 0,
-			'sortorder' => 2,
-			'active'  => 1
-		)
-	);
+		$error = 0;
+		$entity = (int) getEntity('c_holiday_types');
+		$data_to_insert = array(
+			array(
+				'code'    => 'LEAVE_MATERNITY',
+				'label'   => 'Maternity leave',
+				'affect'  => 0,
+				'delay'   => 0,
+				'newbymonth' => 0,
+				'sortorder' => 2,
+				'active'  => 1
+			),
+			array(
+				'code'    => 'LEAVE_PATERNITY',
+				'label'   => 'Paternity leave',
+				'affect'  => 0,
+				'delay'   => 0,
+				'newbymonth' => 0,
+				'sortorder' => 2,
+				'active'  => 1
+			)
+		);
 
-	foreach ($data_to_insert as $row) {
-		$sql_check = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."c_holiday_types WHERE code = '".$this->db->escape($row['code'])."' AND entity = ".$entity;
+		foreach ($data_to_insert as $row) {
+			$sql_check = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."c_holiday_types WHERE code = '".$this->db->escape($row['code'])."' AND entity = ".$entity;
 
-		$resql_check = $this->db->query($sql_check);
-		if ($resql_check) {
-			$obj = $this->db->fetch_object($resql_check);
-			$nb = (int) $obj->nb;
+			$resql_check = $this->db->query($sql_check);
+			if ($resql_check) {
+				$obj = $this->db->fetch_object($resql_check);
+				$nb = (int) $obj->nb;
 
-			if ($nb == 0) {
-			    $sql_insert = "INSERT INTO ".MAIN_DB_PREFIX."c_holiday_types (entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) ";
-			    $sql_insert .= "VALUES (".$entity.", '".$this->db->escape($row['code'])."', '".$this->db->escape($row['label'])."', ".((int) $row['affect']).", ".((int) $row['delay']).", ".((int) $row['newbymonth']).", NULL, ".((int) $row['sortorder']).", ".((int) $row['active']).")";
+				if ($nb == 0) {
+					$sql_insert = "INSERT INTO ".MAIN_DB_PREFIX."c_holiday_types (entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) ";
+					$sql_insert .= "VALUES (".$entity.", '".$this->db->escape($row['code'])."', '".$this->db->escape($row['label'])."', ".((int) $row['affect']).", ".((int) $row['delay']).", ".((int) $row['newbymonth']).", NULL, ".((int) $row['sortorder']).", ".((int) $row['active']).")";
 
-			    $resql_insert = $this->db->query($sql_insert);
+					$resql_insert = $this->db->query($sql_insert);
 
-			    if ($resql_insert) {
-					dol_syslog("modHoliday::init Adding holiday type into " . MAIN_DB_PREFIX . "c_holiday_types: code=" . $row['code'] . ", label=" . $row['label'], LOG_INFO);
-				} else {
-			        $error++;
-			        $this->error = $langs->trans("ErrorSQL", $this->db->error());
-			    }
+					if ($resql_insert) {
+						dol_syslog("modHoliday::init Adding holiday type into " . MAIN_DB_PREFIX . "c_holiday_types: code=" . $row['code'] . ", label=" . $row['label'], LOG_INFO);
+					} else {
+						$error++;
+						$this->error = $langs->trans("ErrorSQL", $this->db->error());
+					}
+				}
+			} else {
+				$error++;
+				$this->error = $langs->trans("ErrorRefNotFound", $row['code']);
 			}
-		} else {
-			$error++;
-			$this->error = $langs->trans("ErrorRefNotFound", $row['code']);
 		}
-	}
 
-	return ($error > 0) ? 0 : 1;
+		return ($error > 0) ? 0 : 1;
 	}
 }

--- a/htdocs/core/modules/modHoliday.class.php
+++ b/htdocs/core/modules/modHoliday.class.php
@@ -347,33 +347,71 @@ class modHoliday extends DolibarrModules
 	 */
 	public function init($options = '')
 	{
+		global $langs;
 		// Permissions
 		$this->remove($options);
-
-		//ODT template
-		/*$src=DOL_DOCUMENT_ROOT.'/install/doctemplates/holiday/template_holiday.odt';
-		$dirodt=DOL_DATA_ROOT.($conf->entity > 1 ? '/'.$conf->entity : '').'/doctemplates/holiday';
-		$dest=$dirodt.'/template_order.odt';
-
-		if (file_exists($src) && ! file_exists($dest))
-		{
-			require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
-			dol_mkdir($dirodt);
-			$result=dol_copy($src, $dest, 0, 0);
-			if ($result < 0)
-			{
-				$langs->load("errors");
-				$this->error=$langs->trans('ErrorFailToCopyFile', $src, $dest);
-				return 0;
-			}
-		}
-		*/
 
 		$sql = array(
 			//	"DELETE FROM ".MAIN_DB_PREFIX."document_model WHERE nom = '".$this->db->escape($this->const[0][2])."' AND type = 'holiday' AND entity = ".((int) $conf->entity),
 			//	"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('".$this->db->escape($this->const[0][2])."','holiday',".((int) $conf->entity).")"
 		);
 
-		return $this->_init($sql, $options);
+		$res = $this->_init($sql, $options);
+
+		if ($res < 0) {
+			return -1;
+		}
+
+    $error = 0;
+    $entity = (int) getEntity('c_holiday_types');
+    $data_to_insert = array(
+        array(
+            'code'    => 'LEAVE_MATERNITY',
+            'label'   => 'Maternity leave',
+            'affect'  => 0,
+            'delay'   => 0,
+            'newbymonth' => 0,
+            'sortorder' => 2,
+            'active'  => 1
+        ),
+        array(
+            'code'    => 'LEAVE_PATERNITY',
+            'label'   => 'Paternity leave',
+            'affect'  => 0,
+            'delay'   => 0,
+            'newbymonth' => 0,
+            'sortorder' => 2,
+            'active'  => 1
+        )
+    );
+
+    foreach ($data_to_insert as $row) {
+        $sql_check = "SELECT COUNT(*) as nb FROM ".MAIN_DB_PREFIX."c_holiday_types WHERE code = '".$this->db->escape($row['code'])."' AND entity = ".$entity;
+
+        $resql_check = $this->db->query($sql_check);
+        if ($resql_check) {
+            $obj = $this->db->fetch_object($resql_check);
+            $nb = (int) $obj->nb;
+
+            if ($nb == 0) {
+                $sql_insert = "INSERT INTO ".MAIN_DB_PREFIX."c_holiday_types (entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) ";
+                $sql_insert .= "VALUES (".$entity.", '".$this->db->escape($row['code'])."', '".$this->db->escape($row['label'])."', ".((int) $row['affect']).", ".((int) $row['delay']).", ".((int) $row['newbymonth']).", NULL, ".((int) $row['sortorder']).", ".((int) $row['active']).")";
+
+                $resql_insert = $this->db->query($sql_insert);
+
+                if ($resql_insert) {
+					dol_syslog("modHoliday::init Adding holiday type into " . MAIN_DB_PREFIX . "c_holiday_types: code=" . $row['code'] . ", label=" . $row['label'], LOG_INFO);
+				} else {
+                    $error++;
+                    $this->error = $langs->trans("ErrorSQL", $this->db->error());
+                }
+            }
+        } else {
+            $error++;
+            $this->error = $langs->trans("ErrorRefNotFound", $row['code']);
+        }
+    }
+
+    return ($error > 0) ? 0 : 1;
 	}
 }

--- a/htdocs/install/mysql/data/llx_c_holiday_types.sql
+++ b/htdocs/install/mysql/data/llx_c_holiday_types.sql
@@ -27,6 +27,8 @@
 -- Generic to all countries
 insert into llx_c_holiday_types(entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) values (__ENTITY__, 'LEAVE_SICK',    'Sick leave',    0, 0, 0,    NULL, 1, 1);
 insert into llx_c_holiday_types(entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) values (__ENTITY__, 'LEAVE_OTHER',   'Other leave',   0, 0, 0,    NULL, 2, 1);
+insert into llx_c_holiday_types(entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) values (__ENTITY__, 'LEAVE_MATERNITY',   'Maternity leave',   0, 0, 0,    NULL, 2, 1);
+insert into llx_c_holiday_types(entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) values (__ENTITY__, 'LEAVE_PATERNITY',   'Paternity leave',   0, 0, 0,    NULL, 2, 1);
 
 -- Not enabled by default, we prefer to have an entry dedicated to the country
 insert into llx_c_holiday_types(entity, code, label, affect, delay, newbymonth, fk_country, sortorder, active) values (__ENTITY__, 'LEAVE_PAID',    'Paid vacation', 1, 7, 0,    NULL, 3, 0);


### PR DESCRIPTION
# NEW Add maternity and paternity leave (disable/enable holiday module)
Applying this PR will make the holiday module add 2 new database entries

- [x] Maternity leave
- [x] Paternity leave

They are added if missing when enabling the holiday module, so if you already have this module, disable and re-enable it.

After that they should show up in the dictionary and be useful in a leave request. For new installations cycling the holiday module is not necessary.


<img width="715" height="364" alt="image" src="https://github.com/user-attachments/assets/388c13bf-acab-4850-a6c5-57fb108d33bb" />



<img width="300" height="309" alt="image" src="https://github.com/user-attachments/assets/2a21abe2-ac4f-4d08-8929-f619bf88afc8" />

This missing leave type was discovered during investigation of issue #33281