### PR TITLE
feat(eventorganization): Add database schema for attendee-contact linkage

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -530,4 +530,8 @@ ALTER TABLE llx_product_warehouse_properties ADD INDEX idx_product_warehouse_pro
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_product FOREIGN KEY (fk_product) REFERENCES llx_product (rowid);
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_entrepot FOREIGN KEY (fk_entrepot) REFERENCES llx_entrepot (rowid);
 
+
+ALTER TABLE llx_element_contact ADD COLUMN fk_attendee integer NULL AFTER fk_socpeople;
+ALTER TABLE llx_element_contact ADD INDEX idx_element_contact_fk_attendee (fk_attendee);
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_element_contact.key.sql
+++ b/htdocs/install/mysql/tables/llx_element_contact.key.sql
@@ -23,4 +23,5 @@ ALTER TABLE llx_element_contact ADD UNIQUE INDEX idx_element_contact_idx1 (eleme
 ALTER TABLE llx_element_contact ADD CONSTRAINT fk_element_contact_fk_c_type_contact FOREIGN KEY (fk_c_type_contact)     REFERENCES llx_c_type_contact(rowid);
 
 ALTER TABLE llx_element_contact ADD INDEX idx_element_contact_fk_socpeople (fk_socpeople);
+ALTER TABLE llx_element_contact ADD INDEX idx_element_contact_fk_attendee (fk_attendee);
 -- Pas de contraite sur fk_socpeople car point sur llx_socpeople mais aussi llx_user

--- a/htdocs/install/mysql/tables/llx_element_contact.sql
+++ b/htdocs/install/mysql/tables/llx_element_contact.sql
@@ -27,5 +27,6 @@ create table llx_element_contact
   element_id		  int NOT NULL, 		    -- ID of element.
   mandatory_signature tinyint,                  -- 1=Indicate that signature is mandatory for this contact on the objet
   fk_c_type_contact	  int NOT NULL,	            -- nature of contact.
-  fk_socpeople        integer NOT NULL          -- ID of contact
+  fk_socpeople        integer NOT NULL,         -- ID of contact
+  fk_attendee         integer NULL.             -- ID of attendee
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_element_contact.sql
+++ b/htdocs/install/mysql/tables/llx_element_contact.sql
@@ -28,5 +28,5 @@ create table llx_element_contact
   mandatory_signature tinyint,                  -- 1=Indicate that signature is mandatory for this contact on the objet
   fk_c_type_contact	  int NOT NULL,	            -- nature of contact.
   fk_socpeople        integer NOT NULL,         -- ID of contact
-  fk_attendee         integer NULL.             -- ID of attendee
+  fk_attendee         integer NULL              -- ID of attendee
 )ENGINE=innodb;


### PR DESCRIPTION
feat(eventorganization): Add database schema for attendee-contact linkage

- Add 'fk_attendee' column to llx_element_contact table (nullable)
- Add index 'idx_element_contact_fk_attendee' for performance optimization
- Update table definition and key files for fresh installs
- Update migration script for existing installations

This column links contacts to specific event attendees, enabling:
- Tracking which attendee a contact is associated with
- Filtering contacts by attendee in event contexts
- Supporting the upcoming attendee replacement feature

This commit only contains database structure changes (SQL files). PHP logic and UI implementation will follow in subsequent PRs once this pr has been merged.

First PR in feature request #38241
