### PR TITLE
FIX install crash when loading subtotals module

### DIFF
--- a/htdocs/core/modules/modSubtotals.class.php
+++ b/htdocs/core/modules/modSubtotals.class.php
@@ -33,6 +33,10 @@
 include_once DOL_DOCUMENT_ROOT."/core/modules/DolibarrModules.class.php";
 require_once DOL_DOCUMENT_ROOT.'/subtotals/class/commonsubtotal.class.php';
 
+if (!defined('SUBTOTALS_SPECIAL_CODE')) {
+	define('SUBTOTALS_SPECIAL_CODE', 81);
+}
+
 /**
  *		Description and activation class for module subtotals
  */


### PR DESCRIPTION
# FIX|Fix install crash when loading Subtotals module

During the final installation step, Dolibarr scans module descriptors and instantiates `modSubtotals`.

In this context, `SUBTOTALS_SPECIAL_CODE` may not be defined yet because `master.inc.php` is not loaded by the installer. This causes a fatal error:

`Undefined constant "SUBTOTALS_SPECIAL_CODE"`

This PR defines the fallback value in the Subtotals module descriptor before it is used, matching the value already defined in `master.inc.php`.

Tested with:
- `php -l htdocs/core/modules/modSubtotals.class.php`
- Final installation step completed successfully


