### PR TITLE
Close #38247 Max_participants on actioncomm events 

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -530,4 +530,6 @@ ALTER TABLE llx_product_warehouse_properties ADD INDEX idx_product_warehouse_pro
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_product FOREIGN KEY (fk_product) REFERENCES llx_product (rowid);
 ALTER TABLE llx_product_warehouse_properties ADD CONSTRAINT fk_product_warehouse_properties_fk_entrepot FOREIGN KEY (fk_entrepot) REFERENCES llx_entrepot (rowid);
 
+ALTER TABLE llx_actioncomm ADD COLUMN max_participants integer DEFAULT NULL AFTER status;
+ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_max_participants (max_participants);
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_actioncomm.key.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.key.sql
@@ -30,5 +30,6 @@ ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_ref_ext (ref_ext);
 ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_percent (percent);
 
 ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_ref (ref, entity);
+ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_max_participants (max_participants);
 -- To test performance to get fast next num on actioncomm
 -- ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_entity_id (entity, id);

--- a/htdocs/install/mysql/tables/llx_actioncomm.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm.sql
@@ -76,6 +76,7 @@ create table llx_actioncomm
   num_vote          integer DEFAULT NULL,          -- use for Event Organization module
   event_paid        smallint NOT NULL DEFAULT 0,    -- use for Event Organization module
   status            smallint NOT NULL DEFAULT 0,    -- use for Event Organization module for now, but could be use after for event global status
+  max_participants  integer DEFAULT NULL,           -- Maximum number of participants allowed for this action (event, meeting, shift)
 
   fk_element		integer DEFAULT NULL,			-- For link to an element (proposal, invoice, order, ...)
   elementtype		varchar(255) DEFAULT NULL,		-- For link to an element (proposal, invoice, order, ...)


### PR DESCRIPTION
Fix #38247 Max_participants on actioncomm events 

feat(eventorganization): Add database schema for participant capacity


- Add 'max_participants' column to llx_actioncomm table (nullable)
- Add index 'idx_actioncomm_max_participants' for performance optimization
- Update table definition and key files for fresh installs
- Update migration script for existing installations

This column defines the maximum number of participants allowed for a session. NULL means unlimited. This is used for events, meetings, and volunteer shifts.

This commit only contains database structure changes (SQL files). PHP logic and UI implementation will follow in subsequent PRs.

Fixes #38247