### PR TITLE
Fix #38225 webportal member is only in top menu, not on front page

### DIFF
--- a/htdocs/public/webportal/tpl/home.tpl.php
+++ b/htdocs/public/webportal/tpl/home.tpl.php
@@ -37,5 +37,11 @@ if (empty($context) || !is_object($context)) {
 				<?php print '<a class="home-links-card__link" href="' . $context->getControllerUrl('invoicelist') . '" title="' . $langs->trans('WebPortalInvoiceListDesc') . '">' . $langs->trans('WebPortalInvoiceListTitle') . '</a>'; ?>
 			</article>
 			<?php endif; ?>
+			<?php if (isModEnabled('member') && in_array(getDolGlobalString('WEBPORTAL_MEMBER_CARD_ACCESS'), ['visible', 'edit']) && $context->logged_member && $context->logged_member->id > 0) : ?>
+			<article class="home-links-card --membercard">
+				<div class="home-links-card__icon" ></div>
+				<?php print '<a class="home-links-card__link" href="' . $context->getControllerUrl('membercard') . '" title="' . $langs->trans('WebPortalMemberCardMenu') . '">' . $langs->trans('WebPortalMemberCardMenu') . '</a>'; ?>
+			</article>
+			<?php endif; ?>
 		</div>
 </main>


### PR DESCRIPTION
# Fix #38225 webportal member is only in top menu, not on front page
Applying this PR will add an "area" with a link to the member info on the front page so it is not just in the top menu.

<img width="724" height="817" alt="image" src="https://github.com/user-attachments/assets/19431ebc-a3f0-4049-bba5-ffcbf0bf0254" />

I am not sure if this is a bug or feature?

Merging this PR should close #38225

Redo of #38226