### PR TITLE
Fix: avoid undefined method stdClass::isEmpty() on PHP 8.1

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -523,10 +523,10 @@ class ProductCombination
 		$child->price_autogen = $parent->price_autogen;
 		$child->weight = $parent->weight;
 		// Only when Parent Status are updated
-		if (is_object($parent->oldcopy) && !empty((array) $parent->oldcopy) && ($parent->status != $parent->oldcopy->status)) {
+		if (is_object($parent->oldcopy) && !empty($parent->oldcopy->id) && ($parent->status != $parent->oldcopy->status)) {
 			$child->status = $parent->status;
 		}
-		if (is_object($parent->oldcopy) && !empty((array) $parent->oldcopy) && ($parent->status_buy != $parent->oldcopy->status_buy)) {
+		if (is_object($parent->oldcopy) && !empty($parent->oldcopy->id) && ($parent->status_buy != $parent->oldcopy->status_buy)) {
 			$child->status_buy = $parent->status_buy;
 		}
 

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -523,10 +523,10 @@ class ProductCombination
 		$child->price_autogen = $parent->price_autogen;
 		$child->weight = $parent->weight;
 		// Only when Parent Status are updated
-		if (is_object($parent->oldcopy) && !$parent->oldcopy->isEmpty() && ($parent->status != $parent->oldcopy->status)) {
+		if (is_object($parent->oldcopy) && !empty((array) $parent->oldcopy) && ($parent->status != $parent->oldcopy->status)) {
 			$child->status = $parent->status;
 		}
-		if (is_object($parent->oldcopy) && !$parent->oldcopy->isEmpty() && ($parent->status_buy != $parent->oldcopy->status_buy)) {
+		if (is_object($parent->oldcopy) && !empty((array) $parent->oldcopy) && ($parent->status_buy != $parent->oldcopy->status_buy)) {
 			$child->status_buy = $parent->status_buy;
 		}
 


### PR DESCRIPTION
# FIX #38235 avoid undefined method stdClass::isEmpty() on PHP 8.1

This fixes a fatal error when updating product prices (variants) on PHP 8.1+. 

During execution, `$parent->oldcopy` is sometimes evaluated as a generic `stdClass` object instead of a full `Product` object. Since `stdClass` does not contain the `isEmpty()` method, PHP 8.1+ throws an `Uncaught Error: Call to undefined method stdClass::isEmpty()` and halts execution.

By casting the object to an array and using `empty()`, we safely check the object state, ensuring PHP 8.1+ compatibility without breaking the existing logic.