### PR TITLE
FIX Unit Price inc.tax is not showing in Purchase Order

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5511,7 +5511,7 @@ abstract class CommonObject
 
 			$i = 0;
 
-			print "<!-- begin printObjectLines() -->\n";
+			print "<!-- ".__METHOD__."::begin printObjectLines() -->\n";
 			foreach ($this->lines as $line) {
 				// Line extrafield. TODO Remove this. extrafields should be already loaded.
 				//$line->fetch_optionals();
@@ -5531,7 +5531,7 @@ abstract class CommonObject
 
 				$i++;
 			}
-			print "<!-- end printObjectLines() -->\n";
+			print "<!-- ".__METHOD__."::end printObjectLines() -->\n";
 		}
 	}
 
@@ -5608,7 +5608,7 @@ abstract class CommonObject
 			}
 
 			// Recalculate unit price with tax if not defined
-			if (empty($line->subprice_ttc) && $line->qty) {	// subprice_ttc may be not stored on old version or not defined for lines with no unit price (like a discount)
+			if ((float) $line->subprice_ttc == 0 && $line->qty) {	// subprice_ttc may be not stored on old version or not defined for lines with no unit price (like a discount)
 				// So we calculate an estimated value just to show something on screen
 				$line->subprice_ttc = (float) price2num($line->total_ttc / $line->qty, 'MU');
 				//other method is less accurate


### PR DESCRIPTION
# FIX Unit Price inc.tax is not showing in Purchase Order
Applying this pr would show the calculated unit price incl. tax which was not calculated, possible due to the contents not being a float?

### Fixed
- [x] View mode

## screenshots with unit price incl. tax
<img width="946" height="281" alt="image" src="https://github.com/user-attachments/assets/177226a0-6baa-48dd-861a-48edce15d78d" />

Applying this PR might close #37671
