### PR TITLE
FIX #37453 AJAX tooltip for project tasks always shows "Access Forbid…

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -526,13 +526,20 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
 		$feature2 = 'evaluation';
 	}
 
-	// @todo check : project_task
-	// @todo possible ?
-	// elseif (substr($features, -3, 3) == 'det') {
-	// 	$features = substr($features, 0, -3);
-	// } elseif (substr($features, -4, 4) == '_det' || substr($features, -4, 4) == 'line') {
-	// 	$features = substr($features, 0, -4);
-	// }
+	// When the object is a task (element='project_task') and $feature2 is empty,
+	// $checkUserAccessToObject() falls into the $checkproject path and uses the task ID
+	// as project ID, which always fails. Setting $feature2='project_task' triggers the
+	// normalization at line 974 that redirects to the $checktask path, which correctly
+	// resolves $task->fk_project before calling getProjectsAuthorizedForUser().
+	if (is_object($object) && in_array($object->element, array('project_task', 'task'))
+		&& (empty($features) || in_array($features, array('projet', 'project')))
+		&& empty($feature2)) {
+		$features = 'projet';
+		$feature2 = 'project_task';
+		if (empty($tableandshare)) {
+			$tableandshare = 'projet_task';
+		}
+	}
 
 	//print $features.' - '.$tableandshare.' - '.$feature2.' - '.$dbt_select."\n";
 


### PR DESCRIPTION
# Fix #37453 AJAX tooltip for project tasks always shows "Access Forbidden" for restricted users
Applying this PR gives tooltip on mouse over access to tasks in projects where the user is a contact evne if the user does not have access to all projects

All credit for this fix should go to @avadnc which posted the fix in bug report #37453


## screenshots

### Access granted, user is a contact of project
<img width="610" height="230" alt="image" src="https://github.com/user-attachments/assets/8086a5b3-9ef0-42dc-b002-180298ed0ad2" />

### access denied, not a contact of project
<img width="767" height="337" alt="image" src="https://github.com/user-attachments/assets/a496c170-681d-49ac-9776-a865ded2569a" />
