### PR TITLE
FIX #37356 Category Products not listed

### DIFF
--- a/htdocs/categories/index.php
+++ b/htdocs/categories/index.php
@@ -80,15 +80,19 @@ llxHeader('', $title, '', '', 0, 0, '', '');
 // Get list of category type
 $arrayofcateg = array();
 foreach ($categstatic->MAP_ID as $key => $idtype) {
-	if ($key == 'service') {
+	if ($key == 'product' && !isModEnabled("product")) {
 		continue;
 	}
+	if ($key == 'service' && !isModEnabled("service")) {
+		continue;
+	}
+
 	$arrayofcateg[$idtype] = array();
 	$arrayofcateg[$idtype]['key'] = $key;
 	$arrayofcateg[$idtype]['nb'] = 0;
 	$arrayofcateg[$idtype]['label'] = $langs->transnoentitiesnoconv($categstatic::$MAP_TYPE_TITLE_AREA[$key]);
 	$arrayofcateg[$idtype]['labelwithoutaccent'] = dol_string_unaccent($langs->transnoentitiesnoconv($categstatic::$MAP_TYPE_TITLE_AREA[$key]));
-	if ($key == 'product') {
+	if ($key == 'product' || $key == 'service') {
 		$arrayofcateg[$idtype]['label'] = $langs->transnoentitiesnoconv("ProductsAndServices");
 		$arrayofcateg[$idtype]['labelwithoutaccent'] = dol_string_unaccent($langs->transnoentitiesnoconv("ProductsAndServices"));
 	}

--- a/htdocs/categories/index.php
+++ b/htdocs/categories/index.php
@@ -80,11 +80,18 @@ llxHeader('', $title, '', '', 0, 0, '', '');
 // Get list of category type
 $arrayofcateg = array();
 foreach ($categstatic->MAP_ID as $key => $idtype) {
+	if ($key == 'service') {
+		continue;
+	}
 	$arrayofcateg[$idtype] = array();
 	$arrayofcateg[$idtype]['key'] = $key;
 	$arrayofcateg[$idtype]['nb'] = 0;
 	$arrayofcateg[$idtype]['label'] = $langs->transnoentitiesnoconv($categstatic::$MAP_TYPE_TITLE_AREA[$key]);
 	$arrayofcateg[$idtype]['labelwithoutaccent'] = dol_string_unaccent($langs->transnoentitiesnoconv($categstatic::$MAP_TYPE_TITLE_AREA[$key]));
+	if ($key == 'product') {
+		$arrayofcateg[$idtype]['label'] = $langs->transnoentitiesnoconv("ProductsAndServices");
+		$arrayofcateg[$idtype]['labelwithoutaccent'] = dol_string_unaccent($langs->transnoentitiesnoconv("ProductsAndServices"));
+	}
 }
 $arrayofcateg = dol_sort_array($arrayofcateg, 'labelwithoutaccent', 'asc', 1, 0, 1);
 


### PR DESCRIPTION
# FIX #37356 Category Products not listed
Applying this PR will bring back Products (and services) line on the list of categories when products are enabled, but services are not.

## Before data array =
```
  "0": {
    "key": "service",
    "nb": 0,
    "label": "Services",
    "labelwithoutaccent": "Services"
  },
```

## After data array =
```
    "0": {
    "key": "product",
    "nb": 0,
    "label": "Products and Services",
    "labelwithoutaccent": "Products and Services"
  },
 ```


## Screenshots
<img width="435" height="993" alt="image" src="https://github.com/user-attachments/assets/33378b0f-c56e-4bf0-82cc-68838d1a129a" />


Applying this PR should close #37356