### PR TITLE
FIX #37327 There is no product description displayed in version 22

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -1145,7 +1145,8 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 
 
 			// Deal with supplier ref price (idprodfournprice = int)
-			if (jQuery('#idprodfournprice').val() > 0)
+			var supplierVal = jQuery('#idprodfournprice').val();
+			if (supplierVal && supplierVal !== '-1' && (supplierVal > 0 || supplierVal.indexOf('idprod_') === 0))
 			{
 				console.log("objectline_create.tpl #idprodfournprice is an ID > 0, so we set some properties into page");
 


### PR DESCRIPTION
# FIX #37327 There is no product description displayed in version 22
Applying this PR would restore the possibility to reload product description on supplier proposals, supplier orders and supplier invoices

This should close #37327

## Screenshots

### PRE change
<img width="576" height="277" alt="image" src="https://github.com/user-attachments/assets/3379f694-f725-4b9b-a66b-bcd823fe209c" />


### POST change
<img width="576" height="288" alt="image" src="https://github.com/user-attachments/assets/e0eb4c10-f9c4-4d26-943f-66594b1196d2" />

This PR only makes use of the existing data already in the HTML. It does not make the supplier pages make the same ajax calls that the customer pages uses

```
192.168.127.1 - - [15/May/2026:12:15:10 +0200] "GET /variants/ajax/getCombinations.php?id=89 HTTP/1.1" 200 2803 "http://localhost:22080/commande/card.php?id=1835" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
192.168.127.1 - - [15/May/2026:12:15:10 +0200] "POST /product/ajax/products.php?action=fetch HTTP/1.1" 200 2847 "http://localhost:22080/commande/card.php?id=1835" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
192.168.127.1 - - [15/May/2026:12:15:13 +0200] "POST /product/ajax/products.php?action=fetch HTTP/1.1" 200 2846 "http://localhost:22080/commande/card.php?id=1835" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
192.168.127.1 - - [15/May/2026:12:15:13 +0200] "GET /variants/ajax/getCombinations.php?id=91 HTTP/1.1" 200 2802 "http://localhost:22080/commande/card.php?id=1835" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15"
```