### PR TITLE
FIX : cost price is not correctly computed when line qty is < to 0

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -98,7 +98,7 @@ class FormMargin
 			}
 
 			$pv = $line->total_ht;
-			$pa_ht = ($pv < 0 ? -$line->pa_ht : $line->pa_ht); // We choosed to have line->pa_ht always positive in database, so we guess the correct sign
+			$pa_ht = (($pv < 0 && $line->qty > 0) ? -$line->pa_ht : $line->pa_ht); // We choosed to have line->pa_ht always positive in database, so we guess the correct sign
 			if (($object->element == 'facture' && $object->type == $object::TYPE_SITUATION)
 				|| ($object->element == 'facture' && $object->type == $object::TYPE_CREDIT_NOTE && $conf->global->INVOICE_USE_SITUATION_CREDIT_NOTE && $object->situation_counter > 0)) {
 				$pa = $line->qty * $pa_ht * ($line->situation_percent / 100);


### PR DESCRIPTION
# FIX cost price is not correctly computed when line qty is < to 0

to reproduce : 

- activate hidden const PROPAL_ENABLE_NEGATIVE_QTY
- activate "margin" native plugin
- create a propal line with qty < 0
- observe that the cost price is positive while it should be negative.

Bug observed on DLB 14.0 up to develop.


<img width="2294" height="678" alt="bug-calcul-marge-14" src="https://github.com/user-attachments/assets/7872ff26-16da-40ca-87ca-591757eb3af9" />

