### PR TITLE
Fix #37675 API Post eventattendee sets ref to same as id

### DIFF
--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -299,7 +299,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 		}
 
 		$result = $this->createCommon($user, $notrigger);
-		if ($result > 0) {
+		if ($result > 0 && empty($this->ref)) {
 			$result = $this->fetch($result);
 			if ($result > 0) {
 				$this->ref = (string) $this->id;

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -299,9 +299,9 @@ class ConferenceOrBoothAttendee extends CommonObject
 		}
 
 		$result = $this->createCommon($user, $notrigger);
-		if ($result > 0 && empty($this->ref)) {
+		if ($result > 0) {
 			$result = $this->fetch($result);
-			if ($result > 0) {
+			if ($result > 0 && empty($this->ref)) {
 				$this->ref = (string) $this->id;
 				$result = $this->update($user);
 			}


### PR DESCRIPTION
# Fix #37675 API Post eventattendee sets ref to same as id
Applying this PR will fix and close bug #37675. This bug was that the ref field was always overwritten during creation with the rowid value.

This PR checks if there is a ref and keeps that, else it writes the rowid as ref.

## Test json
```
{
  "id": 7,
  "import_key": null,
  "array_options": {
    "options_role": "Follow"
  },
  "contacts_ids_internal": null,
  "linkedObjectsIds": null,
  "fk_project": 26,
  "ref": 
"newref.",
  "status": 1,
"date_subscription": 1778917884,
  "email": "***************"
}
```

## Creation still works in GUI
<img width="786" height="439" alt="image" src="https://github.com/user-attachments/assets/ee42b18b-acdb-4aaa-bf6b-0473814530af" />
