### PR TITLE
Fix #36777 Conf doesn't work when I create a third-party

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1474,7 +1474,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 			print '<tr class="marginbottomlarge height50">';
 			if ($conf->browser->layout != 'phone') {
-				print '<td class="titlefieldcreate">'.$form->editfieldkey('', 'customerprospect', '', $object, 0, 'string', '', 0).'</td>';
+				print '<td class="titlefieldcreate">'.$langs->trans("NatureOfThirdParty").''.$form->editfieldkey('', 'customerprospect', '', $object, 0, 'string', '', 0).'</td>';
 			}
 			print '<td class="maxwidthonsmartphone"'.($conf->browser->layout != 'phone' ? 'colspan="3"' : 'colspan="2"').'>';
 
@@ -2317,7 +2317,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 				$selectedcustomer = (GETPOSTISSET('customer') ? GETPOSTINT('customer') : $selectedcustomer);
 				print '<tr class="marginbottomlarge height50">';
 				if ($conf->browser->layout != 'phone') {
-					print '<td class="titlefieldcreate">'.$form->editfieldkey('', 'customerprospect', '', $object, 0, 'string', '', 0).'</td>';
+					print '<td class="titlefieldcreate">'.$langs->trans("NatureOfThirdParty").''.$form->editfieldkey('', 'customerprospect', '', $object, 0, 'string', '', 0).'</td>';
 				}
 				print '<td class="maxwidthonsmartphone"'.($conf->browser->layout != 'phone' ? 'colspan="3"' : 'colspan="2"').'>';
 


### PR DESCRIPTION
# Fix #36777 Conf doesn't work when I create a third-party
Applying this PR will bring back the text "Nature of third party" on third party creation and edit. In develop there might further be the issue that the `Alias name (commercial, trademark, ...)` text is also gone, but let's fix this first.

### pre 
<img width="600" height="165" alt="Image" src="https://github.com/user-attachments/assets/d909c53d-57b5-4b15-9096-c25a17fb9927" />

### post
<img width="586" height="158" alt="image" src="https://github.com/user-attachments/assets/e32f65d6-8050-471e-aab6-b30dbad04b20" />
