### PR TITLE
Fix missing label with thirdparty Alias

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1472,6 +1472,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 			// Alias names (commercial, trademark or alias names)
 			print '<tr id="name_alias"><td>';
 			print '<input type="hidden" name="status" value="1">';
+			print '<label for="name_alias_input">'.$langs->trans('AliasNames').'</label>';
 			print '</td>';
 			print '<td colspan="3"><input type="text" class="minwidth300" name="name_alias" id="name_alias_input" value="'.dol_escape_htmltag($object->name_alias).'" spellcheck="false" placeholder="'.dolPrintHTMLForAttribute($langs->trans('AliasNames')).'"></td></tr>';
 
@@ -2363,7 +2364,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 				// Alias names (commercial, trademark or alias names)
 				print '<tr id="name_alias"><td>';
-				//print '<label for="name_alias_input">'.$langs->trans('AliasNames').'</label>';
+				print '<label for="name_alias_input">'.$langs->trans('AliasNames').'</label>';
 				print '</td>';
 				print '<td colspan="3"><input type="text" class="minwidth300" name="name_alias" id="name_alias_input" value="'.dol_escape_htmltag($object->name_alias).'" placeholder="'.dolPrintHTMLForAttribute($langs->trans('AliasNames')).'" spellcheck="false"></td></tr>';
 


### PR DESCRIPTION
# Fix missing label with thirdparty Alias
Applying this PR will bring back the missing alias text during thirdparty create and/or edit

### pre
<img width="572" height="158" alt="Image" src="https://github.com/user-attachments/assets/b0524f89-b6ab-4dba-9e7d-0b62720ec3e5" />

### post
<img width="582" height="158" alt="image" src="https://github.com/user-attachments/assets/0ae557a2-5395-4df2-b5c2-2a91b99566b3" />

The missing alias was discovered during fixing #36777, but this PR does not fix #36777, to see that fix go here #38275