### PR TITLE
Fix api post member subscription returns negative one

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -655,6 +655,8 @@ class Members extends DolibarrApi
 	 *
 	 * @throws	RestException	403		Access denied
 	 * @throws	RestException	404		Member not found
+	 * @throws	RestException	422		Malformed data
+	 * @throws	RestException	500		server error
 	 */
 	public function createSubscription($id, $start_date, $end_date, $amount, $label = '')
 	{
@@ -664,6 +666,9 @@ class Members extends DolibarrApi
 		if (!is_numeric($start_date) || !is_numeric($end_date) || !is_numeric($amount)) {
 			throw new RestException(422, 'Malformed data: subscription start or end date, or subscription amount, is not numeric');
 		}
+		if ($start_date > $end_date) {
+			throw new RestException(422, 'Malformed data: subscription start is not larger than end date');
+		}
 
 		$member = new Adherent($this->db);
 		$result = $member->fetch($id);
@@ -671,7 +676,12 @@ class Members extends DolibarrApi
 			throw new RestException(404, 'member not found');
 		}
 
-		return $member->subscription((int) $start_date, (float) $amount, 0, '', $label, '', '', '', (int) $end_date);
+		$result =  $member->subscription((int) $start_date, (float) $amount, 0, '', $label, '', '', '', (int) $end_date);
+		if ($result < 1) {
+			throw new RestException(500, $member->error);
+		} else {
+			return $this->getSubscriptions($result);
+		}
 	}
 
 	/**

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -680,7 +680,7 @@ class Members extends DolibarrApi
 		if ($result < 1) {
 			throw new RestException(500, $member->error);
 		} else {
-			return $this->getSubscriptions($result);
+			return $result;
 		}
 	}
 


### PR DESCRIPTION
# Fix #38278 POST to API /members/{id}/subscriptions returns -1
Applying this PR will allow you to post a subscription to a member using the api.

## Underlying issue
The underlying issue was that the API did not check if the start_date and end_date was reversed
### json to trigger
```
{
    "note_public": "Contribution api",
    "start_date": 1778939092,
    "datem": 1778946292,
    "dateh": 1672531200,
    "end_date": 1703980800,
    "fk_type": "1",
    "amount": "50.00000000"
}
```
### API endpoint now returns this json
```
{
  "error": {
    "code": 422,
    "message": "Malformed data: subscription start is not larger than end date"
  }
}
```

### Good json to post
```
{
    "note_public": "Contribution api",
    "end_date": 1778939092,
    "datem": 1778946292,
    "dateh": 1672531200,
    "start_date": 1703980800,
    "fk_type": "1",
    "amount": "50.00000000"
}
```

Here the return result is the new subscription id
