### PR TITLE
FIX API key cannot be cleared/revoked from user card

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -440,7 +440,7 @@ if (empty($reshook)) {
 					$object->pass = GETPOST("password", 'none');	// We can keep 'none' for password fields
 				}
 				if ($caneditpasswordandsee || $user->hasRight("api", "apikey", "generate")) {
-					$object->api_key = GETPOST("api_key", 'alphanohtml');
+					$object->api_key = (GETPOSTISSET("api_key", 'alphanohtml')) ? GETPOST("api_key", 'alphanohtml') : $object->api_key;
 				}
 				if (!empty($user->admin) && $user->id != $id) {
 					// admin flag can only be set/unset by an admin user and not four ourself

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -440,7 +440,7 @@ if (empty($reshook)) {
 					$object->pass = GETPOST("password", 'none');	// We can keep 'none' for password fields
 				}
 				if ($caneditpasswordandsee || $user->hasRight("api", "apikey", "generate")) {
-					$object->api_key = (GETPOST("api_key", 'alphanohtml')) ? GETPOST("api_key", 'alphanohtml') : $object->api_key;
+					$object->api_key = GETPOST("api_key", 'alphanohtml');
 				}
 				if (!empty($user->admin) && $user->id != $id) {
 					// admin flag can only be set/unset by an admin user and not four ourself


### PR DESCRIPTION
### Problem

When a user has an API key and wants to revoke it by clearing the field and saving, the key is silently kept in the database. The API key cannot be removed from the user edit form.

Steps to reproduce:

- Go to a user card with an existing API key
- Edit the user, clear the "API key" field
- Save

The API key is still set in the database / not cleared

### Root Cause
In htdocs/user/card.php, the update action uses a ternary to assign $object->api_key:

// Buggy code
```
$object->api_key = GETPOST('api_key', 'alphanohtml') 
    ? GETPOST('api_key', 'alphanohtml') 
    : $object->api_key;
```