### PR TITLE
NEW add label textline on massaction member subscription

### DIFF
--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -356,6 +356,7 @@ if (empty($reshook)) {
 	if ($action == 'createsubscription_confirm' && $confirm == "yes" && $user->hasRight('adherent', 'creer')) {
 		$tmpmember = new Adherent($db);
 		$adht = new AdherentType($db);
+		$label = GETPOST("label");
 		$nbcreated = 0;
 		$now = dol_now();
 		$amount = price2num(GETPOST('amount', 'alpha'));
@@ -363,7 +364,7 @@ if (empty($reshook)) {
 		foreach ($toselect as $id) {
 			$res = $tmpmember->fetch($id);
 			if ($res > 0) {
-				$result = $tmpmember->subscription($now, (float) $amount);
+				$result = $tmpmember->subscription($now, (float) $amount, 0, '', $label);
 				if ($result < 0) {
 					$error++;
 				} else {
@@ -830,6 +831,7 @@ if ($massaction == 'createsubscription') {
 	$formquestion = array(
 		array('label' => $langs->trans("DateSubscription"), 'type' => 'other', 'value' => $date),
 		array('label' => $langs->trans("Amount"), 'type' => 'text', 'value' => price($amount, 0, '', 0), 'name' => 'amount'),
+		array('label' => $langs->trans("Label"), 'type' => 'text', 'value' => '', 'name' => 'label'),
 		array('type' => 'separator'),
 		array('label' => $langs->trans("MoreActions"), 'type' => 'other', 'value' => $langs->trans("None").' '.img_warning($langs->trans("WarningNoComplementaryActionDone"))),
 	);


### PR DESCRIPTION
# NEW #38286 add label textline on massaction member subscription
Applying this PR wll add a 1 line text box during massaction member subscription asking for a label. This label will be inserted on the subscriptions created.

This pr is fix of #38286

## screenshots
<img width="654" height="273" alt="image" src="https://github.com/user-attachments/assets/0a2b4f79-94c6-4bee-a2a7-8db17d94d9f9" />

<img width="530" height="176" alt="image" src="https://github.com/user-attachments/assets/153d8d25-06d2-496c-ab0d-95eb85e15aa1" />



