### PR TITLE
Fix: ToolThirdParty inputSchema JSON Schema 2020-12 compliance

### DIFF
--- a/htdocs/ai/tools/thirdparty.class.php
+++ b/htdocs/ai/tools/thirdparty.class.php
@@ -72,8 +72,9 @@ class ToolThirdParty extends McpTool
 				"inputSchema" => [
 					"type" => "object",
 					"properties" => [
-						"id" => ["type" => "integer", "required" => true]
-					]
+						"id" => ["type" => "integer", "description" => "The unique numerical ID of the thirdparty."]
+					],
+					"required" => ["id"]
 				]
 			],
 			[
@@ -82,7 +83,7 @@ class ToolThirdParty extends McpTool
 				"inputSchema" => [
 					"type" => "object",
 					"properties" => [
-						"name" => ["type" => "string", "description" => "Name of the thirdparty", "required" => true],
+						"name" => ["type" => "string", "description" => "Name of the thirdparty"],
 						"type" => ["type" => "string", "enum" => ["customer", "prospect", "supplier", "both", "none"], "default" => "customer", "description" => "Type of thirdparty. 'none' means not a customer or prospect."],
 						"email" => ["type" => "string", "description" => "Email address"],
 						"phone" => ["type" => "string", "description" => "Phone number"],
@@ -105,7 +106,7 @@ class ToolThirdParty extends McpTool
 				"inputSchema" => [
 					"type" => "object",
 					"properties" => [
-						"id" => ["type" => "integer", "description" => "The ID of the thirdparty to update.", "required" => true],
+						"id" => ["type" => "integer", "description" => "The ID of the thirdparty to update."],
 						"name" => ["type" => "string", "description" => "The new name for the thirdparty."],
 						"email" => ["type" => "string", "description" => "The new email address."],
 						"phone" => ["type" => "string", "description" => "The new phone number."],
@@ -123,7 +124,7 @@ class ToolThirdParty extends McpTool
 				"inputSchema" => [
 					"type" => "object",
 					"properties" => [
-						"id" => ["type" => "integer", "description" => "The ID of the thirdparty.", "required" => true]
+						"id" => ["type" => "integer", "description" => "The ID of the thirdparty."]
 					],
 					"required" => ["id"]
 				]
@@ -136,11 +137,10 @@ class ToolThirdParty extends McpTool
 					"properties" => [
 						"thirdparty_identifier" => [
 							"type" => ["string", "integer"],
-							"description" => "The ID or name of the thirdparty to add the contact to.",
-							"required" => true
+							"description" => "The ID or name of the thirdparty to add the contact to."
 						],
-						"firstname" => ["type" => "string", "description" => "Contact's first name.", "required" => true],
-						"lastname" => ["type" => "string", "description" => "Contact's last name.", "required" => true],
+						"firstname" => ["type" => "string", "description" => "Contact's first name."],
+						"lastname" => ["type" => "string", "description" => "Contact's last name."],
 						"email" => ["type" => "string", "description" => "Contact's email address."],
 						"phone" => ["type" => "string", "description" => "Contact's phone number."],
 						"role" => ["type" => "string", "description" => "Contact's role or position within the company."]


### PR DESCRIPTION
## Problem

Several tool schemas in `ToolThirdParty::getDefinitions()` declare `"required" => true` **inside individual properties**:

```php
"id" => ["type" => "integer", "required" => true]
```

This is not valid [JSON Schema draft 2020-12](https://json-schema.org/draft/2020-12), which requires `required` to be an **array of property names at the parent object level**:

```json
{
  "type": "object",
  "properties": {
    "id": {"type": "integer"}
  },
  "required": ["id"]
}
```

## Impact

Strict validators — notably **Anthropic's Claude API** used by Claude Desktop Custom Connectors and Claude Code CLI — reject these schemas with:

```
HTTP 400 tools.X.custom.input_schema: JSON schema is invalid.
It must match JSON Schema draft 2020-12.
```

This causes the **entire MCP connection to fail before any tool can be called**, including the 27 other (valid) tools shipped by the module.

Gemini and ChatGPT are more lenient and accept these schemas, which is probably why the bug went unnoticed.

## Fix

This patch:

- Moves `"required": true` flags from individual properties to a proper `"required": [...]` array at the parent level
- Adds the missing parent-level `"required": ["id"]` to `get_thirdparty_details` (which previously had no spec-compliant way to mark `id` as required)
- Fixes **5 tools** in total:
  - `get_thirdparty_details`
  - `create_thirdparty`
  - `update_thirdparty`
  - `list_thirdparty_contacts`
  - `add_thirdparty_contact`

## Tested with

- ✅ Claude Desktop Custom Connectors (BETA): `tools/list` now succeeds, all 32 MCP tools are discovered
- ✅ Claude Code CLI: MCP server connects without 400 errors
- ✅ Existing AI Assistant web UI (Gemini provider): no regression

## Notes for reviewers

- 9 lines changed in 1 file (`htdocs/ai/tools/thirdparty.class.php`), purely schema metadata
- No behavioral change for the AI Assistant web UI
- This is the first of a series of small fixes I've identified while testing the new AI module end-to-end with Claude Desktop. I'll open follow-up PRs separately for clarity.

cc @eldy @sonikf
