### PR TITLE
NEW Member subscription tooltip includes label

### DIFF
--- a/htdocs/adherents/class/subscription.class.php
+++ b/htdocs/adherents/class/subscription.class.php
@@ -446,6 +446,7 @@ class Subscription extends CommonObject
 			$label .= ' '.$this->getLibStatut(5);
 		}*/
 		$label .= '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;
+		$label .= '<br><b>'.$langs->trans('label').':</b> '.$this->note_public;
 		if (!empty($this->dateh)) {
 			$label .= '<br><b>'.$langs->trans('DateStart').':</b> '.dol_print_date($this->dateh, 'day');
 		}

--- a/htdocs/adherents/class/subscription.class.php
+++ b/htdocs/adherents/class/subscription.class.php
@@ -440,13 +440,14 @@ class Subscription extends CommonObject
 		$result = '';
 
 		$langs->load("members");
+		$langs->load("main");
 
 		$label = img_picto('', $this->picto).' <u class="paddingrightonly">'.$langs->trans("Subscription").'</u>';
 		/*if (isset($this->statut)) {
 			$label .= ' '.$this->getLibStatut(5);
 		}*/
 		$label .= '<br><b>'.$langs->trans('Ref').':</b> '.$this->ref;
-		$label .= '<br><b>'.$langs->trans('label').':</b> '.$this->note_public;
+		$label .= '<br><b>'.$langs->trans('Label').':</b> '.$this->note_public;
 		if (!empty($this->dateh)) {
 			$label .= '<br><b>'.$langs->trans('DateStart').':</b> '.dol_print_date($this->dateh, 'day');
 		}

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -717,7 +717,7 @@ if ($action != 'createsubscription' && $action != 'create_thirdparty') {
 	$sql = "SELECT d.rowid, d.firstname, d.lastname, d.societe, d.fk_adherent_type as type,";
 	$sql .= " c.rowid as crowid, c.subscription,";
 	$sql .= " c.datec, c.fk_type as cfk_type,";
-	$sql .= " c.dateadh as dateh,";
+	$sql .= " c.dateadh as dateh, c.note as clabel,";
 	$sql .= " c.datef,";
 	$sql .= " c.fk_bank,";
 	$sql .= " b.rowid as bid,";
@@ -744,6 +744,7 @@ if ($action != 'createsubscription' && $action != 'create_thirdparty') {
 		print_liste_field_titre('DateStart', $_SERVER["PHP_SELF"], '', '', $param, '', $sortfield, $sortorder, 'center ');
 		print_liste_field_titre('DateEnd', $_SERVER["PHP_SELF"], '', '', $param, '', $sortfield, $sortorder, 'center ');
 		print_liste_field_titre('Amount', $_SERVER["PHP_SELF"], '', '', $param, '', $sortfield, $sortorder, 'right ');
+		print_liste_field_titre('Label', $_SERVER["PHP_SELF"], 'clabel', '', $param, '', $sortfield, $sortorder);
 		if (isModEnabled('bank')) {
 			print_liste_field_titre('Account', $_SERVER["PHP_SELF"], '', '', $param, '', $sortfield, $sortorder, 'right ');
 		}
@@ -779,6 +780,7 @@ if ($action != 'createsubscription' && $action != 'create_thirdparty') {
 			print '<td class="center">'.dol_print_date($db->jdate($objp->dateh), 'day')."</td>\n";
 			print '<td class="center">'.dol_print_date($db->jdate($objp->datef), 'day')."</td>\n";
 			print '<td class="right amount">'.price($objp->subscription).'</td>';
+			print '<td class="left">'.$objp->clabel.'</td>';
 			if (isModEnabled('bank')) {
 				print '<td class="tdoverflowmax100 right">';
 				if ($objp->bid) {

--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -763,6 +763,7 @@ if ($action != 'createsubscription' && $action != 'create_thirdparty') {
 
 			$subscriptionstatic->ref = $objp->crowid;
 			$subscriptionstatic->id = $objp->crowid;
+			$subscriptionstatic->note_public = $objp->clabel;
 
 			$typeid = $objp->cfk_type;
 			if ($typeid > 0) {


### PR DESCRIPTION
# NEW Member subscription tooltip includes label
Applying this PR will add the label to the tooltip when doing a mouse over on the link to a member subscription.

This PR is stacked on top of #38289.

The PR is a partial fix of #38277, if the underlying PR #38289 is also merged then #38277 can be closed.

<img width="384" height="241" alt="image" src="https://github.com/user-attachments/assets/b4930f21-369f-421a-b752-500de2c43e38" />
