### PR TITLE
New: accept api_key in query string for header-less MCP clients

### DIFF
--- a/htdocs/ai/server/mcp_server.php
+++ b/htdocs/ai/server/mcp_server.php
@@ -76,12 +76,20 @@ $headers = array_change_key_case($headers, CASE_LOWER);
 
 $authHeader   = $headers['authorization'] ?? '';
 $apiKeyHeader = $headers['x-api-key'] ?? '';
+// Fallback: also accept the key in a query string parameter (?api_key=XXX or ?key=XXX).
+// Required for MCP clients that don't support custom auth headers in their connector UI
+// (e.g. Claude Desktop "Custom Connectors" in beta only exposes OAuth fields).
+// SECURITY NOTE: query-string keys appear in webserver access logs and possibly in Referer
+// headers. Header-based auth (X-API-Key / Authorization) remains preferred and is tried first.
+// Administrators relying on the fallback should restrict access at the webserver level
+// and/or rotate AI_MCP_API_KEY regularly.
+$apiKeyQuery  = $_GET['api_key'] ?? $_GET['key'] ?? '';
 $storedKey    = getDolGlobalString('AI_MCP_API_KEY');
 
 $valid = false;
 
 if (!empty($storedKey)) {
-	// X-API-Key
+	// X-API-Key header (preferred)
 	if (!empty($apiKeyHeader)) {
 		$valid = hash_equals($storedKey, $apiKeyHeader);
 	}
@@ -93,6 +101,11 @@ if (!empty($storedKey)) {
 			$token = trim($matches[1]);
 			$valid = hash_equals($storedKey, $token);
 		}
+	}
+
+	// Query-string fallback (last resort for header-less clients)
+	if (!$valid && !empty($apiKeyQuery)) {
+		$valid = hash_equals($storedKey, $apiKeyQuery);
 	}
 }
 


### PR DESCRIPTION
## Problem

The MCP server accepts the API key via two header methods only:
- `X-API-Key: <token>`
- `Authorization: Bearer <token>`

This works for most MCP clients (Claude Code CLI, MCP Inspector, `mcp-proxy`, custom Python/Node scripts) which expose arbitrary header configuration.

However, **[Claude Desktop's "Custom Connectors" feature](https://modelcontextprotocol.io/docs/develop/connect-remote-servers)** (currently in public beta) does **not** expose any input field for custom auth headers — its UI only offers OAuth Client ID / Client Secret fields:

<img width="500" alt="Claude Desktop Custom Connector dialog showing only OAuth fields" src="https://github.com/user-attachments/assets/placeholder" />

Without a non-header authentication path, **Claude Desktop users cannot connect to a Dolibarr MCP server at all** — every request returns HTTP 401, even though `AI_MCP_API_KEY` is correctly configured and a valid `AI_MCP_USER_ID` is set.

## Fix

This patch adds a **query-string fallback**: clients can include the API key in the URL itself.

```
https://erp.example.com/ai/server/mcp_server.php?api_key=<KEY>
```

Both `?api_key=` and `?key=` are accepted as aliases.

**Important** — the fallback is checked **last**:

1. `X-API-Key` header → preferred path, unchanged
2. `Authorization: Bearer` header → unchanged
3. `?api_key=` / `?key=` query string → new fallback

No behavioral change for clients that already use headers.

## Security considerations (documented inline)

Query-string credentials are less secure than headers because:
- They appear in webserver **access logs** (Apache `access.log`, Nginx, etc.)
- They may leak through `Referer` headers if the server emits any redirect
- They can appear in proxy logs and HTTP intermediaries

Administrators who rely on this fallback should:
- Restrict the endpoint at the webserver level (IP allowlist, mTLS, reverse-proxy rules)
- Configure their webserver to exclude the query string from logs for this URL, e.g. Apache:
  ```apache
  SetEnvIf Request_URI "/ai/server/mcp_server\.php" no_query_log
  CustomLog logs/access_log combined env=!no_query_log
  ```
- Rotate `AI_MCP_API_KEY` periodically

These caveats are added as inline comments in the code so future maintainers and admins are aware.

## Alternative considered: OAuth 2.1 implementation

The MCP spec recommends OAuth 2.1 for remote servers. Implementing it in Dolibarr would require:
- A new `/oauth/authorize` endpoint with PKCE support
- A `/oauth/token` endpoint with refresh token rotation
- Dynamic Client Registration (`/oauth/register`) per MCP spec
- Persistence tables for clients, codes, tokens
- UI for managing OAuth clients

This is a significant body of work (~hundreds of lines + new admin UI) and could be a follow-up PR. The query-string fallback unblocks current Claude Desktop users in the meantime with minimal surface area.

## Tested with

- ✅ Claude Desktop Custom Connectors (beta): connection succeeds, all 32 tools loaded
- ✅ Claude Code CLI with `--header "X-API-Key: ..."`: header path unchanged
- ✅ `curl` with `X-API-Key` header: works
- ✅ `curl` with `Authorization: Bearer`: works
- ✅ `curl` with `?api_key=` only: works (fallback)
- ✅ `curl` with neither: HTTP 401 (unchanged)

## Diff size

`+14 −1` lines in 1 file (`htdocs/ai/server/mcp_server.php`). Pure addition, no existing path modified.

cc @eldy @sonikf
