### PR TITLE
Qual add notrigger to member->validate() function

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -2181,9 +2181,10 @@ class Adherent extends CommonObject
 	 *		Function that validate a member
 	 *
 	 *		@param	User	$user		user adherent qui valide
+	 *		@param	int		$notrigger	1=disable trigger UPDATE (when called by create)
 	 *		@return	int					Return integer <0 if KO, 0 if nothing done, >0 if OK
 	 */
-	public function validate($user)
+	public function validate($user, $notrigger = 0)
 	{
 		global $langs, $conf;
 
@@ -2211,11 +2212,13 @@ class Adherent extends CommonObject
 			$this->status = self::STATUS_VALIDATED;
 
 			// Call trigger
-			$result = $this->call_trigger('MEMBER_VALIDATE', $user);
-			if ($result < 0) {
-				$error++;
-				$this->db->rollback();
-				return -1;
+			if (!$notrigger) {
+				$result = $this->call_trigger('MEMBER_VALIDATE', $user);
+				if ($result < 0) {
+					$error++;
+					$this->db->rollback();
+					return -1;
+				}
 			}
 			// End call triggers
 


### PR DESCRIPTION
# Qual #38285 add notrigger to member->validate() function
This PR will add the option of not doing triggers when calling the member->validate function. This PR does not give any user nor any API the option of not triggering when validating a member, it is just adding a missing parameter that other functions does have. Default value is of course 0.

I discovered this mission option that other member functions does have notrigger
```
htdocs/adherents/class/adherent.class.php:	public function create($user, $notrigger = 0)
htdocs/adherents/class/adherent.class.php:	public function update($user, $notrigger = 0, $nosyncuser = 0, $nosyncuserpass = 0, $nosyncthirdparty = 0, $action = 'update')
htdocs/adherents/class/adherent.class.php:	public function delete($user, $notrigger = 0)
```

during some of my recent member PR's.

This pr should close #38285