### PR TITLE
Fix: MCP server propagates authenticated service user to tools

### DIFF
--- a/htdocs/ai/server/mcp_server.php
+++ b/htdocs/ai/server/mcp_server.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
  * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -131,6 +132,14 @@ if ($userId > 0) {
 
 	if ($result > 0) {
 		$serviceUser->loadRights();
+		// Promote the service user to the global $user so MCP tools that
+		// legitimately rely on the `global $user` pattern (Dolibarr core
+		// convention) see an authenticated user. Without this, there is
+		// no PHP web session in HTTP MCP context and any tool reading
+		// `global $user` would treat the request as unauthenticated even
+		// though authentication via X-API-Key/Bearer succeeded above.
+		global $user;
+		$user = $serviceUser;
 	} else {
 		http_response_code(500);
 		echo json_encode([

--- a/htdocs/ai/tools/crud_objects.class.php
+++ b/htdocs/ai/tools/crud_objects.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
  * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,11 +38,22 @@ class ToolCrudObjects extends McpTool
 	/**
 	 * 	Constructor
 	 *
+	 * 	Aligned with McpHandler's instantiation contract: new $className($db, $user, $conf).
+	 * 	Accepting $user via DI allows this tool to work in HTTP MCP context where no PHP
+	 * 	web session exists. Some sibling tool classes (ToolThirdParty, ToolCategories,
+	 * 	ToolProducts) already use this signature; this aligns ToolCrudObjects with them.
+	 *
 	 * 	@param	DoliDB		$db			Database handler
+	 * 	@param	User|null	$user		Service user provided by McpHandler (from AI_MCP_USER_ID)
+	 * 	@param	Conf|null	$conf		Dolibarr config (optional)
 	 */
-	public function __construct(DoliDB  $db)
+	public function __construct(DoliDB $db, $user = null, $conf = null)
 	{
 		$this->db = $db;
+		$this->user = $user;
+		if ($conf !== null) {
+			$this->conf = $conf;
+		}
 	}
 
 
@@ -322,13 +334,20 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 	 */
 	public function execute(string $name, array $args)
 	{
-		global $user, $langs, $conf, $mysoc;
+		global $langs, $conf, $mysoc;
 
-		// Ensure $this->user is the authenticated global user
-		$this->user = $user;
-
-		if (!$user->id) {
-			return ["error" => "User not authenticated."];
+		// Use the user injected via constructor (McpHandler). Fall back to global $user
+		// when running in a web session context (e.g. AI Assistant) where DI is not used.
+		// is_object() is used instead of empty() because the parent McpTool declares $user
+		// with a non-nullable type hint, which makes PHPStan flag empty($this->user) as
+		// unreachable code.
+		if (!is_object($this->user) || empty($this->user->id)) {
+			global $user;
+			if (is_object($user) && !empty($user->id)) {
+				$this->user = $user;
+			} else {
+				return ["error" => "User not authenticated."];
+			}
 		}
 
 		if (!is_object($mysoc) || empty($mysoc->id)) {

--- a/htdocs/ai/tools/invoices.class.php
+++ b/htdocs/ai/tools/invoices.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
+ * Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,11 +41,36 @@ class ToolInvoices extends McpTool
 	/**
 	 * 	Constructor
 	 *
+	 * 	Aligned with McpHandler's instantiation contract: new $className($db, $user, $conf).
+	 *
 	 * 	@param	DoliDB		$db			Database handler
+	 * 	@param	User|null	$user		Service user provided by McpHandler (from AI_MCP_USER_ID)
+	 * 	@param	Conf|null	$conf		Dolibarr config (optional)
 	 */
-	public function __construct(DoliDB  $db)
+	public function __construct(DoliDB $db, $user = null, $conf = null)
 	{
 		$this->db = $db;
+		$this->user = $user;
+		if ($conf !== null) {
+			$this->conf = $conf;
+		}
+	}
+
+	/**
+	 * Return the authenticated user, preferring DI ($this->user) and falling back to global $user.
+	 * In HTTP MCP context there is no PHP web session — only the service user injected via DI.
+	 *
+	 * @return User|null
+	 */
+	private function getUser()
+	{
+		// is_object() instead of empty() to avoid PHPStan flagging empty() on a
+		// non-nullable typed parent property as unreachable.
+		if (is_object($this->user) && !empty($this->user->id)) {
+			return $this->user;
+		}
+		global $user;
+		return is_object($user) && !empty($user->id) ? $user : null;
 	}
 
 	/**
@@ -312,7 +338,10 @@ class ToolInvoices extends McpTool
 	 */
 	private function validateInvoice($args)
 	{
-		global $user;
+		$user = $this->getUser();
+		if ($user === null) {
+			return ["error" => "User not authenticated."];
+		}
 		$invoice = $this->findInvoice($args['invoice']);
 		if (is_array($invoice)) {
 			return $invoice;
@@ -351,7 +380,10 @@ class ToolInvoices extends McpTool
 	 */
 	private function payInvoice($args)
 	{
-		global $user;
+		$user = $this->getUser();
+		if ($user === null) {
+			return ["error" => "User not authenticated."];
+		}
 		$invoice = $this->findInvoice($args['invoice']);
 		if (is_array($invoice)) {
 			return $invoice;

--- a/htdocs/ai/tools/reports.class.php
+++ b/htdocs/ai/tools/reports.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
+ * Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,11 +41,19 @@ class ToolReports extends McpTool
 	/**
 	 * 	Constructor
 	 *
+	 * 	Aligned with McpHandler's instantiation contract: new $className($db, $user, $conf).
+	 *
 	 * 	@param	DoliDB		$db			Database handler
+	 * 	@param	User|null	$user		Service user provided by McpHandler (from AI_MCP_USER_ID)
+	 * 	@param	Conf|null	$conf		Dolibarr config (optional)
 	 */
-	public function __construct(DoliDB  $db)
+	public function __construct(DoliDB $db, $user = null, $conf = null)
 	{
 		$this->db = $db;
+		$this->user = $user;
+		if ($conf !== null) {
+			$this->conf = $conf;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The MCP server (`htdocs/ai/server/mcp_server.php`) loads a service user from `AI_MCP_USER_ID` but does not expose it as the PHP `global $user`. Several tool classes call `global $user` to identify the caller — they therefore see no authenticated user in HTTP MCP context (no PHP web session exists) and return:

```
"User not authenticated."
```

…even though authentication via `X-API-Key`/`Authorization: Bearer` has already succeeded and a valid service user has been loaded.

## Impact

**~40% of MCP tools are unusable from external HTTP MCP clients** (Claude Desktop Custom Connectors, Claude Code CLI, MCP Inspector, custom scripts):

- `ToolCrudObjects` — all CRUD operations (`create_sales_order`, `create_customer_invoice`, `create_other_document`, `add_line_item`, `delete_object`)
- `ToolInvoices` — `validate_invoice`, `pay_invoice`
- (Some methods of `ToolReports` would have hit the same issue if they used `global $user`.)

The tools that already work via MCP (`ToolThirdParty`, `ToolCategories`, `ToolProducts`) happen to receive `$user` through their constructor — they exposed the bug by contrast.

This bug doesn't appear when using the AI Assistant web UI (`htdocs/ai/assistant/`) because in that context a normal Dolibarr web session is active.

## Fix

Two complementary changes:

### 1. `mcp_server.php` — promote the service user to globals

After loading and `loadRights()`-ing the service user, assign it to `$GLOBALS['user']` and the local `$user`. This acts as a safety net for any tool (in this module or third-party `addMcpTools` hooks) that legitimately relies on the `global $user` pattern.

### 2. Harmonize tool constructors with the McpHandler contract

`McpHandler::loadFromFilesystem()` already instantiates tool classes with `new $className($this->db, $this->user, $this->conf)`. Three classes ignored the second/third arguments — they're now aligned with the rest:

| Class | Before | After |
|---|---|---|
| `ToolCrudObjects` | `__construct(DoliDB $db)` | `__construct(DoliDB $db, $user = null, $conf = null)` |
| `ToolInvoices` | `__construct(DoliDB $db)` | `__construct(DoliDB $db, $user = null, $conf = null)` |
| `ToolReports` | `__construct(DoliDB $db)` | `__construct(DoliDB $db, $user = null, $conf = null)` |

Methods that previously called `global $user` now use the injected `$this->user`, with a fallback to the global for backward compatibility (in case a tool is somehow instantiated without `$user`).

## Why two fixes?

Either one alone would solve the user-visible bug, but combining them is more robust:

- **`$GLOBALS['user']`** covers any tool (including future ones, or external `addMcpTools` hooks) that uses the legacy pattern
- **DI via constructor** makes the dependency explicit, testable, and aligned with sibling classes

## Tested with

- ✅ `create_other_document` with `object_type: proposal` — works (12-line quote created)
- ✅ `create_other_document` with `object_type: supplier_invoice` — works
- ✅ `search_invoice`, `validate_invoice`, `pay_invoice` — work
- ✅ `get_sales_report`, `get_purchase_report` — work
- ✅ AI Assistant web UI — unchanged, no regression

## Diff size

`+58 −10` lines across 4 files.

cc @eldy @sonikf
