### PR TITLE
Fix: FactureFournisseur::addline parameter order in ToolCrudObjects

### DIFF
--- a/htdocs/ai/tools/crud_objects.class.php
+++ b/htdocs/ai/tools/crud_objects.class.php
@@ -599,7 +599,14 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 			$res = $object->addline($desc, $price, $qty, $vat, 0, 0, $fkProduct, $discount, 'HT', 0, 0, $prodType);
 		} elseif ($docType === 'supplier_invoice') {
 			/** @var FactureFournisseur $object */
-			$res = $object->addline($desc, $price, $qty, $vat, 0, 0, $fkProduct, $discount, 0, 0, '', 0, 'HT', 0, $prodType);
+			// IMPORTANT: FactureFournisseur::addline() does NOT share the same signature
+			// as Facture::addline(). Its parameter order is:
+			//   ($desc, $pu, $txtva, $txlocaltax1, $txlocaltax2, $qty, $fk_product, $remise_percent, ...)
+			// i.e. $qty is in position 6, not 3 (unlike customer Facture / Commande / Propal).
+			// The previous call passed our $qty as $txtva (-> a 1% VAT rate) and our $vat
+			// as $txlocaltax1, and position 6 ended up being a hardcoded 0 -> a line was
+			// inserted with qty=0, which Dolibarr silently dropped from the visible totals.
+			$res = $object->addline($desc, $price, $vat, 0, 0, $qty, $fkProduct, $discount, '', '', 0, 0, 'HT', $prodType);
 		} elseif ($docType === 'supplier_order') {
 			/** @var CommandeFournisseur $object */
 			$res = $object->addline($desc, $price, $qty, $vat, 0, 0, $fkProduct, $discount, 0, 0, 'HT', 0, '', '', $prodType);


### PR DESCRIPTION
## Problem

Unlike `Facture::addline()` which takes:
```
($desc, $pu, $qty, $txtva, ...)
```

`FactureFournisseur::addline()` uses a **different parameter order** (Dolibarr API quirk):
```
($desc, $pu, $txtva, $txlocaltax1, $txlocaltax2, $qty, $fk_product, $remise_percent, ...)
```

→ `$qty` is in **position 6**, not 3.

`ToolCrudObjects::processAddLine()` was calling `FactureFournisseur::addline()` with the customer-invoice order, which means:

| Argument we pass | Position in `FactureFournisseur::addline` | Effect |
|---|---|---|
| `$qty = 1` | passed as `$txtva` | VAT rate becomes 1% |
| `$vat = 20` | passed as `$txlocaltax1` | wrong local tax |
| hardcoded `0` | passed as `$qty` | **qty=0, line silently dropped** |

## Impact

Every supplier invoice created via `create_other_document` with `object_type: supplier_invoice` ends up with:
- The invoice **header** correctly created (linked to the right supplier)
- Total HT = **0.00 €** (because no line is visible)
- `lines_added` returned in the success payload **as if everything worked**
- No error in the log

This is silent data corruption — the LLM thinks the operation succeeded.

## Fix

Reorder the parameters to match the actual `FactureFournisseur::addline()` signature:

```diff
- $res = $object->addline($desc, $price, $qty, $vat, 0, 0, $fkProduct, $discount, 0, 0, '', 0, 'HT', 0, $prodType);
+ $res = $object->addline($desc, $price, $vat, 0, 0, $qty, $fkProduct, $discount, '', '', 0, 0, 'HT', $prodType);
```

Plus an inline comment warning future maintainers about this signature quirk so the bug doesn't reappear.

## Other addline calls — unaffected

The other branches of the `if/elseif` chain (`invoice`, `order`, `proposal`, `supplier_order`, `supplier_proposal`) use their respective correct signatures already.

## Tested with

- ✅ `create_other_document` with `object_type: supplier_invoice` and a single line (`quantity: 1, unit_price: 10, vat_rate: 20`) — line now appears with Total HT 10.00 €
- ✅ Multi-line supplier invoice from a real PDF (12 lines) — all 12 lines present with correct totals
- ✅ Customer invoice (`object_type: invoice`) — unchanged, still works

## Diff size

`+9 −1` lines in 1 file (`htdocs/ai/tools/crud_objects.class.php`).

cc @eldy @sonikf
