### PR TITLE
Fix: AI PDF.js text extraction for PDFs using custom CID fonts (TCPDF etc.)

### DIFF
--- a/htdocs/ai/js/ai_assistant.js
+++ b/htdocs/ai/js/ai_assistant.js
@@ -589,7 +589,20 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             const { getDocument } = await getPdfLib();
             const arrayBuffer = await file.arrayBuffer();
-            const pdf = await getDocument({ data: arrayBuffer }).promise;
+            // cMapUrl + standardFontDataUrl are REQUIRED for PDFs that ship with
+            // custom CID fonts referencing ToUnicode CMaps (extremely common with
+            // generators like TCPDF, wkhtmltopdf, iText, etc.). Without these,
+            // getTextContent() returns raw glyph codes that look like garbled
+            // base64. jsdelivr is used here because cdnjs (used elsewhere for the
+            // pdf.js bundle) does not distribute the cmaps/ and standard_fonts/
+            // resource directories.
+            const PDFJS_RES = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@5.4.149';
+            const pdf = await getDocument({
+                data: arrayBuffer,
+                cMapUrl: PDFJS_RES + '/cmaps/',
+                cMapPacked: true,
+                standardFontDataUrl: PDFJS_RES + '/standard_fonts/',
+            }).promise;
 
             let fullText = "";
             const totalPages = pdf.numPages; // Get total pages


### PR DESCRIPTION
## Problem

`extractTextFromPDF()` in `ai_assistant.js` calls `getDocument()` without the `cMapUrl` and `standardFontDataUrl` parameters:

```js
const pdf = await getDocument({ data: arrayBuffer }).promise;
```

PDFs that ship with **custom CID fonts referencing ToUnicode CMaps** therefore cannot be decoded properly by PDF.js. This includes the vast majority of PDFs generated by:

- **TCPDF** (the engine Dolibarr itself uses!)
- wkhtmltopdf
- iText
- DomPDF, mPDF, FPDI…

For these files, `getTextContent()` returns raw glyph codes that visually look like **garbled base64** to the LLM:

```
DAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw...
```

The downstream chat assistant then sees gibberish and either refuses to answer or replies with a generic error.

## Fix

Pass the two URLs to `getDocument()`, pointing them at the jsdelivr CDN package (cdnjs, which is used elsewhere for the pdf.js bundle itself, does not distribute the `cmaps/` and `standard_fonts/` resource directories):

```js
const PDFJS_RES = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@5.4.149';
const pdf = await getDocument({
    data: arrayBuffer,
    cMapUrl: PDFJS_RES + '/cmaps/',
    cMapPacked: true,
    standardFontDataUrl: PDFJS_RES + '/standard_fonts/',
}).promise;
```

This is the [recommended PDF.js configuration](https://github.com/mozilla/pdf.js/blob/master/examples/text-extraction/getinfo.mjs) and matches what the official PDF.js examples do.

## Tested with

- ✅ A TCPDF-generated invoice that previously returned unreadable base64-like output — text now extracts cleanly including French accented characters
- ✅ Native PDF.js test PDFs — unchanged
- ✅ Scanned PDFs (image-only, no text layer) — still return empty text (expected; OCR is a separate concern handled by the image extractor)

## Diff size

`+13 −1` lines in 1 file (`htdocs/ai/js/ai_assistant.js`).

cc @eldy @sonikf
