### PR TITLE
Fix: AI allow free-text invoice/order/proposal lines when no product matches

### DIFF
--- a/htdocs/ai/tools/crud_objects.class.php
+++ b/htdocs/ai/tools/crud_objects.class.php
@@ -539,8 +539,17 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 		if ($productIdentifier !== '') {
 			$findResult = $this->findProduct($productIdentifier);
 			if (is_array($findResult) && isset($findResult['error'])) {
-				// Ensure the return array matches the expected shape by adding 'success' => false
-				return array_merge(['success' => false], $findResult);
+				// Only abort if the caller EXPLICITLY asked for a product (via the 'product'
+				// argument). If they only provided a free-text 'description', we silently
+				// fall through with $prod = null so Dolibarr creates a free-text line item,
+				// which is a perfectly valid Dolibarr feature.
+				// Previous behaviour aborted ALL line creations whose description didn't
+				// match an existing product reference, which broke AI-driven creation of
+				// invoices/orders/proposals from one-off line descriptions.
+				if (isset($args['product'])) {
+					return array_merge(['success' => false], $findResult);
+				}
+				// fall through: $prod stays null
 			}
 			if (is_object($findResult)) {
 				$prod = $findResult;


### PR DESCRIPTION
## Problem

`ToolCrudObjects::processAddLine()` uses the line's `description` as a fallback product identifier when `product` is not explicitly provided:

```php
$productIdentifier = isset($args['product']) ? (string) $args['product']
    : (isset($args['description']) ? (string) $args['description'] : '');
```

It then calls `findProduct()` to look up an existing Dolibarr product by ref/barcode/label. When **no product matches** (the common case for AI-generated lines that describe a one-off service or a custom item), `findProduct()` returns an error array and the function **aborts without ever calling addline()**.

The resulting document gets its header created but **ends up with zero lines** and a 0.00 € total — without any error reported to the caller.

This is contrary to standard Dolibarr behavior: **free-text line items** (no product link, just a description, price, qty, VAT) are a first-class feature of invoices, orders, and proposals. The Dolibarr web UI lets you add free-text lines every day.

## Fix

Distinguish between the two callsite intents:

| Caller args | Intent | Behavior |
|---|---|---|
| `product` provided (e.g. `product: "REF-001"`) | Wants a specific product | Abort with original "not found" error (unchanged) |
| Only `description` provided | Wants a free-text line | Fall through with `$prod = null` — Dolibarr creates a free-text line |

```diff
 if ($productIdentifier !== '') {
     $findResult = $this->findProduct($productIdentifier);
     if (is_array($findResult) && isset($findResult['error'])) {
-        return array_merge(['success' => false], $findResult);
+        if (isset($args['product'])) {
+            return array_merge(['success' => false], $findResult);
+        }
+        // fall through: free-text line
     }
     if (is_object($findResult)) {
         $prod = $findResult;
     }
 }
```

## Why is this important

AI-driven document creation almost always produces free-text lines: the LLM describes what the user asked for ("Service d'OCR — Serveur France — Participation R&D"), it doesn't (and shouldn't) try to invent Dolibarr product references. With the current behavior, the entire `create_*` workflow is broken for any business that doesn't pre-create matching product entries for every possible line wording.

## Tested with

- ✅ `create_other_document` with `object_type: proposal` and 11 free-text lines — all 11 lines now appear with their totals (previously 0 lines, 0.00 €)
- ✅ `create_other_document` with explicit `product: "EXISTING-REF"` — still resolves the product correctly
- ✅ `create_other_document` with explicit `product: "NONEXISTENT-REF"` — still returns an explicit "Product not found" error (unchanged)

## Diff size

`+10 −2` lines in 1 file (`htdocs/ai/tools/crud_objects.class.php`).

cc @eldy @sonikf
