### PR TITLE
Fix:  AI ToolCrudObjects header inputSchema JSON Schema compliance

### DIFF
--- a/htdocs/ai/tools/crud_objects.class.php
+++ b/htdocs/ai/tools/crud_objects.class.php
@@ -196,6 +196,12 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 						"header" => [
 							"type" => "object",
 							"description" => "Invoice header data. Must include 'socid' (Customer ID).",
+							"properties" => [
+								"socid" => ["type" => "integer", "description" => "Customer ID (Thirdparty ID)"],
+								"date" => ["type" => "string", "description" => "Invoice date (YYYY-MM-DD)"],
+								"note_public" => ["type" => "string", "description" => "Public note"],
+								"note_private" => ["type" => "string", "description" => "Private note"]
+							],
 							"required" => ["socid"]
 						],
 						"lines" => [
@@ -233,6 +239,13 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 						"header" => [
 							"type" => "object",
 							"description" => "Header data. Must include 'socid'.",
+							"properties" => [
+								"socid" => ["type" => "integer", "description" => "Thirdparty ID (Customer for proposal, Supplier for supplier_*)"],
+								"date" => ["type" => "string", "description" => "Document date (YYYY-MM-DD)"],
+								"duree_validite" => ["type" => "integer", "description" => "Validity in days (proposal only)"],
+								"note_public" => ["type" => "string", "description" => "Public note"],
+								"note_private" => ["type" => "string", "description" => "Private note"]
+							],
 							"required" => ["socid"]
 						],
 						"lines" => [


### PR DESCRIPTION
## Problem

`create_customer_invoice` and `create_other_document` declare a `header` object whose schema has:

```php
"header" => [
    "type" => "object",
    "description" => "Invoice header data. Must include 'socid' (Customer ID).",
    "required" => ["socid"]
],
```

→ no `"properties"` entry. This is technically allowed by JSON Schema but stricter validators flag it as suspicious: the `required` array references a property that is not declared in `properties`. More importantly, **LLMs (and human reviewers) have no machine-readable description of which fields the header actually accepts**.

The Dolibarr backend (`createDocument()` ligne 405-430) already accepts `socid`, `date`, `duree_validite`, `note_public`, `note_private` and others via dynamic property assignment, but none of these are advertised in the schema.

## Fix

Declare `properties` explicitly on both `header` objects, listing the most commonly useful fields:

```php
"header" => [
    "type" => "object",
    "description" => "...",
    "properties" => [
        "socid" => ["type" => "integer", "description" => "..."],
        "date" => ["type" => "string", "description" => "Document date (YYYY-MM-DD)"],
        "duree_validite" => ["type" => "integer", "description" => "Validity in days (proposal only)"],
        "note_public" => ["type" => "string", "description" => "..."],
        "note_private" => ["type" => "string", "description" => "..."]
    ],
    "required" => ["socid"]
],
```

`duree_validite` is only relevant to proposals so it's added to `create_other_document` but not `create_customer_invoice`.

## Effects

- ✅ Schema now passes strict JSON Schema 2020-12 validators
- ✅ LLMs can produce richer payloads: a single tool call can now create a proposal with a public note, a custom date, and a non-default validity period — previously the LLM had to guess these field names or omit them
- ✅ Backward compatible: the backend was already accepting all these fields, we're just documenting them in the schema

## Tested with

- ✅ `create_other_document` with `header.socid + date + duree_validite + note_public` — all four fields end up on the created Propal correctly
- ✅ `create_customer_invoice` with `header.socid + date + note_public` — Facture correctly created with all fields
- ✅ Existing minimal payloads (just `socid`) — unchanged

## Diff size

`+15 −2` lines in 1 file (`htdocs/ai/tools/crud_objects.class.php`).

cc @eldy @sonikf
