### PR TITLE
Fix: AI parse_intent.php model resolution (array default and wrong constant)

### DIFF
--- a/htdocs/ai/assistant/parse_intent.php
+++ b/htdocs/ai/assistant/parse_intent.php
@@ -293,8 +293,34 @@ try {
 
 		$defUrl = $servicesList[$serviceKey]['url'] ?? '';
 		$url = getDolGlobalString('AI_API_' . strtoupper($serviceKey) . '_URL') ?: $defUrl;
-		$defModel = $servicesList[$serviceKey]['textgeneration'] ?? 'gpt-4o-mini';
-		$model = getDolGlobalString('AI_API_' . strtoupper($serviceKey) . '_MODEL') ?: $defModel;
+		// The model defaults declared in getListOfAIServices() are nested:
+		//   $servicesList[$key]['textgeneration'] = ['default' => 'model-name']
+		// Reading 'textgeneration' without ['default'] returns the inner array, which
+		// then fails the (string) type-hint of UniversalLLMAdapter's 4th argument with:
+		//   "Argument #4 ($model) must be of type string, array given"
+		//
+		// The admin UI (htdocs/ai/admin/setup.php "Prompt and custom AI models" tab) also
+		// stores the per-function model under AI_API_<SERVICE>_MODEL_TEXT (matching the
+		// convention already used by Ai::generateContent() for the same data). The
+		// previous lookup used AI_API_<SERVICE>_MODEL which is never written by that
+		// form, so the user-configured model was silently ignored.
+		$rawDefault = $servicesList[$serviceKey]['textgeneration'] ?? null;
+		if (is_array($rawDefault)) {
+			$defModel = $rawDefault['default'] ?? 'gpt-4o-mini';
+		} else {
+			$defModel = $rawDefault ?: 'gpt-4o-mini';
+		}
+		$prefix = 'AI_API_' . strtoupper($serviceKey);
+		$model = getDolGlobalString($prefix . '_MODEL_TEXT')
+			?: getDolGlobalString($prefix . '_MODEL')
+			?: $defModel;
+		// Defensive: coerce to string if anyone stored an array in this constant
+		if (is_array($model)) {
+			$model = $model['default'] ?? $defModel;
+		}
+		if (!is_string($model) || $model === '') {
+			$model = (string) $defModel;
+		}
 		$adapterType = $servicesList[$serviceKey]['adapter_type'] ?? 'openai';
 
 		if (!empty($apiKey)) {


### PR DESCRIPTION
## Problem

Two bugs combine to make `UniversalLLMAdapter::__construct()` crash on a freshly configured AI module:

```
PHP Exception: UniversalLLMAdapter::__construct():
Argument #4 ($model) must be of type string, array given,
called in /htdocs/ai/assistant/parse_intent.php on line 301
```

### Bug 1 — Wrong shape assumption

`getListOfAIServices()` declares model defaults as a **nested array**:

```php
'textgeneration' => ['default' => 'gemini-3.1-pro-preview']
```

But `parse_intent.php` reads them as if they were flat strings:

```php
$defModel = $servicesList[$serviceKey]['textgeneration'] ?? 'gpt-4o-mini';
// $defModel is now ['default' => 'gemini-3.1-pro-preview']  -- an ARRAY
```

### Bug 2 — Wrong constant name

The admin UI (`htdocs/ai/admin/setup.php`, "Prompt and custom AI models" tab) stores the per-function model under `AI_API_<SERVICE>_MODEL_TEXT`, matching the convention already used by `Ai::generateContent()`:

```php
// Ai::generateContent() (htdocs/ai/class/ai.class.php)
$model = getDolGlobalString('AI_API_'.strtoupper($this->apiService).'_MODEL_TEXT', ...);
```

But `parse_intent.php` reads `AI_API_<SERVICE>_MODEL` (without `_TEXT`), which is **never written** by that form. So the user-configured model was silently ignored and we always fell back to `$defModel` (which is the array from bug #1).

## Impact

Reliable `TypeError` on any default install of the AI module where:
- the user has configured a Google Gemini / ChatGPT / Mistral model via the admin UI
- AND the AI Assistant chat is used (the MCP server path uses a different code path and is unaffected)

The text-mode chat is currently the headline feature of the module, so this hits every user.

## Fix

This patch:

1. Walks `$servicesList[$key]['textgeneration']` correctly — extracts `['default']` when it's an array, accepts strings for backward compatibility
2. Tries `AI_API_<SERVICE>_MODEL_TEXT` first (the constant the admin UI actually writes), falling back to the legacy `AI_API_<SERVICE>_MODEL` for compatibility with anyone who set it manually
3. Defensively coerces the final value to a string and falls back to the default if for any reason it's still not a string

## Tested with

- ✅ Google Gemini configured to `gemini-2.5-flash` via admin UI — model is correctly used in the AI request
- ✅ ChatGPT configured to `gpt-4o-mini` via admin UI — model is correctly used
- ✅ Fresh install with no model configured — falls back to the (now correctly extracted) default string

## Diff size

`+25 −2` lines in 1 file (`htdocs/ai/assistant/parse_intent.php`).

cc @eldy @sonikf
