### PR TITLE
Qual: AI preserve full tool descriptions for modern LLMs

### DIFF
--- a/htdocs/ai/assistant/parse_intent.php
+++ b/htdocs/ai/assistant/parse_intent.php
@@ -270,7 +270,16 @@ try {
 		}
 
 		// If we are sending a lot of tools (Non-Latin or Fallback), we strip descriptions.
-		$isLargeSchema = count($toolsSchema) > 20;
+		// The 20-tool threshold was likely chosen for GPT-3.5 (4K context window). Modern
+		// LLMs handle the full schema trivially: Gemini 2.5 Flash has a 1M token context,
+		// GPT-4o has 128K, Claude Sonnet has 1M. Compression hurts more than it helps
+		// today because it also truncates tool *descriptions* (down to 3 words), which
+		// breaks tool selection (e.g. "create_other_document" becomes "Create documents
+		// other" -- the LLM then thinks supplier_invoice creation is not available).
+		// We raise the threshold to 100 to effectively disable compression for the
+		// default install (~30 tools), while still leaving a safety net for very large
+		// custom installs that register dozens of additional addMcpTools hooks.
+		$isLargeSchema = count($toolsSchema) > 100;
 		$toolsForLLM = cleanToolSchemaForLLM($toolsSchema, $isLargeSchema);
 
 		// Build System Prompt
@@ -727,12 +736,15 @@ function cleanToolSchemaForLLM(array $tools, bool $isLargeSchema = false)
 	$cleaned = [];
 
 	foreach ($tools as $tool) {
-		// Tool Description: Max 3 words
+		// Tool descriptions are how the LLM selects the right tool -- never truncate
+		// them, even when the schema is large. Truncating to 3 words ("Create documents
+		// other", "Add a single") breaks tool selection. If the schema really is too
+		// big for the chosen model, the right answer is to filter the toolset before
+		// it reaches the LLM (which is what filterToolsProfessional() already does
+		// upstream of this function), not to mutilate each tool's description.
+		// Parameter-level compression (stripping defaults, descriptions of optional
+		// fields, etc.) remains gated on $isLargeSchema below.
 		$desc = $tool['description'];
-		if ($isLargeSchema) {
-			$words = explode(' ', $desc);
-			$desc = implode(' ', array_slice($words, 0, 3));
-		}
 
 		// Get parameters
 		$toolParams = $tool['parameters'] ?? $tool['inputSchema'] ?? [];


### PR DESCRIPTION
## Problem

`cleanToolSchemaForLLM()` truncates each tool description to **3 words** whenever the schema has more than 20 tools:

```php
$isLargeSchema = count($toolsSchema) > 20;
// ...
if ($isLargeSchema) {
    $words = explode(' ', $desc);
    $desc = implode(' ', array_slice($words, 0, 3));   // ← 3 words
}
```

This heuristic likely made sense for GPT-3.5 (4K context window) but is **actively harmful** with modern LLMs:

| Model | Context window |
|---|---|
| Gemini 2.5 Flash | **1M tokens** |
| GPT-4o | 128K tokens |
| Claude Sonnet | **1M tokens** |

## Concrete impact

3 words per description is far too aggressive and breaks tool selection. Examples from the actual module:

| Tool | Real description | What the LLM sees |
|---|---|---|
| `create_other_document` | "Create documents other than orders and invoices. Use this for: 'proposal', 'supplier_order', 'supplier_invoice', 'supplier_proposal'..." | **"Create documents other"** |
| `create_sales_order` | "Create a CUSTOMER SALES ORDER. This is specifically for creating ORDERS that customers place with you..." | **"Create a CUSTOMER"** |
| `add_line_item` | "Add a single line to an existing draft document." | **"Add a single"** |

Observed in production: Gemini 2.5 Flash returned "supplier_invoice creation is not available in the system" because the truncated `create_other_document` description didn't mention it. The user-visible AI Assistant chat appeared broken even though all the right tools were present.

## Fix

Two complementary changes:

### 1. Raise the threshold from 20 to 100

The default install has ~30 tools, all comfortably under 100. The safety net stays in place for very large custom installs that register dozens of additional tools via the `addMcpTools` hook.

### 2. Even when compression IS active, never touch the tool-level description

Parameter-level compression (stripping defaults, descriptions of optional fields, collapsing complex objects) still applies and continues to save tokens. But the *tool* description — which is how the LLM picks the right tool — stays intact.

The right answer for truly oversized schemas is to filter the toolset upstream (which `filterToolsProfessional()` already does in `parse_intent.php`), not to mutilate each tool's description.

## Tested with

- ✅ 30-tool default schema sent in full: Gemini 2.5 Flash correctly selects `create_other_document` with `object_type: 'supplier_invoice'`, `'proposal'`, `'supplier_proposal'` — previously returned a "feature not available" message
- ✅ Token usage check: a full 30-tool schema is ~6K tokens — negligible against Gemini's 1M / Claude's 1M / GPT-4o's 128K context

## Diff size

`+17 −4` lines in 1 file (`htdocs/ai/assistant/parse_intent.php`).

cc @eldy @sonikf
