### PR TITLE
New: log MCP tools/call invocations to llx_ai_request_log

### DIFF
--- a/htdocs/ai/server/mcp_server.php
+++ b/htdocs/ai/server/mcp_server.php
@@ -133,8 +133,74 @@ if ($userId > 0) {
 	exit;
 }
 
+// Load the AI request log helper so we can persist tools/call invocations to
+// llx_ai_request_log (same table the AI Assistant web UI logs to). This gives
+// administrators a single place to audit external MCP client activity.
+require_once DOL_DOCUMENT_ROOT . '/ai/lib/ai.lib.php';
+
+/**
+ * Persist an MCP tools/call invocation to the llx_ai_request_log table.
+ * Mirrors what parse_intent.php does for the web AI Assistant.
+ * Only tools/call is logged -- lifecycle methods (initialize, ping,
+ * notifications/initialized, tools/list, ...) are skipped to avoid noise.
+ *
+ * @param array<string,mixed> $req         The JSON-RPC request
+ * @param mixed               $resp        The JSON-RPC response (null for notifications)
+ * @param float               $tStart      microtime(true) captured before processing
+ * @param string              $rawInput    Raw request body
+ * @return void
+ */
+function mcp_log_request(array $req, $resp, float $tStart, string $rawInput): void
+{
+	global $db, $serviceUser;
+
+	$method = isset($req['method']) ? (string) $req['method'] : '';
+	if ($method !== 'tools/call' || !function_exists('ai_log_request')) {
+		return;
+	}
+
+	$params   = isset($req['params']) && is_array($req['params']) ? $req['params'] : [];
+	$toolName = isset($params['name']) ? (string) $params['name'] : '';
+	$toolArgs = isset($params['arguments']) ? $params['arguments'] : [];
+
+	$argsJson = is_string($toolArgs) ? $toolArgs : (string) json_encode($toolArgs);
+	$query    = '[MCP] ' . $toolName . ' ' . dol_substr($argsJson, 0, 1000);
+
+	$responseShape = ['tool' => $toolName, 'arguments' => $toolArgs];
+
+	$status   = 'Success';
+	$errorMsg = '';
+	if (is_array($resp) && isset($resp['error'])) {
+		$status   = 'Error';
+		$errorMsg = is_array($resp['error']) && isset($resp['error']['message'])
+			? (string) $resp['error']['message']
+			: (string) json_encode($resp['error']);
+	} elseif (is_array($resp) && isset($resp['result']['isError']) && $resp['result']['isError']) {
+		$status   = 'Error';
+		$errorMsg = is_array($resp['result']['content'] ?? null) ? (string) json_encode($resp['result']['content']) : '';
+	}
+
+	$rawResStr = is_string($resp) ? $resp : (string) json_encode($resp);
+
+	ai_log_request(
+		$db,
+		$serviceUser,
+		$query,
+		$responseShape,
+		'mcp',
+		microtime(true) - $tStart,
+		1.0,
+		$status,
+		$errorMsg,
+		$rawInput,
+		$rawResStr
+	);
+}
+
 // Request handling
 try {
+	$tStart = microtime(true);
+
 	// Basic payload size limit
 	$rawInput = file_get_contents('php://input');
 	if ($rawInput === false || strlen($rawInput) > 1024 * 1024) {
@@ -168,11 +234,15 @@ try {
 				continue;
 			}
 
+			$reqStart = microtime(true);
 			$res = $server->handleRequest($req);
 
 			if ($res !== null) {
 				$responses[] = $res;
 			}
+
+			// Log each tools/call separately so the admin log viewer shows them individually.
+			mcp_log_request($req, $res, $reqStart, (string) json_encode($req));
 		}
 
 		echo json_encode($responses);
@@ -187,6 +257,10 @@ try {
 		if ($response !== null) {
 			echo json_encode($response);
 		}
+
+		// Log this tools/call to llx_ai_request_log (no-op unless AI_LOG_REQUESTS is enabled
+		// and the method is tools/call).
+		mcp_log_request($request, $response, $tStart, $rawInput);
 	}
 } catch (Exception $e) {
 	dol_syslog(


### PR DESCRIPTION
## Problem

The AI Assistant web UI (`parse_intent.php`) persists every request to `llx_ai_request_log` via `ai_log_request()` (`ai.lib.php`). Administrators can browse the resulting log via the existing Log Viewer (`htdocs/ai/admin/log_viewer.php`).

But the MCP HTTP server (`mcp_server.php`) does **not** call this helper. As a consequence, external MCP client activity (Claude Desktop, Claude Code CLI, MCP Inspector, custom scripts…) is **invisible** to administrators — only `dol_syslog()` entries land in `documents/dolibarr.log`, which is hard to filter and not exposed in the admin UI.

This is especially problematic for compliance and security audit needs: external clients can create/modify Dolibarr objects on behalf of the service user, and admins have no easy way to review what was done, when, and with which arguments.

## Fix

Add an `mcp_log_request()` helper alongside the existing auth/dispatch logic in `mcp_server.php`. The helper:

- Persists every `tools/call` invocation to `llx_ai_request_log`
- Filters out lifecycle methods (`initialize`, `ping`, `notifications/initialized`, `tools/list`, …) to avoid log spam
- Logs with `provider: 'mcp'` so administrators can filter MCP traffic in the Log Viewer
- Captures the tool name + arguments, success/error status, raw request payload, raw response payload
- Records elapsed time per call (per-call inside batches too)

The helper is gated by the same `AI_LOG_REQUESTS` toggle that already controls the web UI logging — **no new admin setting introduced**, the existing "Enable Request Logging" switch in the Server MCP setup page now controls both paths.

## What the Log Viewer shows after this PR

| Date | User | Query | Tool | Provider | Status |
|---|---|---|---|---|---|
| 2026-05-17 14:18 | mcp_service | [MCP] create_other_document {"object_type":"proposal",...} | create_other_document | **mcp** | Success |
| 2026-05-17 14:20 | admin | Liste les factures impayées de CAP-REL | search_invoice | google | Success |

Single source of truth for both web and external MCP traffic.

## Tested with

- ✅ `search_products`, `create_other_document`, `search_invoice`, `get_sales_report` from Claude Desktop — each appears as a new log row with the right tool name, status, payloads, and elapsed time
- ✅ Same tools from Claude Code CLI — logged identically
- ✅ Batch requests — each call inside the batch is logged separately
- ✅ Disabling `AI_LOG_REQUESTS` — both web and MCP paths stop logging (no regression)
- ✅ Error case (e.g. unauthorized tool) — logged with `status: Error` and the error message captured

## Diff size

`+70 −1` lines in 1 file (`htdocs/ai/server/mcp_server.php`).

cc @eldy @sonikf
