### PR TITLE
New: add AI module top menu and left submenu entries

### DIFF
--- a/htdocs/core/modules/modAi.class.php
+++ b/htdocs/core/modules/modAi.class.php
@@ -266,9 +266,55 @@ class modAi extends DolibarrModules
 		$r = 0;
 		// Add here entries to declare new menus
 		/* BEGIN MODULEBUILDER TOPMENU */
+		// Top menu "AI" with a robot icon -- visible once the module is enabled.
+		$this->menu[$r++] = array(
+			'fk_menu'  => '',                          // '' means top-level
+			'type'     => 'top',
+			'titre'    => 'AI',
+			'prefix'   => img_picto('', 'fa-robot', 'class="pictofixedwidth valignmiddle"'),
+			'mainmenu' => 'ai',
+			'leftmenu' => '',
+			'url'      => '/ai/assistant/index.php',
+			'langs'    => 'other',
+			'position' => 1000,
+			'enabled'  => '$conf->ai->enabled',
+			'perms'    => '1',
+			'target'   => '',
+			'user'     => 2,                           // 0=internal, 1=external, 2=both
+		);
 		/* END MODULEBUILDER TOPMENU */
 
 		/* BEGIN MODULEBUILDER LEFTMENU AI */
+		// Left sub-menu "Assistant" under the AI top menu.
+		$this->menu[$r++] = array(
+			'fk_menu'  => 'fk_mainmenu=ai',
+			'type'     => 'left',
+			'titre'    => 'AIAssistant',
+			'mainmenu' => 'ai',
+			'leftmenu' => 'ai_assistant',
+			'url'      => '/ai/assistant/index.php',
+			'langs'    => 'other',
+			'position' => 100,
+			'enabled'  => '$conf->ai->enabled',
+			'perms'    => '1',
+			'target'   => '',
+			'user'     => 2,
+		);
+		// Left sub-menu "Setup" (admins only).
+		$this->menu[$r++] = array(
+			'fk_menu'  => 'fk_mainmenu=ai',
+			'type'     => 'left',
+			'titre'    => 'Setup',
+			'mainmenu' => 'ai',
+			'leftmenu' => 'ai_setup',
+			'url'      => '/ai/admin/setup.php',
+			'langs'    => 'admin',
+			'position' => 200,
+			'enabled'  => '$conf->ai->enabled',
+			'perms'    => '$user->admin',
+			'target'   => '',
+			'user'     => 0,                           // 0=internal only (admin)
+		);
 		/* END MODULEBUILDER LEFTMENU AI */
 
 		/* BEGIN MODULEBUILDER LEFTMENU AVAILABILITIES


### PR DESCRIPTION
## Problem

The AI module ships with a new web Assistant page (`/ai/assistant/index.php`) and the existing admin setup pages, but the module descriptor (`modAi.class.php`) **declares no menu entries** — `$this->menu` stays empty between the `MODULEBUILDER TOPMENU` / `LEFTMENU AI` markers:

<img width="2412" height="1270" alt="image" src="https://github.com/user-attachments/assets/ba69f449-6092-4571-818f-9912523cb37c" />


```php
/* BEGIN MODULEBUILDER TOPMENU */
/* END MODULEBUILDER TOPMENU */

/* BEGIN MODULEBUILDER LEFTMENU AI */
/* END MODULEBUILDER LEFTMENU AI */
```

As a result, **neither the Assistant nor the AI setup pages are reachable from the Dolibarr navigation** — users have to type the URL by hand or bookmark it.

## Fix

Fill the two existing `MODULEBUILDER` placeholders with three menu entries:

### 1. Top menu "AI"
A new top-level entry with a `fa-robot` icon, pointing to `/ai/assistant/index.php`. Available to both internal and external users (`user => 2`) once the module is enabled.

### 2. Left submenu "Assistant"
Under the "AI" top menu, points to the same assistant URL. Internal + external (`user => 2`).

### 3. Left submenu "Setup"
Under the "AI" top menu, points to `/ai/admin/setup.php`. Admin only (`user => 0`, `perms => '$user->admin'`).

## Translation keys

`AIAssistant` and `Setup` are already provided by `other.lang` and `admin.lang` respectively — no new translation strings needed.

## Activation flow (standard Dolibarr behavior)

After applying this change, administrators must **disable/re-enable the AI module** once to make the new entries appear in `llx_menu`. This is the existing Dolibarr mechanism for picking up `$this->menu` changes — no migration script needed.

## Tested with

- ✅ Module disabled → re-enabled: "AI" appears in the top menu with the robot icon
- ✅ Click "AI" top: "Assistant" and "Setup" appear in the left sidebar
- ✅ Non-admin user: "Setup" is hidden (perms gate works)
- ✅ External user: still sees the "AI" top menu and "Assistant" (user => 2)
- ✅ Module disabled: menu entries disappear (enabled => '$conf->ai->enabled')

## Diff size

`+52 −0` lines in 1 file (`htdocs/core/modules/modAi.class.php`).

cc @eldy @sonikf
