### PR TITLE
NEW show linked member status on Thirdparty card

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -3482,6 +3482,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 				if ($result > 0) {
 					$adh->ref = $adh->getFullName($langs);
 					print $adh->getNomUrl(-1);
+					print ' &mdash; '.$adh->getLibStatut(0);
 				} else {
 					print '<span class="opacitymedium">'.$langs->trans("ThirdpartyNotLinkedToMember").'</span>';
 				}


### PR DESCRIPTION
# New #26322 show linked member status on Thirdparty card
Applying this PR will show the members status after the name in the middle right side of the Thirdparty card.

This PR is a fix of #26322

## Show the members status here
<img width="739" height="192" alt="image" src="https://github.com/user-attachments/assets/cb84e7ec-454c-4e04-b910-77a511437e54" />

## No member linked, nothing to show
<img width="759" height="203" alt="image" src="https://github.com/user-attachments/assets/31906b18-c735-4967-ae0d-e11cb94b83cb" />

## A thirdparty with a draft membership
<img width="747" height="196" alt="member_link" src="https://github.com/user-attachments/assets/c6369bb0-e868-43f3-9b23-8feb1318243a" />
