### PR TITLE
New: open AI Assistant in a popup overlay from top-toolbar icon

### DIFF
--- a/htdocs/ai/css/ai_assistant.css
+++ b/htdocs/ai/css/ai_assistant.css
@@ -426,3 +426,79 @@
     background-color: #6c757d;
     border-color: #6c757d;
 }
+
+
+/* -------------------------------------------------------------------------
+ * Popup mode (loaded via dol_openinpopup URL param from the top-toolbar
+ * AI icon -> dolButtonToOpenUrlInDialogPopup() iframe).
+ *
+ * Dolibarr core adds the body class "dol_openinpopup" when this param is
+ * set (htdocs/main.inc.php), so we can target popup-only tweaks here
+ * without touching index.php.
+ *
+ * Sizing strategy:
+ * The chat-container in standalone mode uses "height: 70vh; min-height:
+ * 650px" which is great on a full page but causes the dialog iframe to
+ * overflow on small windows. In popup mode we make the chat-container
+ * fill the iframe viewport exactly (height: 100% of body, body itself
+ * pinned to 100vh of iframe) and drop the 650px floor; .chat-history
+ * keeps its flex-grow:1 + overflow-y:auto so message scroll still works
+ * INTERNALLY without an iframe-level scrollbar.
+ *
+ * We also flatten the visual chrome (border, shadow, rounded corners,
+ * capped max-width, top margin) that is now redundant with the dialog
+ * frame, and hide the duplicate "AI Assistant" H2 (the dialog title bar
+ * already shows it).
+ * ------------------------------------------------------------------------- */
+body.dol_openinpopup {
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+    overflow: hidden;
+}
+
+/* In popup mode the DOM is:
+ *   body > #id-container > .fiche > .ai-chat-container
+ * (top_menu and left_menu blocks are skipped by main.inc.php when
+ *  dol_openinpopup is set, but #id-container and .fiche are always
+ *  emitted). For "height: 100%" on .ai-chat-container to resolve to
+ *  the iframe viewport, every ancestor in the chain must also be
+ *  100% high. */
+body.dol_openinpopup #id-container,
+body.dol_openinpopup .fiche {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+body.dol_openinpopup .ai-chat-container {
+    max-width: none;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    height: 100%;
+    min-height: 0;
+    max-height: 100%;
+}
+
+/* Flexbox shrink fix: a flex-grow:1 child defaults to min-height:auto
+ * (content-based), which prevents the chat-history from shrinking below
+ * its message-content height and causes the WHOLE container to overflow
+ * the iframe after a long response. Forcing min-height:0 lets the
+ * chat-history shrink to fit the available column space and scroll
+ * INTERNALLY (overflow-y:auto is already on .chat-history). */
+body.dol_openinpopup .chat-history {
+    min-height: 0;
+}
+
+/* The dialog title bar already shows "AI Assistant", so hide the redundant
+ * H2 inside .chat-header but keep .header-controls (Clear + mode select). */
+body.dol_openinpopup .chat-header {
+    border-radius: 0;
+    justify-content: flex-end;
+}
+
+body.dol_openinpopup .chat-header h2 {
+    display: none;
+}

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -2731,10 +2731,33 @@ function top_menu_ai()
 	$html = '';
 
 	if (isModEnabled('ai')) {
-		$html .= '<!-- div for quick ai link -->
-	    <div id="topmenu-tool" class="atoplogin dropdown inline-block">
-	        <a accesskey="a" class="nofocusvisible" href="'.DOL_URL_ROOT.'/ai/assistant/index.php" title="'.$langs->trans('AIAssistant').' ('.$conf->browser->stringforfirstkey.' a)"><i class="fa fa-magic"></i></a>
-	    </div>';
+		// Open the AI Assistant in a popup overlay rather than navigating away,
+		// so the user keeps their current page context while interacting with
+		// the assistant. Uses the standard Dolibarr helper which builds an
+		// iframe-in-jQuery-UI-dialog (modal, 80% width, height-150) and auto-
+		// appends dol_hide_topmenu=1&dol_hide_leftmenu=1&dol_openinpopup=NAME
+		// so the embedded page renders without the surrounding chrome.
+		// JS-disabled fallback: the helper degrades to target="_blank".
+		// $label is used by dolButtonToOpenUrlInDialogPopup() both for the
+		// title="" tooltip on the <a> AND for the jQuery UI dialog title.
+		// Include the keyboard-shortcut hint (matching the convention used
+		// e.g. by the PublicVirtualCardUrl call earlier in this file and by
+		// bookmark/quickadd/search) so the icon tooltip on hover reads e.g.
+		// "AI Assistant (Ctrl Alt a)" -- the dialog title shows the same.
+		$ailabel = $langs->trans('AIAssistant').' ('.$conf->browser->stringforfirstkey.' a)';
+		$aibtn = dolButtonToOpenUrlInDialogPopup(
+			'aiassistant',
+			$ailabel,
+			'<i class="fa fa-magic"></i>',
+			'/ai/assistant/index.php',
+			'',
+			'nofocusvisible',
+			'',
+			'',
+			'a'
+		);
+		$html .= '<!-- div for quick ai link (opens AI Assistant in popup) -->
+	    <div id="topmenu-tool" class="atoplogin dropdown inline-block">'.$aibtn.'</div>';
 	}
 
 	return $html;


### PR DESCRIPTION
## Context

Per maintainer feedback on #38307:

> Yes, adding a popup (without leaving current page) is better than opening a complete page.

The AI Assistant top-toolbar icon — added in develop by [`e735bed1`](https://github.com/Dolibarr/dolibarr/commit/e735bed12426ebe66211831b29e1a0f52d5758e4) via `top_menu_ai()` in `main.inc.php` — is currently a plain `<a href>` that navigates the user away from whatever page they were on. This PR makes it open the Assistant in a popup overlay instead, so the user keeps their working context while interacting with the assistant.

## Approach — reuse `dolButtonToOpenUrlInDialogPopup()`

Dolibarr already ships a core helper (`htdocs/core/lib/functions.lib.php`, `dolButtonToOpenUrlInDialogPopup()`) that does exactly this pattern, used extensively elsewhere (e.g. modulebuilder, ECM, virtual card, and 20+ call sites in third-party modules like CAPCRM). It:

- Builds an `<a>` with `accesskey`, `title`, and the icon
- On click, injects `<iframe src="$url" width="100%" height="98%">` into a hidden `<div id="idfordialog$name">`
- Opens the div as a jQuery UI dialog (`modal:true`, `width:'80%'`, `height: window.innerHeight-150`)
- Auto-appends `dol_hide_topmenu=1&dol_hide_leftmenu=1&dol_openinpopup=$name` to the URL → the embedded page renders without the surrounding chrome
- Falls back gracefully to `target="_blank"` when JavaScript is off

**Zero changes needed to `/ai/assistant/index.php`** — the popup-friendly URL params (`dol_openinpopup`, `dol_hide_topmenu`, `dol_hide_leftmenu`) are already handled generically by `main.inc.php`.

## Popup-mode CSS (ai_assistant.css)

The Assistant's standalone CSS uses `max-width: 900px; margin: 20px auto; height: 70vh; min-height: 650px;` — perfect on a full page but produces visual issues inside the dialog iframe (capped width, double "AI Assistant" header, fixed min-height that overflows on small windows). When `main.inc.php` adds the body class `dol_openinpopup`, we activate scoped overrides that:

- Make the chat-container fill the dialog edge-to-edge (`height: 100%` on the full `body > #id-container > .fiche > .ai-chat-container` chain, with `min-height: 0` to honor flex shrink semantics)
- Flatten redundant chrome (border, shadow, rounded corners, capped max-width, top margin)
- Hide the duplicate `<h2>AI Assistant</h2>` since the jQuery UI dialog title bar already shows it, while keeping `.header-controls` (Clear + mode selector) visible
- Apply the flexbox `min-height: 0` fix on `.chat-history` so a long AI response scrolls **inside** the chat-history (its `overflow-y: auto` already exists) rather than overflowing the iframe

The page rendered directly (e.g. `/ai/assistant/index.php` without the popup param) is **unchanged** — every rule is scoped to `body.dol_openinpopup`.

## Behavior

| Before | After |
|---|---|
| Click icon → full page navigation to `/ai/assistant/index.php`, you lose your current page | Click icon → modal dialog opens centered, Assistant chat loads inside the iframe filling the dialog, closing the dialog returns you to your original page with no navigation |
| Accesskey `a` works | Accesskey `a` works (unchanged) |
| Tooltip: "AI (Ctrl+Alt+a)" | Tooltip: localized "AI Assistant" string (the helper uses `$label` for both the title attribute and dialog title) |
| JS off: link follows `href` | JS off: link opens in new tab (`target="_blank"`) — Assistant page renders normally with full chrome |

Other top-toolbar icons (bookmark, quickadd, search, import) are unchanged.

## Tested

- ✅ Click icon → popup opens edge-to-edge; chat works inside iframe
- ✅ Long AI response with table of results → scrolls **internally** in `.chat-history`, dialog stays put
- ✅ Close dialog → back on the original page with no navigation
- ✅ JS disabled → degrades to opening in a new tab, full page renders with original chrome
- ✅ Direct URL `/ai/assistant/index.php` (no popup param) → unchanged layout (`max-width: 900px`, original margins)
- ✅ Accesskey `Ctrl+Alt+a` still triggers the icon

## Diff

| File | Lines |
|---|---|
| `htdocs/main.inc.php` | +20 −4 — `top_menu_ai()` uses `dolButtonToOpenUrlInDialogPopup()` |
| `htdocs/ai/css/ai_assistant.css` | +72 — popup-mode overrides scoped to `body.dol_openinpopup` |

cc @eldy @sonikf
