### PR TITLE
Qual: Better error message for missing translation

### DIFF
--- a/dev/translation/sanity_check_trans_missing_unused.sh
+++ b/dev/translation/sanity_check_trans_missing_unused.sh
@@ -164,7 +164,7 @@ if [ -s "${MISSING_FILE}.grep" ] ; then
 
 	git grep -n --column -r -F -f "${MISSING_FILE}.grep" -- ':*.php' ':*.html' ':*.js' \
 		| sort -t: -k 4 \
-		| sed 's@^\([^:]*:[^:]*:[^:]*:\)\s*@\1 Missing translation; @' > "${MISSING_FILE}.result"
+		| sed 's@^\([^:]*:[^:]*:[^:]*:\)\s*@\1 error - Missing translation; @' > "${MISSING_FILE}.result"
 
 	if [ -s "${MISSING_FILE}.result" ] ; then
 		exit_code=1


### PR DESCRIPTION
# Qual: Better error message for missing translation

Update error message to include 'error - ' after the line:offset: text to correspond to an emacs like error message recognized by logToCs which allows it to appear as a github annotation