### PR TITLE
FIX Import FEC: debit/credit fields filled with journal code value

### DIFF
--- a/htdocs/core/modules/import/modules_import.class.php
+++ b/htdocs/core/modules/import/modules_import.class.php
@@ -1351,7 +1351,7 @@ class ModeleImports
 										break;
 									}
 									$classinstance = new $class($this->db);
-										$computedFieldPos = isset($arrayfield[$fieldname]) ? ((int) $arrayfield[$fieldname]) : 0;
+										$computedFieldPos = isset($arrayfield[$val]) ? ((int) $arrayfield[$val]) : 0;
 										$res = call_user_func_array(array($classinstance, $method), array(&$arrayrecord, $arrayfield, $computedFieldPos));
 									if (empty($classinstance->error) && empty($classinstance->errors)) {
 										$newval = $res; 	// We get new value computed.


### PR DESCRIPTION
FIX Import FEC: debit/credit fields filled with journal code value

The 'compute' rule lookup in modules_import.class.php used $fieldname (short name, e.g. 'debit' after the "preg_replace('/^.*\./i', '', $val)" line 1078) as a key into $arrayfield, but $arrayfield is keyed by the full alias ('b.debit'). The lookup always failed and $computedFieldPos fell back to 0, this is the first column of the source file, which for the FEC import profile is the journal code. As a result, cleanAmount() returned the journal code as both debit and credit.

Regression introduced in #37367 (refactoring of import).