### PR TITLE
NEW Member only subscription on validated resiliated, excluded always rejected

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1846,22 +1846,6 @@ class Adherent extends CommonObject
 			$amount = 0;
 		}
 
-		if ($this->statut != Adherent::STATUS_VALIDATED) {
-			$autoValidate = getDolGlobalInt('MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION');
-
-			if ($autoValidate) {
-				$result = $this->validate($user);
-				if ($result < 0) {
-					$this->error = $langs->trans("ErrorValidationFailed", '- '.$this->error);
-					return -1;
-				}
-				dol_syslog("Auto-validated member " . $this->ref . " (ID: " . $this->id . ") upon subscription creation (Config: MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION=1)", LOG_INFO);
-			} else {
-				$this->error = "MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION=".$autoValidate;
-				return -1;
-			}
-		}
-
 		$this->db->begin();
 
 		if ($datesubend) {
@@ -1902,6 +1886,17 @@ class Adherent extends CommonObject
 				$error++;
 			}
 
+			$noAutoValidate = getDolGlobalInt('MEMBER_DO_NOT_AUTO_VALIDATE_ON_SUBSCRIPTION');
+			if (!$error && !$noAutoValidate && ($this->statut == Adherent::STATUS_DRAFT || $this->statut == Adherent::STATUS_RESILIATED)) {
+				$preStatus = $this->statut;
+				$result = $this->validate($user);
+				if ($result < 0) {
+					$this->error = $langs->trans("ErrorValidationFailed", '- '.$this->error);
+				    dol_syslog("ErrorValidationFailed for member=".$this->id." which had status=".$preStatus, LOG_ERR);
+					$error++;
+				}
+			}
+
 			if (!$error) {
 				$this->db->commit();
 				return $rowid;
@@ -1910,6 +1905,21 @@ class Adherent extends CommonObject
 				return -2;
 			}
 		} else {
+			// CRITICAL FIX: Manually copy error from the child object if not set on self
+			if (empty($this->error) && isset($subscription->error) && !empty($subscription->error)) {
+				$this->error = $subscription->error;
+			}
+
+			// Also check the errors array
+			if (empty($this->error) && isset($subscription->errors) && is_array($subscription->errors) && count($subscription->errors) > 0) {
+				$this->error = $subscription->errors[0];
+			}
+
+			// If still empty, try to get the last DB error directly
+			if (empty($this->error) && !empty($this->db->lasterror)) {
+				$this->error = $this->db->lasterror;
+			}
+
 			$this->setErrorsFromObject($subscription);
 			$this->db->rollback();
 			return -1;

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1892,7 +1892,7 @@ class Adherent extends CommonObject
 				$result = $this->validate($user);
 				if ($result < 0) {
 					$this->error = $langs->trans("ErrorValidationFailed", '- '.$this->error);
-				    dol_syslog("ErrorValidationFailed for member=".$this->id." which had status=".$preStatus, LOG_ERR);
+					dol_syslog("ErrorValidationFailed for member=".$this->id." which had status=".$preStatus, LOG_ERR);
 					$error++;
 				}
 			}

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1835,7 +1835,7 @@ class Adherent extends CommonObject
 	 */
 	public function subscription($date, $amount, $accountid = 0, $operation = '', $label = '', $num_chq = '', $emetteur_nom = '', $emetteur_banque = '', $datesubend = 0, $fk_type = null, $ref_ext = '')
 	{
-		global $user;
+		global $user, $langs;
 
 		require_once DOL_DOCUMENT_ROOT.'/adherents/class/subscription.class.php';
 
@@ -1844,6 +1844,22 @@ class Adherent extends CommonObject
 		// Clean parameters
 		if (!$amount) {
 			$amount = 0;
+		}
+
+		if ($this->statut != Adherent::STATUS_VALIDATED) {
+			$autoValidate = getDolGlobalInt('MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION');
+
+			if ($autoValidate) {
+				$result = $this->validate($user);
+				if ($result < 0) {
+					$this->error = $langs->trans("ErrorValidationFailed", '- '.$this->error);
+					return -1;
+				}
+				dol_syslog("Auto-validated member " . $this->ref . " (ID: " . $this->id . ") upon subscription creation (Config: MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION=1)", LOG_INFO);
+			} else {
+				$this->error = "MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION=".$autoValidate;
+				return -1;
+			}
 		}
 
 		$this->db->begin();

--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -1846,6 +1846,25 @@ class Adherent extends CommonObject
 			$amount = 0;
 		}
 
+		$enforceStatus = getDolGlobalInt('MEMBER_ONLY_SUBSCRIPTION_ON_VALIDATED_RESILIATED');
+		if ($enforceStatus) {
+			$allowedStatuses = array(
+				Adherent::STATUS_VALIDATED,
+				Adherent::STATUS_RESILIATED
+			);
+
+			if (!in_array($this->statut, $allowedStatuses)) {
+				$this->error = $langs->trans("ErrorMemberStatusNotAllowedForSubscription", $this->getLibStatut());
+				$this->errors[] = $this->error;
+				return -1; // Fail immediately, no transaction needed
+			}
+		}
+		if ($this->statut == Adherent::STATUS_EXCLUDED) {
+			$this->error = $langs->trans("ErrorMemberStatusNotAllowedForSubscription", $this->getLibStatut());
+			$this->errors[] = $this->error;
+			return -1; // Fail immediately, no transaction needed
+		}
+
 		$this->db->begin();
 
 		if ($datesubend) {

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -665,8 +665,8 @@ class Members extends DolibarrApi
 	 *
 	 * @throws	RestException	403		Access denied
 	 * @throws	RestException	404		Member not found
+	 * @throws	RestException	409		Duplicate entry
 	 * @throws	RestException	422		Malformed data
-	 * @throws	RestException	500		server error
 	 */
 	public function createSubscription($id, $start_date, $end_date, $amount, $label = '')
 	{
@@ -686,11 +686,28 @@ class Members extends DolibarrApi
 			throw new RestException(404, 'member not found');
 		}
 
-		$result =  $member->subscription((int) $start_date, (float) $amount, 0, '', $label, '', '', '', (int) $end_date);
-		if ($result < 1) {
-			throw new RestException(500, $member->error);
-		} else {
+		try {
+			// This call might throw an exception
+			$result = $member->subscription((int) $start_date, (float) $amount, 0, '', $label, '', '', '', (int) $end_date);
+
+			if ($result < 1) {
+				// If it returns -1 (graceful failure), use the error message
+				$errorMsg = $member->error ? $member->error : 'Unknown error';
+				throw new RestException(422, $errorMsg);
+			}
 			return $result;
+
+		} catch (Exception $e) {
+			// This catches the DB exception that escaped subscription()
+			$msg = $e->getMessage();
+
+			// Map specific DB errors to user-friendly messages
+			if (strpos($msg, 'Duplicate entry') !== false || strpos($msg, 'DB_ERROR_RECORD_ALREADY_EXISTS') !== false) {
+				throw new RestException(409, "A subscription with these parameters already exists.");
+			}
+
+			// For other DB errors, return the message or a generic one
+			throw new RestException(422, $msg);
 		}
 	}
 

--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -696,7 +696,6 @@ class Members extends DolibarrApi
 				throw new RestException(422, $errorMsg);
 			}
 			return $result;
-
 		} catch (Exception $e) {
 			// This catches the DB exception that escaped subscription()
 			$msg = $e->getMessage();

--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -361,7 +361,6 @@ if (empty($reshook)) {
 		$now = dol_now();
 		$amount = price2num(GETPOST('amount', 'alpha'));
 		$error_array = array();
-		$created_array = array();
 		$db->begin();
 		foreach ($toselect as $id) {
 			$res = $tmpmember->fetch($id);
@@ -372,7 +371,6 @@ if (empty($reshook)) {
 					$error_array[$id] = $tmpmember->getNomUrl(1) . '&mdash;' . $tmpmember->error;
 				} else {
 					$nbcreated++;
-					$created_array[$id] = $tmpmember->getNomUrl(1);
 				}
 			} else {
 				$error++;

--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -352,7 +352,7 @@ if (empty($reshook)) {
 		}
 	}
 
-	// Create external user
+	// createsubscription_confirm
 	if ($action == 'createsubscription_confirm' && $confirm == "yes" && $user->hasRight('adherent', 'creer')) {
 		$tmpmember = new Adherent($db);
 		$adht = new AdherentType($db);
@@ -360,6 +360,8 @@ if (empty($reshook)) {
 		$nbcreated = 0;
 		$now = dol_now();
 		$amount = price2num(GETPOST('amount', 'alpha'));
+		$error_array = array();
+		$created_array = array();
 		$db->begin();
 		foreach ($toselect as $id) {
 			$res = $tmpmember->fetch($id);
@@ -367,8 +369,10 @@ if (empty($reshook)) {
 				$result = $tmpmember->subscription($now, (float) $amount, 0, '', $label);
 				if ($result < 0) {
 					$error++;
+					$error_array[$id] = $tmpmember->getNomUrl(1) . '&mdash;' . $tmpmember->error;
 				} else {
 					$nbcreated++;
+					$created_array[$id] = $tmpmember->getNomUrl(1);
 				}
 			} else {
 				$error++;
@@ -379,7 +383,7 @@ if (empty($reshook)) {
 			setEventMessages($langs->trans("XSubsriptionCreated", $nbcreated), null, 'mesgs');
 			$db->commit();
 		} else {
-			setEventMessages($langs->trans("XSubsriptionErrors", $error), null, 'mesgs');
+			setEventMessages($langs->trans("XSubsriptionErrors", $error), $error_array, 'errors');
 			$db->rollback();
 		}
 	}

--- a/htdocs/core/modules/modAdherent.class.php
+++ b/htdocs/core/modules/modAdherent.class.php
@@ -480,9 +480,7 @@ class modAdherent extends DolibarrModules
 
 		$sql = array(
 			"DELETE FROM ".MAIN_DB_PREFIX."document_model WHERE nom = '".$this->db->escape($this->const[0][2])."' AND type='member' AND entity = ".((int) $conf->entity),
-			"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('".$this->db->escape($this->const[0][2])."','member',".((int) $conf->entity).")",
-			"DELETE FROM ".MAIN_DB_PREFIX."const WHERE name = 'MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION' AND entity =".((int) $conf->entity),
-			"INSERT INTO ".MAIN_DB_PREFIX."const (name, entity, value, type, visible, note) VALUES ('MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION', ".((int) $conf->entity).", '0', 'string', 0, 'Auto-validate member status to ‘Validated’ when a subscription is created for a ‘Pending’ member.')"
+			"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('".$this->db->escape($this->const[0][2])."','member',".((int) $conf->entity).")"
 		);
 
 		return $this->_init($sql, $options);

--- a/htdocs/core/modules/modAdherent.class.php
+++ b/htdocs/core/modules/modAdherent.class.php
@@ -480,7 +480,9 @@ class modAdherent extends DolibarrModules
 
 		$sql = array(
 			"DELETE FROM ".MAIN_DB_PREFIX."document_model WHERE nom = '".$this->db->escape($this->const[0][2])."' AND type='member' AND entity = ".((int) $conf->entity),
-			"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('".$this->db->escape($this->const[0][2])."','member',".((int) $conf->entity).")"
+			"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('".$this->db->escape($this->const[0][2])."','member',".((int) $conf->entity).")",
+			"DELETE FROM ".MAIN_DB_PREFIX."const WHERE name = 'MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION' AND entity =".((int) $conf->entity),
+			"INSERT INTO ".MAIN_DB_PREFIX."const (name, entity, value, type, visible, note) VALUES ('MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION', ".((int) $conf->entity).", '0', 'string', 0, 'Auto-validate member status to ‘Validated’ when a subscription is created for a ‘Pending member’.')"
 		);
 
 		return $this->_init($sql, $options);

--- a/htdocs/core/modules/modAdherent.class.php
+++ b/htdocs/core/modules/modAdherent.class.php
@@ -482,7 +482,7 @@ class modAdherent extends DolibarrModules
 			"DELETE FROM ".MAIN_DB_PREFIX."document_model WHERE nom = '".$this->db->escape($this->const[0][2])."' AND type='member' AND entity = ".((int) $conf->entity),
 			"INSERT INTO ".MAIN_DB_PREFIX."document_model (nom, type, entity) VALUES('".$this->db->escape($this->const[0][2])."','member',".((int) $conf->entity).")",
 			"DELETE FROM ".MAIN_DB_PREFIX."const WHERE name = 'MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION' AND entity =".((int) $conf->entity),
-			"INSERT INTO ".MAIN_DB_PREFIX."const (name, entity, value, type, visible, note) VALUES ('MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION', ".((int) $conf->entity).", '0', 'string', 0, 'Auto-validate member status to ‘Validated’ when a subscription is created for a ‘Pending member’.')"
+			"INSERT INTO ".MAIN_DB_PREFIX."const (name, entity, value, type, visible, note) VALUES ('MEMBER_AUTO_VALIDATE_ON_SUBSCRIPTION', ".((int) $conf->entity).", '0', 'string', 0, 'Auto-validate member status to ‘Validated’ when a subscription is created for a ‘Pending’ member.')"
 		);
 
 		return $this->_init($sql, $options);

--- a/htdocs/langs/en_US/members.lang
+++ b/htdocs/langs/en_US/members.lang
@@ -16,6 +16,7 @@ ErrorThisMemberIsNotPublic=This member is not public
 ErrorMemberIsAlreadyLinkedToThisThirdParty=Another member (name: <b>%s</b>, login: <b>%s</b>) is already linked to a third party <b>%s</b>. Remove this link first because a third party can't be linked to only a member (and vice versa).
 ErrorUserPermissionAllowsToLinksToItselfOnly=For security reasons, you must be granted permissions to edit all users to be able to link a member to a user that is not yours.
 ErrorValidationFailed=Validation failed %s
+ErrorMemberStatusNotAllowedForSubscription=Member status %s does not allow subscription
 SetLinkToUser=Link to a Dolibarr user
 SetLinkToThirdParty=Link to a Dolibarr third party
 MemberCountersArePublic=Counters of valid members are public

--- a/htdocs/langs/en_US/members.lang
+++ b/htdocs/langs/en_US/members.lang
@@ -15,6 +15,7 @@ ListOfValidatedPublicMembers=List of validated public members
 ErrorThisMemberIsNotPublic=This member is not public
 ErrorMemberIsAlreadyLinkedToThisThirdParty=Another member (name: <b>%s</b>, login: <b>%s</b>) is already linked to a third party <b>%s</b>. Remove this link first because a third party can't be linked to only a member (and vice versa).
 ErrorUserPermissionAllowsToLinksToItselfOnly=For security reasons, you must be granted permissions to edit all users to be able to link a member to a user that is not yours.
+ErrorValidationFailed=Validation failed %s
 SetLinkToUser=Link to a Dolibarr user
 SetLinkToThirdParty=Link to a Dolibarr third party
 MemberCountersArePublic=Counters of valid members are public


### PR DESCRIPTION
# NEW Member only subscription on validated resiliated, excluded always rejected
Applying this pr will make such that making a subscription for an excluded member will always fail.

Applying this PR will also introduce a new hidden configuration constant MEMBER_ONLY_SUBSCRIPTION_ON_VALIDATED_RESILIATED, which when set to > 0 will only allow subscriptions on members which has been proved.

This PR is a follow up to PR #38287 - AND IS STACKED ONTOP OF #38287

## Screenshots
<img width="741" height="71" alt="no_member_on_rejected" src="https://github.com/user-attachments/assets/7487f6b4-fcc5-4a55-bd23-0cc88a6c86ef" />
<img width="729" height="75" alt="member_status_does_not_allow_subscription" src="https://github.com/user-attachments/assets/d58d2202-a7a3-4652-affa-9540ef977305" />

## API results
```
{
  "error": {
    "code": 422,
    "message": "Member status Excluded member does not allow subscription"
  }
}
{
  "error": {
    "code": 422,
    "message": "Member status Draft (needs to be validated) does not allow subscription"
  }
}
```
