### PR TITLE
Qual: when thirdparty can not be both prospect and customer, remove p…

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1453,6 +1453,10 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 			$selected = $object->client;
 			$selectedcustomer = ((getDolGlobalInt('THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT')==1 && GETPOST("type", 'aZ') != 'p' && GETPOST("type", 'aZ') != 'f') || (getDolGlobalInt('THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT')==3 && GETPOST("type", 'aZ') != 'p' && GETPOST("type", 'aZ') != 'f') ? 1 : 0);
 			$selectedprospect = ((getDolGlobalInt('THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT')==2 && GETPOST("type", 'aZ') != 'c' && GETPOST("type", 'aZ') != 'f') || (getDolGlobalInt('THIRDPARTY_CUSTOMERTYPE_BY_DEFAULT')==3 && GETPOST("type", 'aZ') != 'c' && GETPOST("type", 'aZ') != 'f') ? 1 : 0);
+			if (getDolGlobalInt("SOCIETE_DISABLE_PROSPECTSCUSTOMERS")) {
+				$selectedcustomer = 0;
+				$selectedprospect = 0;
+			}
 			switch ($selected) {
 				case 1:
 					$selectedcustomer = 1;


### PR DESCRIPTION
# Qual #36777 when thirdparty can not be both prospect and customer, remove preselection
Applying this PR would remove the preselection for a thirdparty when the thirdparty configuration is set to:

<img width="768" height="86" alt="image" src="https://github.com/user-attachments/assets/c38690f7-4afc-4639-b24e-12309ec10a3e" />

<img width="518" height="177" alt="image" src="https://github.com/user-attachments/assets/170b5e9f-62ad-4b7e-b9a1-8c1c285b5c19" />

The preselection was removed because when you allow both, then you can get the preselection choice

<img width="768" height="161" alt="image" src="https://github.com/user-attachments/assets/77145a8f-26eb-463e-91a7-bb39646f1468" />

Applying this PR should close #36777

The location was deliberately inserted before the switch such that existing values are shown.