### PR TITLE
Fix selectobject.php unknown-Array Key (#23392 AJAX endless turning)

### DIFF
--- a/htdocs/core/ajax/selectobject.php
+++ b/htdocs/core/ajax/selectobject.php
@@ -108,7 +108,10 @@ if ($objectdesc) {
 	$InfoFieldList[3] = preg_replace('/:\w*$/', '', $vartmp);    // take the filter field
 
 	$classname = $InfoFieldList[0];
-	$classpath = dol_sanitizePathName($InfoFieldList[1]);
+	$classpath = '';
+	if (!empty($InfoFieldList[1])) {
+		$classpath = dol_sanitizePathName($InfoFieldList[1]);
+	}	
 
 	//$addcreatebuttonornot = empty($InfoFieldList[2]) ? 0 : $InfoFieldList[2];
 	$filter = empty($InfoFieldList[3]) ? '' : $InfoFieldList[3];
@@ -172,5 +175,6 @@ $arrayresult = $form->selectForFormsList($objecttmp, (string) $htmlname, 0, 0, $
 $db->close();
 
 if ($outjson) {
+	$debug = json_encode($arrayresult);
 	print json_encode($arrayresult);
 }

--- a/htdocs/core/ajax/selectobject.php
+++ b/htdocs/core/ajax/selectobject.php
@@ -175,6 +175,5 @@ $arrayresult = $form->selectForFormsList($objecttmp, (string) $htmlname, 0, 0, $
 $db->close();
 
 if ($outjson) {
-	$debug = json_encode($arrayresult);
 	print json_encode($arrayresult);
 }

--- a/htdocs/core/ajax/selectobject.php
+++ b/htdocs/core/ajax/selectobject.php
@@ -111,7 +111,7 @@ if ($objectdesc) {
 	$classpath = '';
 	if (!empty($InfoFieldList[1])) {
 		$classpath = dol_sanitizePathName($InfoFieldList[1]);
-	}	
+	}
 
 	//$addcreatebuttonornot = empty($InfoFieldList[2]) ? 0 : $InfoFieldList[2];
 	$filter = empty($InfoFieldList[3]) ? '' : $InfoFieldList[3];


### PR DESCRIPTION
Fix #23392

If the dolibarr insance was in debug mode, a warning is also transmit with the JSON Result:
`<br/><b>Warning</b>: Undefined array key 1 in <b>/var/www/html/dolibarr/htdocs/core/ajax/selectobject.php</b> on line <b>111</b><br/>`
So the UI become invalid data for show the results.

Solution: Integrate Key[1] check.