### PR TITLE
FIX: Add Ghostscript installation and caching for Windows CI

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,6 +26,7 @@ env:
   PHP_INI_SCAN_DIR: C:\myphpini
   CKEY: win-ci-2
   GITHUB_JSON: ${{ toJSON(github) }} # Helps in debugging Github Action
+  GS_VERSION: "10.07.0"   # Ghostscript version
 
 jobs:
   win-test:
@@ -53,6 +54,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # phpts: ts  # ts for thread-safe, default nts
+          # steps:
+
+      - name: Restore cache Ghostscript (also stores cache at end of workflow)
+        uses: actions/cache@v5
+        with:
+          path: |
+            C:\Program Files\gs
+          key: ${{ runner.os }}-imagick-ghostscript-${{ env.GS_VERSION }}
+
+      - name: Install Ghostscript if not found
+        run: |
+          $gsBinDir = "C:\Program Files\gs\gs${{ env.GS_VERSION }}\bin"
+          echo "$gsBinDir" >> $env:GITHUB_PATH
+          $gsPath = "$gsBinDir\gswin64c.exe"
+          if (-not (Test-Path $gsPath)) {
+            choco install ghostscript -y --no-progress --version=${{ env.GS_VERSION }}
+          }
+          if (-not (Test-Path "$gsBinDir\gs.exe")) {
+            New-Item -ItemType SymbolicLink -Path "$gsBinDir\gs.exe" -Target $gsPath -Force
+          }
+          DIR "$gsBinDir"
 
       # Restore cache
       - name: Restore cache
@@ -96,10 +118,13 @@ jobs:
           SET DATA_DIR=%CD%\documents
           SET TEST_DIR=%CD%\test
           SET INITDEMO_DIR=%CD%\dev\initdemo
+          SET SESSION_DIR=%TEMP%\php_sessions
+          mkdir %SESSION_DIR%
           ECHO "==== Create INI file to set open_basedir ==="
           echo [php] > %INIFILE%
-          echo open_basedir^="%HTDOCS_DIR%;%DATA_DIR%;%TEST_DIR%;%INITDEMO_DIR%;%PHPROOT%" >> %INIFILE%
-          REM Unset PHP_INI_SCAN_DIR to disable open_basedir restritions (to limit debug effort)
+          echo open_basedir^="%HTDOCS_DIR%;%DATA_DIR%;%TEST_DIR%;%INITDEMO_DIR%;%PHPROOT%;%SESSION_DIR%" >> %INIFILE%
+          echo session.save_path^="%SESSION_DIR%" >> %INIFILE%
+          REM Unset PHP_INI_SCAN_DIR to disable open_basedir restrictions (to limit debug effort)
           REM SET PHP_INI_SCAN_DIR=
           ECHO "==== Show contents of INI file to set open_basedir ==="
           type %INIFILE%

--- a/dev/setup/phpunit/setup_conf.sh
+++ b/dev/setup/phpunit/setup_conf.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash -xv
-# Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
+# Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
 # shellcheck disable=2050,2089,2090,2086
 
 ME=$(realpath "$0")
@@ -184,9 +184,9 @@ if [ "$DB" = 'mysql' ] || [ "$DB" = 'mariadb' ] || [ "$DB" = 'postgresql' ]; the
 	# Compute md5 based on install file contents, and on db prefix
 	# filefunc.inc.php holds the version, so include it"
 	# shellcheck disable=2046
-	sum=$(md5sum "$ME" $(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f ; echo "${TRAVIS_BUILD_DIR}/filefunc.inc.php" ) | md5sum)
+	sum=$(md5sum "$ME" $(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f -not -path "${TRAVIS_BUILD_DIR}/htdocs/install/doctemplates/*" ; echo "${TRAVIS_BUILD_DIR}/filefunc.inc.php" ) | md5sum)
 	# shellcheck disable=2046
-	cnt=$(md5sum "$ME" $(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f) | wc)
+	cnt=$(md5sum "$ME" $(find "${TRAVIS_BUILD_DIR}/htdocs/install" -type f -not -path "${TRAVIS_BUILD_DIR}/htdocs/install/doctemplates/*") | wc)
 	echo "MD5SUM $sum COUNT:$cnt"
 	load_cache=0
 	if [ -r "$DB_CACHE_FILE".md5 ] && [ -r "$DB_CACHE_FILE" ] && [ -x "$(which "${MYSQLDUMP}")" ] ; then


### PR DESCRIPTION
# FIX: Add Ghostscript installation and caching for Windows CI

Ghostscript is necessary for one of the tests that converts an image into a PDF. This commit adds the necessary steps to install Ghostscript and cache it for the Windows CI workflow.
Automatically creates a symbolic link so that "gs" exists as expected by this imagick php extension (setup).

Also:
- Fix issue with SESSION directory that is located in TEMP directory (add to open_basedir + create in separate directory);
- Exclude doctemplates from dependency to regenerate SQL test database contents.