### PR TITLE
FIX: Rename MAIN_MODULE_OPENIDCONNECT to MAIN_AUTHENTICATION_OIDC_ON in v22->v23 migration

### DIFF
--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -437,4 +437,7 @@ INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUE
 
 INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUES (  4, 'PCG08-PYME-CAT', 'The PYME accountancy spanish plan in catalan language', 1);
 
+-- Rename OIDC enable constant: openidconnect was converted from a module to a config-level feature (#36051)
+UPDATE llx_const SET name = 'MAIN_AUTHENTICATION_OIDC_ON' WHERE name = 'MAIN_MODULE_OPENIDCONNECT';
+
 -- end of migration


### PR DESCRIPTION
Fixes #37867

## Problem

When upgrading from v22 to v23, OpenID Connect authentication is silently disabled.

In v23, the OIDC feature was converted from a Dolibarr module to a config-level feature (#36051). This renamed the enable constant from `MAIN_MODULE_OPENIDCONNECT` to `MAIN_AUTHENTICATION_OIDC_ON` in PHP code — but no database migration was included to rename the existing row in `llx_const`.

After the upgrade, the v23 code reads `MAIN_AUTHENTICATION_OIDC_ON` (absent from the DB) and treats OIDC as disabled. The old `MAIN_MODULE_OPENIDCONNECT = 1` row remains in the DB, orphaned and unread.

The reporter in #37867 confirmed this by manually renaming the constant in the DB, which restored OIDC login.

## Fix

Add an `UPDATE` to `22.0.0-23.0.0.sql` that renames the constant in place, preserving its value.

```sql
UPDATE llx_const SET name = 'MAIN_AUTHENTICATION_OIDC_ON' WHERE name = 'MAIN_MODULE_OPENIDCONNECT';
```

This runs automatically during the v22 → v23 upgrade and covers all existing rows regardless of entity.

## Testing

To reproduce and verify:
1. Start a v22 instance with OIDC enabled (`MAIN_MODULE_OPENIDCONNECT = 1` in `llx_const`).
2. **Without this fix:** run the v23 migration — OIDC is disabled after upgrade.
3. **With this fix:** run the v23 migration — `llx_const` now contains `MAIN_AUTHENTICATION_OIDC_ON = 1`, OIDC remains enabled.
