### PR TITLE
New add fk_role to llx_actioncomm_resources with values from llx_c_actioncomm_role

### DIFF
--- a/htdocs/install/mysql/data/llx_c_actioncomm_role.sql
+++ b/htdocs/install/mysql/data/llx_c_actioncomm_role.sql
@@ -1,0 +1,34 @@
+-- ========================================================================
+-- Copyright (C) 2026 	Jon Bendtsen        <jon.bendtsen.github@jonb.dk>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ========================================================================
+
+-- Default roles for Event Organization
+INSERT INTO llx_c_actioncomm_role (code, label, active, position, picto) VALUES
+('ADMIN', 'Admin', 1, 1, 'admin'),
+('MANAGER', 'Manager', 1, 2, 'user'),
+('LEADER', 'Leader', 1, 3, 'star'),
+('ORGANIZER', 'Organizer', 1, 4, 'calendar'),
+('STAFF', 'Staff', 1, 5, 'user'),
+('SECURITY', 'Security', 1, 6, 'shield'),
+('SPEAKER', 'Speaker', 1, 7, 'user'),
+('VOLUNTEER', 'Volunteer', 1, 8, 'group'),
+('TEACHER', 'Teacher', 1, 9, 'chalkboard'),
+('DJ', 'DJ', 1, 10, 'music'),
+('BAND', 'Band', 1, 11, 'music'),
+('MC', 'MC/Host', 1, 12, 'microphone'),
+('PHOTOGRAPHER', 'Photographer', 1, 13, 'camera'),
+('MEDIC', 'Medic', 1, 14, 'medical');

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -553,4 +553,47 @@ UPDATE llx_const SET name = __ENCRYPT('ACCOUNTANCY_AUXACCOUNT_USE_SEARCH_TO_SELE
 --noqa:enable=PRS
 
 
+-- Adds Role management for Action Comm Resources
+
+-- 1. Create the Role Dictionary Table
+CREATE TABLE IF NOT EXISTS llx_c_actioncomm_role (
+  rowid INTEGER AUTO_INCREMENT PRIMARY KEY,
+  code VARCHAR(32) NOT NULL UNIQUE,
+  label VARCHAR(128) NOT NULL,
+  active TINYINT DEFAULT 1 NOT NULL,
+  position INT DEFAULT 0,
+  picto VARCHAR(48) DEFAULT NULL
+) ENGINE=INNODB;
+
+-- 2. Insert Default Roles
+INSERT INTO llx_c_actioncomm_role (code, label, active, position, picto) VALUES
+('ADMIN', 'Admin', 1, 1, 'admin'),
+('MANAGER', 'Manager', 1, 2, 'user'),
+('LEADER', 'Leader', 1, 3, 'star'),
+('ORGANIZER', 'Organizer', 1, 4, 'calendar'),
+('STAFF', 'Staff', 1, 5, 'user'),
+('SECURITY', 'Security', 1, 6, 'shield'),
+('SPEAKER', 'Speaker', 1, 7, 'user'),
+('VOLUNTEER', 'Volunteer', 1, 8, 'group'),
+('TEACHER', 'Teacher', 1, 9, 'chalkboard'),
+('DJ', 'DJ', 1, 10, 'music'),
+('BAND', 'Band', 1, 11, 'music'),
+('MC', 'MC/Host', 1, 12, 'microphone'),
+('PHOTOGRAPHER', 'Photographer', 1, 13, 'camera'),
+('MEDIC', 'Medic', 1, 14, 'medical');
+
+
+-- 3. Add the FK Role column to Resources
+ALTER TABLE llx_actioncomm_resources ADD COLUMN fk_role INTEGER DEFAULT NULL AFTER mandatory;
+
+ALTER TABLE llx_actioncomm_resources
+ADD CONSTRAINT fk_actioncomm_resources_role
+  FOREIGN KEY (fk_role) REFERENCES llx_c_actioncomm_role(rowid)
+  ON DELETE SET NULL;
+
+-- 4. Add Indexes
+ALTER TABLE llx_actioncomm_resources ADD INDEX idx_actioncomm_resources_fk_role (fk_role);
+ALTER TABLE llx_c_actioncomm_role ADD INDEX idx_c_actioncomm_role_active (active);
+ALTER TABLE llx_c_actioncomm_role ADD INDEX idx_c_actioncomm_role_active_position (active, position);
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_actioncomm_resources.key.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm_resources.key.sql
@@ -1,6 +1,7 @@
 -- ============================================================================
 -- Copyright (C) 2013	Laurent Destailleur	<eldy@users.sourceforge.net>
 -- Copyright (C) 2013	Florian Henry		<florian.henry@open-concept.pro>
+-- Copyright (C) 2026   Jon Bendtsen        <jon.bendtsen.github@jonb.dk>
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License as published by
@@ -21,4 +22,5 @@
 ALTER TABLE llx_actioncomm_resources ADD UNIQUE INDEX uk_actioncomm_resources(fk_actioncomm, element_type, fk_element);
 ALTER TABLE llx_actioncomm_resources ADD INDEX idx_actioncomm_resources_fk_element (fk_element);
 
+ALTER TABLE llx_actioncomm_resources ADD INDEX idx_actioncomm_resources_fk_role (fk_role);
 -- Pas de contrainte sur fk_source et fk_target car pointe sur differentes tables

--- a/htdocs/install/mysql/tables/llx_actioncomm_resources.sql
+++ b/htdocs/install/mysql/tables/llx_actioncomm_resources.sql
@@ -28,5 +28,11 @@ create table llx_actioncomm_resources
   fk_element		integer NOT NULL,			-- Id into table llx_user or llx_resource
   answer_status		varchar(50) NULL,
   mandatory			smallint,
-  transparency		smallint default 1	    -- Used to say if event is 1=OPAQUE=busy or 0=TRANSPARENT
+  fk_role			integer DEFAULT NULL,		-- Id into llx_c_actioncomm_role
+  transparency		smallint default 1,	    -- Used to say if event is 1=OPAQUE=busy or 0=TRANSPARENT
+
+  -- THE FOREIGN KEY CONSTRAINT
+  CONSTRAINT fk_actioncomm_resources_role
+    FOREIGN KEY (fk_role) REFERENCES llx_c_actioncomm_role(rowid)
+    ON DELETE SET NULL
 ) ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_c_actioncomm_role.key.sql
+++ b/htdocs/install/mysql/tables/llx_c_actioncomm_role.key.sql
@@ -1,0 +1,20 @@
+-- ========================================================================
+-- Copyright (C) 2026 		    Jon Bendtsen        <jon.bendtsen.github@jonb.dk>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ========================================================================
+
+ALTER TABLE llx_c_actioncomm_role ADD INDEX idx_c_actioncomm_role_active (active);
+ALTER TABLE llx_c_actioncomm_role ADD INDEX idx_c_actioncomm_role_active_position (active, position);

--- a/htdocs/install/mysql/tables/llx_c_actioncomm_role.sql
+++ b/htdocs/install/mysql/tables/llx_c_actioncomm_role.sql
@@ -1,0 +1,26 @@
+-- ========================================================================
+-- Copyright (C) 2026 		    Jon Bendtsen        <jon.bendtsen.github@jonb.dk>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ========================================================================
+
+CREATE TABLE IF NOT EXISTS llx_c_actioncomm_role (
+  rowid INTEGER AUTO_INCREMENT PRIMARY KEY,
+  code VARCHAR(32) NOT NULL UNIQUE,
+  label VARCHAR(128) NOT NULL,
+  active TINYINT DEFAULT 1 NOT NULL,
+  position INT DEFAULT 0,
+  picto VARCHAR(48) DEFAULT NULL
+) ENGINE=INNODB;


### PR DESCRIPTION
# New add fk_role to llx_actioncomm_resources with values from llx_c_actioncomm_role
Applying this commit adds an fk_role to llx_actioncomm_resources. The values are constraint to values from llx_c_actioncomm_role, which is currently populated with some sane values that should be useable in many situations.

This PR is a partial implementation of #38328

Future PR's will include code to:
- make a dictionary page such that Dolibarr admins can add, edit, change, delete, ... their own values
- assign, view, edit, change, ... roles for users in llx_actioncomm_resources
- and much more

