### PR TITLE
Qual: Fix PHPStan neon files indentation

### DIFF
--- a/dev/tools/phpstan/phpstan_v1_apstats.neon
+++ b/dev/tools/phpstan/phpstan_v1_apstats.neon
@@ -18,35 +18,35 @@ parameters:
 		- scripts
 	excludePaths:
 		analyseAndScan:
-		- htdocs/custom/*
-		- htdocs/documents/*
-		- htdocs/install/*		# We must exclude this dir to avoid to have DOL_DOCUMENT_ROOT defined to .. by inc.php before the bootstrap*.php file can load it.
-		- htdocs/install/doctemplates/*
-		- htdocs/langs/*
-		- htdocs/modulebuilder/template/test/*
+			- htdocs/custom/*
+			- htdocs/documents/*
+			- htdocs/install/*		# We must exclude this dir to avoid to have DOL_DOCUMENT_ROOT defined to .. by inc.php before the bootstrap*.php file can load it.
+			- htdocs/install/doctemplates/*
+			- htdocs/langs/*
+			- htdocs/modulebuilder/template/test/*
 		analyse:
-		- htdocs/includes/geoPHP/*
-		- htdocs/includes/markrogoyski/*
-		- htdocs/includes/maximebf/*
-		- htdocs/includes/mike42/*
-		- htdocs/includes/mobiledetect/*
-		- htdocs/includes/nusoap/*
-		- htdocs/includes/OAuth/*
-		- htdocs/includes/odtphp/*
-		- htdocs/includes/parsedown/*
-		- htdocs/includes/php-iban/*
-		- htdocs/includes/phpoffice/*
-		- htdocs/includes/printipp/*
-		- htdocs/includes/Psr/*
-		- htdocs/includes/restler/*
-		- htdocs/includes/sabre/*
-		- htdocs/includes/stripe/*
-		- htdocs/includes/swiftmailer/*
-		- htdocs/includes/symfony/*
-		- htdocs/includes/tcpdi/*
-		- htdocs/includes/tecnickcom/*
-		- htdocs/includes/webklex/*
-		- htdocs/core/class/lessc.class.php
+			- htdocs/includes/geoPHP/*
+			- htdocs/includes/markrogoyski/*
+			- htdocs/includes/maximebf/*
+			- htdocs/includes/mike42/*
+			- htdocs/includes/mobiledetect/*
+			- htdocs/includes/nusoap/*
+			- htdocs/includes/OAuth/*
+			- htdocs/includes/odtphp/*
+			- htdocs/includes/parsedown/*
+			- htdocs/includes/php-iban/*
+			- htdocs/includes/phpoffice/*
+			- htdocs/includes/printipp/*
+			- htdocs/includes/Psr/*
+			- htdocs/includes/restler/*
+			- htdocs/includes/sabre/*
+			- htdocs/includes/stripe/*
+			- htdocs/includes/swiftmailer/*
+			- htdocs/includes/symfony/*
+			- htdocs/includes/tcpdi/*
+			- htdocs/includes/tecnickcom/*
+			- htdocs/includes/webklex/*
+			- htdocs/core/class/lessc.class.php
 	# checkAlwaysTrueCheckTypeFunctionCall: false
 	# checkAlwaysTrueInstanceof: false
 	# checkAlwaysTrueStrictComparison: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,35 +20,35 @@ parameters:
 		- scripts
 	excludePaths:
 		analyseAndScan:
-		- htdocs/custom/*
-		- htdocs/documents/*
-		- htdocs/install/*		# We must exclude this dir to avoid to have DOL_DOCUMENT_ROOT defined to .. by inc.php before the bootstrap*.php file can load it.
-		- htdocs/install/doctemplates/*
-		- htdocs/langs/*
-		- htdocs/modulebuilder/template/test/*
+			- htdocs/custom/*
+			- htdocs/documents/*
+			- htdocs/install/*		# We must exclude this dir to avoid to have DOL_DOCUMENT_ROOT defined to .. by inc.php before the bootstrap*.php file can load it.
+			- htdocs/install/doctemplates/*
+			- htdocs/langs/*
+			- htdocs/modulebuilder/template/test/*
 		analyse:
-		- htdocs/includes/geoPHP/*
-		- htdocs/includes/markrogoyski/*
-		- htdocs/includes/maximebf/*
-		- htdocs/includes/mike42/*
-		- htdocs/includes/mobiledetect/*
-		- htdocs/includes/nusoap/*
-		- htdocs/includes/OAuth/*
-		- htdocs/includes/odtphp/*
-		- htdocs/includes/parsedown/*
-		- htdocs/includes/php-iban/*
-		- htdocs/includes/phpoffice/*
-		- htdocs/includes/printipp/*
-		- htdocs/includes/Psr/*
-		- htdocs/includes/restler/*
-		- htdocs/includes/sabre/*
-		- htdocs/includes/stripe/*
-		- htdocs/includes/swiftmailer/*
-		- htdocs/includes/symfony/*
-		- htdocs/includes/tcpdi/*
-		- htdocs/includes/tecnickcom/*
-		- htdocs/includes/webklex/*
-		- htdocs/core/class/lessc.class.php
+			- htdocs/includes/geoPHP/*
+			- htdocs/includes/markrogoyski/*
+			- htdocs/includes/maximebf/*
+			- htdocs/includes/mike42/*
+			- htdocs/includes/mobiledetect/*
+			- htdocs/includes/nusoap/*
+			- htdocs/includes/OAuth/*
+			- htdocs/includes/odtphp/*
+			- htdocs/includes/parsedown/*
+			- htdocs/includes/php-iban/*
+			- htdocs/includes/phpoffice/*
+			- htdocs/includes/printipp/*
+			- htdocs/includes/Psr/*
+			- htdocs/includes/restler/*
+			- htdocs/includes/sabre/*
+			- htdocs/includes/stripe/*
+			- htdocs/includes/swiftmailer/*
+			- htdocs/includes/symfony/*
+			- htdocs/includes/tcpdi/*
+			- htdocs/includes/tecnickcom/*
+			- htdocs/includes/webklex/*
+			- htdocs/core/class/lessc.class.php
 	# checkAlwaysTrueCheckTypeFunctionCall: false
 	# checkAlwaysTrueInstanceof: false
 	# checkAlwaysTrueStrictComparison: false


### PR DESCRIPTION
# Qual: Fix PHPStan neon files indentation

Fix indentation of ignored paths as per https://phpstan.org/user-guide/ignoring-errors.

https://cti.dolibarr.org/ still reports issues for odtphp despite exclusion from the git controlled configurations:
<img width="491" height="523" alt="image" src="https://github.com/user-attachments/assets/7998a3c9-f44e-4a06-85c5-e303c55cfdf4" />

This is likely because dev/tools/apstats.php uses a configuration file outside git control:
```
dev/tools/apstats.php:152:187:   $commandcheck = ($dirphpstan ? $dirphpstan.'/' : '').'phpstan --level='.$PHPSTANLEVEL.' -v analyze -a dev/build/phpstan/bootstrap.php --memory-limit 5G --error-format=github -c phpstan_apstats.neon';
```

`./dev/tools/phpstan/phpstan_v1_apstats.neon` exists in git, but not `./dev/tools/phpstan/phpstan_apstats.neon`

This generates about 29 extra entries:
<img width="252" height="33" alt="image" src="https://github.com/user-attachments/assets/07d4caa8-5652-4922-875b-b619616a9bf9" />
<img width="441" height="18" alt="image" src="https://github.com/user-attachments/assets/628ad19c-8cd7-4210-a379-8440598cf859" />


