### PR TITLE
Qual: Update return type annotations in Projects::getRoles()

### DIFF
--- a/dev/build/phpstan/phpstan-baseline.neon
+++ b/dev/build/phpstan/phpstan-baseline.neon
@@ -7111,12 +7111,6 @@ parameters:
 			path: ../../../htdocs/projet/card.php
 
 		-
-			message: '#^Method Projects\:\:getRoles\(\) should return array\<object\> but returns list\<string\>\.$#'
-			identifier: return.type
-			count: 1
-			path: ../../../htdocs/projet/class/api_projects.class.php
-
-		-
 			message: '#^Call to function method_exists\(\) with \$this\(Project\) and ''getLibStatut'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1

--- a/htdocs/projet/class/api_projects.class.php
+++ b/htdocs/projet/class/api_projects.class.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2015   Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016	Laurent Destailleur		<eldy@users.sourceforge.net>
- * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025	Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025       Jessica Kowal        <jessicakowal69@gmail.com>
@@ -529,8 +529,8 @@ class Projects extends DolibarrApi
 	 * @param   int   $id             Id of project
 	 * @param   int   $userid         Id of user (0 = connected user)
 	 * @return array
-	 * @phan-return Object[]
-	 * @phpstan-return Object[]
+	 * @phan-return string[]
+	 * @phpstan-return string[]
 	 *
 	 * @url	GET {id}/roles
 	 */


### PR DESCRIPTION
Qual: Update return type annotations in Projects::getRoles()

The return type annotations for the method Projects::getRoles() have been updated from array<object> to list<string> to better reflect the actual return type.