### PR TITLE
FIX #38320 Invoice generated from order puts last line first (wrong rang order)

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4412,7 +4412,7 @@ class Facture extends CommonInvoice
 					if (!empty($fk_parent_line)) {
 						// Always reorder if child line
 						$this->line_order(true, 'DESC');
-					} elseif ($ranktouse > 0 && $ranktouse <= count($this->lines)) {
+					} elseif ($ranktouse > 0 && $ranktouse < count($this->lines)) {
 						// Update all rank of all other lines starting from the same $ranktouse
 						$linecount = count($this->lines);
 						for ($ii = $ranktouse; $ii <= $linecount; $ii++) {


### PR DESCRIPTION
# FIX #38320 Invoice generated from order puts last line first (wrong rang order)
Applying this PR will ensure that we don't call updateRangOfLine if we add lines at the end, because before it called updateRangOfLine all the time at every insert.

Applying this PR will fix #38320 and should close #38320

Testing manually gives me the same line order in invoice created from an order that the order also have.
