### PR TITLE
[FIX] TakePOS WeighingScale: drop api_key, use DOM data

### DIFF
--- a/htdocs/takepos/ajax/ajax.php
+++ b/htdocs/takepos/ajax/ajax.php
@@ -279,7 +279,7 @@ if ($action == 'getProducts' && $user->hasRight('takepos', 'run')) {
 		}
 	}
 
-	$sql = 'SELECT p.rowid, p.ref, p.label, p.tosell, p.tobuy, p.barcode, p.price, p.price_ttc' ;
+	$sql = 'SELECT p.rowid, p.ref, p.label, p.tosell, p.tobuy, p.barcode, p.price, p.price_ttc, p.fk_unit' ;
 	if (getDolGlobalInt('TAKEPOS_PRODUCT_IN_STOCK') == 1) {
 		if (getDolGlobalInt('CASHDESK_ID_WAREHOUSE'.$_SESSION['takeposterminal'])) {
 			$sql .= ', ps.reel';
@@ -337,7 +337,7 @@ if ($action == 'getProducts' && $user->hasRight('takepos', 'run')) {
 	}
 
 	if (getDolGlobalInt('TAKEPOS_PRODUCT_IN_STOCK') == 1 && !getDolGlobalInt('CASHDESK_ID_WAREHOUSE'.$_SESSION['takeposterminal'])) {
-		$sql .= ' GROUP BY p.rowid, p.ref, p.label, p.tosell, p.tobuy, p.barcode, p.price, p.price_ttc';
+		$sql .= ' GROUP BY p.rowid, p.ref, p.label, p.tosell, p.tobuy, p.barcode, p.price, p.price_ttc, p.fk_unit';
 		// Add fields from hooks
 		$parameters = array();
 		$reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters);
@@ -382,6 +382,7 @@ if ($action == 'getProducts' && $user->hasRight('takepos', 'run')) {
 				'barcode' => $obj->barcode,
 				'price' => empty($objProd->multiprices[$pricelevel]) ? $obj->price : $objProd->multiprices[$pricelevel],
 				'price_ttc' => empty($objProd->multiprices_ttc[$pricelevel]) ? $obj->price_ttc : $objProd->multiprices_ttc[$pricelevel],
+				'fk_unit' => $obj->fk_unit,
 				'object' => 'product',
 				'img' => $ig,
 				'qty' => 1,

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -451,6 +451,12 @@ function LoadProducts(position, issubcat) {
 				$("#prodiv"+ishow).data("iscat", 0);
 				$("#prodiv"+ishow).attr("data-iscat", 0);
 
+				$("#prodiv"+ishow).data("price-ttc", data[idata]['price_ttc']);
+				$("#prodiv"+ishow).attr("data-price-ttc", data[idata]['price_ttc']);
+
+				$("#prodiv"+ishow).data("unit", data[idata]['fk_unit']);
+				$("#prodiv"+ishow).attr("data-unit", data[idata]['fk_unit']);
+
 				$("#prodiv"+ishow).attr("class","wrapper2");
 
 				<?php
@@ -873,6 +879,10 @@ function Search2(keyCodeForEnter, moreorless) {
 					$("#prodiv" + i).data("iscat", 0);
 					$("#prodiv" + i).attr("data-iscat", 0);
 
+					$("#prodiv" + i).data("price-ttc", data[i]['price_ttc']);
+					$("#prodiv" + i).data("unit", data[i]['fk_unit']);
+
+
 					<?php
 					// Add js from hooks
 					$parameters = array();
@@ -1101,30 +1111,30 @@ function WeighingScale(callback) {
 	console.log("Weighing Scale: invoiceid = " + placeid + ", lineid = " + selectedline);
 	<?php if (getDolGlobalString('TAKEPOS_CONNECTOR_TO_WHB_SCALE')) {?>
 		<?php if (getDolGlobalString('WEIGHINGSCALE_PROTOCOL') == "diag06") { ?>
-			// Protocole Dialog-06, il a besoin du prix unitaire, le demander s'il manque
-			var urlProduct;
-			if (idproduct == "" && selectedline > 0) {
-				urlProduct = "<?php echo DOL_URL_ROOT; ?>/api/index.php/takeposconnector/invoices/" + placeid + "/lines/" + selectedline + "/product";
-			} else {
-				urlProduct = "<?php echo DOL_URL_ROOT; ?>/api/index.php/products/" + idproduct;
+			// Protocol Dialog-06: retrieve unit + unit price including VAT in the DOM
+			var unit, priceTtc;
+			if (selectedline > 0) {
+				// Source: selected shopping cart line
+				unit = $('#' + selectedline).data('unit');
+				priceTtc = $('#' + selectedline).data('price-ttc');
+			} else if (idproduct != "") {
+				// Source: clicked product tile (search by data-rowid)
+				var $tile = $('.wrapper2[data-rowid="' + idproduct + '"]').first();
+				unit = $tile.data('unit');
+				priceTtc = $tile.data('price-ttc');
 			}
-			$.ajax({
-				type: "GET",
-				headers: { "DOLAPIKEY": '<?php echo $user->api_key; ?>' },
-				url: urlProduct,
-			})
-			.done(function(product) {
-				if (callback === undefined) {
-					callback = function(qty) {
-						$("#poslines").load("invoice.php?token=<?php echo newToken(); ?>&action=updateqty&place="+place+"&idline="+selectedline+"&number="+qty);
-					};
-				}
-				if (product.fk_unit == "2") {
-					askForWeight(product.multiprices_ttc[1], callback, function (errorMessage) {
-						console.log("Erreur: " + errorMessage);
-					});
-				}
-			});
+			console.log("WeighingScale unit=" + unit + " priceTtc=" + priceTtc);
+
+			if (callback === undefined) {
+				callback = function(qty) {
+					$("#poslines").load("invoice.php?token=<?php echo newToken(); ?>&action=updateqty&place="+place+"&idline="+selectedline+"&number="+qty);
+				};
+			}
+			if (unit == 2) {
+				askForWeight(priceTtc, callback, function (errorMessage) {
+					console.log("Erreur: " + errorMessage);
+				});
+			}
 		<?php } else { ?>
 			// Protocole par défaut de takeposconnector: réception continue du poids/stabilité
 			editnumber = globalWeight;

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -2074,6 +2074,9 @@ if ($placeid > 0) {
 				if ($line->special_code == "4") {
 					$htmlsupplements[$line->fk_parent_line] .= ' title="'.dol_escape_htmltag($langs->trans("AlreadyPrinted")).'"';
 				}
+				$htmlsupplements[$line->fk_parent_line] .= ' data-product="'.$line->fk_product.'"';
+				$htmlsupplements[$line->fk_parent_line] .= ' data-unit="'.$line->fk_unit.'"';
+				$htmlsupplements[$line->fk_parent_line] .= ' data-price-ttc="'.$line->subprice * (1 + $line->tva_tx / 100).'"';
 				$htmlsupplements[$line->fk_parent_line] .= '>';
 				$htmlsupplements[$line->fk_parent_line] .= '<td class="left">';
 				$htmlsupplements[$line->fk_parent_line] .= img_picto('', 'rightarrow.png');
@@ -2119,6 +2122,9 @@ if ($placeid > 0) {
 			if ($line->special_code == "4") {
 				$htmlforlines .= ' title="'.dol_escape_htmltag($langs->trans("AlreadyPrinted")).'"';
 			}
+			$htmlforlines .= ' data-product="'.$line->fk_product.'"';
+			$htmlforlines .= ' data-unit="'.$line->fk_unit.'"';
+			$htmlforlines .= ' data-price-ttc="'.$line->subprice * (1 + $line->tva_tx / 100).'"';
 			$htmlforlines .= '>';
 			$htmlforlines .= '<td class="left">';
 			if (!empty($_SESSION["basiclayout"]) && $_SESSION["basiclayout"] == 1) {


### PR DESCRIPTION
Read product unit and unit price from DOM attributes set server-side instead of calling REST API with $user->api_key embedded in HTML (security issue coming from #37078 (by myself, my bad)).

Removes the hardcoded takeposconnector dependency