### PR TITLE
Fix hard reading on bad screen

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -3666,7 +3666,7 @@ function dol_banner_tab($object, $paramid, $morehtml = '', $shownav = 1, $fieldi
 	if (in_array($object->element, array('product', 'bank_account', 'project_task'))) {
 		/** @var Product|Account|Task $object */
 		if (!empty($object->label)) {
-			$morehtmlref .= '<div class="refidno opacitymedium">' . $object->label . '</div>';
+			$morehtmlref .= '<div class="refidno banner-object-label">' . $object->label . '</div>';
 		}
 	}
 	// Show address and email
@@ -3701,7 +3701,7 @@ function dol_banner_tab($object, $paramid, $morehtml = '', $shownav = 1, $fieldi
 	// $morehtmlstatus is part under the status
 	// $morehtmlright is part of htmlright
 
-	print '<div class="' . ($onlybanner ? 'arearefnobottom ' : 'arearef ') . 'heightref valignmiddle centpercent">';
+	print '<div class="' . ($onlybanner ? 'arearefnobottom ' : 'arearef ') . 'heightref valignmiddle centpercent object-banner-tab-container" data-module-part="'.dolPrintHTMLForAttribute($modulepart).'">';
 	print $form->showrefnav($object, $paramid, $morehtml, $shownav, $fieldid, $fieldref, $morehtmlref, $moreparam, $nodbprefix, $morehtmlleft, $morehtmlstatus, $morehtmlright);
 	print '</div>';
 	print '<div class="underrefbanner clearboth"></div>';


### PR DESCRIPTION
# Fix : banner label display on bad screen

I don't know about you, but for us, a product name and the information attached to it are extremely important.
Back on V20, I patched the UX and look & feel issues only for our internal needs.
Now that I'm working on the migration to V23, I'm trying to fix every issue I encounter. And this time, instead of limiting myself to PHP errors and bugs, I'm also patching UX and look & feel problems directly at the core level.

**Without patch**
<img width="814" height="208" alt="image" src="https://github.com/user-attachments/assets/23aaab0f-69d1-4fd3-8502-12163d8ada7c" />


**Display perception on poor-quality screens or under sunlight**
<img width="1012" height="112" alt="image" src="https://github.com/user-attachments/assets/6c4913ff-7ea1-4a94-b274-7a411202443c" />


**With patch :**
<img width="776" height="127" alt="image" src="https://github.com/user-attachments/assets/d2f8ffc5-a314-46ba-8c5b-80ad58ededae" />
