### PR TITLE
FIX #37775 extrafields not saved when invoice created from a invoice model

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1547,7 +1547,7 @@ if (empty($reshook)) {
 				// Source facture
 				$object->fac_rec = GETPOSTINT('fac_rec');
 
-				$id = $object->create($user); // This include recopy of links from recurring invoice and recurring invoice lines
+				$id = $object->create($user, 0, 0, 0, 0); // This include recopy of links from recurring invoice and recurring invoice lines
 			}
 		}
 

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -456,9 +456,10 @@ class Facture extends CommonInvoice
 	 *	@param  int		$notrigger				1=Does not execute triggers, 0 otherwise
 	 * 	@param	int		$forceduedate			If set, do not recalculate due date from payment condition but force it with value
 	 *  @param	int		$updatecurrencyrate		Update currency rate when generation done from template invoice
+	 *  @param  int     $inheritExtraFields     1=Inherit extra fields from template (default), 0=Keep current object values (allow clearing)
 	 *	@return	int								Return integer <0 if KO, >0 if OK
 	 */
-	public function create(User $user, $notrigger = 0, $forceduedate = 0, $updatecurrencyrate = 0)
+	public function create(User $user, $notrigger = 0, $forceduedate = 0, $updatecurrencyrate = 0, $inheritExtraFields = 1)
 	{
 		global $langs, $conf, $mysoc;
 		$error = 0;
@@ -604,7 +605,9 @@ class Facture extends CommonInvoice
 			$this->note_private = trim($this->note_private);
 			$this->note_private = dol_concatdesc($this->note_private, $langs->trans("GeneratedFromRecurringInvoice", $_facrec->ref));
 
-			$this->array_options = $_facrec->array_options;
+			if ($inheritExtraFields) {
+				$this->array_options = $_facrec->array_options;
+			}
 
 			if (!$this->mode_reglement_id) {
 				$this->mode_reglement_id = 0;


### PR DESCRIPTION
# FIX #37775 extrafields not saved when invoice created from a invoice model
Applying this PR will make it possible to manually create an invoice from an invoice template and still in the form change the extrafields/complementary attributes to suit your needs.

If it is an automatic creation, the functions default value is to overwrite extrafields/complementary attributes from the template invoice.

## work flow

1. user finds template invoice
2. user clicks `create invoice`
3. form loads with values from that template invoice
4. user may modify as they wish
5. user clicks `create draft`
6. draft invoice now includes data from the form, not from the template invoice, which allows the user to change, modify or delete extrafields/complementary attributes

This PR should close #37775