### PR TITLE
Fix : product weight selection when editing the product again

### DIFF
--- a/htdocs/product/class/html.formproduct.class.php
+++ b/htdocs/product/class/html.formproduct.class.php
@@ -619,11 +619,12 @@ class FormProduct
 				$return .= '"';
 				if ($mode == 1 && $lines->short_label == $selected) {
 					$return .= ' selected';
-				} elseif ($mode == 2 && $lines->scale == $selected) {
+				} elseif ($mode == 2 && (int) $lines->scale === (int) $selected) { // Careful null !== 0 !== '0' and when 0 is saved bdd store null
 					$return .= ' selected';
 				} elseif ($mode == 0 && $lines->id == $selected) {
 					$return .= ' selected';
 				}
+
 				$return .= '>';
 				if ($measuring_style == 'time') {
 					$return .= $langs->trans(ucfirst((string) $lines->label));


### PR DESCRIPTION
# Fix 

When a product is configured with the kilogram weight unit, Dolibarr automatically selects the first matching unit from the list when editing the product again. In this case, it switches to grams. This issue does not occur with other units.

The problem is that if the product is saved at this point, the "gram" unit is actually stored instead of "kilogram".




