### PR TITLE
FIX Import - Fallback txt format to csv

### DIFF
--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -1,9 +1,9 @@
 <?php
-/* Copyright (C) 2005-2016 Laurent Destailleur  <eldy@users.sourceforge.net>
- * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
- * Copyright (C) 2012      Christophe Battarel	<christophe.battarel@altairis.fr>
- * Copyright (C) 2022      Charlene Benke		<charlene@patas-monkey.com>
- * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2005-2016  Laurent Destailleur         <eldy@users.sourceforge.net>
+ * Copyright (C) 2005-2009  Regis Houssin               <regis.houssin@inodbox.com>
+ * Copyright (C) 2012       Christophe Battarel         <christophe.battarel@altairis.fr>
+ * Copyright (C) 2022       Charlene Benke              <charlene@patas-monkey.com>
+ * Copyright (C) 2024-2026	MDW                         <mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -703,6 +703,12 @@ if ($step == 3 && $datatoimport) {
 	}
 
 	$model = $format;
+
+	// Fallback: txt to csv (import_txt.modules.php does not exist)
+	if ($model === 'txt') {
+		$model = 'csv';
+	}
+
 	$list = $objmodelimport->listOfAvailableImportFormat($db);
 
 	if (empty($separator)) {

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -1542,6 +1542,12 @@ if ($step == 4 && $datatoimport) {
 	}
 
 	$model = $format;
+
+	// Fallback: txt to csv (import_txt.modules.php does not exist)
+	if ($model === 'txt') {
+		$model = 'csv';
+	}
+
 	$list = $objmodelimport->listOfAvailableImportFormat($db);
 
 	// Create class to use for import
@@ -2086,6 +2092,12 @@ if ($step == 5 && $datatoimport) {
 	}
 
 	$model = $format;
+
+	// Fallback: txt to csv (import_txt.modules.php does not exist)
+	if ($model === 'txt') {
+		$model = 'csv';
+	}
+
 	$list = $objmodelimport->listOfAvailableImportFormat($db);
 	$importid = GETPOST("importid", 'alphanohtml');
 


### PR DESCRIPTION


## Problem

Since v24 alpha, when importing a file with a `.txt` extension, Dolibarr tries to load
`import_txt.modules.php` to handle the format. This file does not exist in
the codebase, causing a fatal PHP error:

<img width="1840" height="201" alt="image" src="https://github.com/user-attachments/assets/5cc80ae6-7790-48e3-864e-26bae3851a93" />

Previously, users were uploading `.csv` files and the import worked fine.
The `.txt` extension is now used by some users/tools to export CSV-formatted
data, so the import should support it transparently.

## Solution

Added a format fallback in `htdocs/imports/import.php`: if the detected
format/model is `txt`, it is silently remapped to `csv` before loading the
import driver class.

This change is applied at every point where `$model` is used to build the
`require_once` path for the import module file.

## Changes

- `htdocs/imports/import.php`: added `txt` → `csv` fallback (4 occurrences)

## Code added (before each `require_once` of the import driver)

```php
// Fallback: .txt files are treated as .csv (import_txt.modules.php does not exist)
if ($model === 'txt') {
    $model = 'csv';
}
```

## Impact

- No regression on existing CSV/XLSX imports
- `.txt` files that are CSV-formatted (comma or semicolon separated) now
  import correctly using the existing CSV driver
- The separator auto-detection logic already in place handles the correct
  delimiter automatically