### PR TITLE
FIX #38378 BOM/MO: PMP averaging on Manufacturing Orders

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1421,7 +1421,11 @@ class BOM extends CommonObject
 				$tmpproduct->pmp = 0;
 				$result = $tmpproduct->fetch($line->fk_product, '', '', '', 0, 1, 1);	// We discard selling price and language loading
 
-				$unit_cost = (float) (is_null($tmpproduct->cost_price) ? $tmpproduct->pmp : $tmpproduct->cost_price);
+				// Fix #38378: the previous is_null() check did not catch cost_price = "0.00000000"
+				// (the DDL default returned as a non-null string by mysqlnd), so unit_cost was forced
+				// to 0 instead of falling back to PMP. Use (double) cast inside empty() so the check
+				// evaluates the numeric value: "0.00000000" -> 0.0 -> empty() true -> PMP fallback.
+				$unit_cost = (float) (!empty((double) $tmpproduct->cost_price) ? $tmpproduct->cost_price : $tmpproduct->pmp);
 				if (empty($unit_cost)) {	// @phpstan-ignore-line phpstan thinks this is always false. No,if unit_cost is 0, it is not.
 					if ($productFournisseur->find_min_price_product_fournisseur($line->fk_product) > 0) {
 						if ($productFournisseur->fourn_remise_percent != "0") {

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1031,7 +1031,10 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 					if ($object->qty > 0) {
 						// add free consume line cost to $bomcostupdated
-						$costprice = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+						// Fix #38378: cost_price is a DECIMAL stored as "0.00000000" by default,
+						// so empty($string) evaluates to false and the PMP fallback is unreachable.
+						// Cast to (double) so empty() evaluates the numeric value, not the string shape.
+						$costprice = price2num((!empty((double) $tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
 						if (empty($costprice)) {
 							require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 							$productFournisseur = new ProductFournisseur($db);
@@ -1736,9 +1739,13 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 								$manufacturingcost = $bomcost;
 								$manufacturingcostsrc = $langs->trans("ValueFromBom");
 							}
+							// Fix #38378: avoid relying on price2num("0.00000000") happening to collapse to "0".
+							// Guard the cost_price branch explicitly so cascade falls through to PMP when needed.
 							if (empty($manufacturingcost)) {
-								$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');
-								$manufacturingcostsrc = $langs->trans("CostPrice");
+								if (!empty((double) $tmpproduct->cost_price)) {
+									$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');
+									$manufacturingcostsrc = $langs->trans("CostPrice");
+								}
 							}
 							if (empty($manufacturingcost)) {
 								$manufacturingcost = price2num($tmpproduct->pmp, 'MU');
@@ -1889,9 +1896,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 									$manufacturingcost = $bomcost;
 									$manufacturingcostsrc = $langs->trans("ValueFromBom");
 								}
+								// Fix #38378: same defensive guard as the cascade above.
 								if (empty($manufacturingcost)) {
-									$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');
-									$manufacturingcostsrc = $langs->trans("CostPrice");
+									if (!empty((double) $tmpproduct->cost_price)) {
+										$manufacturingcost = price2num($tmpproduct->cost_price, 'MU');
+										$manufacturingcostsrc = $langs->trans("CostPrice");
+									}
 								}
 								if (empty($manufacturingcost)) {
 									$manufacturingcost = price2num($tmpproduct->pmp, 'MU');


### PR DESCRIPTION
# FIX #38378 BOM/MO: PMP averaging on Manufacturing Orders

cost_price is stored as DECIMAL and returned by mysqlnd as the string `"0.00000000"` when unset (DDL default = 0, not NULL). The expression `empty($tmpproduct->cost_price)` evaluates to `false` for that string, so the PMP fallback path in `mo_production.php` and `BOM::calculateCosts()` is unreachable on every install where the cost field was never explicitly filled.

The downstream effect is that `$bomcostupdated` and `$bomcost` collapse to 0, the `$manufacturingcost` cascade falls through to the manufactured product's own pre-MO PMP, and that value is then passed to `MouvementStock::_create()` as the production price. MouvementStock then weight-averages the existing PMP against itself, producing an identity: the PMP never changes after a Manufacturing Order, even when it should.

This patch casts `cost_price` to `(double)` inside `empty()` at four call sites so the check evaluates the numeric value. The downstream value passed to `price2num` is unchanged, so no precision is lost.

- `htdocs/mrp/mo_production.php` (primary site + two defensive cascade sites)
- `htdocs/bom/class/bom.class.php` (replaces the incomplete `is_null()` check that did not catch the `"0.00000000"` string case)

A previous attempt at the `Product` class level did not reach these expressions because they read `$tmpproduct->cost_price` directly via inline ternary; the `is_null()` guard already present in `BOM::calculateCosts()` is also insufficient for the same reason.

## Reproduction

Real production case (see #38378 for full trace):

- Manufactured product pre-MO: `pmp = 338.81549`, stock = 826
- Material consumed: `pmp = 332.72137`, `cost_price = "0.00000000"`
- MO produces 1692 units

**Expected after MO:** new PMP ≈ 334.74
**Actual without this patch:** PMP stays at 338.81549 (unchanged, the formula collapses to identity)

## Test plan

Fresh install reproduction:

1. Create product **A**, leave the cost field blank (persists as `"0.00000000"`). Initial stock entry with `price = 100` → `pmp = 100`.
2. Create product **B**, leave cost blank. Initial stock entry with `price = 150`, qty = 50 → `pmp = 150`.
3. Create BOM for **B** consuming 1 unit of **A**. Validate.
4. Create MO for **B**, qty = 10. Validate. Open production tab.
5. **Before patch:** cost-to-produce input pre-filled with `150`; B's PMP stays at `150` after producing.
6. **After patch:** cost-to-produce pre-filled with `100`; B's PMP becomes `(50 × 150 + 10 × 100) / 60 ≈ 141.67`.

## Targeted branch

The bug exists in 18.x, 19.x, 20.x, 21.x, 22.x and `develop`. This PR targets `develop`. Happy to re-target to the oldest currently-maintained branch if a maintainer indicates which.
