### PR TITLE
FIX $show_photos - nbmax not respected when using link-based photo path

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -10227,6 +10227,10 @@ abstract class CommonObject
 						} else {
 							$return .= '</div>';
 						}
+
+						if ($nbmax && $nbphoto >= $nbmax) {
+							break;
+						}
 					}
 				}
 


### PR DESCRIPTION
In product list, we have possibility to show photo but normally is limit to nbmax (1 in this situation)

<img width="1588" height="31" alt="image" src="https://github.com/user-attachments/assets/918686e2-50c4-4c03-a117-95fea41aab84" />

And the result is:

<img width="892" height="750" alt="image" src="https://github.com/user-attachments/assets/b12aeedc-f620-4a87-bf90-550c07a93b70" />

The $nbmax parameter is correctly enforced in the main file loop (via $filearray), but is completely ignored in the secondary loop over $links used when PRODUCT_USE_LINK_PATH_FOR_PHOTO is active.

As a result, all photos are always displayed regardless of the $nbmax value passed to show_photos().

Added a break condition after $nbphoto >= $nbmax in the $links loop to match the existing behavior of the $filearray loop.

With correction (only one external picture is showing):

<img width="519" height="137" alt="image" src="https://github.com/user-attachments/assets/f1908500-dc3e-4286-bc37-76046d10cbfc" />
