### PR TITLE
ticket: standardise send message form with editable TO/CC fields

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1744,6 +1744,7 @@ class FormTicket
 				print '<tr class="email_line"><td class="fieldrequired">'.$langs->trans('MailRecipients');
 				print ' '.$form->textwithpicto('', $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients"), 1, 'help');
 				print '</td><td>';
+				$withto = array();
 				if ($res) {
 					$sendto_free = GETPOSTISSET('sendto') ? GETPOST('sendto', 'alphawithlgt') : '';
 					print '<input class="minwidth200" id="sendto" name="sendto" spellcheck="false" placeholder="email@domain.com" value="'.dol_escape_htmltag($sendto_free).'" />';
@@ -1751,8 +1752,6 @@ class FormTicket
 					// Build recipient list; keys are email addresses (used directly in newMessage())
 					$contacts = $ticketstat->getInfosTicketInternalContact(1);
 					$contacts = array_merge($contacts, $ticketstat->getInfosTicketExternalContact(1));
-
-					$withto = array();
 					$seen_emails = array();
 
 					if (is_array($contacts) && count($contacts) > 0) {

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1781,7 +1781,7 @@ class FormTicket
 							'labelhtml' => dol_escape_htmltag($email).' <span class="opacitymedium">('.$langs->trans('TicketEmailOriginIssuer').')</span>',
 						);
 						$seen_emails[] = strtolower($email);
-					} elseif ($ticketstat->origin_email && !in_array(strtolower($ticketstat->origin_email), $seen_emails)) {
+					} elseif ($ticketstat->origin_email && !in_array(strtolower((string) $ticketstat->origin_email), $seen_emails)) {
 						$email = (string) $ticketstat->origin_email;
 						$withto[$email] = array(
 							'id'        => $email,
@@ -1794,8 +1794,8 @@ class FormTicket
 					if ($ticketstat->fk_soc > 0) {
 						$ticketstat->socid = $ticketstat->fk_soc;
 						$ticketstat->fetch_thirdparty();
-						if (!empty($ticketstat->thirdparty->email) && !in_array(strtolower($ticketstat->thirdparty->email), $seen_emails)) {
-							$email = $ticketstat->thirdparty->email;
+						if (!empty($ticketstat->thirdparty->email) && !in_array(strtolower((string) $ticketstat->thirdparty->email), $seen_emails)) {
+							$email = (string) $ticketstat->thirdparty->email;
 							$withto[$email] = array(
 								'id'        => $email,
 								'label'     => $email,
@@ -1958,7 +1958,9 @@ class FormTicket
 			$defaultmessage = preg_replace("/^\n+/", "", $defaultmessage);
 		}
 
-		$ckeditorenabledforticket = (getDolGlobalString('FCKEDITOR_ENABLE_TICKET') >= ($fromPublicInterface ? 2 : 1));		// 0=no, 1=from backoffice only, 2=from backoffice+public (very dangerous)
+		// 0=no, 1=backoffice only, 2=backoffice+public. showMessageForm() is always email context, so also honour FCKEDITOR_ENABLE_MAIL.
+		$ckeditorenabledforticket = (getDolGlobalString('FCKEDITOR_ENABLE_TICKET') >= ($fromPublicInterface ? 2 : 1))
+			|| (!$fromPublicInterface && getDolGlobalString('FCKEDITOR_ENABLE_MAIL'));
 
 		print '<!-- Message line from showMessageForm -->';
 		print '<tr><td class="tdtop"><label for="message"><span class="fieldrequired">'.$langs->trans("Message").'</span>';

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1817,7 +1817,7 @@ class FormTicket
 						}
 					}
 
-					// Pre-select all contacts on first load; restore POST selection on re-display
+					// Preselect all contacts on first load; restore POST selection on re-display
 					if (GETPOSTISSET('receiver_multiselect')) {
 						$withtoselected = GETPOST('receiver', 'array');
 					} else {
@@ -1847,7 +1847,7 @@ class FormTicket
 				}
 				print '<input class="minwidth200" id="sendtocc" name="sendtocc" spellcheck="false" value="'.dol_escape_htmltag($sendtocc_free).'" />';
 
-				// Reuse $withto contact list; nothing pre-selected for CC
+				// Reuse $withto contact list; nothing preselected for CC
 				if (!empty($withto)) {
 					print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
 					$withtocc_selected = GETPOSTISSET('receivercc_multiselect') ? GETPOST('receivercc', 'array') : array();

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1747,7 +1747,6 @@ class FormTicket
 				if ($res) {
 					$sendto_free = GETPOSTISSET('sendto') ? GETPOST('sendto', 'alphawithlgt') : '';
 					print '<input class="minwidth200" id="sendto" name="sendto" spellcheck="false" value="'.dol_escape_htmltag($sendto_free).'" />';
-					print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
 
 					// Build recipient list; keys are email addresses (used directly in newMessage())
 					$contacts = $ticketstat->getInfosTicketInternalContact(1);
@@ -1826,6 +1825,7 @@ class FormTicket
 					}
 
 					if (!empty($withto)) {
+						print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
 						print $form->multiselectarray('receiver', $withto, $withtoselected, 0, 0, 'inline-block minwidth500', 0, 0, '', '', '', 1);
 					} else {
 						// No contacts linked: emit the flag hidden so newMessage() still reads the free sendto input

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1745,21 +1745,17 @@ class FormTicket
 				print ' '.$form->textwithpicto('', $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients"), 1, 'help');
 				print '</td><td>';
 				if ($res) {
-					// === Input libre (comme withtofree dans FormMail) ===
-					// Valeur POST conservée si retour après erreur, vide sinon
 					$sendto_free = GETPOSTISSET('sendto') ? GETPOST('sendto', 'alphawithlgt') : '';
 					print '<input class="minwidth200" id="sendto" name="sendto" spellcheck="false" value="'.dol_escape_htmltag($sendto_free).'" />';
 					print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
 
-					// === Multiselect des contacts du ticket (comme withto dans FormMail) ===
-					// Les clés sont les adresses email (directement utilisables dans newMessage)
+					// Build recipient list; keys are email addresses (used directly in newMessage())
 					$contacts = $ticketstat->getInfosTicketInternalContact(1);
 					$contacts = array_merge($contacts, $ticketstat->getInfosTicketExternalContact(1));
 
 					$withto = array();
 					$seen_emails = array();
 
-					// Contacts internes et externes liés au ticket
 					if (is_array($contacts) && count($contacts) > 0) {
 						foreach ($contacts as $info_sendto) {
 							if ($info_sendto['email'] != '') {
@@ -1779,7 +1775,6 @@ class FormTicket
 						}
 					}
 
-					// Email d'origine (reply-to ou origin_email)
 					if (!empty($ticketstat->origin_replyto) && !in_array(strtolower($ticketstat->origin_replyto), $seen_emails)) {
 						$email = (string) $ticketstat->origin_replyto;
 						$withto[$email] = array(
@@ -1798,7 +1793,6 @@ class FormTicket
 						$seen_emails[] = strtolower($email);
 					}
 
-					// Email du tiers lié
 					if ($ticketstat->fk_soc > 0) {
 						$ticketstat->socid = $ticketstat->fk_soc;
 						$ticketstat->fetch_thirdparty();
@@ -1813,7 +1807,6 @@ class FormTicket
 						}
 					}
 
-					// Adresse globale de notification (si configurée)
 					if (getDolGlobalInt('TICKET_NOTIFICATION_ALSO_MAIN_ADDRESS') && getDolGlobalString('TICKET_NOTIFICATION_EMAIL_TO')) {
 						$generic_email = getDolGlobalString('TICKET_NOTIFICATION_EMAIL_TO');
 						if (!in_array(strtolower($generic_email), $seen_emails)) {
@@ -1825,9 +1818,7 @@ class FormTicket
 						}
 					}
 
-					// Présélection :
-					// - Premier affichage (mode=init) → tous les contacts présélectionnés par défaut
-					// - Retour après soumission → conserver la sélection de l'utilisateur
+					// Pre-select all contacts on first load; restore POST selection on re-display
 					if (GETPOSTISSET('receiver_multiselect')) {
 						$withtoselected = GETPOST('receiver', 'array');
 					} else {
@@ -1835,7 +1826,6 @@ class FormTicket
 					}
 
 					if (!empty($withto)) {
-						// multiselectarray generates its own wrapper span + hidden receiver_multiselect automatically
 						print $form->multiselectarray('receiver', $withto, $withtoselected, 0, 0, 'inline-block minwidth500', 0, 0, '', '', '', 1);
 					} else {
 						print '<div class="warning">'.$langs->trans('WarningNoEMailsAdded').' '.$langs->trans('TicketGoIntoContactTab').'</div>';
@@ -1843,12 +1833,11 @@ class FormTicket
 				}
 				print '</td></tr>';
 
-				// Send to CC — editable field (same pattern as TO: free input + multiselect)
 				print '<tr class="email_line"><td>';
 				print $form->textwithpicto($langs->trans("MailCC"), $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients"), 1, 'help');
 				print '</td><td>';
 
-				// Free input: keep POST value on error return, otherwise pre-fill with global CC address if configured
+				// Pre-fill with TICKET_SEND_INTERNAL_CC on first load
 				if (GETPOSTISSET('receivercc_multiselect')) {
 					$sendtocc_free = GETPOST('sendtocc', 'alphawithlgt');
 				} else {
@@ -1856,8 +1845,7 @@ class FormTicket
 				}
 				print '<input class="minwidth200" id="sendtocc" name="sendtocc" spellcheck="false" value="'.dol_escape_htmltag($sendtocc_free).'" />';
 
-				// Multiselect — reuse same $withto list built for the TO field; nothing pre-selected by default
-				// multiselectarray generates its own wrapper span + hidden receivercc_multiselect automatically
+				// Reuse $withto contact list; nothing pre-selected for CC
 				if (!empty($withto)) {
 					print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
 					$withtocc_selected = GETPOSTISSET('receivercc_multiselect') ? GETPOST('receivercc', 'array') : array();

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1741,61 +1741,131 @@ class FormTicket
 			$action = '';
 			$reshook = $hookmanager->executeHooks('printFieldTicketEmailTo', $parameters, $this, $action);
 			if (empty($reshook)) {
-				print '<tr class="email_line"><td>'.$langs->trans('MailRecipients');
-				print ' '.$form->textwithpicto('', $langs->trans("TicketMessageRecipientsHelp"), 1, 'help');
+				print '<tr class="email_line"><td class="fieldrequired">'.$langs->trans('MailRecipients');
+				print ' '.$form->textwithpicto('', $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients"), 1, 'help');
 				print '</td><td>';
 				if ($res) {
-					// Retrieve email of all contacts (internal and external)
+					// === Input libre (comme withtofree dans FormMail) ===
+					// Valeur POST conservée si retour après erreur, vide sinon
+					$sendto_free = GETPOSTISSET('sendto') ? GETPOST('sendto', 'alphawithlgt') : '';
+					print '<input class="minwidth200" id="sendto" name="sendto" spellcheck="false" value="'.dol_escape_htmltag($sendto_free).'" />';
+					print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
+
+					// === Multiselect des contacts du ticket (comme withto dans FormMail) ===
+					// Les clés sont les adresses email (directement utilisables dans newMessage)
 					$contacts = $ticketstat->getInfosTicketInternalContact(1);
 					$contacts = array_merge($contacts, $ticketstat->getInfosTicketExternalContact(1));
 
-					$sendto = array();
+					$withto = array();
+					$seen_emails = array();
 
-					// Build array to display recipient list
+					// Contacts internes et externes liés au ticket
 					if (is_array($contacts) && count($contacts) > 0) {
-						foreach ($contacts as $key => $info_sendto) {
+						foreach ($contacts as $info_sendto) {
 							if ($info_sendto['email'] != '') {
-								$sendto[] = dol_escape_htmltag(trim($info_sendto['firstname']." ".$info_sendto['lastname'])." <".$info_sendto['email'].">").' <small class="opacitymedium">('.dol_escape_htmltag($info_sendto['libelle']).")</small>";
+								$email_lc = strtolower($info_sendto['email']);
+								if (!in_array($email_lc, $seen_emails)) {
+									$label_text = trim($info_sendto['firstname'].' '.$info_sendto['lastname']).' <'.$info_sendto['email'].'>';
+									$label_html = dol_htmlentities(trim($info_sendto['firstname'].' '.$info_sendto['lastname']), ENT_QUOTES, 'UTF-8')
+										.' <span class="opacitymedium">('.dol_htmlentities($info_sendto['libelle'], ENT_QUOTES, 'UTF-8').')</span>';
+									$withto[$info_sendto['email']] = array(
+										'id'        => $info_sendto['email'],
+										'label'     => str_replace(array('<', '>'), array('(', ')'), $label_text),
+										'labelhtml' => $label_html,
+									);
+									$seen_emails[] = $email_lc;
+								}
 							}
 						}
 					}
 
-					if (!empty($ticketstat->origin_replyto) && !in_array($ticketstat->origin_replyto, $sendto)) {
-						$sendto[] = dol_escape_htmltag((string) $ticketstat->origin_replyto).' <small class="opacitymedium">('.$langs->trans("TicketEmailOriginIssuer").")</small>";
-					} elseif ($ticketstat->origin_email && !in_array($ticketstat->origin_email, $sendto)) {
-						$sendto[] = dol_escape_htmltag((string) $ticketstat->origin_email).' <small class="opacitymedium">('.$langs->trans("TicketEmailOriginIssuer").")</small>";
+					// Email d'origine (reply-to ou origin_email)
+					if (!empty($ticketstat->origin_replyto) && !in_array(strtolower($ticketstat->origin_replyto), $seen_emails)) {
+						$email = (string) $ticketstat->origin_replyto;
+						$withto[$email] = array(
+							'id'        => $email,
+							'label'     => $email,
+							'labelhtml' => dol_escape_htmltag($email).' <span class="opacitymedium">('.$langs->trans('TicketEmailOriginIssuer').')</span>',
+						);
+						$seen_emails[] = strtolower($email);
+					} elseif ($ticketstat->origin_email && !in_array(strtolower($ticketstat->origin_email), $seen_emails)) {
+						$email = (string) $ticketstat->origin_email;
+						$withto[$email] = array(
+							'id'        => $email,
+							'label'     => $email,
+							'labelhtml' => dol_escape_htmltag($email).' <span class="opacitymedium">('.$langs->trans('TicketEmailOriginIssuer').')</span>',
+						);
+						$seen_emails[] = strtolower($email);
 					}
 
+					// Email du tiers lié
 					if ($ticketstat->fk_soc > 0) {
 						$ticketstat->socid = $ticketstat->fk_soc;
 						$ticketstat->fetch_thirdparty();
-
-						if (!empty($ticketstat->thirdparty->email) && !in_array($ticketstat->thirdparty->email, $sendto)) {
-							$sendto[] = $ticketstat->thirdparty->email.' <small class="opacitymedium">('.$langs->trans('Customer').')</small>';
+						if (!empty($ticketstat->thirdparty->email) && !in_array(strtolower($ticketstat->thirdparty->email), $seen_emails)) {
+							$email = $ticketstat->thirdparty->email;
+							$withto[$email] = array(
+								'id'        => $email,
+								'label'     => $email,
+								'labelhtml' => dol_escape_htmltag($email).' <span class="opacitymedium">('.$langs->trans('Customer').')</span>',
+							);
+							$seen_emails[] = strtolower($email);
 						}
 					}
 
-					if (getDolGlobalInt('TICKET_NOTIFICATION_ALSO_MAIN_ADDRESS')) {
-						$sendto[] = getDolGlobalString('TICKET_NOTIFICATION_EMAIL_TO').' <small class="opacitymedium">(generic email)</small>';
+					// Adresse globale de notification (si configurée)
+					if (getDolGlobalInt('TICKET_NOTIFICATION_ALSO_MAIN_ADDRESS') && getDolGlobalString('TICKET_NOTIFICATION_EMAIL_TO')) {
+						$generic_email = getDolGlobalString('TICKET_NOTIFICATION_EMAIL_TO');
+						if (!in_array(strtolower($generic_email), $seen_emails)) {
+							$withto[$generic_email] = array(
+								'id'        => $generic_email,
+								'label'     => $generic_email,
+								'labelhtml' => dol_escape_htmltag($generic_email).' <span class="opacitymedium">(generic)</span>',
+							);
+						}
 					}
 
-					// Print recipient list
-					if (is_array($sendto) && count($sendto) > 0) {
-						print img_picto('', 'email', 'class="pictofixedwidth"');
-						print implode(', ', $sendto);
+					// Présélection :
+					// - Premier affichage (mode=init) → tous les contacts présélectionnés par défaut
+					// - Retour après soumission → conserver la sélection de l'utilisateur
+					if (GETPOSTISSET('receiver_multiselect')) {
+						$withtoselected = GETPOST('receiver', 'array');
+					} else {
+						$withtoselected = array_keys($withto);
+					}
+
+					if (!empty($withto)) {
+						// multiselectarray generates its own wrapper span + hidden receiver_multiselect automatically
+						print $form->multiselectarray('receiver', $withto, $withtoselected, 0, 0, 'inline-block minwidth500', 0, 0, '', '', '', 1);
 					} else {
 						print '<div class="warning">'.$langs->trans('WarningNoEMailsAdded').' '.$langs->trans('TicketGoIntoContactTab').'</div>';
 					}
 				}
 				print '</td></tr>';
+
+				// Send to CC — editable field (same pattern as TO: free input + multiselect)
+				print '<tr class="email_line"><td>';
+				print $form->textwithpicto($langs->trans("MailCC"), $langs->trans("YouCanUseCommaSeparatorForSeveralRecipients"), 1, 'help');
+				print '</td><td>';
+
+				// Free input: keep POST value on error return, otherwise pre-fill with global CC address if configured
+				if (GETPOSTISSET('receivercc_multiselect')) {
+					$sendtocc_free = GETPOST('sendtocc', 'alphawithlgt');
+				} else {
+					$sendtocc_free = getDolGlobalString('TICKET_SEND_INTERNAL_CC');
+				}
+				print '<input class="minwidth200" id="sendtocc" name="sendtocc" spellcheck="false" value="'.dol_escape_htmltag($sendtocc_free).'" />';
+
+				// Multiselect — reuse same $withto list built for the TO field; nothing pre-selected by default
+				// multiselectarray generates its own wrapper span + hidden receivercc_multiselect automatically
+				if (!empty($withto)) {
+					print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
+					$withtocc_selected = GETPOSTISSET('receivercc_multiselect') ? GETPOST('receivercc', 'array') : array();
+					print $form->multiselectarray('receivercc', $withto, $withtocc_selected, 0, 0, 'inline-block minwidth500', 0, 0, '', '', '', 1);
+				}
+				print '</td></tr>';
 			} else {
 				print $hookmanager->resPrint;
-			}
-			// Send to CC
-			$sendtocc = getDolGlobalString('TICKET_SEND_INTERNAL_CC');
-			if ($sendtocc) {
-				print '<tr class="email_line"><td><span class="">'.$langs->trans("MailCC").'</span></td>';
-				print '<td><span class="">'.img_picto('', 'email', 'class="pictofixedwidth"').$sendtocc.'</span></td></tr>';
 			}
 		}
 

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1746,7 +1746,7 @@ class FormTicket
 				print '</td><td>';
 				if ($res) {
 					$sendto_free = GETPOSTISSET('sendto') ? GETPOST('sendto', 'alphawithlgt') : '';
-					print '<input class="minwidth200" id="sendto" name="sendto" spellcheck="false" value="'.dol_escape_htmltag($sendto_free).'" />';
+					print '<input class="minwidth200" id="sendto" name="sendto" spellcheck="false" placeholder="email@domain.com" value="'.dol_escape_htmltag($sendto_free).'" />';
 
 					// Build recipient list; keys are email addresses (used directly in newMessage())
 					$contacts = $ticketstat->getInfosTicketInternalContact(1);
@@ -1830,7 +1830,7 @@ class FormTicket
 					} else {
 						// No contacts linked: emit the flag hidden so newMessage() still reads the free sendto input
 						print '<input type="hidden" name="receiver_multiselect" value="1">';
-						print '<div class="warning">'.$langs->trans('WarningNoEMailsAdded').' '.$langs->trans('TicketGoIntoContactTab').'</div>';
+						print ' &nbsp;<span class="opacitymedium"><small>'.$langs->trans('WarningNoEMailsAdded').'</small></span>';
 					}
 				}
 				print '</td></tr>';

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1828,6 +1828,8 @@ class FormTicket
 					if (!empty($withto)) {
 						print $form->multiselectarray('receiver', $withto, $withtoselected, 0, 0, 'inline-block minwidth500', 0, 0, '', '', '', 1);
 					} else {
+						// No contacts linked: emit the flag hidden so newMessage() still reads the free sendto input
+						print '<input type="hidden" name="receiver_multiselect" value="1">';
 						print '<div class="warning">'.$langs->trans('WarningNoEMailsAdded').' '.$langs->trans('TicketGoIntoContactTab').'</div>';
 					}
 				}
@@ -1850,6 +1852,9 @@ class FormTicket
 					print ' <span class="opacitymedium">'.$langs->trans("and").'/'.$langs->trans("or").'</span> ';
 					$withtocc_selected = GETPOSTISSET('receivercc_multiselect') ? GETPOST('receivercc', 'array') : array();
 					print $form->multiselectarray('receivercc', $withto, $withtocc_selected, 0, 0, 'inline-block minwidth500', 0, 0, '', '', '', 1);
+				} else {
+					// No contacts: emit the flag hidden so newMessage() still reads the free sendtocc input
+					print '<input type="hidden" name="receivercc_multiselect" value="1">';
 				}
 				print '</td></tr>';
 			} else {

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -3160,18 +3160,27 @@ class Ticket extends CommonObject
 										}
 									}
 
-									if (!empty($sendto_manual)) {
-										$sendto = $sendto_manual;
-									}
+									$sendto = $sendto_manual;
 								}
 
 								// CC: start with TICKET_SEND_INTERNAL_CC, then append form selection
 								$sendtocc = array();
+								$sendtocc_emails = array(); // lowercase email index for case-insensitive dedup
 								if (getDolGlobalString("TICKET_SEND_INTERNAL_CC")) {
 									foreach (explode(',', getDolGlobalString("TICKET_SEND_INTERNAL_CC")) as $cc_entry) {
 										$cc_entry = trim($cc_entry);
-										if ($cc_entry) {
+										if (!$cc_entry) {
+											continue;
+										}
+										// Extract bare email from optional "Name <email>" format
+										if (preg_match('/<\s*([^>]+)\s*>/', $cc_entry, $m)) {
+											$cc_email = strtolower(trim($m[1]));
+										} else {
+											$cc_email = strtolower($cc_entry);
+										}
+										if (!in_array($cc_email, $sendtocc_emails)) {
 											$sendtocc[] = $cc_entry;
+											$sendtocc_emails[] = $cc_email;
 										}
 									}
 								}
@@ -3181,8 +3190,9 @@ class Ticket extends CommonObject
 									if (is_array($receivercc_selected)) {
 										foreach ($receivercc_selected as $email) {
 											$email = trim((string) $email);
-											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL) && !in_array($email, $sendtocc)) {
+											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL) && !in_array(strtolower($email), $sendtocc_emails)) {
 												$sendtocc[] = $email;
+												$sendtocc_emails[] = strtolower($email);
 											}
 										}
 									}
@@ -3200,8 +3210,9 @@ class Ticket extends CommonObject
 											} else {
 												$email = $entry;
 											}
-											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL) && !in_array($email, $sendtocc)) {
+											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL) && !in_array(strtolower($email), $sendtocc_emails)) {
 												$sendtocc[] = $email;
+												$sendtocc_emails[] = strtolower($email);
 											}
 										}
 									}

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -3127,13 +3127,10 @@ class Ticket extends CommonObject
 									$sendto = $hookmanager->resArray;
 								}
 
-								// If the user submitted the standardised form (with receiver[] multiselect
-								// and/or the free sendto input), override the auto-computed list with what
-								// the user actually chose / typed — same behaviour as other mail forms.
+								// If standardised form submitted, override auto-computed recipients with user selection
 								if (GETPOSTISSET('receiver_multiselect')) {
 									$sendto_manual = array();
 
-									// 1. Emails selected in the multiselect (keys = emails in our implementation)
 									$receiver_selected = GETPOST('receiver', 'array');
 									if (is_array($receiver_selected)) {
 										foreach ($receiver_selected as $email) {
@@ -3144,7 +3141,7 @@ class Ticket extends CommonObject
 										}
 									}
 
-									// 2. Free-text input (comma-separated, supports "Name <email>" format)
+									// Free input: plain email or "Name <email>", comma-separated
 									$sendto_free = GETPOST('sendto', 'alphawithlgt');
 									if ($sendto_free !== '') {
 										foreach (explode(',', $sendto_free) as $entry) {
@@ -3168,8 +3165,7 @@ class Ticket extends CommonObject
 									}
 								}
 
-								// Build CC list from the standardised form (receivercc[] multiselect + sendtocc free input).
-								// Always start with the global internal CC address if configured.
+								// CC: start with TICKET_SEND_INTERNAL_CC, then append form selection
 								$sendtocc = array();
 								if (getDolGlobalString("TICKET_SEND_INTERNAL_CC")) {
 									foreach (explode(',', getDolGlobalString("TICKET_SEND_INTERNAL_CC")) as $cc_entry) {
@@ -3181,7 +3177,6 @@ class Ticket extends CommonObject
 								}
 
 								if (GETPOSTISSET('receivercc_multiselect')) {
-									// Emails selected in the CC multiselect
 									$receivercc_selected = GETPOST('receivercc', 'array');
 									if (is_array($receivercc_selected)) {
 										foreach ($receivercc_selected as $email) {
@@ -3192,7 +3187,7 @@ class Ticket extends CommonObject
 										}
 									}
 
-									// Free-text CC input
+									// Free input: plain email or "Name <email>", comma-separated
 									$sendtocc_free = GETPOST('sendtocc', 'alphawithlgt');
 									if ($sendtocc_free !== '') {
 										foreach (explode(',', $sendtocc_free) as $entry) {

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -3127,9 +3127,89 @@ class Ticket extends CommonObject
 									$sendto = $hookmanager->resArray;
 								}
 
+								// If the user submitted the standardised form (with receiver[] multiselect
+								// and/or the free sendto input), override the auto-computed list with what
+								// the user actually chose / typed — same behaviour as other mail forms.
+								if (GETPOSTISSET('receiver_multiselect')) {
+									$sendto_manual = array();
+
+									// 1. Emails selected in the multiselect (keys = emails in our implementation)
+									$receiver_selected = GETPOST('receiver', 'array');
+									if (is_array($receiver_selected)) {
+										foreach ($receiver_selected as $email) {
+											$email = trim((string) $email);
+											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+												$sendto_manual[$email] = $email;
+											}
+										}
+									}
+
+									// 2. Free-text input (comma-separated, supports "Name <email>" format)
+									$sendto_free = GETPOST('sendto', 'alphawithlgt');
+									if ($sendto_free !== '') {
+										foreach (explode(',', $sendto_free) as $entry) {
+											$entry = trim($entry);
+											if ($entry === '') {
+												continue;
+											}
+											if (preg_match('/.*<\s*([^>]+)\s*>/', $entry, $matches)) {
+												$email = trim($matches[1]);
+											} else {
+												$email = $entry;
+											}
+											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+												$sendto_manual[$email] = $entry;
+											}
+										}
+									}
+
+									if (!empty($sendto_manual)) {
+										$sendto = $sendto_manual;
+									}
+								}
+
+								// Build CC list from the standardised form (receivercc[] multiselect + sendtocc free input).
+								// Always start with the global internal CC address if configured.
 								$sendtocc = array();
 								if (getDolGlobalString("TICKET_SEND_INTERNAL_CC")) {
-									$sendtocc = explode(',', getDolGlobalString("TICKET_SEND_INTERNAL_CC"));
+									foreach (explode(',', getDolGlobalString("TICKET_SEND_INTERNAL_CC")) as $cc_entry) {
+										$cc_entry = trim($cc_entry);
+										if ($cc_entry) {
+											$sendtocc[] = $cc_entry;
+										}
+									}
+								}
+
+								if (GETPOSTISSET('receivercc_multiselect')) {
+									// Emails selected in the CC multiselect
+									$receivercc_selected = GETPOST('receivercc', 'array');
+									if (is_array($receivercc_selected)) {
+										foreach ($receivercc_selected as $email) {
+											$email = trim((string) $email);
+											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL) && !in_array($email, $sendtocc)) {
+												$sendtocc[] = $email;
+											}
+										}
+									}
+
+									// Free-text CC input
+									$sendtocc_free = GETPOST('sendtocc', 'alphawithlgt');
+									if ($sendtocc_free !== '') {
+										foreach (explode(',', $sendtocc_free) as $entry) {
+											$entry = trim($entry);
+											if ($entry === '') {
+												continue;
+											}
+											if (preg_match('/.*<\s*([^>]+)\s*>/', $entry, $matches)) {
+												$email = trim($matches[1]);
+											} else {
+												$email = $entry;
+											}
+											if ($email && filter_var($email, FILTER_VALIDATE_EMAIL) && !in_array($email, $sendtocc)) {
+												$sendtocc[] = $email;
+											}
+										}
+									}
 								}
 
 								// Don't try to send email when no recipient


### PR DESCRIPTION
  # NEW Standardise ticket message form recipient fields

  The ticket send-message form (`presend_addmessage`) displayed the
  recipient list as plain read-only text. Contacts linked to the ticket
  were auto-filled but the user had no way to edit them or add a custom
  email address.
  
  This change brings the form in line with the standard `FormMail`
  behaviour used across other Dolibarr modules (propal, invoice, etc.):

  - **To field**: free-text input (manual address entry) + multiselect
    dropdown listing all contacts linked to the ticket (internal
    contacts, external contacts, origin email, thirdparty email),
    **all pre-selected by default**
  - **CC field**: same free-text input + multiselect pattern, with
    nothing pre-selected. The global `TICKET_SEND_INTERNAL_CC` address
    is pre-filled in the free input when set
  - On form re-display after a validation error, user input is preserved
  - `newMessage()` now reads `receiver[]`, `sendto`, `receivercc[]` and
    `sendtocc` POST fields to build the final recipient lists instead of
    always recomputing them from the database
  
  **Files changed:**
  - `htdocs/core/class/html.formticket.class.php`
  - `htdocs/ticket/class/ticket.class.php`
