### PR TITLE
Qual: Fix Phan notices, set PHP min to 7.2 to avoid some

### DIFF
--- a/dev/tools/apstats.php
+++ b/dev/tools/apstats.php
@@ -326,8 +326,8 @@ foreach ($output_arrglpu as $valgitlog) {		// The most recent lines are first.
 			}
 
 			$arrayofalerts[$tmpval['commitid']] = $tmpval;
-		} elseif (array_key_exists($alreadyfoundcommitid, $arrayofalerts)) { // Test for static analysis
-			if (!array_key_exists('commitidbis', $arrayofalerts[$alreadyfoundcommitid])) {
+		} else { // Test for static analysis
+			if (!array_key_exists($alreadyfoundcommitid, $arrayofalerts) || !array_key_exists('commitidbis', $arrayofalerts[$alreadyfoundcommitid])) {
 				$arrayofalerts[$alreadyfoundcommitid]['commitidbis'] = array();
 			}
 

--- a/dev/tools/apstats.php
+++ b/dev/tools/apstats.php
@@ -2,7 +2,7 @@
 <?php
 /*
  * Copyright (C) 2023-2024 	Laurent Destailleur 	<eldy@users.sourceforge.net>
- * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -103,7 +103,7 @@ $PHPSTANLEVEL = 9;
 // PHAN setup. Configuration is required, otherwise phan is disabled.
 $PHAN_CONFIG = "{$path}phan/config_extended.php";
 $PHAN_BASELINE = "{$path}phan/baseline_extended.txt";		// BASELINE is ignored if it does not exist
-$PHAN_MIN_PHP = "7.0";
+$PHAN_MIN_PHP = "7.2";  // Set to minimum target version, avoids PhanCompatibleNullableTypePHP70 for instance
 $PHAN_MEMORY_OPT = "--memory-limit 5G";
 
 if (!is_readable($PHAN_CONFIG)) {

--- a/dev/tools/apstats.php
+++ b/dev/tools/apstats.php
@@ -169,7 +169,7 @@ $output_phan_json = array();
 $res_exec_phan = 0;
 if ($dir_phan != 'disabled') {
 	if (is_readable($PHAN_BASELINE)) {
-		$PHAN_BASELINE_OPT = "-B '${PHAN_BASELINE}'";
+		$PHAN_BASELINE_OPT = "-B '{$PHAN_BASELINE}'";
 	} else {
 		$PHAN_BASELINE_OPT = '';
 	}
@@ -194,7 +194,7 @@ foreach (array('proj', 'dep') as $source) {
 	print 'Analyze SCC result for lines of code for '.$source."\n";
 	if ($source == 'proj') {
 		$output_arr = &$output_arrproj;
-	} elseif ($source == 'dep') {
+	} elseif ($source == 'dep') {  // @phpstan-ignore equal.alwaysTrue
 		$output_arr = &$output_arrdep;
 	} else {
 		print 'Bad value for $source';
@@ -317,7 +317,7 @@ foreach ($output_arrglpu as $valgitlog) {		// The most recent lines are first.
 			exec($commandgetbranch, $output_arrgetbranch, $resexecgetbranch);
 
 			foreach ($output_arrgetbranch as $valbranch) {
-				if (empty($tmpval['branch'])) {
+				if (!array_key_exists('branch', $tmpval)) {
 					$tmpval['branch'] = array();
 				}
 				if (preg_match('/^\s*origin\/(develop|\d)/', $valbranch)) {
@@ -326,8 +326,8 @@ foreach ($output_arrglpu as $valgitlog) {		// The most recent lines are first.
 			}
 
 			$arrayofalerts[$tmpval['commitid']] = $tmpval;
-		} else {
-			if (empty($arrayofalerts[$alreadyfoundcommitid]['commitidbis'])) {
+		} elseif (array_key_exists($alreadyfoundcommitid, $arrayofalerts)) { // Test for static analysis
+			if (!array_key_exists('commitidbis', $arrayofalerts[$alreadyfoundcommitid])) {
 				$arrayofalerts[$alreadyfoundcommitid]['commitidbis'] = array();
 			}
 
@@ -339,7 +339,7 @@ foreach ($output_arrglpu as $valgitlog) {		// The most recent lines are first.
 			exec($commandgetbranch, $output_arrgetbranch, $resexecgetbranch);
 
 			foreach ($output_arrgetbranch as $valbranch) {
-				if (empty($tmpval['branch'])) {
+				if (!array_key_exists('branch', $tmpval)) {
 					$tmpval['branch'] = array();
 				}
 				if (preg_match('/^\s*origin\/(develop|\d)/', $valbranch)) {
@@ -599,7 +599,7 @@ foreach (array('proj', 'dep') as $source) {
 			$html .= '<td class="right nowrap">'.(empty($val['Files']) ? '' : formatNumber($val['Files'])).'</td>';
 			$html .= '<td class="right nowrap">'.(empty($val['Lines']) ? '' : formatNumber($val['Lines'])).'</td>';
 			$html .= '<td class="nowrap">';
-			$percent = $val['Lines'] / $arrayofmax['Lines'];
+			$percent = (float) $val['Lines'] / (int) $arrayofmax['Lines'];
 			$widthbar = round(200 * $percent);
 			$html .= '<div class="bargraph" style="width: '.max(1, $widthbar).'px">&nbsp;</div>';
 			$html .= '</td>';
@@ -755,7 +755,7 @@ $html .= '</div>';
 if (array_key_exists('proj', $arraycocomo)) {
 	$html .= '<div class="box inline-box back2">';
 	$html .= 'COCOMO effort<br><span class="small opacitymedium">(Basic/Semi-detached model)</span><br>';
-	$html .= '<b>'.formatNumber($arraycocomo['proj']['people'] * $arraycocomo['proj']['effort'] + $arraycocomo['dep']['people'] * $arraycocomo['dep']['effort']);
+	$html .= '<b>'.formatNumber((int) $arraycocomo['proj']['people'] * (float) $arraycocomo['proj']['effort'] + (int) $arraycocomo['dep']['people'] * (float) $arraycocomo['dep']['effort']);
 	$html .= ' months people</b>';
 	$html .= '</div>';
 }
@@ -836,7 +836,7 @@ $title_security_short = "Last security issues";
 $title_security = ($project ? "[".$project."] " : "").$title_security_short;
 
 $html .= '<section class="chapter" id="securityalerts">'."\n";
-$html .= '<h2><span class="fas fa-code pictofixedwidth"></span>'.$title_security_short.' <span class="opacitymedium">(last '.($nbofmonth != 1 ? $nbofmonth.' months' : 'month').')</span></h2>'."\n";
+$html .= '<h2><span class="fas fa-code pictofixedwidth"></span>'.$title_security_short.' <span class="opacitymedium">(last '.($nbofmonth != 1 ? $nbofmonth.' months' : 'month').')</span></h2>'."\n";  // @phpstan-ignore  notEqual.alwaysTrue
 
 $html .= '<div class="boxallwidth">'."\n";
 $html .= '<div class="div-table-responsive">'."\n";
@@ -1103,8 +1103,8 @@ if ($fh) {
 /**
  * function to format a number
  *
- * @param	string|int		$number			Number to format
- * @param	int				$nbdec			Number of decimal digits
+ * @param	string|float	$number			Number to format
+ * @param	int<0,max>		$nbdec			Number of decimal digits
  * @return	string							Formatted string
  */
 function formatNumber($number, $nbdec = 0)
@@ -1115,8 +1115,8 @@ function formatNumber($number, $nbdec = 0)
 /**
  * cleanVal
  *
- * @param array 	$val		Array of a PR
- * @return 						Array of a PR
+ * @param object 	$val		Array of a PR
+ * @return array{url:string,number:string,title:string,created_at:string,updated_at:string}	Array of a PR
  */
 function cleanVal($val)
 {
@@ -1134,8 +1134,8 @@ function cleanVal($val)
 /**
  * cleanVal2
  *
- * @param array 	$val		Array of a PR
- * @return 						Array of a PR
+ * @param string 	$val		Line of a PR
+ * @return array{commitid:string,url:string,issueid:string,issueidvdp:string,issueidcve:string,title:string,created_at:string,updated_at:string,branch:string[]}	Array of a PR
  */
 function cleanVal2($val)
 {
@@ -1150,6 +1150,7 @@ function cleanVal2($val)
 	$tmpval['title'] = array_key_exists(5, $tmp) ? preg_replace('/\.$/', '', $tmp[5]) : '';
 	$tmpval['created_at'] = array_key_exists(0, $tmp) ? $tmp[0] : '';
 	$tmpval['updated_at'] = '';
+	$tmpval['branch'] = array();
 
 	$reg = array();
 	if (preg_match('/#(\d+)/', $tmpval['title'], $reg)) {

--- a/htdocs/ai/assistant/download_pdf.php
+++ b/htdocs/ai/assistant/download_pdf.php
@@ -144,9 +144,15 @@ try {
 			} else {
 				// Table Builder for List
 				$keys = array_keys($rows[0]);
-				$keys = array_filter($keys, function (string $k) {
-					return $k !== 'url' && $k !== 'rowid';
-				});
+				$keys = array_filter(
+					$keys,
+					/**
+					 * @return bool Select only fields other than url and rowid
+					 */
+					static function (string $k) {
+						return $k !== 'url' && $k !== 'rowid';
+					}
+				);
 
 				$html .= '<table cellpadding="4"><thead><tr>';
 				foreach ($keys as $k) {
@@ -175,9 +181,15 @@ try {
 	} elseif (isset($data[0]) && is_array($data[0])) {
 		// Simple list (e.g. search invoices)
 		$keys = array_keys($data[0]);
-		$keys = array_filter($keys, function (string $k) {
-			return $k !== 'url' && $k !== 'rowid';
-		});
+		$keys = array_filter(
+			$keys,
+			/**
+			 * @return bool Select only fields other than url and rowid
+			 */
+			static function (string $k) {
+				return $k !== 'url' && $k !== 'rowid';
+			}
+		);
 
 		$html .= '<table cellpadding="4"><thead><tr nobr="true">';
 		foreach ($keys as $key) {

--- a/htdocs/ai/server/mcp_server.php
+++ b/htdocs/ai/server/mcp_server.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
+ * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -158,11 +159,11 @@ require_once DOL_DOCUMENT_ROOT . '/ai/lib/ai.lib.php';
  * Only tools/call is logged -- lifecycle methods (initialize, ping,
  * notifications/initialized, tools/list, ...) are skipped to avoid noise.
  *
- * @param array<string,mixed> $req         The JSON-RPC request
- * @param mixed               $resp        The JSON-RPC response (null for notifications)
- * @param float               $tStart      microtime(true) captured before processing
- * @param string              $rawInput    Raw request body
- * @return void
+ * @param array<string,mixed>	$req		The JSON-RPC request
+ * @param ?mixed				$resp		The JSON-RPC response (null for notifications)
+ * @param float					$tStart		microtime(true) captured before processing
+ * @param string				$rawInput	Raw request body
+ * @return void								No return value, only logs the request
  */
 function mcp_log_request(array $req, $resp, float $tStart, string $rawInput): void
 {

--- a/htdocs/ai/tools/categories.class.php
+++ b/htdocs/ai/tools/categories.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
+ * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +32,6 @@ require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
  */
 class ToolCategories extends McpTool
 {
-
 	/**
 	 * 	Constructor
 	 *
@@ -649,9 +649,10 @@ class ToolCategories extends McpTool
 			$path_parts[] = ["label" => $cat->label];
 			$full_path = implode(' > ', array_map(
 				/**
-				* @param array{label:string} $p
-				*/
-				function ($p) {
+				 * @param array{label:string} $p
+				 * @return string
+				 */
+				static function ($p) {
 					return $p['label'];
 				},
 				$path_parts

--- a/htdocs/ai/tools/crud_objects.class.php
+++ b/htdocs/ai/tools/crud_objects.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
+ * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +32,6 @@ require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
  */
 class ToolCrudObjects extends McpTool
 {
-
 	/**
 	 * 	Constructor
 	 *
@@ -384,7 +384,6 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 	 *                                   } Arguments including type, header data, and optional lines.
 	 *
 	 * @return array<string, mixed>
-	 *
 	 */
 	private function createDocument(array $args)
 	{
@@ -508,7 +507,6 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 	 *                                   } Line arguments.
 	 *
 	 * @return array<string, mixed>
-	 *
 	 */
 	private function processAddLine(CommonObject $object, array $args)
 	{
@@ -685,7 +683,6 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 	 * @param array{object_type:string,parent_id:int,product_id?:int,description?:string,quantity?:float|int,unit_price?:float|int,vat_rate?:float|int} $args Tool arguments for adding a line item
 	 *
 	 * @return array{success:bool,line_id?:int,error?:string}
-	 *
 	 */
 	private function addLineItem(array $args)
 	{
@@ -921,7 +918,7 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 	 * @param   int    $lineId Line RowID.
 	 * @param   int    $unitId Unit RowID.
 	 *
-	 * @return  void
+	 * @return  void			Only attempts to update the database, no result indication
 	 */
 	private function updateLineUnit(string $type, int $lineId, int $unitId): void
 	{


### PR DESCRIPTION
# Qual: Fix Phan notices, set PHP min to 7.2 to avoid some

Fix some new notices since Apr 14, not appearing in CI, but in cti.
Set the minimum php version to 7.2 for Phan in ap_stats.php to avoid Phan notices about PHP7.0 version compatibility.