### PR TITLE
Fix #38407: API addtimespent crashes with "Illegal offset type" on PHP 8+

### DIFF
--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -610,12 +610,13 @@ class Tasks extends DolibarrApi
 	 * { "date": "2016-12-31 23:15:00", "duration": 1800, "user_id": 1, "note": "My time test" }
 	 *
 	 * @param   int         	$id                 Task ID
-	 * @param   datetime|string	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
+	 * @param   datetime    	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
+	 * @phan-param string $date
 	 * @param   int         	$duration           Duration in seconds (3600 = 1h)
 	 * @param   int         	$product_id         The product id that is used, default is null
 	 * @param   int         	$user_id            User (Use 0 for connected user)
 	 * @param   string      	$note               Note
-	 * @param   int|null    	$progress           Progress percentage (0-100). If null, progress is not updated
+	 * @param   int         	$progress           Progress percentage (0-100). Use -1 to leave progress unchanged
 	 *
 	 * @url POST    {id}/addtimespent
 	 *      NOTE: Should be "POST {id}/timespent", since POST already implies "add"

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -610,8 +610,7 @@ class Tasks extends DolibarrApi
 	 * { "date": "2016-12-31 23:15:00", "duration": 1800, "user_id": 1, "note": "My time test" }
 	 *
 	 * @param   int         	$id                 Task ID
-	 * @param   datetime    	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
-	 * @phan-param string $date
+	 * @param   datetime|string	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
 	 * @param   int         	$duration           Duration in seconds (3600 = 1h)
 	 * @param   int         	$product_id         The product id that is used, default is null
 	 * @param   int         	$user_id            User (Use 0 for connected user)

--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -610,7 +610,8 @@ class Tasks extends DolibarrApi
 	 * { "date": "2016-12-31 23:15:00", "duration": 1800, "user_id": 1, "note": "My time test" }
 	 *
 	 * @param   int         	$id                 Task ID
-	 * @param   datetime|string	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
+	 * @param   datetime    	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
+	 * @phan-param string $date
 	 * @param   int         	$duration           Duration in seconds (3600 = 1h)
 	 * @param   int         	$product_id         The product id that is used, default is null
 	 * @param   int         	$user_id            User (Use 0 for connected user)


### PR DESCRIPTION
## Summary

Fixes #38407.

`POST /api/index.php/tasks/{id}/addtimespent` returns HTTP 500 with the following PHP fatal error on PHP 8+:

```
PHP Fatal error: Uncaught TypeError: Illegal offset type in isset or empty
in /var/www/html/includes/restler/framework/Luracast/Restler/Data/Validator.php:427
```

## Root cause

`Tasks::addTimeSpent()` declares two parameters with union types in its docblock:

```php
* @param   datetime|string  $date     ...
* @param   int|null         $progress ...
```

Restler's `ValidationInfo` parses any `a|b` `@param` type into an *array* (`['datetime', 'string']`, `['int', 'null']`). `Validator::validate()` then runs, at line 427:

```php
isset(static::$preFilters[$info->type])
```

— using that array as an array key. On PHP 8+ this throws `Illegal offset type in isset or empty`, so the endpoint crashes before any business logic runs. Note that this is hit **even when `$progress` is omitted from the request**, because the validator iterates over every parameter definition.

## Fix

Replace the two union-type annotations with single types, following the convention already used by `Tasks::putTimeSpent()` in the same file:

- `$date`: `@param datetime` plus a `@phan-param string` line — preserves static-analysis type info without confusing Restler.
- `$progress`: `@param int`. The function signature already has `$progress = -1` and the body checks `if (!empty($progress) && $progress >= 0 && $progress <= 100)`, so `-1` already encodes "leave progress unchanged" — `int|null` was not actually needed.

The endpoint code itself is unchanged.

## Scope note

Only `htdocs/projet/class/api_tasks.class.php` is affected — a grep across all `api_*.class.php` files shows these are the only two union-type `@param` annotations on exposed API endpoints (the one occurrence in `api_objectlinks.class.php` is on a private helper that is not routed through Restler validation).

A broader fix could also harden `Validator::validate()` at line 427 to guard against array-typed `$info->type`, but that touches the bundled Restler framework and felt out of scope for this issue.

## Test plan

- [x] Verified the crash reproduces on `dolibarr/dolibarr:23.0.2` (Docker) against `POST /tasks/{id}/addtimespent` with a JSON body.
- [x] After applying this patch inside the running container, the same request returns `200 {"success":{"code":200,"message":"Time spent added"}}` and a row is added to `llx_element_time`.
- [x] Verified `POST` without a `progress` field also succeeds (it previously crashed during validation of the absent `progress` param).
