### PR TITLE
NEW: Add supplier contract management (fk_contract_type field) SQL Structure

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -130,4 +130,7 @@ ALTER TABLE llx_facture ADD INDEX idx_facture_situation_cycle_ref (situation_cyc
 
 
 
+-- Add contract type field (0=customer, 1=supplier)
+ALTER TABLE llx_contrat ADD COLUMN fk_contract_type tinyint DEFAULT 0 AFTER ref_ext;
+
 -- end of migration - nothing after this line

--- a/htdocs/install/mysql/tables/llx_contrat.sql
+++ b/htdocs/install/mysql/tables/llx_contrat.sql
@@ -25,6 +25,7 @@ create table llx_contrat
   ref_customer				varchar(255),		            -- customer contract ref
   ref_supplier				varchar(255),		            -- supplier contract ref
   ref_ext					varchar(255),		            -- external contract ref
+  fk_contract_type			tinyint DEFAULT 0,				-- contract type: 0=customer, 1=supplier
   entity					integer DEFAULT 1 NOT NULL,		-- multi company id
   tms						timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   datec						datetime,                   	-- creation date


### PR DESCRIPTION
- Add fk_contract_type column to llx_contrat (0=customer, 1=supplier) with SQL migration
- Add fetch/create support for fk_contract_type in Contrat class
- Display contract type (read-only) on the contract card
- Show supplier contracts list on the supplier thirdparty tab (fourn/card.php)
- Add "Create contract" button on the supplier tab pointing to contract_type=1
- Filter customer contracts by fk_contract_type=0 on the customer tab (comm/card.php)
- Add fk_contract_type column with search filter in contract list (list.php)
- Add fk_contract_type column with search filter in services list (services_list.php)
- Add translation keys: ContractType, CustomerContract, SupplierContract, LastSupplierContracts