### PR TITLE
Fix #38421 Bug: time.php search-by-date form loses task id (?id=N), returns all project times

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -404,21 +404,28 @@ if (!empty($project_ref) && !empty($withproject)) {
 // To show all time lines for project
 $projectidforalltimes = 0;
 if (GETPOSTINT('projectid') > 0) {
-	$projectidforalltimes = GETPOSTINT('projectid');
-
-	$result = $projectstatic->fetch($projectidforalltimes);
-	if (!empty($projectstatic->socid)) {
-		$projectstatic->fetch_thirdparty();
-	}
-	$res = $projectstatic->fetch_optionals();
+    $projectidforalltimes = GETPOSTINT('projectid');
+    $result = $projectstatic->fetch($projectidforalltimes);
 } elseif (GETPOST('project_ref', 'alpha')) {
-	$projectstatic->fetch(0, GETPOST('project_ref', 'alpha'));
-	$projectidforalltimes = $projectstatic->id;
-	$withproject = 1;
+    $projectstatic->fetch(0, GETPOST('project_ref', 'alpha'));
+    $projectidforalltimes = $projectstatic->id;
+    $withproject = 1;
 } elseif ($id > 0) {
-	$object->fetch($id);
-	$result = $projectstatic->fetch($object->fk_project);
+    // Fetch task first to get the project ID
+    if ($object->fetch($id) > 0) {
+        // Fetch the project associated with the task
+        if ($projectstatic->fetch($object->fk_project) > 0) {
+            $projectidforalltimes = $projectstatic->id;
+        }
+    }
 }
+if ($projectidforalltimes > 0) {
+    if (!empty($projectstatic->socid)) {
+        $projectstatic->fetch_thirdparty();
+    }
+    $res = $projectstatic->fetch_optionals();
+}
+
 // If not task selected and no project selected
 $allprojectforuser = 0;
 

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -404,26 +404,26 @@ if (!empty($project_ref) && !empty($withproject)) {
 // To show all time lines for project
 $projectidforalltimes = 0;
 if (GETPOSTINT('projectid') > 0) {
-    $projectidforalltimes = GETPOSTINT('projectid');
-    $result = $projectstatic->fetch($projectidforalltimes);
+	$projectidforalltimes = GETPOSTINT('projectid');
+	$result = $projectstatic->fetch($projectidforalltimes);
 } elseif (GETPOST('project_ref', 'alpha')) {
-    $projectstatic->fetch(0, GETPOST('project_ref', 'alpha'));
-    $projectidforalltimes = $projectstatic->id;
-    $withproject = 1;
+	$projectstatic->fetch(0, GETPOST('project_ref', 'alpha'));
+	$projectidforalltimes = $projectstatic->id;
+	$withproject = 1;
 } elseif ($id > 0) {
-    // Fetch task first to get the project ID
-    if ($object->fetch($id) > 0) {
-        // Fetch the project associated with the task
-        if ($projectstatic->fetch($object->fk_project) > 0) {
-            $projectidforalltimes = $projectstatic->id;
-        }
-    }
+	// Fetch task first to get the project ID
+	if ($object->fetch($id) > 0) {
+		// Fetch the project associated with the task
+		if ($projectstatic->fetch($object->fk_project) > 0) {
+			$projectidforalltimes = $projectstatic->id;
+		}
+	}
 }
 if ($projectidforalltimes > 0) {
-    if (!empty($projectstatic->socid)) {
-        $projectstatic->fetch_thirdparty();
-    }
-    $res = $projectstatic->fetch_optionals();
+	if (!empty($projectstatic->socid)) {
+		$projectstatic->fetch_thirdparty();
+	}
+	$res = $projectstatic->fetch_optionals();
 }
 
 // If not task selected and no project selected

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1663,7 +1663,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 			$projectsListId = $projectstatic->getProjectsAuthorizedForUser($user, 0, 1, $user->socid > 0 ? $user->socid : 0, $filterproj);
 			$sql .= " AND p.rowid IN (".$db->sanitize($projectsListId).")"; // public and assigned to, or restricted to company for external users
 		}
-		if (empty($projectidforalltimes) && empty($allprojectforuser)) {
+		if (!empty($id)) {
 			// Limit on one task
 			$sql .= " AND t.fk_element =".((int) $object->id);
 		} elseif (!empty($projectidforalltimes)) {

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -99,10 +99,10 @@ $search_task_label = GETPOST('search_task_label', 'alpha');
 $search_user = GETPOST('search_user', 'intcomma');
 $search_valuebilled = GETPOST('search_valuebilled', 'intcomma');
 $search_product_ref = GETPOST('search_product_ref', 'alpha');
-$search_company = GETPOST('$search_company', 'alpha');
-$search_company_alias = GETPOST('$search_company_alias', 'alpha');
-$search_project_ref = GETPOST('$search_project_ref', 'alpha');
-$search_project_label = GETPOST('$search_project_label', 'alpha');
+$search_company = GETPOST('search_company', 'alpha');
+$search_company_alias = GETPOST('search_company_alias', 'alpha');
+$search_project_ref = GETPOST('search_project_ref', 'alpha');
+$search_project_label = GETPOST('search_project_label', 'alpha');
 $search_timespent_starthour = GETPOSTINT("search_timespent_duration_starthour");
 $search_timespent_startmin = GETPOSTINT("search_timespent_duration_startmin");
 $search_timespent_endhour = GETPOSTINT("search_timespent_duration_endhour");
@@ -1996,20 +1996,20 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 		}
 		// Thirdparty
 		if (!empty($arrayfields['p.fk_soc']['checked'])) {
-			print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="$search_company" value="' . dol_escape_htmltag($search_company) . '"></td>';
+			print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="search_company" value="' . dol_escape_htmltag($search_company) . '"></td>';
 		}
 
 		// Thirdparty alias
 		if (!empty($arrayfields['s.name_alias']['checked'])) {
-			print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="$search_company_alias" value="' . dol_escape_htmltag($search_company_alias) . '"></td>';
+			print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="search_company_alias" value="' . dol_escape_htmltag($search_company_alias) . '"></td>';
 		}
 
 		if (!empty($allprojectforuser)) {
 			if (!empty($arrayfields['p.project_ref']['checked'])) {
-				print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="$search_project_ref" value="' . dol_escape_htmltag($search_project_ref) . '"></td>';
+				print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="search_project_ref" value="' . dol_escape_htmltag($search_project_ref) . '"></td>';
 			}
 			if (!empty($arrayfields['p.project_label']['checked'])) {
-				print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="$search_project_label" value="' . dol_escape_htmltag($search_project_label) . '"></td>';
+				print '<td class="liste_titre"><input type="text" class="flat maxwidth100" name="search_project_label" value="' . dol_escape_htmltag($search_project_label) . '"></td>';
 			}
 		}
 		// Task

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1464,6 +1464,11 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 		print '<input type="hidden" name="tab" value="' . $tab . '">';
 		print '<input type="hidden" name="page_y" value="">';
 
+		// Preserve task ID across search submissions
+		if (!empty($id)) {
+			print '<input type="hidden" name="id" value="' . ((int) $id) . '">';
+		}
+
 		// Form to convert time spent into invoice
 		if ($massaction == 'generateinvoice') {
 			if (!empty($projectstatic->thirdparty) && $projectstatic->thirdparty->id > 0) {


### PR DESCRIPTION
# Fix #38421 Bug: time.php search-by-date form loses task id (?id=N), returns all project times
Applying this PR will fix the bug, such that the time.php search by dates only returns tasks within my project

This PR should fix and close #38421

## screenshots

### all my tasks with time
<img width="638" height="416" alt="image" src="https://github.com/user-attachments/assets/fc7c0a06-d19b-48ee-99c0-fec35fe8f090" />

### tasks in 1 project, but date until is before any "work" was done
<img width="468" height="290" alt="image" src="https://github.com/user-attachments/assets/7b720b41-2676-4abb-a6d7-2e1c9482f671" />

### Tasks in 1 project, with date from 
<img width="799" height="343" alt="image" src="https://github.com/user-attachments/assets/3261daf5-8773-43e2-8939-b776fac33193" />

