### PR TITLE
NEW UXUI add helptext to function formconfirm

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6597,7 +6597,7 @@ class Form
 			$more .= '<div class="tagtable paddingtopbottomonly centpercent noborderspacing">' . "\n";
 			foreach ($formquestion as $key => $input) {
 				if (is_array($input) && !empty($input)) {
-					$size = (!empty($input['size']) ? ' size="' . $input['size'] . '"' : '');    // deprecated. Use morecss instead.
+					$size = (!empty($input['size']) ? ' size="' . $input['size'] . '"' : '');	// deprecated. Use morecss instead.
 					$moreattr = (!empty($input['moreattr']) ? ' ' . $input['moreattr'] : '');
 					$morecss = (!empty($input['morecss']) ? ' ' . $input['morecss'] : '');
 
@@ -6773,13 +6773,13 @@ class Form
 			$formconfirm .= '<script nonce="' . getNonce() . '" type="text/javascript">' . "\n";
 			$formconfirm .= "/* Code for the jQuery('#dialogforpopup').dialog() */\n";
 			$formconfirm .= 'jQuery(document).ready(function() {
-            $(function() {
-            	$( "#' . $dialogconfirm . '" ).dialog({
-                    autoOpen: ' . ($autoOpen ? "true" : "false") . ',';
+			$(function() {
+				$( "#' . $dialogconfirm . '" ).dialog({
+					autoOpen: ' . ($autoOpen ? "true" : "false") . ',';
 			if ($newselectedchoice == 'no') {
 				$formconfirm .= '
 						open: function() {
-            				$(this).parent().find("button.ui-button:eq(2)").focus();
+							$(this).parent().find("button.ui-button:eq(2)").focus();
 						},';
 			}
 
@@ -6792,35 +6792,35 @@ class Form
 			$postconfirmas = 'GET';
 
 			$formconfirm .= '
-                    resizable: false,
+					resizable: false,
 					height: \'' . dol_escape_js($height) . '\',
-                    width: \'' . dol_escape_js($width) . '\',
-                    modal: true,
-                    closeOnEscape: false,
-                    buttons: {
-                        "' . dol_escape_js($langs->transnoentities($labelbuttonyes)) . '": function() {
+					width: \'' . dol_escape_js($width) . '\',
+					modal: true,
+					closeOnEscape: false,
+					buttons: {
+						"' . dol_escape_js($langs->transnoentities($labelbuttonyes)) . '": function() {
 							var options = "token=' . urlencode(newToken()) . '";
-                        	var inputok = ' . json_encode($inputok) . ';	/* List of fields into form */
+							var inputok = ' . json_encode($inputok) . ';	/* List of fields into form */
 							var page = \'' . dol_escape_js(!empty($page) ? $page : '') . '\';
-                         	var pageyes = \'' . dol_escape_js(!empty($pageyes) ? $pageyes : '') . '\';
+							var pageyes = \'' . dol_escape_js(!empty($pageyes) ? $pageyes : '') . '\';
 
-                         	if (inputok.length > 0) {
-                         		$.each(inputok, function(i, inputname) {
-                         			var more = "";
+							if (inputok.length > 0) {
+								$.each(inputok, function(i, inputname) {
+									var more = "";
 									var inputvalue;
-                         			if ($("input[name=\'" + inputname + "\']").attr("type") == "radio") {
+									if ($("input[name=\'" + inputname + "\']").attr("type") == "radio") {
 										inputvalue = $("input[name=\'" + inputname + "\']:checked").val();
 									} else {
-                         		    	if ($("#" + inputname).attr("type") == "checkbox") { more = ":checked"; }
-                         				inputvalue = $("#" + inputname + more).val();
+										if ($("#" + inputname).attr("type") == "checkbox") { more = ":checked"; }
+										inputvalue = $("#" + inputname + more).val();
 									}
-                         			if (typeof inputvalue == "undefined") { inputvalue=""; }
+									if (typeof inputvalue == "undefined") { inputvalue=""; }
 									console.log("formconfirm check inputname="+inputname+" inputvalue="+inputvalue);
-                         			options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
-                         		});
-                         	}
-                         	var urljump = pageyes + (pageyes.indexOf("?") < 0 ? "?" : "&") + options;
-            				if (pageyes.length > 0) {';
+									options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
+								});
+							}
+							var urljump = pageyes + (pageyes.indexOf("?") < 0 ? "?" : "&") + options;
+							if (pageyes.length > 0) {';
 			if ($postconfirmas == 'GET') {
 				$formconfirm .= 'location.href = urljump;';
 			} else {
@@ -6834,25 +6834,25 @@ class Form
 			$formconfirm .= '
 								console.log("after post ok");
 							}
-	                        $(this).dialog("close");
-                        },
-                        "' . dol_escape_js($langs->transnoentities($labelbuttonno)) . '": function() {
-                        	var options = "token=' . urlencode(newToken()) . '";
-                         	var inputko = ' . json_encode($inputko) . ';	/* List of fields into form */
+							$(this).dialog("close");
+						},
+						"' . dol_escape_js($langs->transnoentities($labelbuttonno)) . '": function() {
+							var options = "token=' . urlencode(newToken()) . '";
+							var inputko = ' . json_encode($inputko) . ';	/* List of fields into form */
 							var page = "' . dol_escape_js(!empty($page) ? $page : '') . '";
-                         	var pageno="' . dol_escape_js(!empty($pageno) ? $pageno : '') . '";
-                         	if (inputko.length > 0) {
-                         		$.each(inputko, function(i, inputname) {
-                         			var more = "";
-                         			if ($("#" + inputname).attr("type") == "checkbox") { more = ":checked"; }
-                         			var inputvalue = $("#" + inputname + more).val();
-                         			if (typeof inputvalue == "undefined") { inputvalue=""; }
-                         			options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
-                         		});
-                         	}
-                         	var urljump=pageno + (pageno.indexOf("?") < 0 ? "?" : "&") + options;
-                         	//alert(urljump);
-            				if (pageno.length > 0) {';
+							var pageno="' . dol_escape_js(!empty($pageno) ? $pageno : '') . '";
+							if (inputko.length > 0) {
+								$.each(inputko, function(i, inputname) {
+									var more = "";
+									if ($("#" + inputname).attr("type") == "checkbox") { more = ":checked"; }
+									var inputvalue = $("#" + inputname + more).val();
+									if (typeof inputvalue == "undefined") { inputvalue=""; }
+									options += "&" + inputname + "=" + encodeURIComponent(inputvalue);
+								});
+							}
+							var urljump=pageno + (pageno.indexOf("?") < 0 ? "?" : "&") + options;
+							//alert(urljump);
+							if (pageno.length > 0) {';
 			if ($postconfirmas == 'GET') {
 				$formconfirm .= 'location.href = urljump;';
 			} else {
@@ -6866,21 +6866,21 @@ class Form
 			$formconfirm .= '
 								console.log("after post ko");
 							}
-                            $(this).dialog("close");
-                        }
-                    }
-                }
-                );
+							$(this).dialog("close");
+						}
+					}
+				}
+				);
 
-            	var button = "' . $button . '";
-            	if (button.length > 0) {
-                	$( "#" + button ).click(function() {
-                		$("#' . $dialogconfirm . '").dialog("open");
-        			});
-                }
-            });
-            });
-            </script>';
+				var button = "' . $button . '";
+				if (button.length > 0) {
+					$( "#" + button ).click(function() {
+						$("#' . $dialogconfirm . '").dialog("open");
+					});
+				}
+			});
+			});
+			</script>';
 			$formconfirm .= "<!-- end ajax formconfirm -->\n";
 		} else {
 			$formconfirm .= "\n<!-- begin formconfirm page=" . dol_escape_htmltag($page) . " -->\n";
@@ -6949,7 +6949,6 @@ class Form
 
 		return $formconfirm;
 	}
-
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6794,7 +6794,8 @@ class Form
 
 			// Show JQuery confirm box.
 			// Add 'flex-direction: column' and 'justify-content: space-between' to push content to top and buttons to bottom
-			$formconfirm .= '<div id="' . $dialogconfirm . '" title="' . dol_escape_htmltag($title) . '" style="display: none; display: flex; flex-direction: column; justify-content: space-between;">';
+			$formconfirm .= '<div id="' . $dialogconfirm . '" title="' . dol_escape_htmltag($title) . '" style="display: none;">';
+			$formconfirm .= '<div style="display: flex; flex-direction: column; height: 100%;">';
 			if (is_array($formquestion) && array_key_exists('text', $formquestion) && !empty($formquestion['text'])) {
 				$formconfirm .= '<div class="confirmtext">' . $formquestion['text'] . '</div>' . "\n";
 			}
@@ -6813,6 +6814,7 @@ class Form
 				$formconfirm .= $question;
 				$formconfirm .= '</div>';
 			}
+			$formconfirm .= '</div>';
 			$formconfirm .= '</div>' . "\n";
 
 			$formconfirm .= "\n<!-- begin code of popup for formconfirm page=" . $page . " -->\n";

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6963,8 +6963,6 @@ class Form
 				$formconfirm .= '</td></tr>' . "\n";
 			}
 
-			// Line with question (unchanged from original)
-			$formconfirm .= '<tr class="valid">';
 			// Let's add a row that acts as a spacer.
 			$formconfirm .= '<tr class="valid"><td class="valid" colspan="2" style="height: 1px; border-top: 2px solid #e0e0e0; padding-top: 30px;"></td></tr>' . "\n";
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6608,9 +6608,6 @@ class Form
 			if (is_array($formquestion) && count($formquestion) > 2) {
 				$height += ((count($formquestion) - 2) * 24) + 10;
 			}
-			if (!empty($helpContent)) {
-				$height += 24; // Account for collapsed help summary
-			}
 		}
 
 		if (is_array($formquestion) && !empty($formquestion)) {

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6971,6 +6971,8 @@ class Form
 			// Let's add a row that acts as a spacer.
 			$formconfirm .= '<tr class="valid"><td class="valid" colspan="2" style="height: 1px; border-top: 2px solid #e0e0e0; padding-top: 30px;"></td></tr>' . "\n";
 
+			// Question row
+			$formconfirm .= '<tr class="valid">';
 			$formconfirm .= '<td class="valid">' . $question . '</td>';
 			$formconfirm .= '<td class="valid center">';
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6807,7 +6807,7 @@ class Form
 			}
 			if (!empty($question)) {
 				// margin-top: auto pushes this element to the bottom of the flex container
-				$formconfirm .= '<div class="confirmmessage" style="margin-top: auto; font-weight: bold; padding-top: 15px;">';
+				$formconfirm .= '<div class="confirmmessage" style="margin-top: auto; padding-top: 15px;">';
 				$formconfirm .= img_help(0, '') . ' ' . $question;
 				$formconfirm .= '</div>';
 			}

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6808,7 +6808,7 @@ class Form
 			if (!empty($question)) {
 				// margin-top: auto pushes this element to the bottom of the flex container
 				$formconfirm .= '<div class="confirmmessage" style="margin-top: auto; font-weight: bold; padding-top: 15px;">';
-				$formconfirm .= $question;
+				$formconfirm .= img_help(0, '') . ' ' . $question;
 				$formconfirm .= '</div>';
 			}
 			$formconfirm .= '</div>';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6502,6 +6502,34 @@ class Form
 		return $output;
 	}
 
+	/**
+	 *  Generate a collapsible help block with a standard '?' icon.
+	 *  Designed for use in formconfirm() to provide context without clutter.
+	 *
+	 *  @param  string  $content        The detailed explanation text (HTML allowed)
+	 *  @param  string  $icon           FontAwesome icon class (default: 'fa-question-circle')
+	 *  @return string                  The HTML string for the help block
+	 */
+	public function getHelpBlock($content, $icon = 'fa-question-circle')
+	{
+		global $langs;
+
+		// Sanitize content (assuming it might contain HTML, but escaping text nodes if needed)
+		// We trust the caller to pass safe HTML or translated strings.
+
+		$html = '<details class="dolibarr-help-block" style="margin-top:8px;">';
+		$html .= '<summary style="cursor:pointer; color:#0056b3; font-weight:normal; list-style:none; font-size:0.9em; display:flex; align-items:center;">';
+		$html .= '<span class="fa ' . $icon . '" style="margin-right:6px;"></span>';
+		$html .= $langs->trans("Help"); // Standardized title
+		$html .= '</summary>';
+		$html .= '<div style="margin-top:6px; padding:10px; background:#f8f9fa; border:1px solid #dee2e6; border-radius:4px; font-size:0.9em; color:#555; line-height:1.5;">';
+		$html .= $content;
+		$html .= '</div>';
+		$html .= '</details>';
+
+		return $html;
+	}
+
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 
 	/**
@@ -6553,9 +6581,12 @@ class Form
 	 * @param int 			$disableformtag 	1=Disable form tag. Can be used if we are already inside a <form> section.
 	 * @param string 		$labelbuttonyes 	Label for Yes
 	 * @param string 		$labelbuttonno 		Label for No
+	 * @param string 		$helpContent 		Optional help text to display in a collapsible block at the bottom left of the dialog.
+	 * 											If set, a standard '?' icon with the label "Help" will appear.
+	 * 											Clicking it expands the content provided here. Supports HTML.
 	 * @return string                        	HTML ajax code if a confirm ajax popup is required, Pure HTML code if it's an html form
 	 */
-	public function formconfirm($page, $title, $question, $action, $formquestion = '', $selectedchoice = '', $useajax = 0, $height = 0, $width = 600, $disableformtag = 0, $labelbuttonyes = 'Yes', $labelbuttonno = 'No')
+	public function formconfirm($page, $title, $question, $action, $formquestion = '', $selectedchoice = '', $useajax = 0, $height = 0, $width = 600, $disableformtag = 0, $labelbuttonyes = 'Yes', $labelbuttonno = 'No', $helpContent = '')
 	{
 		global $langs, $conf;
 
@@ -6576,6 +6607,9 @@ class Form
 			$height = 250;
 			if (is_array($formquestion) && count($formquestion) > 2) {
 				$height += ((count($formquestion) - 2) * 24) + 10;
+			}
+			if (!empty($helpContent)) {
+				$height += 24; // Account for collapsed help summary
 			}
 		}
 
@@ -6759,14 +6793,26 @@ class Form
 			}
 
 			// Show JQuery confirm box.
-			$formconfirm .= '<div id="' . $dialogconfirm . '" title="' . dol_escape_htmltag($title) . '" style="display: none;">';
+			// Add 'flex-direction: column' and 'justify-content: space-between' to push content to top and buttons to bottom
+			$formconfirm .= '<div id="' . $dialogconfirm . '" title="' . dol_escape_htmltag($title) . '" style="display: none; display: flex; flex-direction: column; justify-content: space-between;">';
 			if (is_array($formquestion) && array_key_exists('text', $formquestion) && !empty($formquestion['text'])) {
 				$formconfirm .= '<div class="confirmtext">' . $formquestion['text'] . '</div>' . "\n";
 			}
 			if (!empty($more)) {
 				$formconfirm .= '<div class="confirmquestions">' . $more . '</div>' . "\n";
 			}
-			$formconfirm .= ($question ? '<div class="confirmmessage">' . img_help(0, '') . ' ' . $question . '</div>' : '');
+			// NEW: Add help block if content provided
+			if (!empty($helpContent)) {
+				$formconfirm .= '<div style="text-align:left; margin-top:12px; padding-top:8px; border-top:1px solid #eee; clear:both;">';
+				$formconfirm .= $this->getHelpBlock($helpContent);
+				$formconfirm .= '</div>';
+			}
+			if (!empty($question)) {
+				// margin-top: auto pushes this element to the bottom of the flex container
+				$formconfirm .= '<div class="confirmmessage" style="margin-top: auto; font-weight: bold; padding-top: 15px;">';
+				$formconfirm .= $question;
+				$formconfirm .= '</div>';
+			}
 			$formconfirm .= '</div>' . "\n";
 
 			$formconfirm .= "\n<!-- begin code of popup for formconfirm page=" . $page . " -->\n";
@@ -6911,10 +6957,21 @@ class Form
 				$formconfirm .= '</td></tr>' . "\n";
 			}
 
-			// Line with question
+			// NEW: Help block row (between form fields and question)
+			if (!empty($helpContent)) {
+				$formconfirm .= '<tr class="valid"><td class="valid" colspan="2" style="padding-top:8px; border-top:1px solid #eee;">';
+				$formconfirm .= $this->getHelpBlock($helpContent);
+				$formconfirm .= '</td></tr>' . "\n";
+			}
+
+			// Line with question (unchanged from original)
 			$formconfirm .= '<tr class="valid">';
+			// Let's add a row that acts as a spacer.
+			$formconfirm .= '<tr class="valid"><td class="valid" colspan="2" style="height: 1px; border-top: 2px solid #e0e0e0; padding-top: 30px;"></td></tr>' . "\n";
+
 			$formconfirm .= '<td class="valid">' . $question . '</td>';
 			$formconfirm .= '<td class="valid center">';
+
 			$formconfirm .= $this->selectyesno("confirm", $newselectedchoice, 0, false, 0, 0, 'marginleftonly marginrightonly', $labelbuttonyes, $labelbuttonno);
 			$formconfirm .= '<input class="button valignmiddle confirmvalidatebutton small" type="submit" value="' . $langs->trans("Validate") . '">';
 			$formconfirm .= '</td>';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6964,7 +6964,7 @@ class Form
 			}
 
 			// Let's add a row that acts as a spacer.
-			$formconfirm .= '<tr class="valid"><td class="valid" colspan="2" style="height: 1px; border-top: 2px solid #e0e0e0; padding-top: 30px;"></td></tr>' . "\n";
+			$formconfirm .= '<tr class="valid"><td class="valid" colspan="2" style="border-top: 2px solid #e0e0e0; padding-top: 30px;"></td></tr>' . "\n";
 
 			// Question row
 			$formconfirm .= '<tr class="valid">';


### PR DESCRIPTION
# UXUI add helptext to function formconfirm
Applying this PR will add the option to include a help text to the popup for confirming a massaction.

This PR is stacked on top of #38430 - _Qual public function formconfirm - replace spaces with tabs_

This PR is implemented using HTML tags summary and details so it should be friendly with screenreaders and any browser. Since it uses HTML tags summary and details and not mouseover, it should also be mobile friendly.

If the developer that calls function formconfirm doesn't take the height of the help text into concern this will result in a vertical scrollbar - mostly only when the help text is expanded.

This PR also moves the $formquestion in function formconfirm down to be just above the line before the yes/no buttons. This is to separate it from the help text and anker it to the yes/no buttons.

The visual look is implemented in a new function getHelpBlock that can be called directly if any developer wants to use it elsewhere.

This PR indirectly introduces new translation texts depending on how a developer generates the $helpContent that function formconfirm is called with.

## Example Screenshots (from upcoming commit that uses this)

### No helpContent, new default where $formquestion are moved down
<img width="578" height="379" alt="image" src="https://github.com/user-attachments/assets/1f75fb3f-0e75-4d77-9169-21f79c4e3e13" />

### With helpcontent - closed
<img width="576" height="378" alt="image" src="https://github.com/user-attachments/assets/2bfac0b4-6471-4129-b0f2-60a8dfa5bff8" />

### With helpcontent - open and unfolded
<img width="579" height="381" alt="image" src="https://github.com/user-attachments/assets/bd530101-040c-41bb-a4de-cf7611d171cf" />


### Height too short for unfolding without - result is vertical scrollbar
<img width="576" height="285" alt="image" src="https://github.com/user-attachments/assets/2082ed7f-1b3b-4502-b199-acc005289dde" />

## Goal
The goal is to keep the UXUI visibly clean, but still provide explanations to any user that might wonder why they can or can not do something or see something they might expect.