### PR TITLE
CLOSE #35561 - End-of-month calculation functionality for recurring invoices

### DIFF
--- a/htdocs/compta/facture/card-rec.php
+++ b/htdocs/compta/facture/card-rec.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2017-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2023       Nick Fragoulis
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026 Joris Le Blansch <ping@apio.systems>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1454,7 +1455,7 @@ if ($action == 'create') {
 		print "</td></tr>";
 
 		// Date next run
-		print "<tr><td>".$langs->trans('NextDateToExecution')."</td><td>";
+		print "<tr><td>".$form->textwithpicto($langs->trans('NextDateToExecution'), $langs->trans("NextDateToExecutionHelp"))."</td><td>";
 		$date_next_execution = isset($date_next_execution) ? $date_next_execution : (GETPOSTINT('remonth') ? dol_mktime(12, 0, 0, GETPOSTINT('remonth'), GETPOSTINT('reday'), GETPOSTINT('reyear')) : -1);
 		print $form->selectDate($date_next_execution, '', 1, 1, 0, "add", 1, 1);
 		print "</td></tr>";
@@ -1968,9 +1969,9 @@ if ($action == 'create') {
 			// Date when (next invoice generation)
 			print '<tr><td>';
 			if ($action == 'date_when' || $object->frequency > 0) {
-				print $form->editfieldkey($langs->trans("NextDateToExecution"), 'date_when', $object->date_when, $object, $user->hasRight('facture', 'creer'), 'day');
+				print $form->editfieldkey($form->textwithpicto($langs->trans("NextDateToExecution"), $langs->trans("NextDateToExecutionHelp")), 'date_when', $object->date_when, $object, $user->hasRight('facture', 'creer'), 'day');
 			} else {
-				print $langs->trans("NextDateToExecution");
+				print $form->textwithpicto($langs->trans("NextDateToExecution"), $langs->trans("NextDateToExecutionHelp"));
 			}
 			print '</td><td>';
 			if ($action == 'date_when' || $object->frequency > 0) {

--- a/htdocs/compta/facture/class/facture-rec.class.php
+++ b/htdocs/compta/facture/class/facture-rec.class.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2017-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2023       Nick Fragoulis
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026 Joris Le Blansch <ping@apio.systems>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1338,16 +1339,67 @@ class FactureRec extends CommonInvoice
 
 
 	/**
-	 * Return the next date of
+	 * Return the next date of execution
+	 * Handles end-of-month scenarios when day >= 28 for monthly recurring invoices.
+	 * If the original date is on day 28, 29, 30, or 31, the system will automatically
+	 * calculate the appropriate last day of the target month.
 	 *
-	 * @return  int|false   false if KO, timestamp if OK
+	 * @return  int|false   Timestamp of next date or false on error.
 	 */
 	public function getNextDate()
 	{
 		if (empty($this->date_when)) {
 			return false;
 		}
-		return dol_time_plus_duree($this->date_when, $this->frequency, $this->unit_frequency, 1);
+
+		// Get the original day of the month from date_when
+		$dateInfo = dol_getdate($this->date_when);
+		$originalDay = (int) $dateInfo['mday'];
+		$originalMonth = (int) $dateInfo['mon'];
+		$originalYear = (int) $dateInfo['year'];
+		$originalHour = (int) $dateInfo['hours'];
+		$originalMin = (int) $dateInfo['minutes'];
+		$originalSec = (int) $dateInfo['seconds'];
+
+		// Special handling for end-of-month: if day >= 28 and frequency is monthly
+		if ($originalDay >= 28 && $this->unit_frequency == 'm') {
+			// Get the last day of the original month to determine if this was an "end of month" date
+			$lastDayOfOriginalMonth = (int) date('t', $this->date_when);
+
+			// Calculate target month and year
+			$targetMonth = $originalMonth + (int) $this->frequency;
+			$targetYear = $originalYear;
+
+			// Handle year rollover
+			while ($targetMonth > 12) {
+				$targetMonth -= 12;
+				$targetYear++;
+			}
+			while ($targetMonth < 1) {
+				$targetMonth += 12;
+				$targetYear--;
+			}
+
+			// Get the last day of the target month
+			$lastDayOfTargetMonth = (int) date('t', dol_mktime(0, 0, 0, $targetMonth, 1, $targetYear));
+
+			// Determine the target day:
+			// If original was last day of month, OR original day >= 29, use end-of-month behavior
+			if ($originalDay >= $lastDayOfOriginalMonth || $originalDay >= 29) {
+				// End of month mode: use the last day of target month
+				$targetDay = $lastDayOfTargetMonth;
+			} else {
+				// Day is 28 but not end of month in a 30/31 day month
+				// Keep as 28 or use last day if target month is shorter (like February)
+				$targetDay = min($originalDay, $lastDayOfTargetMonth);
+			}
+
+			// Return the calculated date
+			return dol_mktime($originalHour, $originalMin, $originalSec, $targetMonth, $targetDay, $targetYear);
+		}
+
+		// For yearly frequency or days < 28, use standard calculation
+		return dol_time_plus_duree($this->date_when, $this->frequency, $this->unit_frequency);
 	}
 
 	/**

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -422,6 +422,7 @@ FrequencyPer_y=Every %s years
 FrequencyUnit=Frequency unit
 toolTipFrequency=Examples:<br><b>Set 7, Day</b>: give a new invoice every 7 days<br><b>Set 3, Month</b>: give a new invoice every 3 month
 NextDateToExecution=Date for next invoice generation
+NextDateToExecutionHelp=If you set a day >= 28, the invoice will be generated on the last day of each month (end-of-month mode). For example, setting the 31st will generate invoices on Jan 31, Feb 28/29, Mar 31, Apr 30, etc.
 NextDateToExecutionShort=Date next gen.
 DateLastGeneration=Date of latest generation
 DateLastGenerationShort=Date latest gen.


### PR DESCRIPTION
Re-submitting this PR, since somehow it got "lost" or at least ignored even though closed.

CLOSE https://github.com/Dolibarr/dolibarr/issues/35561 End-of-month calculation functionality for recurring invoices

This fixes https://github.com/Dolibarr/dolibarr/issues/35561 for me and hopefully others. Indeed, as it stands you can't generate invoices for each last day of the month which is a very common practice in lots of professions.

<img width="947" height="224" alt="549399907-f5ba4a49-915f-4801-8e00-720c348ffa27" src="https://github.com/user-attachments/assets/0c1d4dd8-ba42-4993-b26d-60ffe1fe4b33" />

If you set a day >= 28, the invoice will be generated on the last day of each month (end-of-month mode). For example, setting the 31st will generate invoices on Jan 31, Feb 28/29, Mar 31, Apr 30, etc.

This modification will make sure that if a day for a recurring monthly invoice is set >= 28, it is considered to be for the end of each coming month and schedules the next generation accordingly. This could be subject to discussion of course for say someone that always wants to invoice on day 28. I think this is the simplest compromise rather than having a separate month-end function/option in the recurring invoice template. Some help text have been added to make the user aware of this functionality.

