### PR TITLE
NEW massaction for assigning project contacts or thirdparty contacts to project tasks

### DIFF
--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -479,3 +479,5 @@ WarningEvaluationEmptyValidate=Can't validate evaluation, levels on skills not d
 ErrorBadParametersForDirectDebitFileCreate=Can't create bank transfer file: expected format parameter is not provided.
 ErrorBadParametersForDirectDebitFileCreateDids=Can't create bank transfer file: IDs of existing payment requests are not provided.
 ErrorExpeditionQtyTooHigh=Shipped quantity (%s) exceeds the remaining quantity to deliver (%s).
+SkippedAlreadyAssigned=Skipped %s - already assigned
+ErrorNoGoodSelected=No valid %s selected for assignment

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -481,3 +481,4 @@ ErrorBadParametersForDirectDebitFileCreateDids=Can't create bank transfer file: 
 ErrorExpeditionQtyTooHigh=Shipped quantity (%s) exceeds the remaining quantity to deliver (%s).
 SkippedAlreadyAssigned=Skipped %s - already assigned
 ErrorNoGoodSelected=No valid %s selected for assignment
+ErrorAssignToTasks=Failed to make %s assignments of %s to tasks

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -340,6 +340,8 @@ EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
 AssignUsersToSelectedTasks=Assign selected users to selected tasks?
 Select1ToNUsersAndRole=Select 1 to n users & role
 Select1ToNUsersGroupsAndRole=Select 1 to n users / groups & 1 role
+SuccessfullyAssignedUsersTasks=Successfully performced %s assignments of users to tasks
+SkippedAlreadyAssigned=Skipped %s - already assigned
 # Help texts
 HelpPublicProjectUserAssignment=Public project: Any active user | group can be assigned.
 HelpPrivateProjectUserAssignment=Private project: Only project contacts can be assigned, so groups and other users are hidden.

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -338,11 +338,12 @@ UpdateWithLastHourlyRate=Update all recorded time spent of each user with the la
 UpdateUndefinedWithLastHourlyRate=Update the time spent that has no hourly rate defined with the last hourly rate of the user
 EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
 AssignUsersToSelectedTasks=Assign selected users to selected tasks?
+AssignContactsToSelectedTasks=Assign selected contacts to selected tasks?
 Select1ToNUsersAndRole=Select 1 to n users & role
 Select1ToNUsersGroupsAndRole=Select 1 to n users / groups & 1 role
-SuccessfullyAssignedUsersTasks=Successfully performed %s assignments of users to tasks
-SkippedAlreadyAssigned=Skipped %s - already assigned
-ErrorNoUserSelected=No valid users selected for assignment
+SuccessfullyAssignedToTasks=Successfully performed %s assignments of %s to tasks
 # Help texts
 HelpPublicProjectUserAssignment=Public project: Any active user | group can be assigned.
 HelpPrivateProjectUserAssignment=Private project: Only project contacts can be assigned, so groups and other users are hidden.
+HelpAssignThirdPartyContacts=Thirdparty Project: Only contacts of this thirdparty can be assigned
+HelpAssignProjectContacts=Only showing contacts already assigned to this project, because all possible contacts would too big

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -342,6 +342,7 @@ Select1ToNUsersAndRole=Select 1 to n users & role
 Select1ToNUsersGroupsAndRole=Select 1 to n users / groups & 1 role
 SuccessfullyAssignedUsersTasks=Successfully performed %s assignments of users to tasks
 SkippedAlreadyAssigned=Skipped %s - already assigned
+ErrorNoUserSelected=No valid users selected for assignment
 # Help texts
 HelpPublicProjectUserAssignment=Public project: Any active user | group can be assigned.
 HelpPrivateProjectUserAssignment=Private project: Only project contacts can be assigned, so groups and other users are hidden.

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -337,3 +337,10 @@ TaskHourlyRateUpdated=Task's hourly rate updated
 UpdateWithLastHourlyRate=Update all recorded time spent of each user with the last hourly rate of the user
 UpdateUndefinedWithLastHourlyRate=Update the time spent that has no hourly rate defined with the last hourly rate of the user
 EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
+AssignUsersToSelectedTasks=Assign selected users to selected tasks?
+AssignUsersToSelectedTasks=Assign selected users to selected tasks?
+Select1ToNUsersAndRole=Select 1 to n users & role
+# Help texts
+HelpPublicProjectUserAssignment=Public project: Any active user can be assigned.
+HelpPrivateProjectUserAssignment=Private project: Only project contacts can be assigned, so other users are hidden.
+HelpThirdPartyProjectAssignment=Company project: Only contacts of this company can be assigned.

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -339,8 +339,7 @@ UpdateUndefinedWithLastHourlyRate=Update the time spent that has no hourly rate 
 EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
 AssignUsersToSelectedTasks=Assign selected users to selected tasks?
 AssignContactsToSelectedTasks=Assign selected contacts to selected tasks?
-Select1ToNUsersAndRole=Select 1 to n users & role
-Select1ToNUsersGroupsAndRole=Select 1 to n users / groups & 1 role
+Select1ToXAndRole=Select 1 to n %s & 1 role
 SuccessfullyAssignedToTasks=Successfully performed %s assignments of %s to tasks
 # Help texts
 HelpPublicProjectUserAssignment=Public project: Any active user | group can be assigned.

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -340,7 +340,7 @@ EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
 AssignUsersToSelectedTasks=Assign selected users to selected tasks?
 AssignUsersToSelectedTasks=Assign selected users to selected tasks?
 Select1ToNUsersAndRole=Select 1 to n users & role
+Select1ToNUsersGroupsAndRole=Select 1 to n users / groups & 1 role
 # Help texts
-HelpPublicProjectUserAssignment=Public project: Any active user can be assigned.
-HelpPrivateProjectUserAssignment=Private project: Only project contacts can be assigned, so other users are hidden.
-HelpThirdPartyProjectAssignment=Company project: Only contacts of this company can be assigned.
+HelpPublicProjectUserAssignment=Public project: Any active user | group can be assigned.
+HelpPrivateProjectUserAssignment=Private project: Only project contacts can be assigned, so groups and other users are hidden.

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -340,7 +340,7 @@ EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
 AssignUsersToSelectedTasks=Assign selected users to selected tasks?
 Select1ToNUsersAndRole=Select 1 to n users & role
 Select1ToNUsersGroupsAndRole=Select 1 to n users / groups & 1 role
-SuccessfullyAssignedUsersTasks=Successfully performced %s assignments of users to tasks
+SuccessfullyAssignedUsersTasks=Successfully performed %s assignments of users to tasks
 SkippedAlreadyAssigned=Skipped %s - already assigned
 # Help texts
 HelpPublicProjectUserAssignment=Public project: Any active user | group can be assigned.

--- a/htdocs/langs/en_US/projects.lang
+++ b/htdocs/langs/en_US/projects.lang
@@ -338,7 +338,6 @@ UpdateWithLastHourlyRate=Update all recorded time spent of each user with the la
 UpdateUndefinedWithLastHourlyRate=Update the time spent that has no hourly rate defined with the last hourly rate of the user
 EnterUsersHourlyRateFirst=First, enter the hourly rate for the user(s)...
 AssignUsersToSelectedTasks=Assign selected users to selected tasks?
-AssignUsersToSelectedTasks=Assign selected users to selected tasks?
 Select1ToNUsersAndRole=Select 1 to n users & role
 Select1ToNUsersGroupsAndRole=Select 1 to n users / groups & 1 role
 # Help texts

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -613,13 +613,17 @@ if ($id > 0 || !empty($ref)) {
 	$arrayofmassactions = array();
 	if ($user->hasRight('projet', 'creer')) {
 		$arrayofmassactions['preassignusers'] = img_picto('', 'user', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("Users").' | '.$langs->trans("Groups"));
-		$arrayofmassactions['preassigncontacts'] = img_picto('', 'contact', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("Project").' | '.$langs->trans("ThirdPartiesArea"));
+		if (!empty($object->thirdparty->id)) {
+			$arrayofmassactions['preassignthirdcontacts'] = img_picto('', 'company', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("ThirdPartyContacts"));
+		}
+		// NEW: Assign to Project Contacts (Always available)
+		$arrayofmassactions['preassignprojectcontacts'] = img_picto('', 'contact', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("ProjectContact"));
 		$arrayofmassactions['preclonetasks'] = img_picto('', 'clone', 'class="pictofixedwidth"').$langs->trans("Clone");
 	}
 	if ($permissiontodelete) {
 		$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 	}
-	if (in_array($massaction, array('presend', 'predelete', 'preassignusers', 'preassigncontacts'))) {
+	if (in_array($massaction, array('presend', 'predelete', 'preassignusers', 'preassignprojectcontacts', 'preassignthirdcontacts'))) {
 		$arrayofmassactions = array();
 	}
 	$massactionbutton = $form->selectMassAction('', $arrayofmassactions) ?? '';
@@ -963,10 +967,13 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		$action = 'confirm_assignusers';
 	}
 	// Convert "pre" mass actions into confirmation actions
-	if ($massaction == 'preassigncontacts') {
-		$action = 'confirm_assigncontacts';
+	if ($massaction == 'preassignprojectcontacts') {
+		$action = 'confirm_assignprojectcontacts';
 	}
-
+	// Convert "pre" mass actions into confirmation actions
+	if ($massaction == 'preassignthirdcontacts') {
+		$action = 'confirm_assignthirdcontacts';
+	}
 	// Assign users confirmation form
 	if ($action == 'confirm_assignusers') {
 		// 1. Define the help text
@@ -1190,121 +1197,110 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		}
 	}
 
-	// Assign contacts confirmation form
-	if ($action == 'confirm_assigncontacts') {
-		// 1. Define Help Text
-		$helpText = $object->public
-			? $langs->trans("HelpPublicProjectContactAssignment")
-			: $langs->trans("HelpPrivateProjectContactAssignment");
-
-		// 2. Build Visibility Value (Kept for UI consistency)
-		$visibilityHtml = (
-			img_picto($langs->trans($object->public ? 'SharedProject' : 'PrivateProject'), $object->public ? 'fa-globe' : 'fa-lock', 'class="paddingrightonly"') . $langs->trans($object->public ? 'SharedProject' : 'PrivateProject')
-		);
-
-		// 3. Prepare Form Questions Array
-		$formquestion = array();
-
-		// --- DIV 1: Static Third Party Section ---
-		// Label: Use getNomUrl(1, '', 42)
-		// If $object->thirdparty is not loaded or invalid, this might return empty or just the ID.
-		// We do NOT validate.
-		$tpLabelHtml = '';
-		if (!empty($object->thirdparty->id)) {
-			$tpLabelHtml = $object->thirdparty->getNomUrl(1, '', 42);
+	// --- MODAL 1: Assign Third Party Contacts ---
+	if ($action == 'confirm_assignthirdcontacts') {
+		if (empty($object->thirdparty->id)) {
+			setEventMessages($langs->trans("ErrorRefNotFound", $langs->trans("ThirdParty")), null, 'errors');
 		} else {
-			// Fallback if thirdparty object is empty but fk_soc exists (shouldn't happen if fetch_thirdparty ran, but safe guard)
-			$tpLabelHtml = $langs->trans("ThirdParty") . ': ' . (empty($object->fk_soc) ? $langs->trans("None") : $object->fk_soc);
-		}
-
-		$tpContacts = array();
-		if (!empty($object->thirdparty->id)) {
-			$sql = "SELECT t.rowid, t.entity, t.lastname, t.firstname, t.civility, t.email, t.statut";
-			$sql .= " FROM " . MAIN_DB_PREFIX . "socpeople as t";
-			$sql .= " WHERE t.fk_soc = " . ((int) $object->thirdparty->id);
-			$sql .= " AND t.entity IN (" . getEntity('socpeople') . ")";
-			$sql .= " AND t.statut = 1"; // Only active contacts (matching show_contacts default)
-			$sql .= " ORDER BY t.lastname, t.firstname";
-
-			$resql = $db->query($sql);
-			if ($resql) {
-				$contactStatic = new Contact($db);
-				while ($obj = $db->fetch_object($resql)) {
-					// Use getFullName for consistent formatting (matches Dolibarr standards)
-					$contactStatic->firstname = $obj->firstname;
-					$contactStatic->lastname = $obj->lastname;
-					$contactStatic->civility_code = $obj->civility;
-
-					$fullName = $contactStatic->getFullName($langs, 0, 1, 0);
-					if (empty($fullName)) {
-						$fullName = "Contact #" . $obj->rowid;
-					}
-
-					$emailSuffix = !empty($obj->email) ? ' (' . $obj->email . ')' : '';
-					$tpContacts[$obj->rowid] = $fullName . $emailSuffix;
-				}
-				$db->free($resql);
-			}
-		}
-
-		$tpSelectHtml = $form->multiselectarray('tp_contacts', $tpContacts, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1);
-
-		if (!empty($object->thirdparty->id)) {
-			$formquestion[] = array(
-				'type'  => 'other',
-				'name'  => 'tp_section',
-				'label' => $langs->trans("ThirdPartyName"),
-				'value' => $tpLabelHtml
+			// 1. Fetch formatted contacts using the new helper
+			// Format: "Firstname Lastname (email)"
+			$tpContacts = $object->thirdparty->getContactListFormatted(
+				1, // Status: Active only
+				array('name', ' (', 'email', ')') // Custom format
 			);
 
+			if (empty($tpContacts)) {
+				setEventMessages($langs->trans("ErrorRefNotFound", $langs->trans("ThirdPartyContacts")), null, 'warnings');
+			}
+
+			$formquestion = array();
 			$formquestion[] = array(
 				'type'  => 'other',
-				'name'  => 'tp_section',
-				'label' => $langs->trans("ThirdPartyContacts"),
+				'name'  => 'tp_info',
+				'label' => $langs->trans("ThirdParty"),
+				'value' => $object->thirdparty->getNomUrl(1, '', 42)
+			);
+			$tpSelectHtml = $form->multiselectarray('tp_contacts', $tpContacts, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1);
+			$formquestion[] = array(
+				'type'  => 'other',
+				'name'  => 'tp_contacts',
+				'label' => $langs->trans("Contacts"),
 				'value' => $tpSelectHtml
 			);
+
+			// Role Selector
+			$statictask = new Task($db);
+			$formcompany = new FormCompany($db);
+			$formquestion[] = array(
+				'type'  => 'other',
+				'name'  => 'taskrole',
+				'label' => $langs->trans("ContactRole"),
+				'value' => $formcompany->selectTypeContact($statictask, '', 'taskrole', 'external', 'position', 0, 'minwidth200', 0, 1)
+			);
+
+			$taskIdsStr = implode(',', $arrayofselected);
+			print $form->formconfirm(
+				$_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr,
+				$langs->transnoentities('Select1ToNContactsAndRole'),
+				$langs->trans('AssignContactsToSelectedTasks', count($arrayofselected)),
+				'assignthirdcontacts',
+				$formquestion,
+				'',
+				1,
+				400,
+				600,
+				0,
+				'Yes',
+				'No',
+				$langs->trans("HelpAssignThirdPartyContacts")
+			);
 		}
+	}
 
-		// Visibility Info (Always shown)
-		$formquestion[] = array(
-			'type'  => 'other',
-			'name'  => 'visibility',
-			'label' => $langs->trans("Project") . ' ' . $langs->trans("Visibility"),
-			'value' => $visibilityHtml
-		);
-
-		// --- DIV 2: Project Contacts Section (Only for Private Projects) ---
+	// --- MODAL 2: Assign Project Contacts ---
+	if ($action == 'confirm_assignprojectcontacts') {
+		// 1. Fetch Project Contacts (Using your existing logic)
 		$projectContacts = array();
+		$rawProjectContacts = $object->liste_contact(-1, 'external');
 
-		if (!$object->public) {
-			$rawProjectContacts = $object->liste_contact(-1, 'external');
-			if (is_array($rawProjectContacts)) {
-				$contactStatic = new Contact($db);
-				foreach ($rawProjectContacts as $contactData) {
-					$contactTmp = new Contact($db);
-					if ($contactTmp->fetch($contactData['id']) > 0 && $contactTmp->statut == 1) {
-						$fullName = trim($contactTmp->firstname . ' ' . $contactTmp->lastname);
-						if (empty($fullName)) {
-							$fullName = "Contact #" . $contactTmp->id;
-						}
-						$emailSuffix = !empty($contactTmp->email) ? ' (' . $contactTmp->email . ')' : '';
-						$projectContacts[$contactTmp->id] = $fullName . $emailSuffix;
-					}
+		if (is_array($rawProjectContacts)) {
+			$contactStatic = new Contact($db);
+			foreach ($rawProjectContacts as $contactData) {
+				$contactTmp = new Contact($db);
+				if ($contactTmp->fetch($contactData['id']) > 0 && $contactTmp->statut == 1) {
+					$fullName = trim($contactTmp->firstname . ' ' . $contactTmp->lastname);
+					if (empty($fullName)) $fullName = "Contact #" . $contactTmp->id;
+					$emailSuffix = !empty($contactTmp->email) ? ' (' . $contactTmp->email . ')' : '';
+					$projectContacts[$contactTmp->id] = $fullName . $emailSuffix;
 				}
 			}
 		}
 
-		$projectSelectHtml = '';
-		if (!$object->public) {
+		$formquestion = array();
+		$formquestion[] = array(
+			'type'  => 'other',
+			'name'  => 'project_info',
+			'label' => $langs->trans("Project"),
+			'value' => $object->getNomUrl(1, '', 42)
+		);
+		if (empty($projectContacts)) {
+			$formquestion[] = array(
+				'type'  => 'other',
+				'name'  => 'project_contacts',
+				'label' => $langs->trans("Contacts"),
+				'value' => '<span class="warning">' . $langs->trans("NoProjectContactsFound") . '</span>'
+			);
+		} else {
 			$projectSelectHtml = $form->multiselectarray('project_contacts', $projectContacts, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1);
 			$formquestion[] = array(
 				'type'  => 'other',
-				'name'  => 'project_section',
-				'label' => $langs->trans("ContactsAssignedToProject"),
+				'name'  => 'project_contacts',
+				'label' => $langs->trans("Contacts"),
 				'value' => $projectSelectHtml
 			);
 		}
 
+		// Role Selector
 		$statictask = new Task($db);
 		$formcompany = new FormCompany($db);
 		$formquestion[] = array(
@@ -1314,9 +1310,22 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			'value' => $formcompany->selectTypeContact($statictask, '', 'taskrole', 'external', 'position', 0, 'minwidth200', 0, 1)
 		);
 
-		// Build a string of task IDs
 		$taskIdsStr = implode(',', $arrayofselected);
-		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToNContactsAndRole'), $langs->trans('AssignContactsToSelectedTasks', count($arrayofselected)), 'assigncontacts', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
+		print $form->formconfirm(
+			$_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr,
+			$langs->transnoentities('Select1ToNContactsAndRole'),
+			$langs->trans('AssignContactsToSelectedTasks', count($arrayofselected)),
+			'assignprojectcontacts',
+			$formquestion,
+			'',
+			1,
+			400,
+			600,
+			0,
+			'Yes',
+			'No',
+			$langs->trans("HelpAssignProjectContacts")
+		);
 	}
 
 	// Get list of tasks in tasksarray and taskarrayfiltered

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1134,7 +1134,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 					$userTmp = new User($db);
 					if ($userTmp->fetch($uid) > 0) {
 						$userLink = $userTmp->getNomUrl(0);
-						$baseMsg = '&emsp;' . $userLink . ' : ' . $taskLink;
+						$baseMsg = '&emsp;' . $taskLink . ' : ' . $userLink;
 
 						$res = $taskstatic->add_contact($uid, $taskrole, 'internal');
 
@@ -1158,6 +1158,9 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 						$failMessages[] = '&emsp;' . $langs->trans("User") . ' #' . $uid . ' : ' . $taskLink . ' : ' . $langs->trans("ErrorRecordNotFound");
 					}
 				}
+				$successMessages[] = '&emsp;';
+				$skipMessages[] = '&emsp;';
+				$failMessages[] = '&emsp;';
 			}
 		}
 

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1307,17 +1307,16 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 		$statictask = new Task($db);
 		$formcompany = new FormCompany($db);
-		// Role selector (always)
 		$formquestion[] = array(
 			'type'  => 'other',
 			'name'  => 'taskrole',
 			'label' => $langs->trans("ContactRole"),
-			'value' => $formcompany->selectTypeContact($statictask, '', 'taskrole', 'internal', 'position', 0, 'minwidth200', 0, 1)
+			'value' => $formcompany->selectTypeContact($statictask, '', 'taskrole', 'external', 'position', 0, 'minwidth200', 0, 1)
 		);
 
 		// Build a string of task IDs
 		$taskIdsStr = implode(',', $arrayofselected);
-		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToNUsersGroupsAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToNContactsAndRole'), $langs->trans('AssignContactsToSelectedTasks', count($arrayofselected)), 'assigncontacts', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
 	}
 
 	// Get list of tasks in tasksarray and taskarrayfiltered

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1249,12 +1249,21 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 		$tpSelectHtml = $form->multiselectarray('tp_contacts', $tpContacts, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1);
 
-		$formquestion[] = array(
-			'type'  => 'other',
-			'name'  => 'tp_section',
-			'label' => $langs->trans("ContactsOfThirdParty"),
-			'value' => '<div style="margin-bottom: 15px;">' . $tpLabelHtml . '<br>' . $tpSelectHtml . '</div>'
-		);
+		if (!empty($object->thirdparty->id)) {
+			$formquestion[] = array(
+				'type'  => 'other',
+				'name'  => 'tp_section',
+				'label' => $langs->trans("ThirdPartyName"),
+				'value' => $tpLabelHtml
+			);
+
+			$formquestion[] = array(
+				'type'  => 'other',
+				'name'  => 'tp_section',
+				'label' => $langs->trans("ThirdPartyContacts"),
+				'value' => $tpSelectHtml
+			);
+		}
 
 		// Visibility Info (Always shown)
 		$formquestion[] = array(

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -47,7 +47,7 @@ if (isModEnabled('category')) {
  */
 
 // Load translation files required by the page
-$langsLoad = array('projects', 'users', 'companies', 'main');
+$langsLoad = array('projects', 'users', 'companies', 'main', 'errors');
 if (isModEnabled('eventorganization')) {
 	$langsLoad[] = 'eventorganization';
 }

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1273,6 +1273,38 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			'value' => $visibilityHtml
 		);
 
+		// --- DIV 2: Project Contacts Section (Only for Private Projects) ---
+		$projectContacts = array();
+
+		if (!$object->public) {
+			$rawProjectContacts = $object->liste_contact(-1, 'external');
+			if (is_array($rawProjectContacts)) {
+				$contactStatic = new Contact($db);
+				foreach ($rawProjectContacts as $contactData) {
+					$contactTmp = new Contact($db);
+					if ($contactTmp->fetch($contactData['id']) > 0 && $contactTmp->statut == 1) {
+						$fullName = trim($contactTmp->firstname . ' ' . $contactTmp->lastname);
+						if (empty($fullName)) {
+							$fullName = "Contact #" . $contactTmp->id;
+						}
+						$emailSuffix = !empty($contactTmp->email) ? ' (' . $contactTmp->email . ')' : '';
+						$projectContacts[$contactTmp->id] = $fullName . $emailSuffix;
+					}
+				}
+			}
+		}
+
+		$projectSelectHtml = '';
+		if (!$object->public) {
+			$projectSelectHtml = $form->multiselectarray('project_contacts', $projectContacts, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1);
+			$formquestion[] = array(
+				'type'  => 'other',
+				'name'  => 'project_section',
+				'label' => $langs->trans("ContactsAssignedToProject"),
+				'value' => $projectSelectHtml
+			);
+		}
+
 		$statictask = new Task($db);
 		$formcompany = new FormCompany($db);
 		// Role selector (always)

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -276,7 +276,6 @@ if (empty($reshook)) {
 	// Mass actions
 	$objectclass = 'Task';
 	$objectlabel = 'Tasks';
-	$permissiontoadd = $user->hasRight('projet', 'creer');
 	$permissiontoread = $user->hasRight('projet', 'lire');
 	$permissiontodelete = $user->hasRight('projet', 'supprimer');
 	$uploaddir = $conf->project->dir_output.'/tasks';
@@ -1050,6 +1049,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	}
 
 	// Process the user assignment
+	$permissiontoadd = $user->hasRight('projet', 'creer');
 	if ($action == 'assignusers' && $confirm == 'yes' && $permissiontoadd) {
 		// 1. Get Task IDs from URL (safe and reliable)
 		$taskIdsRaw = GETPOST('taskselect', 'alpha'); // e.g., "5,6,7"

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -46,7 +46,7 @@ if (isModEnabled('category')) {
  */
 
 // Load translation files required by the page
-$langsLoad = array('projects', 'users', 'companies');
+$langsLoad = array('projects', 'users', 'companies', 'main');
 if (isModEnabled('eventorganization')) {
 	$langsLoad[] = 'eventorganization';
 }
@@ -610,12 +610,13 @@ if ($id > 0 || !empty($ref)) {
 
 	$arrayofmassactions = array();
 	if ($user->hasRight('projet', 'creer')) {
+		$arrayofmassactions['preassignusers'] = img_picto('', 'user', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("Users"));
 		$arrayofmassactions['preclonetasks'] = img_picto('', 'clone', 'class="pictofixedwidth"').$langs->trans("Clone");
 	}
 	if ($permissiontodelete) {
 		$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 	}
-	if (in_array($massaction, array('presend', 'predelete'))) {
+	if (in_array($massaction, array('presend', 'predelete', 'preassignusers'))) {
 		$arrayofmassactions = array();
 	}
 	$massactionbutton = $form->selectMassAction('', $arrayofmassactions) ?? '';
@@ -953,6 +954,50 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	$objecttmp = new Task($db);
 	$trackid = 'task'.$taskstatic->id;
 	include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
+
+	// Convert "pre" mass actions into confirmation actions
+	if ($massaction == 'preassignusers') {
+		$action = 'confirm_assignusers';
+	}
+
+	// Assign users confirmation form
+	if ($action == 'confirm_assignusers') {
+		// 1. Define the help text
+		$helpText = $object->public
+			? $langs->trans("HelpPublicProjectUserAssignment")
+			: $langs->trans("HelpPrivateProjectUserAssignment");
+
+		// 2. Build the visibility value (clean, no help icon here)
+		$visibilityHtml = (
+			img_picto($langs->trans($object->public ? 'SharedProject' : 'PrivateProject'), $object->public ? 'fa-globe' : 'fa-lock', 'class="paddingrightonly"') . $langs->trans($object->public ? 'SharedProject' : 'PrivateProject')
+		);
+
+		$formquestion = array(
+			// 1. Add the Visibility info as a read-only field to help the enduser understand why users in the dropdown box may be limited
+			array(
+				'type' => 'other',
+				'name' => 'visibility',
+				'label' => $langs->trans("Project").' '.$langs->trans("Visibility"),
+				'value' => $visibilityHtml
+			),
+			array(
+				'type' => 'other',
+				'name' => 'userids',
+				'label' => $langs->trans("Users"),
+				'value' => $form->select_dolusers('', 'userids[]', 1, null, 0, '', '', 0, 0, 0, '(statut:=:1)', 0, '', 'multiple class="minwidth500"')
+			),
+			array(
+				'type' => 'other',
+				'name' => 'taskrole',
+				'label' => $langs->trans("Role"),
+				'value' => $form->selectarray('taskrole', array(
+					'TASKEXECUTIVE' => $langs->trans("TypeContact_project_internal_PROJECTLEADER"),
+					'TASKCONTRIBUTOR' => $langs->trans("TypeContact_project_internal_PROJECTCONTRIBUTOR")
+				), 'TASKCONTRIBUTOR', 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200')
+			)
+		);
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id, $langs->transnoentities('Select1ToNUsersAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
+	}
 
 	// Get list of tasks in tasksarray and taskarrayfiltered
 	// We need all tasks (even not limited to a user because a task to user can have a parent that is not affected to him).

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -31,6 +31,7 @@ require_once DOL_DOCUMENT_ROOT.'/projet/class/task.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/project.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.formcompany.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
 require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 if (isModEnabled('category')) {
@@ -1031,15 +1032,14 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			'value' => $form->multiselectarray('userids', $userArray, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1)
 		);
 
+		$statictask = new Task($db);
+		$formcompany = new FormCompany($db);
 		// Role selector (always)
 		$formquestion[] = array(
 			'type'  => 'other',
 			'name'  => 'taskrole',
 			'label' => $langs->trans("Role"),
-			'value' => $form->selectarray('taskrole', array(
-				'TASKEXECUTIVE'	=> $langs->trans("TypeContact_project_internal_PROJECTLEADER"),
-				'TASKCONTRIBUTOR'  => $langs->trans("TypeContact_project_internal_PROJECTCONTRIBUTOR")
-			), 'TASKCONTRIBUTOR', 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200')
+			'value' => $formcompany->selectTypeContact($statictask, '', 'taskrole', 'internal', 'position', 0, 'minwidth200', 0, 1)
 		);
 
 		// Build a string of task IDs

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1172,7 +1172,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			setEventMessages($langs->trans("SkippedAlreadyAssigned", $skippedCount), $skipMessages, 'warnings');
 		}
 		if ($failCount > 0) {
-			setEventMessages($langs->trans("ErrorTaskAlreadyAssigned", $failCount), $failMessages, 'errors');
+			setEventMessages($langs->trans("ErrorAssignToTasks", $failCount, $langs->trans("Users")), $failMessages, 'errors');
 		}
 
 		if (!headers_sent()) {

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -610,7 +610,7 @@ if ($id > 0 || !empty($ref)) {
 
 	$arrayofmassactions = array();
 	if ($user->hasRight('projet', 'creer')) {
-		$arrayofmassactions['preassignusers'] = img_picto('', 'user', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("Users"));
+		$arrayofmassactions['preassignusers'] = img_picto('', 'user', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("Users").' | '.$langs->trans("Groups"));
 		$arrayofmassactions['preclonetasks'] = img_picto('', 'clone', 'class="pictofixedwidth"').$langs->trans("Clone");
 	}
 	if ($permissiontodelete) {
@@ -972,31 +972,76 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			img_picto($langs->trans($object->public ? 'SharedProject' : 'PrivateProject'), $object->public ? 'fa-globe' : 'fa-lock', 'class="paddingrightonly"') . $langs->trans($object->public ? 'SharedProject' : 'PrivateProject')
 		);
 
-		$formquestion = array(
-			// 1. Add the Visibility info as a read-only field to help the enduser understand why users in the dropdown box may be limited
-			array(
-				'type' => 'other',
-				'name' => 'visibility',
-				'label' => $langs->trans("Project").' '.$langs->trans("Visibility"),
-				'value' => $visibilityHtml
-			),
-			array(
-				'type' => 'other',
-				'name' => 'userids',
-				'label' => $langs->trans("Users"),
-				'value' => $form->select_dolusers('', 'userids[]', 1, null, 0, '', '', 0, 0, 0, '(statut:=:1)', 0, '', 'multiple class="minwidth500"')
-			),
-			array(
-				'type' => 'other',
-				'name' => 'taskrole',
-				'label' => $langs->trans("Role"),
-				'value' => $form->selectarray('taskrole', array(
-					'TASKEXECUTIVE' => $langs->trans("TypeContact_project_internal_PROJECTLEADER"),
-					'TASKCONTRIBUTOR' => $langs->trans("TypeContact_project_internal_PROJECTCONTRIBUTOR")
-				), 'TASKCONTRIBUTOR', 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200')
-			)
+		// Build user array based on project visibility
+		$userArray = array();
+
+		if ($object->public) {
+			// Public: any active internal user
+			$sql = "SELECT u.rowid, u.firstname, u.lastname";
+			$sql .= " FROM " . MAIN_DB_PREFIX . "user u";
+			$sql .= " WHERE u.statut = 1 AND u.entity IN (" . getEntity('user') . ")";
+			$sql .= " ORDER BY u.lastname, u.firstname";
+		} else {
+			// Private: only users already assigned as internal contacts to this project
+			$sql = "SELECT u.rowid, u.firstname, u.lastname";
+			$sql .= " FROM " . MAIN_DB_PREFIX . "user u";
+			$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "element_contact ec ON ec.fk_socpeople = u.rowid";
+			$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "c_type_contact ctc ON ctc.rowid = ec.fk_c_type_contact";
+			$sql .= " WHERE ec.element_id = " . ((int) $object->id);
+			$sql .= " AND ctc.element = 'project' AND ctc.source = 'internal'";
+			$sql .= " AND u.statut = 1";
+			$sql .= " GROUP BY u.rowid, u.firstname, u.lastname";
+			$sql .= " ORDER BY u.lastname, u.firstname";
+		}
+
+		$resql = $db->query($sql);
+		if ($resql) {
+			while ($obj = $db->fetch_object($resql)) {
+				$userArray[$obj->rowid] = dolGetFirstLastname($obj->firstname, $obj->lastname);
+			}
+			$db->free($resql);
+		}
+
+		// 4. Build formquestion
+		$formquestion = array();
+
+		// Visibility info (always)
+		$formquestion[] = array(
+			'type'  => 'other',
+			'name'  => 'visibility',
+			'label' => $langs->trans("Project") . ' ' . $langs->trans("Visibility"),
+			'value' => $visibilityHtml
 		);
-		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id, $langs->transnoentities('Select1ToNUsersAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
+
+		// Group selector (public only)
+		if ($object->public) {
+			$formquestion[] = array(
+				'type'  => 'other',
+				'name'  => 'groupid',
+				'label' => $langs->trans("Group"),
+				'value' => $form->select_dolgroups('', 'groupid', 1, '', 0, '', '', 0, 0, 'minwidth250')
+			);
+		}
+
+		// Multi-user selector (always, content varies)
+		$formquestion[] = array(
+			'type'  => 'other',
+			'name'  => 'userids',
+			'label' => $langs->trans("Users"),
+			'value' => $form->multiselectarray('userids', $userArray, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1)
+		);
+
+		// Role selector (always)
+		$formquestion[] = array(
+			'type'  => 'other',
+			'name'  => 'taskrole',
+			'label' => $langs->trans("Role"),
+			'value' => $form->selectarray('taskrole', array(
+				'TASKEXECUTIVE'	=> $langs->trans("TypeContact_project_internal_PROJECTLEADER"),
+				'TASKCONTRIBUTOR'  => $langs->trans("TypeContact_project_internal_PROJECTCONTRIBUTOR")
+			), 'TASKCONTRIBUTOR', 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200')
+		);
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id, $langs->transnoentities('Select1ToNUsersGroupsAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
 	}
 
 	// Get list of tasks in tasksarray and taskarrayfiltered

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -613,12 +613,13 @@ if ($id > 0 || !empty($ref)) {
 	$arrayofmassactions = array();
 	if ($user->hasRight('projet', 'creer')) {
 		$arrayofmassactions['preassignusers'] = img_picto('', 'user', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("Users").' | '.$langs->trans("Groups"));
+		$arrayofmassactions['preassigncontacts'] = img_picto('', 'contact', 'class="pictofixedwidth"').$langs->trans("AssignTaskToUser", $langs->trans("Project").' | '.$langs->trans("ThirdPartiesArea"));
 		$arrayofmassactions['preclonetasks'] = img_picto('', 'clone', 'class="pictofixedwidth"').$langs->trans("Clone");
 	}
 	if ($permissiontodelete) {
 		$arrayofmassactions['predelete'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Delete");
 	}
-	if (in_array($massaction, array('presend', 'predelete', 'preassignusers'))) {
+	if (in_array($massaction, array('presend', 'predelete', 'preassignusers', 'preassigncontacts'))) {
 		$arrayofmassactions = array();
 	}
 	$massactionbutton = $form->selectMassAction('', $arrayofmassactions) ?? '';
@@ -961,6 +962,10 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 	if ($massaction == 'preassignusers') {
 		$action = 'confirm_assignusers';
 	}
+	// Convert "pre" mass actions into confirmation actions
+	if ($massaction == 'preassigncontacts') {
+		$action = 'confirm_assigncontacts';
+	}
 
 	// Assign users confirmation form
 	if ($action == 'confirm_assignusers') {
@@ -1183,6 +1188,95 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			echo '<script>window.location.href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '";</script>';
 			exit;
 		}
+	}
+
+	// Assign contacts confirmation form
+	if ($action == 'confirm_assigncontacts') {
+		// 1. Define Help Text
+		$helpText = $object->public
+			? $langs->trans("HelpPublicProjectContactAssignment")
+			: $langs->trans("HelpPrivateProjectContactAssignment");
+
+		// 2. Build Visibility Value (Kept for UI consistency)
+		$visibilityHtml = (
+			img_picto($langs->trans($object->public ? 'SharedProject' : 'PrivateProject'), $object->public ? 'fa-globe' : 'fa-lock', 'class="paddingrightonly"') . $langs->trans($object->public ? 'SharedProject' : 'PrivateProject')
+		);
+
+		// 3. Prepare Form Questions Array
+		$formquestion = array();
+
+		// --- DIV 1: Static Third Party Section ---
+		// Label: Use getNomUrl(1, '', 42)
+		// If $object->thirdparty is not loaded or invalid, this might return empty or just the ID.
+		// We do NOT validate.
+		$tpLabelHtml = '';
+		if (!empty($object->thirdparty->id)) {
+			$tpLabelHtml = $object->thirdparty->getNomUrl(1, '', 42);
+		} else {
+			// Fallback if thirdparty object is empty but fk_soc exists (shouldn't happen if fetch_thirdparty ran, but safe guard)
+			$tpLabelHtml = $langs->trans("ThirdParty") . ': ' . (empty($object->fk_soc) ? $langs->trans("None") : $object->fk_soc);
+		}
+
+		$tpContacts = array();
+		if (!empty($object->thirdparty->id)) {
+			$sql = "SELECT t.rowid, t.entity, t.lastname, t.firstname, t.civility, t.email, t.statut";
+			$sql .= " FROM " . MAIN_DB_PREFIX . "socpeople as t";
+			$sql .= " WHERE t.fk_soc = " . ((int) $object->thirdparty->id);
+			$sql .= " AND t.entity IN (" . getEntity('socpeople') . ")";
+			$sql .= " AND t.statut = 1"; // Only active contacts (matching show_contacts default)
+			$sql .= " ORDER BY t.lastname, t.firstname";
+
+			$resql = $db->query($sql);
+			if ($resql) {
+				$contactStatic = new Contact($db);
+				while ($obj = $db->fetch_object($resql)) {
+					// Use getFullName for consistent formatting (matches Dolibarr standards)
+					$contactStatic->firstname = $obj->firstname;
+					$contactStatic->lastname = $obj->lastname;
+					$contactStatic->civility_code = $obj->civility;
+
+					$fullName = $contactStatic->getFullName($langs, 0, 1, 0);
+					if (empty($fullName)) {
+						$fullName = "Contact #" . $obj->rowid;
+					}
+
+					$emailSuffix = !empty($obj->email) ? ' (' . $obj->email . ')' : '';
+					$tpContacts[$obj->rowid] = $fullName . $emailSuffix;
+				}
+				$db->free($resql);
+			}
+		}
+
+		$tpSelectHtml = $form->multiselectarray('tp_contacts', $tpContacts, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1);
+
+		$formquestion[] = array(
+			'type'  => 'other',
+			'name'  => 'tp_section',
+			'label' => $langs->trans("ContactsOfThirdParty"),
+			'value' => '<div style="margin-bottom: 15px;">' . $tpLabelHtml . '<br>' . $tpSelectHtml . '</div>'
+		);
+
+		// Visibility Info (Always shown)
+		$formquestion[] = array(
+			'type'  => 'other',
+			'name'  => 'visibility',
+			'label' => $langs->trans("Project") . ' ' . $langs->trans("Visibility"),
+			'value' => $visibilityHtml
+		);
+
+		$statictask = new Task($db);
+		$formcompany = new FormCompany($db);
+		// Role selector (always)
+		$formquestion[] = array(
+			'type'  => 'other',
+			'name'  => 'taskrole',
+			'label' => $langs->trans("ContactRole"),
+			'value' => $formcompany->selectTypeContact($statictask, '', 'taskrole', 'internal', 'position', 0, 'minwidth200', 0, 1)
+		);
+
+		// Build a string of task IDs
+		$taskIdsStr = implode(',', $arrayofselected);
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToNUsersGroupsAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
 	}
 
 	// Get list of tasks in tasksarray and taskarrayfiltered

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -135,6 +135,7 @@ $extrafields->fetch_name_optionals_label($taskstatic->table_element);
 $search_array_options = $extrafields->getOptionalsFromPost($taskstatic->table_element, '', 'search_');
 
 // Default to no permission
+$permissiontoadd = 0;
 $permissiontoread = 0;
 $permissiontodelete = 0;
 
@@ -275,6 +276,7 @@ if (empty($reshook)) {
 	// Mass actions
 	$objectclass = 'Task';
 	$objectlabel = 'Tasks';
+	$permissiontoadd = $user->hasRight('projet', 'creer');
 	$permissiontoread = $user->hasRight('projet', 'lire');
 	$permissiontodelete = $user->hasRight('projet', 'supprimer');
 	$uploaddir = $conf->project->dir_output.'/tasks';
@@ -1045,6 +1047,139 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		// Build a string of task IDs
 		$taskIdsStr = implode(',', $arrayofselected);
 		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToNUsersGroupsAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
+	}
+
+	// Process the user assignment
+	if ($action == 'assignusers' && $confirm == 'yes' && $permissiontoadd) {
+		// 1. Get Task IDs from URL (safe and reliable)
+		$taskIdsRaw = GETPOST('taskselect', 'alpha'); // e.g., "5,6,7"
+		$selectedTasks = array();
+		if (!empty($taskIdsRaw)) {
+			$selectedTasks = explode(',', $taskIdsRaw);
+			$selectedTasks = array_map('intval', $selectedTasks);
+			$selectedTasks = array_unique($selectedTasks, SORT_NUMERIC); // Remove duplicates
+		}
+
+		// 2. Resolve User IDs
+		$allSelectedUserIds = array();
+
+		// A. Expand Group if selected
+		$groupid = GETPOSTINT('groupid');
+		if ($groupid > 0) {
+			require_once DOL_DOCUMENT_ROOT . '/user/class/usergroup.class.php';
+			$usergroup = new UserGroup($db);
+			if ($usergroup->fetch($groupid) > 0) {
+				$groupUsers = $usergroup->listUsersForGroup('statut = 1', 0);
+				if (is_array($groupUsers)) {
+					foreach ($groupUsers as $u) $allSelectedUserIds[] = $u->id;
+				}
+			}
+		}
+
+		// B. Add Manual Selection
+		$useridsRaw = GETPOST('userids', 'alpha');
+		if (!empty($useridsRaw)) {
+			$manualIds = array_map('intval', explode(',', $useridsRaw));
+			$allSelectedUserIds = array_merge($allSelectedUserIds, $manualIds);
+		}
+
+		// C. Deduplicate
+		$allSelectedUserIds = array_unique($allSelectedUserIds, SORT_NUMERIC);
+
+		// 3. ENFORCE PRIVACY
+		if (!$object->public) {
+			// Get allowed IDs (ensure they are integers)
+			$allowedIds = array_map('intval', array_column($object->liste_contact(-1, 'internal'), 'id'));
+
+			if (!empty($allowedIds)) {
+				// Intersect with numeric comparison
+				$validUserIds = array_intersect($allSelectedUserIds, $allowedIds);
+				// Re-index array to avoid gaps (optional but good practice)
+				$validUserIds = array_values($validUserIds);
+			} else {
+				$validUserIds = array();
+			}
+		} else {
+			$validUserIds = $allSelectedUserIds;
+		}
+
+		// 4. Validation
+		if (empty($validUserIds)) {
+			setEventMessages($langs->trans("ErrorNoUserSelected"), null, 'errors');
+			header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
+			exit;
+		}
+
+		// Task roles
+		$taskrole = GETPOSTINT('taskrole');
+		if (empty($taskrole)) {
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Role")), null, 'errors');
+			header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
+			exit;
+		}
+
+		// 6. Execute Assignment
+		$taskstatic = new Task($db);
+		$successCount = 0;
+		$failCount = 0;
+		$skippedCount = 0;
+		$failMessages = array();
+		$skipMessages = array();
+		$successMessages = array();
+
+		foreach ($selectedTasks as $taskId) {
+			if ($taskstatic->fetch($taskId) > 0) {
+				$taskLink = $taskstatic->getNomUrl(0);
+				foreach ($validUserIds as $uid) {
+					$userTmp = new User($db);
+					if ($userTmp->fetch($uid) > 0) {
+						$userLink = $userTmp->getNomUrl(0);
+						$baseMsg = '&emsp;' . $userLink . ' : ' . $taskLink;
+
+						$res = $taskstatic->add_contact($uid, $taskrole, 'internal');
+
+						if ($res > 0) {
+							$successCount++;
+							$successMessages[] = $baseMsg;
+						} elseif ($res == 0) {
+							$skippedCount++;
+							$skipMessages[] = $baseMsg;
+						} else {
+							if ($taskstatic->error == 'DB_ERROR_RECORD_ALREADY_EXISTS') {
+								$skippedCount++;
+								$skipMessages[] = $baseMsg;
+							} else {
+								$failCount++;
+								$failMessages[] = $baseMsg . ' : ' . $taskstatic->error;
+							}
+						}
+					} else {
+						$failCount++;
+						$failMessages[] = '&emsp;' . $langs->trans("User") . ' #' . $uid . ' : ' . $taskLink . ' : ' . $langs->trans("ErrorRecordNotFound");
+					}
+				}
+			}
+		}
+
+		// 7. Feedback
+		if ($successCount > 0) {
+			setEventMessages($langs->trans("SuccessfullyAssignedUsersTasks", $successCount), $successMessages, 'mesgs');
+		}
+		if ($skippedCount > 0) {
+			setEventMessages($langs->trans("SkippedAlreadyAssigned", $skippedCount), $skipMessages, 'warnings');
+		}
+		if ($failCount > 0) {
+			setEventMessages($langs->trans("SomeAssignmentsFailed", $failCount), $failMessages, 'errors');
+		}
+
+		if (!headers_sent()) {
+			header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
+			exit;
+		} else {
+			// Fallback: Reload via JS or just exit (messages will show on current page)
+			echo '<script>window.location.href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '";</script>';
+			exit;
+		}
 	}
 
 	// Get list of tasks in tasksarray and taskarrayfiltered

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1021,7 +1021,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 				'type'  => 'other',
 				'name'  => 'groupid',
 				'label' => $langs->trans("Group"),
-				'value' => $form->select_dolgroups('', 'groupid', 1, '', 0, '', '', 0, 0, 'minwidth250')
+				'value' => $form->select_dolgroups(0, 'groupid', 1, '', 0, '', array(), 0, 0, 'minwidth250')
 			);
 		}
 

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1328,6 +1328,123 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		);
 	}
 
+	// --- BLOCK 1: Validation Check (Abort if not ready) ---
+	if ($action == 'assignthirdcontacts' || $action == 'assignprojectcontacts') {
+		$contactVarName = ($action == 'assignthirdcontacts') ? 'tp_contacts' : 'project_contacts';
+		$selectedContactIds = GETPOST($contactVarName, 'array');
+		$role = GETPOSTINT('taskrole');
+		$taskIdsRaw = GETPOST('taskselect', 'alpha');
+
+		$taskIds = array();
+		if (!empty($taskIdsRaw)) {
+			$taskIds = explode(',', $taskIdsRaw);
+			$taskIds = array_map('intval', $taskIds);
+			$taskIds = array_filter($taskIds);
+		}
+
+		if (!$user->hasRight('projet', 'creer')) {
+			setEventMessages($langs->trans("ErrorForbidden"), null, 'errors');
+			$action = '';
+			$massaction = '';
+		} elseif (empty($selectedContactIds)) {
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->trans("SearchIntoContacts")), null, 'errors');
+			$action = '';
+			$massaction = '';
+		} elseif (empty($role)) {
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->trans("ContactRole")), null, 'errors');
+			$action = '';
+			$massaction = '';
+		} elseif (empty($taskIds)) {
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->trans("Tasks")), null, 'errors');
+			$action = '';
+			$massaction = '';
+		}
+	}
+
+	// --- BLOCK 2: Process Data (Only if ready) ---
+	// Assumes Block 1 has already validated everything.
+	if ($action == 'assignthirdcontacts' || $action == 'assignprojectcontacts') {
+		$contactVarName = ($action == 'assignthirdcontacts') ? 'tp_contacts' : 'project_contacts';
+		$selectedContactIds = GETPOST($contactVarName, 'array');
+		$role = GETPOSTINT('taskrole');
+		$taskIdsRaw = GETPOST('taskselect', 'alpha');
+
+		// Parse Task IDs (Safe extraction, no validation needed)
+		$selectedTasks = array();
+		if (!empty($taskIdsRaw)) {
+			$selectedTasks = explode(',', $taskIdsRaw);
+			$selectedTasks = array_map('intval', $selectedTasks);
+			$selectedTasks = array_unique($selectedTasks, SORT_NUMERIC);
+		}
+
+		// Execute Assignment
+		$taskStatic = new Task($db);
+		$successCount = 0;
+		$skippedCount = 0;
+		$failCount = 0;
+
+		$successMessages = array();
+		$skipMessages = array();
+		$failMessages = array();
+
+		foreach ($selectedTasks as $taskId) {
+			if ($taskStatic->fetch($taskId) > 0) {
+				$taskLink = $taskStatic->getNomUrl(0);
+
+				foreach ($selectedContactIds as $cid) {
+					$contactTmp = new Contact($db);
+					if ($contactTmp->fetch($cid) > 0) {
+						$contactLink = $contactTmp->getNomUrl(0);
+						$baseMsg = '&emsp;' . $taskLink . ' : ' . $contactLink;
+
+						$res = $taskStatic->add_contact($cid, $role, 'external');
+
+						if ($res > 0) {
+							$successCount++;
+							$successMessages[] = $baseMsg;
+						} elseif ($res == 0) {
+							// res=0 means "already added" -> Skip
+							$skippedCount++;
+							$skipMessages[] = $baseMsg;
+						} else {
+							// res < 0 means real error
+							$failCount++;
+							$failMessages[] = $baseMsg . ' : ' . $taskStatic->error;
+						}
+					} else {
+						// Should not happen if Block 1 passed, but safe fallback
+						$failCount++;
+						$failMessages[] = '&emsp;' . $langs->trans("Contact") . ' #' . $cid . ' : ' . $taskLink . ' : ' . $langs->trans("ErrorRecordNotFound");
+					}
+				}
+				// Spacing
+				$successMessages[] = '&emsp;';
+				$skipMessages[] = '&emsp;';
+				$failMessages[] = '&emsp;';
+			}
+		}
+
+		// Feedback
+		if ($successCount > 0) {
+			setEventMessages($langs->trans("SuccessfullyAssignedToTasks", $successCount), $successMessages, 'mesgs');
+		}
+		if ($skippedCount > 0) {
+			setEventMessages($langs->trans("SkippedAlreadyAssigned", $skippedCount), $skipMessages, 'warnings');
+		}
+		if ($failCount > 0) {
+			setEventMessages($langs->trans("ErrorNoGoodSelected", $failCount), $failMessages, 'errors');
+		}
+
+		// Redirect
+		if (!headers_sent()) {
+			header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
+			exit;
+		} else {
+			echo '<script>window.location.href="' . $_SERVER["PHP_SELF"] . '?id=' . $id . '";</script>';
+			exit;
+		}
+	}
+
 	// Get list of tasks in tasksarray and taskarrayfiltered
 	// We need all tasks (even not limited to a user because a task to user can have a parent that is not affected to him).
 	$filteronthirdpartyid = $socid;

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1039,7 +1039,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		$formquestion[] = array(
 			'type'  => 'other',
 			'name'  => 'taskrole',
-			'label' => $langs->trans("Role"),
+			'label' => $langs->trans("ContactRole"),
 			'value' => $formcompany->selectTypeContact($statictask, '', 'taskrole', 'internal', 'position', 0, 'minwidth200', 0, 1)
 		);
 
@@ -1113,7 +1113,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		// Task roles
 		$taskrole = GETPOSTINT('taskrole');
 		if (empty($taskrole)) {
-			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Role")), null, 'errors');
+			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("ContactRole")), null, 'errors');
 			header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
 			exit;
 		}
@@ -1169,7 +1169,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			setEventMessages($langs->trans("SkippedAlreadyAssigned", $skippedCount), $skipMessages, 'warnings');
 		}
 		if ($failCount > 0) {
-			setEventMessages($langs->trans("SomeAssignmentsFailed", $failCount), $failMessages, 'errors');
+			setEventMessages($langs->trans("ErrorTaskAlreadyAssigned", $failCount), $failMessages, 'errors');
 		}
 
 		if (!headers_sent()) {

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1241,7 +1241,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			$taskIdsStr = implode(',', $arrayofselected);
 			print $form->formconfirm(
 				$_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr,
-				$langs->transnoentities('Select1ToNContactsAndRole'),
+				$langs->transnoentities('Select1ToXAndRole', $langs->trans("ThirdPartyContacts")),
 				$langs->trans('AssignContactsToSelectedTasks', count($arrayofselected)),
 				'assignthirdcontacts',
 				$formquestion,
@@ -1288,7 +1288,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 				'type'  => 'other',
 				'name'  => 'project_contacts',
 				'label' => $langs->trans("Contacts"),
-				'value' => '<span class="warning">' . $langs->trans("NoProjectContactsFound") . '</span>'
+				'value' => '<span class="warning">' . $langs->trans("ErrorRefNotFound", $langs->trans("ProjectContact")) . '</span>'
 			);
 		} else {
 			$projectSelectHtml = $form->multiselectarray('project_contacts', $projectContacts, array(), 0, 0, 'minwidth250', 0, 0, '', '', '', 1);
@@ -1313,7 +1313,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		$taskIdsStr = implode(',', $arrayofselected);
 		print $form->formconfirm(
 			$_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr,
-			$langs->transnoentities('Select1ToNContactsAndRole'),
+			$langs->transnoentities('Select1ToXAndRole', $langs->trans("ProjectContact")),
 			$langs->trans('AssignContactsToSelectedTasks', count($arrayofselected)),
 			'assignprojectcontacts',
 			$formquestion,

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1432,7 +1432,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 			setEventMessages($langs->trans("SkippedAlreadyAssigned", $skippedCount), $skipMessages, 'warnings');
 		}
 		if ($failCount > 0) {
-			setEventMessages($langs->trans("ErrorNoGoodSelected", $failCount), $failMessages, 'errors');
+			setEventMessages($langs->trans("ErrorAssignToTasks", $failCount, $langs->trans("TaskContact")), $failMessages, 'errors');
 		}
 
 		// Redirect

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1426,7 +1426,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 		// Feedback
 		if ($successCount > 0) {
-			setEventMessages($langs->trans("SuccessfullyAssignedToTasks", $successCount), $successMessages, 'mesgs');
+			setEventMessages($langs->trans("SuccessfullyAssignedToTasks", $successCount, $langs->trans("TaskContact")), $successMessages, 'mesgs');
 		}
 		if ($skippedCount > 0) {
 			setEventMessages($langs->trans("SkippedAlreadyAssigned", $skippedCount), $skipMessages, 'warnings');

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1045,7 +1045,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 		// Build a string of task IDs
 		$taskIdsStr = implode(',', $arrayofselected);
-		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToNUsersGroupsAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToXAndRole', $langs->trans("Users").' / '.$langs->trans("Groups")), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
 	}
 
 	// Process the user assignment

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1105,7 +1105,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 		// 4. Validation
 		if (empty($validUserIds)) {
-			setEventMessages($langs->trans("ErrorNoUserSelected"), null, 'errors');
+			setEventMessages($langs->trans("ErrorNoGoodSelected", $langs->trans("Users")), null, 'errors');
 			header("Location: " . $_SERVER["PHP_SELF"] . "?id=" . $id);
 			exit;
 		}
@@ -1166,7 +1166,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 
 		// 7. Feedback
 		if ($successCount > 0) {
-			setEventMessages($langs->trans("SuccessfullyAssignedUsersTasks", $successCount), $successMessages, 'mesgs');
+			setEventMessages($langs->trans("SuccessfullyAssignedToTasks", $successCount, $langs->trans("Users")), $successMessages, 'mesgs');
 		}
 		if ($skippedCount > 0) {
 			setEventMessages($langs->trans("SkippedAlreadyAssigned", $skippedCount), $skipMessages, 'warnings');

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -1041,7 +1041,10 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 				'TASKCONTRIBUTOR'  => $langs->trans("TypeContact_project_internal_PROJECTCONTRIBUTOR")
 			), 'TASKCONTRIBUTOR', 0, 0, 0, '', 0, 0, 0, '', 'maxwidth200')
 		);
-		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id, $langs->transnoentities('Select1ToNUsersGroupsAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
+
+		// Build a string of task IDs
+		$taskIdsStr = implode(',', $arrayofselected);
+		print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$id.'&taskselect='.$taskIdsStr, $langs->transnoentities('Select1ToNUsersGroupsAndRole'), $langs->trans('AssignUsersToSelectedTasks', count($arrayofselected)), 'assignusers', $formquestion, '', 1, 400, 600, 0, 'Yes', 'No', $helpText);
 	}
 
 	// Get list of tasks in tasksarray and taskarrayfiltered


### PR DESCRIPTION
# NEW massaction for assigning project contacts or thirdparty contacts to project tasks
Applying this PR will add 2 new massactions for assigning conctacts to project tasks. This PR adds both Contacts from the project, or contacts of the thirdparty. The last one only appears if the project has a thirdparty assigned.

I've explored adding contacts from any thirdparty for public projects with no thirdparty assigned, but did not find a good UXUI in the small popup, so this exercise is left for a future user.

This PR is stacked on top of #38438 and is the last partial fix of #38424. With both PR's #38424 can be closed.

This PR also depends on #38443 to implement the function used to get the contacts from a thirdparty

## Screenshots
<img width="288" height="274" alt="image" src="https://github.com/user-attachments/assets/d4fb067f-8098-468b-b74b-31cbe2006b56" />


### assigning thirdparty contacts
<img width="576" height="380" alt="image" src="https://github.com/user-attachments/assets/68a16d25-b24f-47c4-88e5-de21b6d4d444" />


### assigning project contacts
<img width="575" height="380" alt="image" src="https://github.com/user-attachments/assets/de3a18d2-28ad-46e0-9439-09d7db93b931" />
