### PR TITLE
Correct bug when merging suppliers having common products

### DIFF
--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -1022,6 +1022,22 @@ class ProductFournisseur extends Product
 	 */
 	public static function replaceThirdparty(DoliDB $dbs, $origin_id, $dest_id)
 	{
+		// Issue #38456 To avoid sql errors like "Error in query (1062): Duplicate entry '610185-2551-1-1' for key 'uk_product_fournisseur_price_ref'" when calling CommonObject::commonReplaceThirdparty(..
+		// we delete origin product prices existing in destination before update
+		$sql = 'DELETE p_old FROM '.$dbs->prefix().'product_fournisseur_price p_old
+				WHERE
+					p_old.fk_soc = '.$origin_id.' AND
+					EXISTS (
+						SELECT 1
+						FROM '.$dbs->prefix().'product_fournisseur_price p_new
+						WHERE
+							p_new.fk_product = p_old.fk_product AND
+							p_new.fk_soc = '.$dest_id.')';
+
+		if (!$dbs->query($sql)) {
+			return false;
+		}
+
 		$tables = array(
 			'product_fournisseur_price'
 		);

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -1022,8 +1022,8 @@ class ProductFournisseur extends Product
 	 */
 	public static function replaceThirdparty(DoliDB $dbs, $origin_id, $dest_id)
 	{
-		// Issue #38456 To avoid sql errors like "Error in query (1062): Duplicate entry '610185-2551-1-1' for key 'uk_product_fournisseur_price_ref'" when calling CommonObject::commonReplaceThirdparty(..
-		// we delete origin product prices existing in destination before update
+		/* Issue #38456 To avoid sql errors like "Error in query (1062): Duplicate entry '610185-2551-1-1' for key 'uk_product_fournisseur_price_ref'" when calling CommonObject::commonReplaceThirdparty(..
+		we delete origin product prices existing in destination before update */
 		$sql = ' DELETE p_old FROM '.$dbs->prefix().'product_fournisseur_price p_old ';
 		$sql .= '	 WHERE p_old.fk_soc = '.$origin_id.' AND ';
 		$sql .= '		 EXISTS (SELECT 1 FROM '.$dbs->prefix().'product_fournisseur_price p_new	WHERE p_new.fk_product = p_old.fk_product AND p_new.fk_soc = '.$dest_id.')';

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -1025,8 +1025,8 @@ class ProductFournisseur extends Product
 		/* Issue #38456 To avoid sql errors like "Error in query (1062): Duplicate entry '610185-2551-1-1' for key 'uk_product_fournisseur_price_ref'" when calling CommonObject::commonReplaceThirdparty(..
 		we delete origin product prices existing in destination before update */
 		$sql = ' DELETE p_old FROM '.$dbs->prefix().'product_fournisseur_price p_old ';
-		$sql .= '	 WHERE p_old.fk_soc = '.$origin_id.' AND ';
-		$sql .= '		 EXISTS (SELECT 1 FROM '.$dbs->prefix().'product_fournisseur_price p_new	WHERE p_new.fk_product = p_old.fk_product AND p_new.fk_soc = '.$dest_id.')';
+		$sql .= '	 WHERE p_old.fk_soc = '.(int) $origin_id.' AND ';
+		$sql .= '		 EXISTS (SELECT 1 FROM '.$dbs->prefix().'product_fournisseur_price p_new WHERE p_new.fk_product = p_old.fk_product AND p_new.fk_soc = '.(int) $dest_id.')';
 
 		if (!$dbs->query($sql)) {
 			return false;

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -1024,15 +1024,9 @@ class ProductFournisseur extends Product
 	{
 		// Issue #38456 To avoid sql errors like "Error in query (1062): Duplicate entry '610185-2551-1-1' for key 'uk_product_fournisseur_price_ref'" when calling CommonObject::commonReplaceThirdparty(..
 		// we delete origin product prices existing in destination before update
-		$sql = 'DELETE p_old FROM '.$dbs->prefix().'product_fournisseur_price p_old
-				WHERE
-					p_old.fk_soc = '.$origin_id.' AND
-					EXISTS (
-						SELECT 1
-						FROM '.$dbs->prefix().'product_fournisseur_price p_new
-						WHERE
-							p_new.fk_product = p_old.fk_product AND
-							p_new.fk_soc = '.$dest_id.')';
+		$sql = ' DELETE p_old FROM '.$dbs->prefix().'product_fournisseur_price p_old ';
+		$sql .= '	 WHERE p_old.fk_soc = '.$origin_id.' AND ';
+		$sql .= '		 EXISTS (SELECT 1 FROM '.$dbs->prefix().'product_fournisseur_price p_new	WHERE p_new.fk_product = p_old.fk_product AND p_new.fk_soc = '.$dest_id.')';
 
 		if (!$dbs->query($sql)) {
 			return false;


### PR DESCRIPTION
Fix #38456 
To avoid sql errors like "Error in query (1062): Duplicate entry '610185-2551-1-1' for key 'uk_product_fournisseur_price_ref'" when calling CommonObject::commonReplaceThirdparty(.. we delete origin product prices existing in destination before update
