### PR TITLE
FIX: TakePOS dropdown user menu layout broken missing side-nav-vert context under MD theme

### DIFF
--- a/htdocs/takepos/css/pos.css.php
+++ b/htdocs/takepos/css/pos.css.php
@@ -92,6 +92,18 @@ html,body {
 	max-height:calc(100vh-50px);
 }
 
+/* Fix dropdown user-header layout missing .side-nav-vert context under TakePOS */
+.bodytakepos #topmenu-login-dropdown .dropdown-menu {
+	line-height: 1.3em;
+}
+
+.bodytakepos #topmenu-login-dropdown .dropdown-menu > .user-header {
+	min-height: 100px;
+	padding: 10px;
+	text-align: center;
+	white-space: normal;
+}
+
 .center {
 	text-align: center;
 }


### PR DESCRIPTION
#### FIX

- TakePOS: Fix dropdown user menu layout broken under MD theme.
  `.side-nav-vert` context is absent in TakePOS, causing `.user-header` layout rules to not apply.
  Adds missing `line-height`, `min-height`, `padding`, `text-align` and `white-space` rules.
  Related to #38431