### PR TITLE
FIX Reception: require receptionlinebatch.class.php to avoid Fatal when Reception is loaded indirectly

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -39,6 +39,7 @@
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT."/core/class/commonobjectline.class.php";
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonincoterm.class.php';
+require_once DOL_DOCUMENT_ROOT.'/reception/class/receptionlinebatch.class.php';
 if (isModEnabled("propal")) {
 	require_once DOL_DOCUMENT_ROOT.'/comm/propal/class/propal.class.php';
 }


### PR DESCRIPTION
## Bug

`htdocs/reception/class/reception.class.php` instantiates `ReceptionLineBatch` in 4 methods (`create()`, `addline()`, `update_line()`, `fetch_lines_free()` — lines 460, 1075, 1149, 1230) but **never requires** `receptionlinebatch.class.php`.

In normal navigation it works only because the entry pages (`reception/card.php`, `reception/list.php`, …) happen to require both classes side-by-side. Any code path that loads `Reception` through a generic helper triggers a fatal.

## Reproduction

Trigger path observed in production (Dolibarr 23.0, module `usernavhistory` enabled — but the bug is in the core, the module just exposes it):

```
index.php
 -> llxHeader -> main_area
 -> HookManager::executeHooks
 -> ActionsUserNavHistory::printMainArea
 -> UserNavHistory::fetchAll
 -> fetchObjectByElement()   [core/lib/functions.lib.php]
 -> Reception::fetch()
 -> Reception::fetch_lines_free()
 -> new ReceptionLineBatch($this->db)   <-- FATAL
```

Resulting error:

```
PHP Fatal error: Uncaught Error: Class "ReceptionLineBatch" not found
in htdocs/reception/class/reception.class.php on line 1230
```

The same fatal can be reached from any external module or API path that loads `Reception` via `fetchObjectByElement()` (or any wrapper) without also having loaded `receptionlinebatch.class.php` separately.

## Fix

Add the missing `require_once` at the top of `reception.class.php`, alongside the existing `require_once`s for `commonobject`, `commonobjectline`, `commonincoterm`, `propal` and `commande`:

```php
require_once DOL_DOCUMENT_ROOT.'/reception/class/receptionlinebatch.class.php';
```

This makes `ReceptionLineBatch` always available whenever `Reception` is loaded, matching the convention used by other core classes that pre-load their line/child classes (e.g. `commande`, `expedition`).

## Test plan

- [x] `php -l htdocs/reception/class/reception.class.php` — no syntax error
- [x] Stand-alone load: `require 'reception.class.php'` then `class_exists('ReceptionLineBatch')` returns `true`
- [x] Production workaround confirms scope: disabling the standard reception module suppresses the fatal (because no Reception object ends up in the navigation history). The fix above removes the need for that workaround.
- [ ] Open a reception card normally — unchanged (extra `require_once` is a no-op since the file was already loaded by `card.php`)
- [ ] Trigger any hook / API path that calls `fetchObjectByElement()` on a reception — no fatal

## Scope

- Single-line addition, no behavioral change for normal navigation.
- No SQL, no JS, no AJAX, no multicompany impact, no migration.
- Bug is present on `23.0`, `22.0`, `21.0` and `develop` (verified by `grep` on each branch — none of them requires `receptionlinebatch.class.php` from within `reception.class.php`). Targeting `23.0` so the fix flows up through the standard cascade merge.