### PR TITLE
Fix github moderation workflow

### DIFF
--- a/.github/workflows/moderation.yml
+++ b/.github/workflows/moderation.yml
@@ -48,7 +48,6 @@ jobs:
 
             console.log('Detected language:', isEnglish ? 'english' : 'not english')
 
-            #if (hasYoutubeMusic || !isEnglish) {
             if (hasYoutubeMusic) {
               console.log('Deleting comment...')
 


### PR DESCRIPTION
Remove line with bad comment (# is not a valid comment sign in javascript)

see worflow error in https://github.com/Dolibarr/dolibarr/actions/runs/26629213600