### PR TITLE
[FIX] add token to prevent CSRF when selecting customer in TakePOS

### DIFF
--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -1956,7 +1956,7 @@ while ($i < $imaxinloop) {
 		$j = 0;
 		print '<tr data-rowid="'.$companystatic->id.'" class="oddeven row-with-select"';
 		if ($contextpage == 'poslist') {
-			print ' onclick="location.href=\'list.php?action=change&contextpage=poslist&idcustomer='.$obj->rowid.'&place='.urlencode($place).'\'"';
+			print ' onclick="location.href=\'list.php?action=change&contextpage=poslist&idcustomer='.$obj->rowid.'&place='.urlencode($place).'&token='.newToken().'\'"';
 		}
 		print '>';
 


### PR DESCRIPTION
# FIX add token to prevent CSRF when selecting customer in TakePOS

To change the client in TakePOS, the user clicks the "Client" button, which opens the client list. They can then select the desired client. This selection performs a request that, without the session token, would cause a CSRF error.