### PR TITLE
fix(auth): backport OIDC empty-password LDAP check to 22.0 (already in develop)

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -777,7 +777,7 @@ if (!defined('NOLOGIN')) {
 		}
 
 		// End test login / passwords
-		if (!$login || (in_array('ldap', $authmode) && empty($passwordtotest))) {	// With LDAP we refused empty password because some LDAP are "opened" for anonymous access so connection is a success.
+		if (!$login || (in_array('ldap', $authmode) && !in_array('openid_connect', $authmode) && empty($passwordtotest))) {	// With LDAP we refused empty password because some LDAP are "opened" for anonymous access so connection is a success.
 			// No data to test login, so we show the login page.
 			dol_syslog("--- Access to ".(empty($_SERVER["REQUEST_METHOD"]) ? '' : $_SERVER["REQUEST_METHOD"].' ').$_SERVER["PHP_SELF"]." - action=".GETPOST('action', 'aZ09')." - actionlogin=".GETPOST('actionlogin', 'aZ09')." - showing the login form and exit", LOG_NOTICE);
 			if (defined('NOREDIRECTBYMAINTOLOGIN')) {


### PR DESCRIPTION
## Problem

In v22, when `$dolibarr_main_authentication = 'dolibarr,ldap,openid_connect'`, the OIDC login flow loops back to the login page after a successful callback.

**Reproduction**:
1. Enable OIDC + LDAP in `$dolibarr_main_authentication`
2. Click "Login via OIDC", complete the IdP authentication
3. After the callback, the browser is redirected back to the login page indefinitely → never reaches the dashboard

**Root cause** : the LDAP empty-password guard at `htdocs/main.inc.php:780` (22.0 branch) triggers when `$passwordtotest` is empty (which is the normal state during an OIDC callback flow — the IdP has already authenticated the user, no password is being submitted). The guard then forces a redirect back to the login form, breaking the OIDC handshake.

## Fix

This is a **backport** of the same one-line fix **already merged on `develop`** (see `htdocs/main.inc.php:808` there) :

```diff
- if (!$login || (in_array('ldap', $authmode) && empty($passwordtotest))) {
+ if (!$login || (in_array('ldap', $authmode) && !in_array('openid_connect', $authmode) && empty($passwordtotest))) {
```

→ Skip the LDAP empty-password guard when an OIDC flow is currently being processed (detected by `openid_connect` being present in `$authmode`).

## Test

Verified manually on a Dolibarr 22.0.x instance with Authentik (OIDC IdP) :
- **Before** : post-OIDC-callback loops back to the login page (regression vs 21.x)
- **After** : post-OIDC-callback lands on the dashboard as expected
- **No impact** on pure LDAP auth (when `openid_connect` is NOT in `$authmode`)
- **No impact** on pure Dolibarr local auth (with username + password)

## Notes

This PR only contains a 1-line change. The fix already exists on `develop` so this is purely a backport for users on the 22.0 LTS branch.
