### PR TITLE
FIX #37842 Enforce access control on productlot_note.php

### DIFF
--- a/htdocs/product/stock/productlot_note.php
+++ b/htdocs/product/stock/productlot_note.php
@@ -59,15 +59,19 @@ if ($id > 0 || !empty($ref)) {
 	$upload_dir = $conf->productlot->multidir_output[!empty($object->entity) ? $object->entity : $conf->entity]."/".$object->id;
 }
 
-$permissionnote = $user->hasRight('produit', 'lire'); // Used by the include of actions_setnotes.inc.php
+$permissiontoread = $user->hasRight('produit', 'lire');
+$permissionnote = $user->hasRight('produit', 'creer'); // Used by the include of actions_setnotes.inc.php
 
-// Security check (enable the most restrictive one)
-//if ($user->socid > 0) accessforbidden();
-//if ($user->socid > 0) $socid = $user->socid;
-//$isdraft = (($object->status == $object::STATUS_DRAFT) ? 1 : 0);
-//restrictedArea($user, $object->element, $object->id, $object->table_element, '', 'fk_soc', 'rowid', $isdraft);
-//if (empty($conf->calibration->enabled)) accessforbidden();
-//if (!$permissiontoread) accessforbidden();
+// Security check
+if (!isModEnabled('productbatch')) {
+	accessforbidden('Module not enabled');
+}
+if ($user->socid > 0) { // Protection if external user
+	accessforbidden();
+}
+if (!$permissiontoread) {
+	accessforbidden();
+}
 
 
 /*


### PR DESCRIPTION
The three security checks in `productlot_note.php` were left commented out from the boilerplate, so any logged-in user (including external users) could read and edit notes on every product lot by enumerating `?id=`. Mirrored the pattern already used in `productlot_card.php` and `productlot_document.php`: enforce the module check, the external-user check, and `produit/lire`.

Bumped `$permissionnote` from `produit/lire` to `produit/creer` so a read-only user can't overwrite notes through the `actions_setnotes.inc.php` include.

Tested on a local 21.0.4 with a no-rights user: page now returns the standard accessforbidden screen. Admin access unchanged. Same code is present identically in 18.0 through develop.
