### PR TITLE
FIX #38199 Normalize blank sellist/select value before notnull check

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -170,6 +170,9 @@ if ($action == 'add' && !empty($permissiontoadd)) {
 		if (!empty($object->fields[$key]['foreignkey']) && $value == '-1') {
 			$value = ''; // This is an explicit foreign key field
 		}
+		if ((preg_match('/^sellist/i', $object->fields[$key]['type']) || $object->fields[$key]['type'] == 'select') && $value === '0') {
+			$value = ''; // The blank option of sellist and select fields is posted as "0"
+		}
 
 		//var_dump($key.' '.$value.' '.$object->fields[$key]['type'].' '.$object->fields[$key]['notnull']);
 
@@ -331,6 +334,9 @@ if ($action == 'update' && !empty($permissiontoadd)) {
 		}
 		if (!empty($object->fields[$key]['foreignkey']) && $value == '-1') {
 			$value = ''; // This is an explicit foreign key field
+		}
+		if ((preg_match('/^sellist/i', $object->fields[$key]['type']) || $object->fields[$key]['type'] == 'select') && $value === '0') {
+			$value = ''; // The blank option of sellist and select fields is posted as "0"
 		}
 
 		$object->$key = $value;


### PR DESCRIPTION
A blank `sellist` or `select` field declared `notnull => 1` was not caught by the mandatory check in `actions_addupdatedelete.inc.php`. The blank option of those two field types is rendered with `value="0"` in `commonobject::showInputField` (around lines 8107 and 8259), so the POSTed value is the string `"0"`. The existing normalization only converts `"-1"` to `""` for `integer:` and `foreignkey` types, so `"0"` reached the database and triggered a raw SQL foreign key error instead of the localized `ErrorFieldRequired` message.

Normalize `"0"` to `""` for `sellist` and `select` in both the add and update branches, right next to the existing `integer:`/`foreignkey` normalization. Strict equality (`===`) is used so a legitimate value of `0` on other field types is never altered.

Side note on the issue: it reports the bug as a PHP 8.2+ regression, but `"0" == ""` has always been false on every supported PHP version. The bug existed before too, it was just silent because few core objects declare a `sellist`/`select` field as `notnull`.

Tested on 21.0.4 with a small repro that runs the dispatch logic against both field types: before the patch the blank value reaches the notnull check unaltered and the check passes; after the patch it is normalized to `""` and `ErrorFieldRequired` is raised. No regression on `integer:`, `foreignkey`, `varchar`, or non-blank `sellist`/`select` values.
