### PR TITLE
FIX #37935 Refuse login submission with credentials in query string

### DIFF
--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -136,6 +136,7 @@ ErrorLabelAlreadyExists=This label already exists
 ErrorCantReadFile=Failed to read file '%s'
 ErrorCantReadDir=Failed to read directory '%s'
 ErrorBadLoginPassword=Bad value for login or password
+ErrorLoginMustBePostMethod=For security reasons, login credentials must be sent using the POST method, not in the URL
 ErrorLoginDisabled=Your account has been disabled
 ErrorFailedToRunExternalCommand=Failed to run external command. Check it is available and runnable by your PHP server user. Check also the command is not protected on shell level by a security layer like apparmor.
 ErrorFailedToChangePassword=Failed to change password

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -749,7 +749,8 @@ if (!defined('NOLOGIN')) {
 		// "password" in the query string, so this does not affect them.
 		if (GETPOST('actionlogin', 'aZ09') == 'login' && (isset($_GET['username']) || isset($_GET['password']))) {
 			dol_syslog("--- Login submission with credentials in the query string refused for ".$_SERVER["PHP_SELF"], LOG_WARNING);
-			$_SESSION["dol_loginmesg"] = 'ErrorLoginMustBePostMethod';
+			$langs->loadLangs(array('main', 'errors'));
+			$_SESSION["dol_loginmesg"] = $langs->transnoentitiesnoconv("ErrorLoginMustBePostMethod");
 			$test = false;
 		}
 

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -742,6 +742,17 @@ if (!defined('NOLOGIN')) {
 			dol_syslog('--- Security warning: credentials reported as leaked were used to try to login. HTTP_EXPOSED_CREDENTIAL_CHECK='.((int) $_SERVER['HTTP_EXPOSED_CREDENTIAL_CHECK']), LOG_NOTICE);
 		}
 
+		// Refuse a login submission that carries credentials in the query string.
+		// This avoids the username/password ending up in web server access logs,
+		// the browser history, the Referrer header or any HTTP proxy log (CWE-598).
+		// OAuth callbacks legitimately use GET and never carry "username" or
+		// "password" in the query string, so this does not affect them.
+		if (GETPOST('actionlogin', 'aZ09') == 'login' && (isset($_GET['username']) || isset($_GET['password']))) {
+			dol_syslog("--- Login submission with credentials in the query string refused for ".$_SERVER["PHP_SELF"], LOG_WARNING);
+			$_SESSION["dol_loginmesg"] = 'ErrorLoginMustBePostMethod';
+			$test = false;
+		}
+
 		// Validation of login/pass/entity
 		// If ok, the variable login will be returned
 		// If error, we will put error message in session under the name dol_loginmesg


### PR DESCRIPTION
When the login form is submitted via GET (or the same URL is replayed), `username` and `password` end up in the web server access log, the browser history and the `Referer` header sent to the next page. This is CWE-598 (sensitive data in the query string).

The patch refuses any request carrying `actionlogin=login` together with `username` or `password` in `$_GET`, before `checkLoginPassEntity` runs, and writes a warning to the syslog. OAuth callbacks (`afteroauthloginreturn`, `beforeoauthloginredirect`) and the normal POST login form path are untouched because they never carry credentials in the query string.

Verified locally on 21.0.4: POST login still authenticates and the session is usable on `/admin/`; the same call with username/password moved to the query string is now rejected and the browser stays on the login page.

Open to feedback on whether to merge or rework.
