### PR TITLE
Fix #37661 Mark price_base_type as required in product import

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -517,7 +517,7 @@ class modProduct extends DolibarrModules
 			'p.price_min' => "MinPrice",
 			'p.price_ttc' => "SellingPriceTTC", //with tax
 			'p.price_min_ttc' => "SellingMinPriceTTC",
-			'p.price_base_type' => "PriceBaseType", //price base: with-tax (TTC) or without (HT) tax. Displays accordingly in Product card
+			'p.price_base_type' => "PriceBaseType*", //price base: with-tax (TTC) or without (HT) tax. Required so that an empty cell does not produce a NULL row.
 			'p.tva_tx' => 'VATRate',
 			'p.datec' => 'DateCreation',
 			'p.cost_price' => "CostPrice"


### PR DESCRIPTION
When the `price_base_type` column is left blank in a CSV imported via the Products import profile, the import engine writes the literal SQL keyword `null` in the INSERT instead of letting MariaDB apply the column default (`'HT'`), so the product row ends up with `price_base_type = NULL`. Subsequent reads of the product then treat the price as neither HT nor TTC, which is what the issue describes.

Mark the field with the `*` required marker in `modProduct::import_fields_array`. The CSV and XLSX engines both honour that marker (lines 419 and 485 of their `import_insert` method) and raise `ErrorMissingMandatoryValue` when the mapped cell is empty. The existing `import_regex_array` entry `\AHT\z|\ATTC\z` continues to constrain the accepted values, so the rest of the validation chain is unchanged.

Tested locally on 21.0.4 by reproducing the NULL insertion directly in the DB (the column defaults to `'HT'` but the engine bypasses that default by sending `null` explicitly). With the patch, an empty cell triggers the mandatory-field error at import time and the import is rejected with a clear message instead of producing a corrupt row.

Side effect to be aware of: existing import profiles that did not map `price_base_type` will now fail at the config step until the mapping is added. This matches the behaviour the project already enforces for `Ref`, `Label`, `Type`, `OnSell`, `OnBuy`.
