### PR TITLE
Fix #38058 Reset top menu context on entry of admin/modules.php

### DIFF
--- a/htdocs/admin/modules.php
+++ b/htdocs/admin/modules.php
@@ -34,6 +34,13 @@ if (!defined('CSRFCHECK_WITH_TOKEN') && (empty($_GET['action']) || $_GET['action
 	define('CSRFCHECK_WITH_TOKEN', '1'); // Force use of CSRF protection with tokens even for GET
 }
 
+// The modules list is a setup hub: force the menu context to "home" when the
+// caller did not provide one, so the previously visited module's menu does not
+// stick when the user comes back to this page (issue 38058).
+if (!isset($_GET['mainmenu']) && !isset($_POST['mainmenu'])) {
+	$_GET['mainmenu'] = 'home';
+}
+
 // Load Dolibarr environment
 require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';


### PR DESCRIPTION
`htdocs/admin/modules.php` never declares its own menu context, so `loadMenu` in `core/menus/standard/eldy_menu.php` falls back to whatever value the previous page wrote into `$_SESSION["mainmenu"]`. After opening a module's config page (gear icon -> `?mainmenu=<module>`), then clicking "Back to list of modules", the previous module's top menu stays highlighted on the list, and the gear icon of the next module inherits it until that next page sets its own context.

Force `$_GET["mainmenu"] = "home"` at the very top of `admin/modules.php` when the caller did not provide a mainmenu, before `main.inc.php` is loaded. `loadMenu` then sees the GET value, writes `"home"` into the session, and the top menu reflects the setup hub. An explicit `mainmenu` in the URL (for example the `?mainmenu=home` links emitted by `admin/index.php` and the `SetupIsReadyForUse` string in `modules.php` itself) keeps full precedence.

Verified on 21.0.4 end to end: visit `agenda_other.php?mainmenu=agenda`, then `modules.php`. Before the patch the Agenda top menu stays highlighted; after the patch the Home menu is highlighted (`mainmenutd_home` carries the `tmenusel` class). Visiting `modules.php?mainmenu=tools` still selects Tools, so explicit caller intent is preserved.
