### PR TITLE
Fix #37800 Preserve line breaks in entity-only text in dol_htmlwithnojs

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8618,7 +8618,15 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 					// like '<h1>Foo</h1><p>bar</p>' that wrongly ends up, without the trick, with '<h1>Foo<p>bar</p></h1>'
 					// like 'abc' that wrongly ends up, without the trick, with '<p>abc</p>'
 
-					if (dol_textishtml($out)) {
+					// dol_textishtml() returns true on plain text that only happens to contain
+					// an HTML entity (for example a multi-line description with a "&" that the
+					// editor encodes as "&amp;"). In that case the content has no real tag, so
+					// it should still be normalized with dol_nl2br to keep its line breaks.
+					$ishtml = dol_textishtml($out);
+					if ($ishtml && !preg_match('/<[a-z!\/]/i', $out)) {
+						$ishtml = false;
+					}
+					if ($ishtml) {
 						$out = '<?xml encoding="UTF-8"><html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">'.$out.'</div></body></html>';
 					} else {
 						$out = '<?xml encoding="UTF-8"><html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">'.dol_nl2br($out).'</div></body></html>';


### PR DESCRIPTION
When `MAIN_RESTRICTHTML_ONLY_VALID_HTML` is enabled, `dol_htmlwithnojs` uses `dol_textishtml` to decide whether to apply `dol_nl2br` before feeding the content to `DOMDocument`. `dol_textishtml` currently returns true on plain text that merely contains an HTML entity (line 9050 of `functions.lib.php` matches the `&[A-Z0-9]{1,6};` pattern). A multi-line description whose `&` was encoded as `&amp;` by the editor therefore takes the "as html" branch, `dol_nl2br` is skipped, `DOMDocument` normalizes the raw line feeds away, and the rendered output (card preview, PDF) ends up on a single line.

If `dol_textishtml` says "yes" but the content does not actually contain any HTML tag (no `<` followed by a letter, `!` or `/`), treat it as plain text and apply `dol_nl2br` anyway. Real HTML content (with at least one tag) keeps the existing path untouched.

Localized fix in `dol_htmlwithnojs` rather than a change to `dol_textishtml` itself, which is referenced from 23 files and whose existing behaviour other callers may rely on (the TODO comment at line 9051 acknowledges the same limitation).

Verified with a standalone repro of the branch decision on six representative inputs (plain multi-line, multi-line with `&amp;`, multi-line with `&copy;`, real HTML with tags and entities, real HTML with `<br/>`, plain text with `<b>`). Only the two entity-only multi-line cases switch path (now go through `nl2br`); the four real-HTML or plain-text cases are unaffected.

Side note: the reporter suggested a `str_replace("&", "&", ...)` workaround on the `restricthtmlallowunvalid` branch. That string is a no-op (it replaces "&" with "&") so the workaround as written cannot have any effect; the underlying detection in `dol_textishtml` is what needs adjusting.
