### PR TITLE
Fix #38182 Backport oldcopy empty check to 21.0

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1454,7 +1454,8 @@ class Product extends CommonObject
 
 		if ($result >= 0) {
 			// $this->oldcopy should have been set by the caller of update (here properties were already modified)
-			if (is_null($this->oldcopy) || (is_object($this->oldcopy) && $this->oldcopy->isEmpty())) {
+			// Note that this->oldcopy must be object and not stdClass, if not the method hasbatch() will not work.
+			if (is_null($this->oldcopy) || (is_object($this->oldcopy) && empty($this->oldcopy->id))) {
 				$this->oldcopy = dol_clone($this, 1);
 			}
 			// Test if batch management is activated on existing product


### PR DESCRIPTION
Updating a product selling price via `/product/price.php` triggers a fatal `Call to undefined method stdClass::isEmpty()` at `Product::update` line 1457 on 21.0. In the `update_price` flow, `$this->oldcopy` is a `stdClass` (not a `Product` instance), so `isEmpty()` does not exist on it. The page returns HTTP 500 and the open transaction is forcibly closed by `DoliDBMysqli::close`.

Replace the `isEmpty()` call with `empty($this->oldcopy->id)`, which is the form already shipped on 22.0, 23.0 and develop after upstream commit `ef94452f77f`. The accompanying comment from that commit is also brought in.

This is the same bug as #37792 (closed, fixed in 23.0.3 and forward); the fix was never backported to 21.0 even though the bug is still triggered there.
