### PR TITLE
Fix #38171 Allow underscore in extrafields old-syntax filter regex

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1408,7 +1408,7 @@ class ExtraFields
 
 					// Fix better compatibility with some old extrafield syntax filter "(field=123)"
 					$reg = array();
-					if (preg_match('/^\(?([a-z0-9]+)([=<>]+)(\d+)\)?$/i', $InfoFieldList[4], $reg)) {
+					if (preg_match('/^\(?([a-z0-9_]+)([=<>]+)(\d+)\)?$/i', $InfoFieldList[4], $reg)) {
 						$InfoFieldList[4] = '('.$reg[1].':'.$reg[2].':'.$reg[3].')';
 					}
 
@@ -1638,7 +1638,7 @@ class ExtraFields
 
 					// Fix better compatibility with some old extrafield syntax filter "(field=123)"
 					$reg = array();
-					if (preg_match('/^\(?([a-z0-9]+)([=<>]+)(\d+)\)?$/i', $InfoFieldList[4], $reg)) {
+					if (preg_match('/^\(?([a-z0-9_]+)([=<>]+)(\d+)\)?$/i', $InfoFieldList[4], $reg)) {
 						$InfoFieldList[4] = '('.$reg[1].':'.$reg[2].':'.$reg[3].')';
 					}
 


### PR DESCRIPTION
`ExtraFields::showInputField` normalises the legacy `(field=123)` filter syntax of "List from a table" extrafields into the modern USF `(field:=:123)` form. The compatibility regex `/^\(?([a-z0-9]+)([=<>]+)(\d+)\)?$/i` only accepts alphanumeric field names, so a filter like `fk_typent=2` does not match, the filter is left as is, and `forgeSQLFromUniversalSearchCriteria` later fails with `Filter error` because the raw expression is not valid universal search syntax.

Accept the underscore in the field name class. The two identical occurrences in the file (one per dispatch branch) are updated.

Verified with a standalone PHP repro on five inputs (`fk_typent=2`, `(fk_typent=2)`, `rowid=5`, `(field=123)`, `name_field=10`): the new regex matches every legitimate input including the underscored field names; nothing that used to match stops matching.
