### PR TITLE
Fix #38491 Name the field in the ticket too-long error message

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -421,7 +421,8 @@ class Ticket extends CommonObject
 		if (isset($this->message)) {
 			$this->message = trim($this->message);
 			if (dol_strlen($this->message) > 65000) {
-				$this->errors[] = 'ErrorFieldTooLong';
+				$langs->loadLangs(array('errors', 'ticket'));
+				$this->errors[] = $langs->trans('ErrorFieldTooLong', $langs->transnoentitiesnoconv('InitialMessage'));
 				dol_syslog(get_class($this).'::create error -1 message too long', LOG_ERR);
 				$result = -1;
 			}
@@ -1043,7 +1044,8 @@ class Ticket extends CommonObject
 		if (isset($this->message)) {
 			$this->message = trim($this->message);
 			if (dol_strlen($this->message) > 65000) {
-				$this->errors[] = 'ErrorFieldTooLong';
+				$langs->loadLangs(array('errors', 'ticket'));
+				$this->errors[] = $langs->trans('ErrorFieldTooLong', $langs->transnoentitiesnoconv('InitialMessage'));
 				dol_syslog(get_class($this).'::update error -1 message too long', LOG_ERR);
 				return -1;
 			}

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -421,6 +421,7 @@ class Ticket extends CommonObject
 		if (isset($this->message)) {
 			$this->message = trim($this->message);
 			if (dol_strlen($this->message) > 65000) {
+				global $langs;
 				$langs->loadLangs(array('errors', 'ticket'));
 				$this->errors[] = $langs->trans('ErrorFieldTooLong', $langs->transnoentitiesnoconv('InitialMessage'));
 				dol_syslog(get_class($this).'::create error -1 message too long', LOG_ERR);
@@ -1044,6 +1045,7 @@ class Ticket extends CommonObject
 		if (isset($this->message)) {
 			$this->message = trim($this->message);
 			if (dol_strlen($this->message) > 65000) {
+				global $langs;
 				$langs->loadLangs(array('errors', 'ticket'));
 				$this->errors[] = $langs->trans('ErrorFieldTooLong', $langs->transnoentitiesnoconv('InitialMessage'));
 				dol_syslog(get_class($this).'::update error -1 message too long', LOG_ERR);


### PR DESCRIPTION
When a ticket message exceeds 65000 characters, `Ticket::verify()` (called by `create`) and `Ticket::update()` appended the bare string `'ErrorFieldTooLong'` to `$this->errors`. `setEventMessages` forwards that string and `dol_htmloutput_mesg` runs `$langs->trans()` on it, which yields the raw template `Field %s is too long.` with the `%s` placeholder still visible because no argument was passed.

Replace the bare key with a pre-translated message that names the field ("Initial message"), the same pattern already used in `htdocs/barcode/printsheet.php` for the same lang key. Two identical sites in the file are updated (one in `verify`, called by `create`, and one in `update`). The `errors` and `ticket` lang files are loaded defensively before translation because both methods can run before the page-level `loadLangs`.

Same wording change on 21.0, 22.0, 23.0 and develop; this PR targets 21.0 per the project's N-2 recommendation.
