### PR TITLE
Fix #38154 Keep full label in option text of select_all_categories

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5584,7 +5584,12 @@ class Form
 					$output .= '<option ' . $add . 'value="' . $cate_arbo[$key]['id'] . '"';
 					$output .= ' data-html="' . dol_escape_htmltag($labeltoshow) . '"';
 					$output .= '>';
-					$output .= dol_trunc($cate_arbo[$key]['fulllabel'], $maxlength, 'middle');
+					// The visible (truncated) label is rendered via data-html in
+					// templateResult of the select2 combobox; the bare option text
+					// must keep the full label so that the select2 search matcher
+					// (ajax_combobox in core/lib/ajax.lib.php) can find a hit on
+					// characters that lie outside the truncated portion.
+					$output .= dol_escape_htmltag($cate_arbo[$key]['fulllabel']);
 					$output .= '</option>';
 
 					$cate_arbo[$key]['data-html'] = $labeltoshow;


### PR DESCRIPTION
The select2 combobox built around `select_all_categories` renders the truncated label via the `data-html` attribute (see `templateResult` in `core/lib/ajax.lib.php` `ajax_combobox`), and runs its search matcher on the bare `<option>` text. When the option text itself was the truncated label, any character outside the visible portion was unreachable from the search box, so long category names whose distinctive part fell in the hidden middle stopped matching.

Write the full label in the option text and keep `data-html` as the truncated visible rendering. The dropdown still looks compact, but the matcher can now find a hit anywhere in the full category name.

The full label is run through `dol_escape_htmltag` to keep the generated HTML safe (the previous bare `dol_trunc` output was not escaped). Same regression on 21.0, 22.0, 23.0 and develop; PR targets 21.0.

Regression was introduced by commit `1e76422a500` ("NEW Show picto and color into combo for selection of tags") shipped in v21, which matches the reporter's note that the search worked fine on v20 and earlier.
