### PR TITLE
Fix #37571 Accept "0" as a valid chart-of-accounts field value

### DIFF
--- a/htdocs/accountancy/admin/card.php
+++ b/htdocs/accountancy/admin/card.php
@@ -78,10 +78,10 @@ if (GETPOST('cancel', 'alpha')) {
 
 if ($action == 'add' && $user->hasRight('accounting', 'chartofaccount')) {
 	if (!$cancel) {
-		if (!$account_number) {
+		if ((string) $account_number === '') {
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("AccountNumber")), null, 'errors');
 			$action = 'create';
-		} elseif (!$label) {
+		} elseif ((string) $label === '') {
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Label")), null, 'errors');
 			$action = 'create';
 		} else {
@@ -133,10 +133,10 @@ if ($action == 'add' && $user->hasRight('accounting', 'chartofaccount')) {
 	}
 } elseif ($action == 'edit' && $user->hasRight('accounting', 'chartofaccount')) {
 	if (!$cancel) {
-		if (!$account_number) {
+		if ((string) $account_number === '') {
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("AccountNumber")), null, 'errors');
 			$action = 'update';
-		} elseif (!$label) {
+		} elseif ((string) $label === '') {
 			setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Label")), null, 'errors');
 			$action = 'update';
 		} else {


### PR DESCRIPTION
The required-field check in `htdocs/accountancy/admin/card.php` used the truthy form `!$account_number` and `!$label`. PHP coerces the string `"0"` to `false`, so the form rejected those values as missing even though they were submitted. `"00"`, `"01"`, `"0.0"` all worked because their truthy form is `true`.

Compare the input against the empty string explicitly to keep the existing rejection of an actually missing value while accepting the literal `"0"`. Same treatment on the four affected sites: account number and label, in both the add and edit branches.

`GETPOST` returns a string here, so no other tests need to change. The downstream `empty()` tests in `accountancy/class/accountingaccount.class.php` may still need their own pass (the reporter notes the same false-positive on the SQL path), but they are out of scope for this atomic fix.

Verified with a standalone repro on eight inputs: `""` stays rejected, `"0"` is now accepted, and `"00"`, `"01"`, `"1"`, `"10"`, `"0.0"`, `"abc"` keep their previous accepted state.
