### PR TITLE
Fix #37836 Preserve task id when submitting the timespent filter

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1434,6 +1434,9 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 		print '<input type="hidden" name="sortfield" value="' . $sortfield . '">';
 		print '<input type="hidden" name="sortorder" value="' . $sortorder . '">';
 
+		// Carry the task id through the filter submit so that the timespent list
+		// stays scoped to the current task instead of falling back to the global view.
+		print '<input type="hidden" name="id" value="' . ((int) $id) . '">';
 		print '<input type="hidden" name="projectid" value="' . $projectidforalltimes . '">';
 		print '<input type="hidden" name="withproject" value="' . $withproject . '">';
 		print '<input type="hidden" name="tab" value="' . $tab . '">';


### PR DESCRIPTION
The timespent list inside a task page is scoped by the `id` query parameter (`/projet/tasks/time.php?id=X`). The filter form right above the list emits hidden inputs for `projectid`, `withproject`, `tab` and `page_y` but no input for `id`, so submitting the search rewrites the URL to `/projet/tasks/time.php` without `id` and the page falls back to the global view, displaying entries from every task.

Add a hidden `id` input next to the others. The form already emits `projectid` and `withproject`, so no other parameter is affected.

The same form on 21.0 and 22.0 still contained the `id` input; the regression appeared on 23.0 (the input was dropped together with unrelated layout changes in the v23 timespent refactor). PR targets 23.0 since 21.0 and 22.0 are unaffected.

Verified by re-reading the filter form on 21.0 (line 1424), 22.0 (line 1440), 23.0 (gap between sortorder and projectid), and develop (same gap as 23.0); the patch restores the missing line at the same position.
