### PR TITLE
Fix #37445 Suppress PHP message display in API responses

### DIFF
--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -29,6 +29,15 @@
 
 use Luracast\Restler\Format\UploadFormat;
 
+// API endpoints return JSON (or XML). A stray PHP warning or notice in the
+// response body corrupts the parser on the caller side. Silence the display
+// of PHP messages here while keeping them in the server log so that the
+// problem is still observable to the operator (filefunc.inc.php only does
+// this when dolibarr_main_prod is set, which leaves development setups
+// emitting HTML into every API answer).
+@ini_set('display_errors', '0');
+@ini_set('log_errors', '1');
+
 if (!defined('NOCSRFCHECK')) {
 	define('NOCSRFCHECK', '1'); // Do not check anti CSRF attack test
 }


### PR DESCRIPTION
API endpoints return JSON or XML. When PHP `display_errors` is on (the default outside production), any warning or notice raised before the response is written ends up in the response body and breaks the parser on the caller side. The reporter noted that "HTML should never appear before a JSON answer", which is exactly what happens to a development or staging install whose `conf.php` does not set `dolibarr_main_prod`.

Set `display_errors=0` and `log_errors=1` at the top of `api/index.php` so that the messages stay visible in the server log while the response body stays clean. This applies to every API call independently of the production flag handled by `filefunc.inc.php`.

The setting is scoped to `api/index.php` and does not affect any other front (admin pages, public pages); their existing display behaviour is unchanged. Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.
