### PR TITLE
Fix #37909 Fall back to default data root when the value is empty

### DIFF
--- a/htdocs/install/inc.php
+++ b/htdocs/install/inc.php
@@ -214,7 +214,11 @@ if (!defined('DONOTLOADCONF') && file_exists($conffile) && filesize($conffile) >
 		}
 
 		// Clean parameters
-		$dolibarr_main_data_root = isset($dolibarr_main_data_root) ? trim($dolibarr_main_data_root) : DOL_DOCUMENT_ROOT.'/../documents';
+		// isset() is true on an empty string, which would let DOL_DATA_ROOT
+		// resolve to '' and the lock file to /install.lock (rejected by a
+		// restrictive open_basedir). Use !empty() so an empty value falls
+		// back to the default relative documents path.
+		$dolibarr_main_data_root = !empty($dolibarr_main_data_root) ? trim($dolibarr_main_data_root) : DOL_DOCUMENT_ROOT.'/../documents';
 		$dolibarr_main_url_root         = isset($dolibarr_main_url_root) ? trim($dolibarr_main_url_root) : '';
 		$dolibarr_main_url_root_alt     = isset($dolibarr_main_url_root_alt) ? trim($dolibarr_main_url_root_alt) : '';
 		$dolibarr_main_document_root    = isset($dolibarr_main_document_root) ? trim($dolibarr_main_document_root) : '';
@@ -266,7 +270,7 @@ if (!isset($dolibarr_main_db_prefix) || !$dolibarr_main_db_prefix) {
 define('MAIN_DB_PREFIX', (isset($dolibarr_main_db_prefix) ? $dolibarr_main_db_prefix : ''));
 
 define('DOL_CLASS_PATH', 'class/'); // Filesystem path to class dir
-define('DOL_DATA_ROOT', (isset($dolibarr_main_data_root) ? $dolibarr_main_data_root : DOL_DOCUMENT_ROOT.'/../documents'));
+define('DOL_DATA_ROOT', (!empty($dolibarr_main_data_root) ? $dolibarr_main_data_root : DOL_DOCUMENT_ROOT.'/../documents'));
 define('DOL_MAIN_URL_ROOT', (isset($dolibarr_main_url_root) ? $dolibarr_main_url_root : '')); // URL relative root
 $uri = preg_replace('/^http(s?):\/\//i', '', constant('DOL_MAIN_URL_ROOT')); // $uri contains url without http*
 $suburi = strstr($uri, '/'); // $suburi contains url without domain


### PR DESCRIPTION
`isset($dolibarr_main_data_root)` returns true even when the value is an empty string. On a fresh install where `fileconf.php` has set the variable but the field was left blank, `install/inc.php` kept that empty string, `DOL_DATA_ROOT` resolved to `''`, and the lock file path became `/install.lock`. A web server with a restrictive `open_basedir` then rejected the `file_exists()` check with *"open_basedir restriction in effect. File(/install.lock) is not within the allowed path(s)"* and the installer failed.

Switch the two `isset()` guards on `$dolibarr_main_data_root` to `!empty()` so an empty value falls back to the default `DOL_DOCUMENT_ROOT.'/../documents'` path, which sits inside any sensible `open_basedir` scope.

The other `isset()` guards in the same block default to `''` anyway (`url_root`, `document_root`, ...), so they are not affected by the same issue and stay untouched.

Same code on 21.0, 22.0, 23.0 and develop; PR targets 21.0.
