### PR TITLE
Fix #37904 Honour subscription end-of-period setting in mass action

### DIFF
--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -363,11 +363,22 @@ if (empty($reshook)) {
 		$nbcreated = 0;
 		$now = dol_now();
 		$amount = price2num(GETPOST('amount', 'alpha'));
+		// Honour MEMBER_SUBSCRIPTION_SUGGEST_END_OF_MONTH and
+		// MEMBER_SUBSCRIPTION_SUGGEST_END_OF_YEAR the same way as the
+		// single subscription form (adherents/subscription.php), otherwise
+		// the mass action falls back to a one-year duration in
+		// Adherent::subscription() and ignores the global setting.
+		$datesubend = 0;
+		if (getDolGlobalInt('MEMBER_SUBSCRIPTION_SUGGEST_END_OF_MONTH')) {
+			$datesubend = dol_get_last_day((int) dol_print_date($now, "%Y"), (int) dol_print_date($now, "%m"));
+		} elseif (getDolGlobalInt('MEMBER_SUBSCRIPTION_SUGGEST_END_OF_YEAR')) {
+			$datesubend = dol_get_last_day((int) dol_print_date($now, "%Y"));
+		}
 		$db->begin();
 		foreach ($toselect as $id) {
 			$res = $tmpmember->fetch($id);
 			if ($res > 0) {
-				$result = $tmpmember->subscription($now, $amount);
+				$result = $tmpmember->subscription($now, $amount, 0, '', '', '', '', '', $datesubend);
 				if ($result < 0) {
 					$error++;
 				} else {


### PR DESCRIPTION
The "Create subscription" mass action on the members list called `Adherent::subscription()` with no `$datesubend` argument, which makes the method fall back to "+1 year" (`adherent.class.php` line 1713) regardless of the `MEMBER_SUBSCRIPTION_SUGGEST_END_OF_MONTH` or `MEMBER_SUBSCRIPTION_SUGGEST_END_OF_YEAR` global settings. The single subscription form (`adherents/subscription.php` line 1006-1013), the API (`api_members.class.php`) and the public payment return (`public/payment/paymentok.php`) all pass the value computed from these constants and therefore worked as expected.

Compute the same end date from the two constants before the loop in `adherents/list.php` and forward it as the ninth argument of the method call. The two constants are evaluated in the same order as the single subscription form so the behaviour matches.

Two other callers already pass a value at the same argument position, so the method signature stays unchanged. Same code on 21.0 through develop; PR targets 21.0.
