### PR TITLE
Fix #38482 Show validation error on intervention line update inline

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -697,8 +697,10 @@ if (empty($reshook)) {
 
 		$result = $objectline->update($user);
 		if ($result < 0) {
-			dol_print_error($db);
-			exit;
+			// Surface validation errors (e.g. mandatory extrafield left empty) as an
+			// event message on the same page instead of breaking with a full Dolibarr
+			// error screen that loses the user's edit context.
+			setEventMessages($objectline->error, $objectline->errors, 'errors');
 		}
 
 		// Define output language


### PR DESCRIPTION
Updating a line of an intervention with an invalid value (typical case: a mandatory extrafield left empty) made the page bail out with `dol_print_error + exit`, which renders the generic Dolibarr error screen and loses the user's edit context.

Replace the bail out with a `setEventMessages` on the same page, matching the pattern already used at lines 135, 180, 497, 503, 526, 548, 566, 571, 649 and elsewhere in `fichinter/card.php` (`object->error, object->errors, 'errors'`). The caller stays on the intervention card, sees the validation message and can correct the field without losing what was being typed.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.

The reporter @Timoune974 already sketched the same fix in the issue.
