### PR TITLE
Fix #38347 Hide zero local-tax lines on TakePOS receipt

### DIFF
--- a/htdocs/takepos/receipt.php
+++ b/htdocs/takepos/receipt.php
@@ -299,14 +299,19 @@ if (getDolGlobalString('TAKEPOS_SHOW_DATE_OF_PRINING')) {
 
 // Now show local taxes if company uses them
 
-if (price2num($object->total_localtax1, 'MU') || $mysoc->useLocalTax(1)) { ?>
+// $mysoc->useLocalTax(N) is a country-wide flag (true as soon as the country has a
+// matching c_tva row with a localtaxN_type), so on its own it always prints the line
+// for Spanish companies even when the company is "No sujeto a RE / IRPF". Mirror the
+// pattern used by compta/facture/card.php, card-rec.php and prelevement.php and gate
+// the country check on $mysoc->localtaxN_assuj == "1".
+if (($mysoc->localtax1_assuj == "1" && $mysoc->useLocalTax(1)) || price2num($object->total_localtax1, 'MU')) { ?>
 <tr>
 	<th class="right"><?php if ($gift != 1) {
 		echo ''.$langs->trans("TotalLT1").'</th><td class="right">'.price($object->total_localtax1, 1, '', 1, - 1, - 1, $conf->currency)."\n";
 					  } ?></th>
 </tr>
 <?php } ?>
-<?php if (price2num($object->total_localtax2, 'MU') || $mysoc->useLocalTax(2)) { ?>
+<?php if (($mysoc->localtax2_assuj == "1" && $mysoc->useLocalTax(2)) || price2num($object->total_localtax2, 'MU')) { ?>
 <tr>
 	<th class="right"><?php if ($gift != 1) {
 		echo ''.$langs->trans("TotalLT2").'</th><td class="right">'.price($object->total_localtax2, 1, '', 1, - 1, - 1, $conf->currency)."\n";


### PR DESCRIPTION
`$mysoc->useLocalTax(N)` is a country-wide flag: it returns true as soon as the country has a `c_tva` row with a non-zero `localtaxN_type` (see `societe.class.php:4729`). For a Spanish company that is *"No sujeto a RE / IRPF"* the flag is therefore still true, and the TakePOS receipt prints `Total Impuesto 2` / `Total Impuesto 3` lines with `0,00 EUR` amounts which simplified-invoice regulations do not allow.

Mirror the pattern already used by `compta/facture/card.php` (lines 5125 and 5137), `compta/facture/card-rec.php`, `fourn/facture/card-rec.php` and `compta/facture/prelevement.php`: gate the country-level `useLocalTax` check on `$mysoc->localtaxN_assuj == "1"`. A non-subject company no longer shows the zero line; companies that are genuinely subject still see it even at 0 EUR; a non-zero `total_localtax` keeps forcing the line regardless of `assuj`, which covers shipments where the buyer triggers the tax.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.

This is the minimal "Option A"-style fix the reporter outlined, kept aligned with the existing four call sites instead of removing the country check entirely.
