### PR TITLE
Fix #37600 surface trigger error when closing proposal via API

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -2689,10 +2689,16 @@ class Propal extends CommonObject
 				$this->db->commit();
 				return 1;
 			} else {
-				$this->statut = $this->oldcopy->status;
-				$this->status = $this->oldcopy->status;
-				$this->date_signature = $this->oldcopy->date_signature;
-				$this->note_private = $this->oldcopy->note_private;
+				foreach ($this->errors as $errmsg) {
+					dol_syslog(__METHOD__.' Error: '.$errmsg, LOG_ERR);
+					$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+				}
+				if (!empty($this->oldcopy)) {
+					$this->statut = $this->oldcopy->status;
+					$this->status = $this->oldcopy->status;
+					$this->date_signature = $this->oldcopy->date_signature;
+					$this->note_private = $this->oldcopy->note_private;
+				}
 
 				$this->db->rollback();
 				return -1;


### PR DESCRIPTION
When a trigger handler on PROPAL_CLOSE_SIGNED or PROPAL_CLOSE_REFUSED fails inside `Propal::closeProposal()`, the function returns -1 without ever copying the handler messages from `$this->errors` (plural, populated by `call_trigger`) into `$this->error` (singular). The REST endpoint `POST /proposals/{id}/close` then surfaces `Error when closing Commercial Proposal:` with no detail, which is what the reporter sees when mail sending is disabled but the close trigger still runs other handlers.

Aggregate the per-handler messages into `$this->error` using the same foreach pattern already used 10 times in this class (`classifyBilled`, `setCancel`, ...). I also guarded the `oldcopy` restoration: `$this->oldcopy` is only assigned inside the success branch around line 2671, so a SQL UPDATE failure before that point used to dereference a null property and turn the rollback into a fatal.

Same code path on 21.0 through develop; PR targets 21.0.

Tested locally: forced a trigger handler to return -1, hit `POST /api/index.php/proposals/{id}/close`, response now contains the real handler message instead of an empty tail.