### PR TITLE
Fix #38407 guard Restler date/time validators against non-string input

### DIFF
--- a/htdocs/includes/restler/framework/Luracast/Restler/Data/Validator.php
+++ b/htdocs/includes/restler/framework/Luracast/Restler/Data/Validator.php
@@ -273,7 +273,8 @@ class Validator implements iValidate
     public static function date($input, ValidationInfo $info = null)
     {
         if (
-            preg_match(
+            is_string($input)
+            && preg_match(
                 '#^(?P<year>\d{2}|\d{4})-(?P<month>\d{1,2})-(?P<day>\d{1,2})$#',
                 $input,
                 $date
@@ -302,7 +303,8 @@ class Validator implements iValidate
     public static function datetime($input, ValidationInfo $info = null)
     {
         if (
-            preg_match('/^(?P<year>19\d\d|20\d\d)\-(?P<month>0[1-9]|1[0-2])\-' .
+            is_string($input)
+            && preg_match('/^(?P<year>19\d\d|20\d\d)\-(?P<month>0[1-9]|1[0-2])\-' .
                 '(?P<day>0\d|[1-2]\d|3[0-1]) (?P<h>0\d|1\d|2[0-3]' .
                 ')\:(?P<i>[0-5][0-9])\:(?P<s>[0-5][0-9])$/',
                 $input, $date)
@@ -345,7 +347,7 @@ class Validator implements iValidate
      */
     public static function time($input, ValidationInfo $info = null)
     {
-        if (preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/', $input)) {
+        if (is_string($input) && preg_match('/^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/', $input)) {
             return $input;
         }
         throw new Invalid(
@@ -367,7 +369,7 @@ class Validator implements iValidate
      */
     public static function time12($input, ValidationInfo $info = null)
     {
-        if (preg_match(
+        if (is_string($input) && preg_match(
             '/^([1-9]|1[0-2]|0[1-9]){1}(:[0-5][0-9])?\s?([aApP][mM]{1})?$/',
             $input)
         ) {


### PR DESCRIPTION
When an API client posts an array (or any non-string value) for a parameter whose declared type or auto-detected type via the parameter name (`date`, `datetime`, `time`, `time12`) is a date/time format, the Restler validators called `preg_match()` directly on the raw input. On PHP 8.0+, `preg_match()` throws a hard TypeError when the subject is not a string, turning a bad request into a fatal 500 with a stack trace leaking in the response body.

`POST /api/index.php/tasks/{id}/addtimespent` with `date` as an array (or the malformed multiline JSON in the report) is one trigger path, because the parameter name `date` is auto-promoted to the `date` type via `Routes::$fieldTypesByName`.

Guard the four affected validators (`date`, `datetime`, `time`, `time12`) with an `is_string()` check so a non-string value falls through to the normal `Invalid` exception. The client gets a clean 400 with the expected format hint instead of a PHP fatal; behavior for valid strings is unchanged.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0. The file was previously patched in this repo for PHP 8 compat (commit fd8bfcfd3b9), so a small additional guard is in line with prior maintenance.

Tested locally on PHP 8.2 with the reporter's payload variant: the response went from a fatal 500 with stack trace to a 400 `Invalid value specified for \`date\`. Expecting date and time in \`YYYY-MM-DD HH:MM:SS\` format`. The happy path with a valid string passes validation as before.