### PR TITLE
Fix #38407 surface trigger error in task addTimeSpent / updateTimeSpent

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1657,6 +1657,16 @@ class Task extends CommonObjectLine
 			$ret = -1;
 		}
 
+		// Propagate trigger handler messages from $this->errors (plural array)
+		// to $this->error (singular string) so callers like the REST API can
+		// surface a useful message instead of an empty error tail.
+		if ($ret <= 0 && empty($this->error) && !empty($this->errors)) {
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(__METHOD__.' Error: '.$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
+		}
+
 		if ($ret > 0) {
 			// Recalculate amount of time spent for task and update denormalized field
 			$sql = "UPDATE ".MAIN_DB_PREFIX."projet_task";
@@ -2095,6 +2105,16 @@ class Task extends CommonObjectLine
 			$this->error = $this->db->lasterror();
 			$this->db->rollback();
 			$ret = -1;
+		}
+
+		// Propagate trigger handler messages from $this->errors (plural array)
+		// to $this->error (singular string) so callers like the REST API can
+		// surface a useful message instead of an empty error tail.
+		if ($ret < 0 && empty($this->error) && !empty($this->errors)) {
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(__METHOD__.' Error: '.$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
 		}
 
 		if ($ret == 1 && (($this->timespent_old_duration != $this->timespent_duration) || getDolGlobalString('TIMESPENT_ALWAYS_UPDATE_THM'))) {


### PR DESCRIPTION
When a trigger handler on `TASK_TIMESPENT_CREATE` or `TASK_TIMESPENT_MODIFY` fails, `Task::addTimeSpent()` and `Task::updateTimeSpent()` returned -1 without ever copying the messages from `$this->errors` (plural, populated by `call_trigger`) into `$this->error` (singular). The REST endpoints `POST /tasks/{id}/addtimespent` and `PUT /tasks/{id}/timespent/{timespent_id}` then surfaced `Error when adding time:` with no detail, which is the symptom the reporter saw and matches the closeProposal issue I fixed in #38521.

Aggregate the per-handler messages into `$this->error` using the same foreach pattern already shipped in that PR. The guard `$ret <= 0 && empty($this->error) && !empty($this->errors)` keeps any pre-existing singular error message untouched (it is already filled on the SQL failure branches above) and only fills the gap when only the array form has been populated.

The original report also mentions a PHP 8 TypeError coming from Restler when the API client sends a non-string for the `date` parameter (`Validator.php:427`). That deeper hardening is tracked separately in the closed PR #38523 and needs to be revisited bundled with a non-vendored file or a CI tweak (PHPCS bails on a vendored-only file list); the current PR keeps to the Dolibarr-owned code path and at least gives the reporter a useful 500 message instead of an empty tail when the trigger is the cause.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.