### PR TITLE
Fix #35593 use acceptLocalLinktoMedia in mailing editor

### DIFF
--- a/htdocs/comm/mailing/card.php
+++ b/htdocs/comm/mailing/card.php
@@ -761,6 +761,10 @@ if (empty($reshook)) {
 $form = new Form($db);
 $htmlother = new FormOther($db);
 
+// Same check as the email templates editor in admin/mails_templates.php so the
+// local media browser is shown consistently in both places.
+$acceptlocallinktomedia = (acceptLocalLinktoMedia() > 0 ? 1 : 0);
+
 $help_url = 'EN:Module_EMailing|FR:Module_Mailing|ES:M&oacute;dulo_Mailing';
 llxHeader(
 	'',
@@ -894,7 +898,7 @@ if ($action == 'create') {	// aaa
 	print '<div style="padding-top: 10px">';
 	// wysiwyg editor
 	require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-	$doleditor = new DolEditor('bodyemail', GETPOST('bodyemail', 'restricthtmlallowunvalid'), '', 600, 'dolibarr_mailings', '', true, -1, getDolGlobalInt('FCKEDITOR_ENABLE_MAILING'), 20, '100%');
+	$doleditor = new DolEditor('bodyemail', GETPOST('bodyemail', 'restricthtmlallowunvalid'), '', 600, 'dolibarr_mailings', '', true, $acceptlocallinktomedia, getDolGlobalInt('FCKEDITOR_ENABLE_MAILING'), 20, '100%');
 	$doleditor->Create();
 	print '</div>';
 
@@ -1334,7 +1338,7 @@ if ($action == 'create') {	// aaa
 				$readonly = 1;
 				// wysiwyg editor
 				require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', false, -1, getDolGlobalInt('FCKEDITOR_ENABLE_MAILING'), 20, '100%', $readonly);
+				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', false, $acceptlocallinktomedia, getDolGlobalInt('FCKEDITOR_ENABLE_MAILING'), 20, '100%', $readonly);
 				$doleditor->Create();
 			} else {
 				print dol_htmlentitiesbr($object->body);
@@ -1553,19 +1557,19 @@ if ($action == 'create') {	// aaa
 			if ($action == 'edit') {
 				// wysiwyg editor
 				require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', true, -1, getDolGlobalInt('FCKEDITOR_ENABLE_MAILING'), 20, '100%');
+				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', true, $acceptlocallinktomedia, getDolGlobalInt('FCKEDITOR_ENABLE_MAILING'), 20, '100%');
 				$doleditor->Create();
 			}
 			if ($action == 'edittxt') {
 				// wysiwyg editor
 				require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', true, -1, 0, 20, '100%');
+				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', true, $acceptlocallinktomedia, 0, 20, '100%');
 				$doleditor->Create();
 			}
 			if ($action == 'edithtml') {
 				// HTML source editor
 				require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', true, -1, 'ace', 20, '100%');
+				$doleditor = new DolEditor('bodyemail', $object->body, '', 600, 'dolibarr_mailings', '', true, $acceptlocallinktomedia, 'ace', 20, '100%');
 				$doleditor->Create(0, '', false, 'HTML Source', 'php');
 			}
 


### PR DESCRIPTION
Since v21 the wysiwyg editor in `comm/mailing/card.php` was created with `\$uselocalbrowser = -1`, which `DolEditor` maps to the hidden constant `WYSIWYG_ALLOW_UPLOAD_MEDIA_FILES` (default 0). The local image browser that was available before v21 disappears on any installation that does not explicitly set that constant. The regression was introduced by commit 691b542b4d5 ("Debug v21").

The email templates editor in `admin/mails_templates.php` already solves the same problem with the dedicated helper `acceptLocalLinktoMedia()`, which also honors `MAIN_DISALLOW_MEDIAS_IN_EMAIL_TEMPLATES` and an IP allowlist for private networks. The maintainer (@eldy) confirmed in the issue thread that the two editors are meant to behave the same way and the constant "should be used anywhere".

Mirror that pattern in the mailing page: compute `\$acceptlocallinktomedia` once near the top and pass it as the `\$uselocalbrowser` argument to all five `DolEditor` instances (create, view, edit, edittxt, edithtml). Default-deny for internet-exposed installs is preserved through `acceptLocalLinktoMedia()` own checks, while a local install on a private network gets the image browser back without having to set the hidden `WYSIWYG_ALLOW_UPLOAD_MEDIA_FILES` flag.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.

Tested locally on PHP 8.2: page renders without notice or warning with the patch applied; behavior follows `acceptLocalLinktoMedia()` exactly as in the templates editor.