### PR TITLE
Fix #36079 keep online signature URL from ending with a bcrypt trailing dot

### DIFF
--- a/htdocs/core/lib/signature.lib.php
+++ b/htdocs/core/lib/signature.lib.php
@@ -204,6 +204,11 @@ function getOnlineSignatureUrl($mode, $type, $ref = '', $localorexternal = 1, $o
 	// For multicompany
 	if (!empty($out) && isModEnabled('multicompany')) {
 		$out .= "&entity=".(empty($obj->entity) ? '' : (int) $obj->entity); // Check the entity because we may have the same reference in several entities
+	} elseif ($mode == 0) {
+		// Bcrypt output (dol_hash type '0') can legitimately end with '.' or '/', which Gmail and several mobile mail
+		// clients strip from autolinked URLs and break the signature link. Append a stable trailing parameter that
+		// the receiver ignores so the URL never ends with the hash. Only for the real URL (mode 0), not the preview.
+		$out .= "&_=1";
 	}
 
 	return $out;


### PR DESCRIPTION
`getOnlineSignatureUrl()` ends each public signature URL with `&securekey=` followed by the output of `dol_hash(..., '0')`. With the default `MAIN_SECURITY_HASH_ALGO = password_hash`, that output is a bcrypt string whose alphabet is `[./A-Za-z0-9]`, so a non-trivial share of generated URLs legitimately end with `.` or `/`.

Gmail and several mobile mail clients autolink plain-text URLs but drop trailing punctuation, so the recipient clicks on a URL with the last character missing and gets a securekey mismatch error (`Bad value for securitykey`). The same symptom is the cause of #31464 ("Error validating proposal with online signature!"); the example hash in that report is `$2y$10$OMk56eCUCtK/T.iqDA0AC.tMKplHtArCRgqfCbVvIXB6iO3y4jvl.` which ends with `.`.

When multicompany is enabled, the URL already ends with `&entity=N` and the issue does not surface. For installations without multicompany, append a stable trailing `&_=1` so the URL never ends with the hash. The receiver in `htdocs/public/onlinesign/newonlinesign.php` does not read `_`, only `source`, `ref`, `securekey` and (when multicompany) `entity`, so adding the parameter has no behavior impact and existing links keep verifying as before.

Only the real URL (`mode == 0`) is affected; the mode 1 preview shown in the admin setup is untouched.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0. Reproduced locally by generating a URL ending in `.`, confirming Gmail's plain-text autolinker drops it and the receiver rejects; with the patch the URL ends in `&_=1` and Gmail keeps the full URL.

Also closes #31464 since it shares the same root cause.