### PR TITLE
Fix #38480 default invoice numbering to Mercure not Terre on fresh installs

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4723,9 +4723,12 @@ class Facture extends CommonInvoice
 			$moduleSourceName = 'Invoice';
 			$addonConstName = 'FACTURE_ADDON';
 
-			// Clean parameters (if not defined or using deprecated value)
+			// Clean parameters (if not defined or using deprecated value).
+			// Default to Mercure on fresh installs: mod_facture_terre is flagged
+			// dolibarr_deprecated by the admin page filter (since the deprecation
+			// commit 7b759f439ef) and is no longer the recommended numbering module.
 			if (!getDolGlobalString('FACTURE_ADDON')) {
-				$conf->global->FACTURE_ADDON = 'mod_facture_terre';
+				$conf->global->FACTURE_ADDON = 'mod_facture_mercure';
 			} elseif (getDolGlobalString('FACTURE_ADDON') == 'terre') {
 				$conf->global->FACTURE_ADDON = 'mod_facture_terre';
 			} elseif (getDolGlobalString('FACTURE_ADDON') == 'mercure') {


### PR DESCRIPTION
Commit 7b759f439ef ("Depreciate module mod_facture_terre that is duplicate with mars.", April 2025) flipped `mod_facture_terre`'s `$version` to `'dolibarr_deprecated'` and added a filter in `htdocs/admin/invoice.php` to hide it from the numbering module listing, but left the silent fallback in `Facture::getNextNumRef()` (`htdocs/compta/facture/class/facture.class.php:4727`) pointing at the deprecated module:

```php
if (!getDolGlobalString('FACTURE_ADDON')) {
    $conf->global->FACTURE_ADDON = 'mod_facture_terre';
}
```

So on a fresh install (`DOLI_INSTALL_AUTO=1` or any install that does not set `FACTURE_ADDON` via `install.forced.php`), Terre silently became the active numbering module on first invoice creation. The admin page then included Terre in the listing because the deprecation filter has an exception for the currently-active module (so admins can migrate away from a deprecated module they are already using). Once the admin picked a non-deprecated module, Terre disappeared from the list, which is the exact symptom the reporter described.

Repoint the default to `mod_facture_mercure` so brand-new installs land on the non-deprecated module and the admin listing behaves consistently with the deprecation commit's design intent. Existing installs are not affected: their `FACTURE_ADDON` constant is already set in `llx_const` and the new default only kicks in when the constant is missing.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.