### PR TITLE
Fix #25107 honour FOR_ALL_STATUS in mass send action

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -316,19 +316,23 @@ if (!$error && $massaction == 'confirm_presend') {
 
 			foreach ($listofobjectref[$thirdpartyid] as $objectid => $objectobj) {
 				//var_dump($thirdpartyid.' - '.$objectid.' - '.$objectobj->statut);
-				if ($objectclass == 'Propal' && $objectobj->status == Propal::STATUS_DRAFT) {
+				// Honour the same per-object hidden constants used by the "Send by email"
+				// button on the card pages (comm/propal/card.php, commande/card.php,
+				// compta/facture/card.php) so the behaviour is consistent between the
+				// single-object action and the mass action.
+				if ($objectclass == 'Propal' && $objectobj->status == Propal::STATUS_DRAFT && !getDolGlobalString('PROPOSAL_SENDBYEMAIL_FOR_ALL_STATUS')) {
 					$langs->load("errors");
 					$nbignored++;
 					$resaction .= '<div class="error">'.$langs->trans('ErrorOnlyProposalNotDraftCanBeSentInMassAction', $objectobj->ref).'</div><br>';
 					continue; // Payment done or started or canceled
 				}
-				if ($objectclass == 'Commande' && $objectobj->status == Commande::STATUS_DRAFT) {
+				if ($objectclass == 'Commande' && $objectobj->status == Commande::STATUS_DRAFT && !getDolGlobalString('COMMANDE_SENDBYEMAIL_FOR_ALL_STATUS')) {
 					$langs->load("errors");
 					$nbignored++;
 					$resaction .= '<div class="error">'.$langs->trans('ErrorOnlyOrderNotDraftCanBeSentInMassAction', $objectobj->ref).'</div><br>';
 					continue;
 				}
-				if ($objectclass == 'Facture' && $objectobj->status == Facture::STATUS_DRAFT) {
+				if ($objectclass == 'Facture' && $objectobj->status == Facture::STATUS_DRAFT && !getDolGlobalString('FACTURE_SENDBYEMAIL_FOR_ALL_STATUS')) {
 					$langs->load("errors");
 					$nbignored++;
 					$resaction .= '<div class="error">'.$langs->trans('ErrorOnlyInvoiceValidatedCanBeSentInMassAction', $objectobj->ref).'</div><br>';


### PR DESCRIPTION
The per-card "Send by email" button on Propal, Commande and Facture already honours the hidden constants `PROPOSAL_SENDBYEMAIL_FOR_ALL_STATUS`, `COMMANDE_SENDBYEMAIL_FOR_ALL_STATUS` and `FACTURE_SENDBYEMAIL_FOR_ALL_STATUS` to allow sending drafts (see `htdocs/comm/propal/card.php:3142`, `htdocs/commande/card.php:3016`, `htdocs/compta/facture/card.php:5899`). The mass "Send by email" action in the corresponding lists silently dropped draft objects regardless of those constants, so an administrator who intentionally enabled the override saw inconsistent behaviour between the card and the list.

Apply the same constant check on the three draft-skip guards in `htdocs/core/actions_massactions.inc.php` so the mass action behaves the same way as the single-object button. Default behaviour is unchanged: with none of the constants set, drafts are still skipped with the existing `ErrorOnlyXxxNotDraftCanBeSentInMassAction` error message.

The reporter also mentioned supplier orders. `CommandeFournisseur` is not currently subject to a draft-skip guard in this code path, so the supplier-order branch of the report would need a separate diagnosis (likely upstream of this file). The present PR covers the three classes that have the documented inconsistency.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.