### PR TITLE
Fix #31495 clone supplier prices when cloning a product

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -991,6 +991,15 @@ if (empty($reshook)) {
 							}
 						}
 
+						if (!$error && GETPOST('clone_supplier_prices')) {
+							$result = $clone->clone_fournisseurs($object->id, $id);
+							if ($result < 1) {
+								setEventMessages($langs->trans('ErrorProductClone'), null, 'errors');
+								setEventMessages($clone->error, $clone->errors, 'errors');
+								$error++;
+							}
+						}
+
 						if (!$error && isModEnabled('bom') && $user->hasRight('bom', 'write')) {
 							$defbomidac = 0; // to avoid cloning same BOM twice
 							if (GETPOST('clone_defbom') && $object->fk_default_bom > 0) {
@@ -1028,7 +1037,6 @@ if (empty($reshook)) {
 								}
 							}
 						}
-						// $clone->clone_fournisseurs($object->id, $id);
 					} else {
 						if ($clone->error == 'ErrorProductAlreadyExists') {
 							$refalreadyexists++;
@@ -3009,6 +3017,7 @@ if (($action == 'clone' && (empty($conf->use_javascript_ajax) || !empty($conf->d
 	if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
 		$formquestionclone[] = array('type' => 'checkbox', 'name' => 'clone_prices', 'label' => $langs->trans("ClonePricesProduct").' ('.$langs->trans("CustomerPrices").')', 'value' => 0);
 	}
+	$formquestionclone[] = array('type' => 'checkbox', 'name' => 'clone_supplier_prices', 'label' => $langs->trans("ClonePricesProduct").' ('.$langs->trans("SupplierPrices").')', 'value' => 0);
 	if (getDolGlobalString('PRODUIT_SOUSPRODUITS')) {
 		$formquestionclone[] = array('type' => 'checkbox', 'name' => 'clone_composition', 'label' => $langs->trans('CloneCompositionProduct'), 'value' => 1);
 	}


### PR DESCRIPTION
The product clone form already exposes a "Clone prices (Customer prices)" checkbox that drives `Product::clone_price()`. The matching supplier-side helper `Product::clone_fournisseurs()` existed in `product.class.php` but was only invoked through a dead commented-out call in `htdocs/product/card.php:1031`, so users who cloned a product or service lost all their vendor prices silently. @ems-co identified the dead line in October 2024 and several follow-ups in the issue thread tried to uncomment it and reported it did not actually clone, which was correct: the call was not wired to any UI signal.

Add a second "Clone prices (Vendor prices)" checkbox, default off to preserve current behaviour, and call `clone_fournisseurs()` when it is ticked using the same error-handling pattern as the customer-side clone. Remove the misleading commented-out call that has been confusing contributors for years.

`clone_fournisseurs()` itself copies into `llx_product_fournisseur_price` the columns `price, quantity, fk_user, tva_tx, fk_soc`. It does not copy `ref_fourn` (vendor SKU) because that field is part of a separate `INSERT` block in the same method that is intentionally commented out (it would conflict with the unique key on the supplier-ref row). Surfacing the SKU clone is a separate scope and not addressed here; the original report only mentioned vendor prices.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0. The new checkbox is unconditionally added because supplier prices are a core feature, unlike `clone_prices` which is gated on `PRODUIT_MULTIPRICES`.