### PR TITLE
Fix #27987 refuse to save signature when too-many-links sanitizer fires

### DIFF
--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -443,3 +443,4 @@ ThisIdNotDefined=Id not defined
 OperNotDefined=Payment method not defined
 EmptyMessageNotAllowedError=Empty message is not allowed
 SomeShipmentExists=Error, there is some shipment linked to the order. Deletion refused.
+ErrorTooManyLinksIntoHTMLString=The HTML content contains too many links or images. Reduce the number or raise MAIN_SECURITY_MAX_IMG_IN_HTML_CONTENT.

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -314,6 +314,16 @@ if (empty($reshook)) {
 			$object->email = preg_replace('/\s+/', '', GETPOST("email", 'alphanohtml'));
 			$object->job = GETPOST("job", 'alphanohtml');
 			$object->signature = GETPOST("signature", 'restricthtml');
+			// restricthtml may swap the value with the literal 'ErrorTooManyLinksIntoHTMLString'
+			// when the html exceeds MAIN_SECURITY_MAX_IMG_IN_HTML_CONTENT (see issue #27987).
+			// Refuse the save so the literal does not end up persisted and later sent as an
+			// email body to customers.
+			if ($object->signature === 'ErrorTooManyLinksIntoHTMLString') {
+				$error++;
+				$langs->load("errors");
+				setEventMessages($langs->trans('ErrorTooManyLinksIntoHTMLString'), null, 'errors');
+				$action = 'create';
+			}
 			$object->accountancy_code = GETPOST("accountancy_code", 'alphanohtml');
 			$object->note_public = GETPOST("note_public", 'restricthtml');
 			$object->note_private = GETPOST("note_private", 'restricthtml');
@@ -497,6 +507,16 @@ if (empty($reshook)) {
 				$object->email = preg_replace('/\s+/', '', GETPOST("email", 'alphanohtml'));
 				$object->job = GETPOST("job", 'alphanohtml');
 				$object->signature = GETPOST("signature", 'restricthtml');
+				// restricthtml may swap the value with the literal 'ErrorTooManyLinksIntoHTMLString'
+				// when the html exceeds MAIN_SECURITY_MAX_IMG_IN_HTML_CONTENT (see issue #27987).
+				// Refuse the save so the literal does not end up persisted and later sent as an
+				// email body to customers.
+				if ($object->signature === 'ErrorTooManyLinksIntoHTMLString') {
+					$error++;
+					$langs->load("errors");
+					setEventMessages($langs->trans('ErrorTooManyLinksIntoHTMLString'), null, 'errors');
+					$action = 'edit';
+				}
 				$object->accountancy_code = GETPOST("accountancy_code", 'alphanohtml');
 				$object->openid = GETPOST("openid", 'alphanohtml');
 				$object->fk_user = GETPOSTINT("fk_user") > 0 ? GETPOSTINT("fk_user") : 0;


### PR DESCRIPTION
When the user signature contains more inline links/images than `MAIN_SECURITY_MAX_IMG_IN_HTML_CONTENT` allows, `GETPOST('signature', 'restricthtml')` returns the literal string `'ErrorTooManyLinksIntoHTMLString'` instead of the sanitized HTML (see `htdocs/core/lib/functions.lib.php:8755-8757`). On the `user/card.php` save sites, that literal was assigned verbatim to `$object->signature` and persisted; the next outgoing email then used the literal as the signature block, so the customer received an email whose entire signature was the string `ErrorTooManyLinksIntoHTMLString`. @iouston reported this symptom in April 2025 ("the mail is threw but the content of mail is replaced by TooManyLinksIntoHTMLString [...] This is very bad for the customer which received it. In this case the mail should not be send").

Detect the literal at both save sites (`action == 'add'` around line 316 and `action == 'update'` around line 499), increment `$error`, surface a clear `setEventMessages` and route the user back to the form so the signature is not persisted. The `MAIN_SECURITY_MAX_IMG_IN_HTML_CONTENT` setting is the legitimate guard; this PR only ensures its rejection output never reaches the database or downstream emails.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0. Other forms that use `restricthtml` for HTML body fields (mails_senderprofile signature, ticket signatures, mail templates) are subject to the same root cause and should get the same guard, but they are separate save flows and out of scope for this atomic fix.