### PR TITLE
Fix #31135 align project dropdown filter on supplier recurring invoices

### DIFF
--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -1005,7 +1005,10 @@ if ($action == 'create') {
 			$projectid = GETPOST('projectid') ? GETPOST('projectid') : $object->fk_project;
 			$langs->load('projects');
 			print '<tr><td>' . $langs->trans('Project') . '</td><td>';
-			$numprojet = $formproject->select_projects($object->thirdparty->id, $projectid, 'projectid', 0, 0, 1, 0, 0, 0, 0, '', 0, 0, '');
+			// Mirror the regular supplier invoice card.php: honour PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS
+			// (so projects unrelated to this supplier can be picked when the constant is set) and exclude
+			// closed projects from the dropdown (see issue #31135).
+			$numprojet = $formproject->select_projects((!getDolGlobalString('PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS') ? $object->thirdparty->id : -1), $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 0, 0, '');
 			print ' &nbsp; <a href="' . DOL_URL_ROOT . '/projet/card.php?socid=' . $object->thirdparty->id . '&action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&socid=' . $object->thirdparty->id . (!empty($id) ? '&id=' . $id : '')) . '">' . $langs->trans("AddProject") . '</a>';
 			print '</td></tr>';
 		}
@@ -1196,7 +1199,10 @@ if ($action == 'create') {
 					$morehtmlref .= '<form method="post" action="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '">';
 					$morehtmlref .= '<input type="hidden" name="action" value="classin">';
 					$morehtmlref .= '<input type="hidden" name="token" value="' . newToken() . '">';
-					$morehtmlref .= $formproject->select_projects($object->socid, $object->fk_project, 'projectid', $maxlength, 0, 1, 0, 1, 0, 0, '', 1);
+					// Mirror the regular supplier invoice card.php: honour PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS
+					// and exclude closed projects so the picker behaves like the one in the non-recurring
+					// supplier invoice form (see issue #31135).
+					$morehtmlref .= $formproject->select_projects((!getDolGlobalString('PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS') ? $object->socid : -1), $object->fk_project, 'projectid', $maxlength, 0, 1, 1, 1, 0, 0, '', 1);
 					$morehtmlref .= '<input type="submit" class="button valignmiddle" value="' . $langs->trans("Modify") . '">';
 					$morehtmlref .= '</form>';
 				} else {

--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -1005,9 +1005,6 @@ if ($action == 'create') {
 			$projectid = GETPOST('projectid') ? GETPOST('projectid') : $object->fk_project;
 			$langs->load('projects');
 			print '<tr><td>' . $langs->trans('Project') . '</td><td>';
-			// Mirror the regular supplier invoice card.php: honour PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS
-			// (so projects unrelated to this supplier can be picked when the constant is set) and exclude
-			// closed projects from the dropdown (see issue #31135).
 			$numprojet = $formproject->select_projects((!getDolGlobalString('PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS') ? $object->thirdparty->id : -1), $projectid, 'projectid', 0, 0, 1, 1, 0, 0, 0, '', 0, 0, '');
 			print ' &nbsp; <a href="' . DOL_URL_ROOT . '/projet/card.php?socid=' . $object->thirdparty->id . '&action=create&status=1&backtopage=' . urlencode($_SERVER["PHP_SELF"] . '?action=create&socid=' . $object->thirdparty->id . (!empty($id) ? '&id=' . $id : '')) . '">' . $langs->trans("AddProject") . '</a>';
 			print '</td></tr>';
@@ -1199,9 +1196,6 @@ if ($action == 'create') {
 					$morehtmlref .= '<form method="post" action="' . $_SERVER['PHP_SELF'] . '?id=' . $object->id . '">';
 					$morehtmlref .= '<input type="hidden" name="action" value="classin">';
 					$morehtmlref .= '<input type="hidden" name="token" value="' . newToken() . '">';
-					// Mirror the regular supplier invoice card.php: honour PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS
-					// and exclude closed projects so the picker behaves like the one in the non-recurring
-					// supplier invoice form (see issue #31135).
 					$morehtmlref .= $formproject->select_projects((!getDolGlobalString('PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS') ? $object->socid : -1), $object->fk_project, 'projectid', $maxlength, 0, 1, 1, 1, 0, 0, '', 1);
 					$morehtmlref .= '<input type="submit" class="button valignmiddle" value="' . $langs->trans("Modify") . '">';
 					$morehtmlref .= '</form>';


### PR DESCRIPTION
`htdocs/fourn/facture/card-rec.php` showed an almost-empty project dropdown when classifying or creating a recurring supplier invoice: only closed projects unrelated to the supplier and a few orphan ones appeared. The regular supplier invoice form (`htdocs/fourn/facture/card.php` at `2756` and `3290`) does not have that problem because it honours the global `PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS` toggle and passes `$discard_closed=1` to `FormProjets::select_projects()`; the recurring form passed the thirdparty id unconditionally and `$discard_closed=0`.

Mirror the regular form in both call sites (the create flow around line 1008 and the classify-edit flow around line 1199): use `(!PROJECT_CAN_ALWAYS_LINK_TO_ALL_SUPPLIERS ? socid : -1)` for the `socid` filter and pass `$discard_closed=1`. Open projects of any thirdparty are now selectable when the constant is set, closed projects no longer appear in either branch.

The thread on the issue has two opposed views (@lamrani002 vs @apio-sys and @leonbrehme). The convergent point all participants agree on is that the recurring form should behave the same as the non-recurring one, which is what this PR delivers; the broader question of whether closed projects should ever be selectable is the same in both forms and is not in scope here.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.