### PR TITLE
Fix #29985 add entity index on llx_product_attribute

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -332,4 +332,7 @@ ALTER TABLE llx_webhook_history MODIFY COLUMN url varchar(255);
 
 UPDATE llx_c_socialnetworks SET icon = 'fa-mastodon' WHERE icon = '' AND code = 'mastodon';
 
+-- Performance: speed up variants/list.php on multi-entity installs with many attributes (see #29985)
+ALTER TABLE llx_product_attribute ADD INDEX idx_product_attribute_entity (entity);
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_product_attribute-variants.key.sql
+++ b/htdocs/install/mysql/tables/llx_product_attribute-variants.key.sql
@@ -17,3 +17,4 @@
 -- ============================================================================
 
 ALTER TABLE llx_product_attribute ADD UNIQUE INDEX uk_product_attribute_ref (ref);
+ALTER TABLE llx_product_attribute ADD INDEX idx_product_attribute_entity (entity);


### PR DESCRIPTION
`htdocs/variants/list.php` builds the list of attributes with a query that groups on `t.rowid` and joins `llx_product_attribute_value` and `llx_product_attribute_combination2val` to count values and products per attribute. The `WHERE` clause filters on `t.entity` to scope the list to the current Dolibarr entity, but `llx_product_attribute` has no index on `entity`, so the engine has to scan the full table before the joins can be evaluated.

The reporter (@enjoping) profiled the page on an install with 7291 attribute values and 103593 `combination2val` rows: adding an index on `llx_product_attribute(entity)` drops the query cost from ~117000 to ~2340 (50x improvement). The second index they suggested (`fk_prod_attr` on `llx_product_attribute_combination2val`) already exists since the 20.0.0->21.0.0 migration (`idx_product_att_com2v_prod_attr`), so only the entity index is missing.

Add the missing index to the table definition (for fresh installs) and to the `21.0.0-22.0.0.sql` migration (for existing installs upgrading to 22.x). The rewrite of the JOIN to subqueries that the reporter also proposed is left out of this PR: it touches the hooks contract for `printFieldListFrom`, `printFieldListWhere` and `printFieldListGroupBy` and warrants a separate discussion. The index alone is enough to make the page load in a reasonable time for the reported workload.

PR targets `develop` because the 21.0.0->22.0.0 migration only exists from 22.0 onward (the 21.0 branch has already shipped its migration). Same schema on develop.