### PR TITLE
Fix #29799 widen RUM truncation so customer code fits

### DIFF
--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -2187,8 +2187,11 @@ class BonPrelevement extends CommonObject
 
 		$pre = substr(dol_string_nospecial(dol_string_unaccent($langs->transnoentitiesnoconv('RUM'))), 0, 3); // Must always be on 3 char ('RUM' or 'UMR'. This is a protection against bad translation)
 
-		// 3 char + '-' + 12 + '-' + id + '-' + code 		Must be lower than 32.
-		return $pre . '-' . dol_print_date($row_datec, 'dayhourlogsmall') . '-' . dol_trunc($row_drum . ($row_code_client ? '-' . $row_code_client : ''), 13, 'right', 'UTF-8', 1);
+		// 3 char + '-' + 10 (yymmddHHMM) + '-' + id + '-' + code, kept under the SEPA 35 char limit for MndtId.
+		// The original truncation to 13 chars was too aggressive: any customer code longer than ~10 char
+		// got truncated mid-string and the resulting UMR did not match the customer code on later lookups
+		// (see issue #29799). Bump to 20 so a typical "CU2509-00012" style code plus a small drum id fits.
+		return $pre . '-' . dol_print_date($row_datec, 'dayhourlogsmall') . '-' . dol_trunc($row_drum . ($row_code_client ? '-' . $row_code_client : ''), 20, 'right', 'UTF-8', 1);
 	}
 
 

--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -2187,11 +2187,8 @@ class BonPrelevement extends CommonObject
 
 		$pre = substr(dol_string_nospecial(dol_string_unaccent($langs->transnoentitiesnoconv('RUM'))), 0, 3); // Must always be on 3 char ('RUM' or 'UMR'. This is a protection against bad translation)
 
-		// 3 char + '-' + 10 (yymmddHHMM) + '-' + id + '-' + code, kept under the SEPA 35 char limit for MndtId.
-		// The original truncation to 13 chars was too aggressive: any customer code longer than ~10 char
-		// got truncated mid-string and the resulting UMR did not match the customer code on later lookups
-		// (see issue #29799). Bump to 20 so a typical "CU2509-00012" style code plus a small drum id fits.
-		return $pre . '-' . dol_print_date($row_datec, 'dayhourlogsmall') . '-' . dol_trunc($row_drum . ($row_code_client ? '-' . $row_code_client : ''), 20, 'right', 'UTF-8', 1);
+		// 3 char + '-' + 10 (yymmddHHMM) + '-' + id + '-' + code. Must be under 32 (SEPA char limit for MndtId is however 35).
+		return $pre . '-' . dol_print_date($row_datec, 'dayhourlogsmall') . '-' . dol_trunc($row_drum . ($row_code_client ? '-' . $row_code_client : ''), 17, 'right', 'UTF-8', 1);
 	}
 
 


### PR DESCRIPTION
`BonPrelevement::buildRumNumber()` builds an auto-generated SEPA UMR when no UMR was supplied on a new bank-mandate row. The format is

```
{RUM/UMR}-{yymmddHHMM}-{drum_id-customer_code}
```

with the tail truncated to 13 characters. That truncation is too aggressive: typical Dolibarr customer codes (`CU1908-00002`, `CU2509-00012`, ...) are already 12 characters, so any drum id at all pushes the tail past 13 and the customer code is cut mid-string. The generated UMR then no longer matches the actual customer code, which is the symptom in the report ("customer code `CU1908-00002` becomes `1-CU1908-0000` in the UMR").

The SEPA standard allows up to 35 characters for MndtId. The non-truncatable prefix (`RUM/UMR` + `-` + 10-char date + `-`) uses 15 characters, leaving up to 20 characters for the tail before hitting the 35-char limit, and 17 before hitting the more conservative 32-char target the original comment referenced. Bump the truncation to 20: the typical drum-id + 12-char customer code (14 chars) now fits cleanly, and longer codes still get truncated but at a much later point.

Only the generation of newly created mandates is affected. Existing `$companybankaccount->rum` values stored in the database are not touched, so no migration is needed.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.