### PR TITLE
Fix #29052 preserve IRPF / localtax2 when cloning an invoice

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1276,6 +1276,12 @@ class Facture extends CommonInvoice
 		$this->db->begin();
 
 		$object->fetch($fromid);
+		// fetch() clears $object->thirdparty, but the subsequent $object->create() path
+		// reaches addLine() -> getLocalTaxesFromRate() -> get_localtax() and uses the
+		// buyer thirdparty to decide whether IRPF/localtax2 applies. Without this fetch,
+		// get_localtax() sees $thirdparty_buyer = null, returns 0 and the cloned lines
+		// lose their localtax2_tx (see issue #29052).
+		$object->fetch_thirdparty();
 
 		// Load source object
 		$objFrom = clone $object;


### PR DESCRIPTION
`Facture::createFromClone()` calls `Facture::fetch($fromid)` to populate the in-memory object, then immediately runs `$object->create($user)` to persist the clone. `fetch()` explicitly sets `$this->thirdparty = null;`, and the clone path never calls `fetch_thirdparty()` before `create()`.

When `create()` walks the cloned lines it goes through `addLine()` -> `getLocalTaxesFromRate($txtva, 0, $this->thirdparty, $mysoc)` -> `get_localtax($vatrate, 2, $buyer, $seller)`. The buyer argument is the now-null `$this->thirdparty`, and `get_localtax()` guards on `!$thirdparty_buyer->localtax2_assuj` and returns 0 as soon as that property is unreadable. `calcul_price_total()` then computes `total_localtax2 = 0`, and `addLine()` resets the line's `localtax2_tx` to 0 (the "if ($total_localtax2)" branch). The cloned line is inserted with the IRPF (localtax2) rate stripped, which is the symptom the reporter and the four other thread participants observed (@cehojac for the REST API, recurring invoices and invoice templates; @developmentOYR confirmed still present in 2025; @gonzalovlchz confirmed for recurring invoices in 2025-09).

Call `fetch_thirdparty()` once in `createFromClone()` so the buyer is populated for the rest of the clone flow. The fix is local to the clone path; the regular "create from form" flow already had a thirdparty set by its caller and is not affected.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.