### PR TITLE
Fix #32053 use getDolGlobalString for INVOICE_SUPPLIER_ADDON_PDF

### DIFF
--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -1033,7 +1033,7 @@ if ($action == 'create') {
 		print "<tr><td>" . $langs->trans('Model') . "</td><td>";
 		include_once DOL_DOCUMENT_ROOT . '/core/modules/supplier_invoice/modules_facturefournisseur.php';
 		$list = ModelePDFSuppliersInvoices::liste_modeles($db);
-		print $form->selectarray('modelpdf', $list, $conf->global->INVOICE_SUPPLIER_ADDON_PDF);
+		print $form->selectarray('modelpdf', $list, getDolGlobalString('INVOICE_SUPPLIER_ADDON_PDF'));
 		print "</td></tr>";
 
 		// Public note


### PR DESCRIPTION
`htdocs/fourn/facture/card-rec.php` rendered the PDF model dropdown by reading the constant directly with `$conf->global->INVOICE_SUPPLIER_ADDON_PDF`. On PHP 8 that raises `Warning: Undefined property stdClass::$INVOICE_SUPPLIER_ADDON_PDF` whenever the constant is not set, which is the typical case on a fresh install or on installs that have never picked an explicit supplier invoice PDF model. The warning shows up in the UI when an admin converts a supplier invoice into a recurring template (see issue #32053, still present in 21.0.0 per @mikygee).

Replace the direct property read with `getDolGlobalString()` which returns an empty string when the constant is undefined; `selectarray()` then just renders the dropdown without a preselected value, matching the previous behaviour minus the PHP warning.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.