### PR TITLE
Fix #32343 normalize product accountancy code so API matches GUI

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1026,6 +1026,19 @@ class Product extends CommonObject
 		$this->accountancy_code_sell_intra = trim($this->accountancy_code_sell_intra);
 		$this->accountancy_code_sell_export = trim($this->accountancy_code_sell_export);
 
+		// Normalize the accountancy codes the way the admin dropdown does it, so an API client that
+		// sends '606111000' ends up with the same '606111' value the GUI stores (see issue #32343).
+		// When ACCOUNTING_MANAGE_ZERO is on, trailing zeros are part of the code and must be kept.
+		if (!getDolGlobalString('ACCOUNTING_MANAGE_ZERO')) {
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/accounting.lib.php';
+			$this->accountancy_code_buy = clean_account($this->accountancy_code_buy);
+			$this->accountancy_code_buy_intra = clean_account($this->accountancy_code_buy_intra);
+			$this->accountancy_code_buy_export = clean_account($this->accountancy_code_buy_export);
+			$this->accountancy_code_sell = clean_account($this->accountancy_code_sell);
+			$this->accountancy_code_sell_intra = clean_account($this->accountancy_code_sell_intra);
+			$this->accountancy_code_sell_export = clean_account($this->accountancy_code_sell_export);
+		}
+
 		// Barcode value
 		$this->barcode = trim($this->barcode);
 		$this->mandatory_period = empty($this->mandatory_period) ? 0 : $this->mandatory_period;
@@ -1439,6 +1452,19 @@ class Product extends CommonObject
 		$this->accountancy_code_sell = trim($this->accountancy_code_sell);
 		$this->accountancy_code_sell_intra = trim($this->accountancy_code_sell_intra);
 		$this->accountancy_code_sell_export = trim($this->accountancy_code_sell_export);
+
+		// Normalize the accountancy codes the way the admin dropdown does it, so an API client that
+		// sends '606111000' ends up with the same '606111' value the GUI stores (see issue #32343).
+		// When ACCOUNTING_MANAGE_ZERO is on, trailing zeros are part of the code and must be kept.
+		if (!getDolGlobalString('ACCOUNTING_MANAGE_ZERO')) {
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/accounting.lib.php';
+			$this->accountancy_code_buy = clean_account($this->accountancy_code_buy);
+			$this->accountancy_code_buy_intra = clean_account($this->accountancy_code_buy_intra);
+			$this->accountancy_code_buy_export = clean_account($this->accountancy_code_buy_export);
+			$this->accountancy_code_sell = clean_account($this->accountancy_code_sell);
+			$this->accountancy_code_sell_intra = clean_account($this->accountancy_code_sell_intra);
+			$this->accountancy_code_sell_export = clean_account($this->accountancy_code_sell_export);
+		}
 
 
 		$this->db->begin();


### PR DESCRIPTION
The admin product page renders the accountancy code dropdown via `FormAccounting::select_account()`. For each row in `llx_accounting_account` it displays the padded label `length_accountg($obj->account_number)` but the option value is the raw `account_number`, so picking `606111000 - Wood for resale` submits the form with `accountancy_code_sell = '606111'`.

When the same value is set through the REST API (`POST /api/index.php/products` with `accountancy_code_sell = '606111000'`) `Product::create()` only does a `trim()` and stores the value verbatim. The next GUI render of the product card then cannot match `'606111000'` against the dropdown option list (which still uses raw `'606111'` as the value) and falls back to the blank `- - -` option; saving the form silently rewrites the value to whatever was selected, which is exactly the cycle the reporter and @mikygee described.

Apply `clean_account()` (which is `rtrim('0')`) to the six accountancy code fields right after the existing `trim()` in `Product::create()` and `Product::update()`, and only when the global `ACCOUNTING_MANAGE_ZERO` constant is off (the same condition that drives `length_accountg()` in the admin dropdown). Installs that rely on trailing zeros being part of the code (`ACCOUNTING_MANAGE_ZERO = 1`) keep the previous behaviour; default installs end up with the same stored value whether the row comes in through the form or the API.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.