### PR TITLE
Fix #32372 surface variant updateProperties failure instead of price=0

### DIFF
--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -436,7 +436,14 @@ class ProductCombination
 		$parent = new Product($this->db);
 		$parent->fetch($this->fk_product_parent);
 
-		$this->updateProperties($parent, $user);
+		// Propagate failure of updateProperties (otherwise an update where the variant
+		// percentage drives the new price below the parent product's price_min returns
+		// success but leaves the variant product at the price=0 it had right after
+		// createProductCombination, see issue #32372).
+		$result = $this->updateProperties($parent, $user);
+		if ($result < 0) {
+			return $result;
+		}
 
 		return 1;
 	}


### PR DESCRIPTION
`ProductCombination::update()` called `$this->updateProperties($parent, $user)` at line 439 and discarded the return value. `updateProperties()` walks the parent's price levels, computes the variant price from the combination's `variation_price` / `variation_price_percentage` and calls `Product::updatePrice()` on the child product. `updatePrice()` refuses to set a price below the configured `price_min` (returns -1 with `ErrorPriceCantBeLowerThanMinPrice`), but `ProductCombination::update()` still returned 1 because the failure was thrown away.

`createProductCombination()` initialises the new variant product with `price = price_ttc = price_min = price_min_ttc = 0` to keep a clean price history, then commits the combination by calling `$newcomb->update($user)`. When the parent product has a non-zero minimum price and the variation drops the computed price below it, `updateProperties()` returns -1, `update()` reports success anyway, the combination is committed and the variant product stays at price 0. The card displays price 0 and minimum 0 with no error message, which is exactly the behaviour the reporter described and that @JonBendtsen confirmed was still present on develop after the v22 release.

Capture `updateProperties()`'s return value and propagate the negative result so the calling `createProductCombination()` sees the failure, rolls back the transaction and surfaces the underlying `ErrorPriceCantBeLowerThanMinPrice` message. The variant is no longer silently created with a 0 price; users get either the legitimate adjusted price (when the variation is permissible) or a clear error prompting them to drop the parent's minimum price first.

Same code path on 21.0, 22.0, 23.0 and develop; PR targets 21.0.