### PR TITLE
Fix #34596 guard extralanguages access for PHP 8

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -437,7 +437,10 @@ class Form
 			}
 			$extralanguages->fetch_name_extralanguages('societe');
 
-			if (!is_array($extralanguages->attributes[$object->element]) || empty($extralanguages->attributes[$object->element][$fieldname])) {
+			// ExtraLanguages::fetch_name_extralanguages() leaves $this->attributes empty
+			// when MAIN_USE_ALTERNATE_TRANSLATION_FOR is not configured, so PHP 8 raises
+			// 'Undefined array key' on the read below if we do not guard it (issue #34596).
+			if (empty($extralanguages->attributes[$object->element]) || !is_array($extralanguages->attributes[$object->element]) || empty($extralanguages->attributes[$object->element][$fieldname])) {
 				return ''; // No extralang field to show
 			}
 
@@ -10312,7 +10315,9 @@ class Form
 				}
 				$extralanguages->fetch_name_extralanguages('societe');
 
-				if (!empty($extralanguages->attributes['societe']['name'])) {
+				// Guard against PHP 8 'Undefined array key' when MAIN_USE_ALTERNATE_TRANSLATION_FOR
+				// is not configured and fetch_name_extralanguages() leaves attributes empty (issue #34596).
+				if (!empty($extralanguages->attributes['societe']) && !empty($extralanguages->attributes['societe']['name'])) {
 					$object->fetchValuesForExtraLanguages();
 
 					$htmltext = '';


### PR DESCRIPTION
On a default install MAIN_USE_ALTERNATE_TRANSLATION_FOR is not set, so ExtraLanguages::fetch_name_extralanguages() leaves \$this->attributes empty. PHP 8 then raises "Undefined array key 'societe'" at two read sites in html.form.class.php that only check the inner key.

Add an explicit parent-key check on both sites so the array access does not raise. Same paths exist on 21.0 / 22.0 / 23.0 / develop; this PR targets 21.0.

Reproduced on PHP 8.2: vanilla expression \`!is_array(\$attrs['societe']) || empty(\$attrs['societe'][\$f])\` raises Undefined array key on the first read; patched expression \`empty(\$attrs['societe']) || !is_array(\$attrs['societe']) || empty(\$attrs['societe'][\$f])\` short-circuits cleanly with zero warnings. Second site uses the same parent-key empty() guard for consistency.