### PR TITLE
Fix #34610 set product default unit on line picker

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -928,6 +928,14 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 							console.log("stringforvatrateselection="+stringforvatrateselection+" -> value of option label for this key="+$('#tva_tx option[value="'+stringforvatrateselection+'"]').val());
 							$('#tva_tx option[value="'+stringforvatrateselection+'"]').prop('selected', true);
 
+							// Sync the measuring unit dropdown with the product's default fk_unit
+							// (issue #34610). Without this the dropdown keeps the static initial
+							// value (the first c_units row, typically "Kg") regardless of what
+							// the selected product is configured with.
+							if (typeof data.fk_unit != 'undefined' && data.fk_unit != null && $("#units").length) {
+								$("#units").val(data.fk_unit).trigger('change');
+							}
+
 								<?php
 								if (getDolGlobalInt('PRODUIT_AUTOFILL_DESC') == 1) {
 									if (getDolGlobalInt('MAIN_MULTILANGS') && getDolGlobalString('PRODUIT_TEXTS_IN_THIRDPARTY_LANGUAGE')) { ?>

--- a/htdocs/product/ajax/products.php
+++ b/htdocs/product/ajax/products.php
@@ -286,6 +286,10 @@ if ($action == 'fetch' && !empty($id)) {
 			'qty' => $outqty,
 			'discount' => $outdiscount,
 			'mandatory_period' => $mandatory_period,
+			// Return the product's default measuring unit so the order/proposal/invoice
+			// line form can preselect it when the user picks a product, instead of
+			// always falling back to the first entry of llx_c_units (issue #34610).
+			'fk_unit' => $object->fk_unit,
 			'array_options'=>$object->array_options
 		);
 	}


### PR DESCRIPTION
The product picker on order/proposal/invoice lines always left the measuring-unit dropdown at the static initial value (the first row of llx_c_units, typically "Kg"), even when the picked product had its own default in llx_product.fk_unit. Five users on the issue thread confirmed the same symptom.

Two pieces were missing:
1. htdocs/product/ajax/products.php did not include fk_unit in the JSON payload.
2. htdocs/core/tpl/objectline_create.tpl.php did not update #units when the ajax response came back.

Add fk_unit to the JSON and a small jQuery snippet right after the VAT update that pushes it into #units and fires change so Select2 redraws. Products without an fk_unit (NULL) keep the previous static default thanks to the typeof / null guard. Same code path on 21.0 / 22.0 / 23.0 / develop.

Reproduced on PHP 8.2 with the Docker dev install: created a product with fk_unit=2, called Product::fetch + replayed the AJAX response shape - JSON now carries \`"fk_unit":"2"\`. JS side guard \`typeof data.fk_unit != 'undefined' && data.fk_unit != null && \$("#units").length\` is the only thing that needs to be true for the update to fire.