### PR TITLE
Fix #34540 use template language for __(TranslationKey)__ substitution

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -1038,7 +1038,7 @@ class FormMail extends Form
 				$defaultlines = $arraydefaultmessage->content_lines;
 				if (isset($defaultlines)) {
 					foreach ($this->substit_lines as $lineid => $substit_line) {
-						$lines .= make_substitutions($defaultlines, $substit_line)."\n";
+						$lines .= make_substitutions($defaultlines, $substit_line, $outputlangs)."\n";
 					}
 				}
 				$this->substit['__LINES__'] = $lines;
@@ -1083,7 +1083,10 @@ class FormMail extends Form
 				if (GETPOSTISSET("message") && !GETPOST('modelselected')) {
 					$defaultmessage = GETPOST("message", "restricthtml");
 				} else {
-					$defaultmessage = make_substitutions($defaultmessage, $this->substit);
+					// Pass $outputlangs so __(TranslationKey)__ in the template body is resolved
+					// in the language of the selected email template, not the operator's language
+					// (see issue #34540).
+					$defaultmessage = make_substitutions($defaultmessage, $this->substit, $outputlangs);
 					// Clean first \n and br (to avoid empty line when CONTACTCIVNAME is empty)
 					$defaultmessage = preg_replace("/^(<br>)+/", "", $defaultmessage);
 					$defaultmessage = preg_replace("/^\n+/", "", $defaultmessage);
@@ -1460,7 +1463,7 @@ class FormMail extends Form
 	 */
 	public function getHtmlForTopic($arraydefaultmessage, $helpforsubstitution)
 	{
-		global $langs, $form;
+		global $conf, $langs, $form;
 
 		$defaulttopic = GETPOST('subject', 'restricthtml');
 
@@ -1472,7 +1475,17 @@ class FormMail extends Form
 			}
 		}
 
-		$defaulttopic = make_substitutions($defaulttopic, $this->substit);
+		// Resolve __(TranslationKey)__ in the language of the selected template
+		// (see issue #34540). Falls back to the caller's language when the template
+		// has no explicit language pinned.
+		$outputlangs = $langs;
+		if (is_object($arraydefaultmessage) && !empty($arraydefaultmessage->lang)) {
+			$outputlangs = new Translate("", $conf);
+			$outputlangs->setDefaultLang($arraydefaultmessage->lang);
+			$outputlangs->load('other');
+		}
+
+		$defaulttopic = make_substitutions($defaulttopic, $this->substit, $outputlangs);
 
 		$out = '<tr>';
 		$out .= '<td class="fieldrequired">';


### PR DESCRIPTION
make_substitutions resolves __(TranslationKey)__ via its third \$outputlangs argument, falling back to the global \$langs (operator language) when nothing is passed. The mail-template helpers in html.formmail.class.php already compute the recipient language at lines 509-518 (from \$this->param['langsmodels'] or the template's own lang column) but the three sites that turn the template body and subject into the final preview dropped the argument:

- line 1041 (rebuilding __LINES__ from content_lines)
- line 1086 (substituting the template body for the form preview)
- line 1478 (substituting the topic in getHtmlForTopic)

So a key set up in two languages was always resolved with the operator's locale, never the recipient's. Pass \$outputlangs at the two main render sites, and compute it from the template's lang column in getHtmlForTopic so subject and body are localised together. Templates with no explicit lang still resolve via the operator's language, preserving the prior behaviour for that case.

Reproduced on PHP 8.2 in Docker: make_substitutions("Body __(Hello)__", []) with operator en_US returns "Body Hello"; passing a fr_FR Translate returns "Body Bonjour".