### PR TITLE
Fix #34656 keep reminder cron running when one template lookup fails

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5876,12 +5876,24 @@ class Facture extends CommonInvoice
 					// Select email template according to language of recipient
 					$arraymessage = $formmail->getEMailTemplate($this->db, 'facture_send', $user, $outputlangs, (is_numeric($template) ? $template : 0), 1, (is_numeric($template) ? '' : $template));
 					if (is_numeric($arraymessage) && $arraymessage <= 0) {
-						// The template is missing in the recipient's language (or under
-						// the chosen code). Log the issue and skip this invoice, instead
-						// of aborting the whole cron run so a single broken thirdparty
-						// does not silently stop the reminders for everyone else
-						// (see issue #34656).
 						$langs->load("errors");
+						if (is_numeric($template)) {
+							// The cron was started with a template id and that id cannot be
+							// resolved at all. This is almost certainly a global setup error
+							// (template deleted or wrong id passed to the cron), and every
+							// remaining invoice in this batch would fail the same way. Stop
+							// here so the operator can fix the setup before retrying, instead
+							// of flooding the cron output with one identical error per
+							// invoice (per @eldy's review of PR #38547).
+							$this->output .= $langs->trans('ErrorFailedToFindEmailTemplate', $template);
+							return 0;
+						}
+						// The cron was started with a template label and getEMailTemplate
+						// also filters by the recipient's language (see html.formmail.class.php
+						// line 1786). Only the invoices for thirdparties whose default_lang
+						// has no matching template fail; the rest of the batch is fine.
+						// Log the error and continue so a single missing translation does
+						// not stop reminders for everyone else (see issue #34656).
 						$errorsMsg[] = $langs->trans('ErrorFailedToFindEmailTemplate', $template).' (invoice '.$tmpinvoice->ref.')';
 						continue;
 					}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -5876,9 +5876,14 @@ class Facture extends CommonInvoice
 					// Select email template according to language of recipient
 					$arraymessage = $formmail->getEMailTemplate($this->db, 'facture_send', $user, $outputlangs, (is_numeric($template) ? $template : 0), 1, (is_numeric($template) ? '' : $template));
 					if (is_numeric($arraymessage) && $arraymessage <= 0) {
+						// The template is missing in the recipient's language (or under
+						// the chosen code). Log the issue and skip this invoice, instead
+						// of aborting the whole cron run so a single broken thirdparty
+						// does not silently stop the reminders for everyone else
+						// (see issue #34656).
 						$langs->load("errors");
-						$this->output .= $langs->trans('ErrorFailedToFindEmailTemplate', $template);
-						return 0;
+						$errorsMsg[] = $langs->trans('ErrorFailedToFindEmailTemplate', $template).' (invoice '.$tmpinvoice->ref.')';
+						continue;
 					}
 
 					// PREPARE EMAIL


### PR DESCRIPTION
Facture::sendEmailsRemindersOnInvoiceDueDate() walks unpaid invoices and looks up an email template per recipient. When the lookup at line 5877 returned an error, it did \`return 0\` from inside the while-loop, abandoning every remaining invoice. One bad thirdparty wedged the reminders for everybody.

Replace the early return with a per-invoice diagnostic + continue, mirroring the existing failure path of the same function: \`\$errorsMsg[]\` is the same array filled at lines 6058 and 6061, and is emitted into \`\$this->error\` at line 6078 once the loop completes. So the operator still sees the diagnostic in the cron output and the subsequent invoices are still processed.

Reproduced on PHP 8.2 in Docker via a control-flow replay (4 invoices, the second one with a missing template): vanilla path sends only the first then aborts; patched path sends 3 of 4 and records "ErrorFailedToFindEmailTemplate (invoice B)" in the errors array.