### PR TITLE
Fix #34352 mass subscription end date from AdherentType duration

### DIFF
--- a/htdocs/adherents/list.php
+++ b/htdocs/adherents/list.php
@@ -378,7 +378,20 @@ if (empty($reshook)) {
 		foreach ($toselect as $id) {
 			$res = $tmpmember->fetch($id);
 			if ($res > 0) {
-				$result = $tmpmember->subscription($now, $amount, 0, '', '', '', '', '', $datesubend);
+				// Mirror the single subscription form (adherents/subscription.php): if no
+				// global EOM/EOY override was set, compute the end date from the member's
+				// AdherentType duration_value/duration_unit so a 6-month type does not
+				// silently fall back to the 1-year default in Adherent::subscription()
+				// (see issue #34352).
+				$datesubendthismember = $datesubend;
+				if (!$datesubendthismember && $tmpmember->typeid > 0) {
+					if ($adht->fetch($tmpmember->typeid) > 0) {
+						$delay = !empty($adht->duration_value) ? $adht->duration_value : 1;
+						$delayunit = !empty($adht->duration_unit) ? $adht->duration_unit : 'y';
+						$datesubendthismember = dol_time_plus_duree(dol_time_plus_duree($now, $delay, $delayunit), -1, 'd');
+					}
+				}
+				$result = $tmpmember->subscription($now, $amount, 0, '', '', '', '', '', $datesubendthismember);
 				if ($result < 0) {
 					$error++;
 				} else {


### PR DESCRIPTION
The single subscription form (adherents/subscription.php) computes the end date from the selected AdherentType (duration_value + duration_unit), and only falls back to one year when those are empty. The mass action on the member list (adherents/list.php createsubscription_confirm) skipped that step and called Adherent::subscription(..., \$datesubend=0). Adherent::subscription treats 0 as "no end date" and defaults to one year minus one day, so a member type configured for 6 months ended up with a 12 month subscription whenever the mass action was used.

Compute the per-member end date before the call, mirroring the single form: fetch the AdherentType of the current member, take duration_value/duration_unit, add to \$now. The existing MEMBER_SUBSCRIPTION_SUGGEST_END_OF_MONTH/EOY override (commit b1d906d6d38) still wins when set because \$datesubend keeps its computed value; the per-type fallback only kicks in when no global override was used.

Reproduced on PHP 8.2 in Docker: a 6-month type via the patched arithmetic yields end=2026-11-30 for a 2026-05-31 start; the vanilla mass action defaulted to 2027-05-30 (1 year).