### PR TITLE
Fix #34069 read shipping weight, dimensions and quantities as floats

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -254,10 +254,10 @@ if (empty($reshook)) {
 		// Weight and box dimensions are physical measurements that frequently use
 		// decimals (1.6 kg, 0.25 m, ...), so they must be read as floats and not
 		// truncated to int (see issue #34069 for the shipping module).
-		$object->weight = GETPOST('weight', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('weight', 'alpha'));
-		$object->sizeH = GETPOST('sizeH', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('sizeH', 'alpha'));
-		$object->sizeW = GETPOST('sizeW', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('sizeW', 'alpha'));
-		$object->sizeS = GETPOST('sizeS', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('sizeS', 'alpha'));
+		$object->weight = GETPOST('weight', 'alpha') == '' ? "NULL" : GETPOSTFLOAT('weight');
+		$object->sizeH = GETPOST('sizeH', 'alpha') == '' ? "NULL" : GETPOSTFLOAT('sizeH');
+		$object->sizeW = GETPOST('sizeW', 'alpha') == '' ? "NULL" : GETPOSTFLOAT('sizeW');
+		$object->sizeS = GETPOST('sizeS', 'alpha') == '' ? "NULL" : GETPOSTFLOAT('sizeS');
 		$object->size_units = GETPOSTINT('size_units');
 		$object->weight_units = GETPOSTINT('weight_units');
 
@@ -582,18 +582,18 @@ if (empty($reshook)) {
 			$object->tracking_url = trim(GETPOST('tracking_url', 'restricthtml'));
 		}
 		if ($action == 'settrueWeight') {
-			$object->trueWeight = (float) price2num(GETPOST('trueWeight', 'alpha'));
+			$object->trueWeight = GETPOSTFLOAT('trueWeight');
 			$object->weight_units = GETPOSTINT('weight_units');
 		}
 		if ($action == 'settrueWidth') {
-			$object->trueWidth = (float) price2num(GETPOST('trueWidth', 'alpha'));
+			$object->trueWidth = GETPOSTFLOAT('trueWidth');
 		}
 		if ($action == 'settrueHeight') {
-			$object->trueHeight = (float) price2num(GETPOST('trueHeight', 'alpha'));
+			$object->trueHeight = GETPOSTFLOAT('trueHeight');
 			$object->size_units = GETPOSTINT('size_units');
 		}
 		if ($action == 'settrueDepth') {
-			$object->trueDepth = (float) price2num(GETPOST('trueDepth', 'alpha'));
+			$object->trueDepth = GETPOSTFLOAT('trueDepth');
 		}
 		if ($action == 'setshipping_method_id') {
 			$object->shipping_method_id = GETPOSTINT('shipping_method_id');
@@ -1361,7 +1361,7 @@ if ($action == 'create') {
 							print '<td class="center">';
 							if ($line->product_type == Product::TYPE_PRODUCT || getDolGlobalString('STOCK_SUPPORTS_SERVICES') || ($line->product_type == Product::TYPE_SERVICE && getDolGlobalString('SHIPMENT_SUPPORTS_SERVICES'))) {
 								if (GETPOSTISSET('qtyl'.$indiceAsked) && GETPOST('qtyl'.$indiceAsked) !== '') {
-									$deliverableQty = (float) price2num(GETPOST('qtyl'.$indiceAsked, 'alpha'), 'MS');
+									$deliverableQty = GETPOSTFLOAT('qtyl'.$indiceAsked, 'MS');
 								}
 								print '<input name="idl'.$indiceAsked.'" type="hidden" value="'.$line->id.'">';
 								print '<input name="qtyl'.$indiceAsked.'" id="qtyl'.$indiceAsked.'" class="qtyl right" type="text" size="4" value="'.$deliverableQty.'">';

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -251,10 +251,13 @@ if (empty($reshook)) {
 		$object->origin = $origin;
 		$object->origin_id = $origin_id;
 		$object->fk_project = GETPOSTINT('projectid');
-		$object->weight = GETPOSTINT('weight') == '' ? "NULL" : GETPOSTINT('weight');
-		$object->sizeH = GETPOSTINT('sizeH') == '' ? "NULL" : GETPOSTINT('sizeH');
-		$object->sizeW = GETPOSTINT('sizeW') == '' ? "NULL" : GETPOSTINT('sizeW');
-		$object->sizeS = GETPOSTINT('sizeS') == '' ? "NULL" : GETPOSTINT('sizeS');
+		// Weight and box dimensions are physical measurements that frequently use
+		// decimals (1.6 kg, 0.25 m, ...), so they must be read as floats and not
+		// truncated to int (see issue #34069 for the shipping module).
+		$object->weight = GETPOST('weight', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('weight', 'alpha'));
+		$object->sizeH = GETPOST('sizeH', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('sizeH', 'alpha'));
+		$object->sizeW = GETPOST('sizeW', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('sizeW', 'alpha'));
+		$object->sizeS = GETPOST('sizeS', 'alpha') == '' ? "NULL" : (float) price2num(GETPOST('sizeS', 'alpha'));
 		$object->size_units = GETPOSTINT('size_units');
 		$object->weight_units = GETPOSTINT('weight_units');
 
@@ -579,18 +582,18 @@ if (empty($reshook)) {
 			$object->tracking_url = trim(GETPOST('tracking_url', 'restricthtml'));
 		}
 		if ($action == 'settrueWeight') {
-			$object->trueWeight = GETPOSTINT('trueWeight');
+			$object->trueWeight = (float) price2num(GETPOST('trueWeight', 'alpha'));
 			$object->weight_units = GETPOSTINT('weight_units');
 		}
 		if ($action == 'settrueWidth') {
-			$object->trueWidth = GETPOSTINT('trueWidth');
+			$object->trueWidth = (float) price2num(GETPOST('trueWidth', 'alpha'));
 		}
 		if ($action == 'settrueHeight') {
-			$object->trueHeight = GETPOSTINT('trueHeight');
+			$object->trueHeight = (float) price2num(GETPOST('trueHeight', 'alpha'));
 			$object->size_units = GETPOSTINT('size_units');
 		}
 		if ($action == 'settrueDepth') {
-			$object->trueDepth = GETPOSTINT('trueDepth');
+			$object->trueDepth = (float) price2num(GETPOST('trueDepth', 'alpha'));
 		}
 		if ($action == 'setshipping_method_id') {
 			$object->shipping_method_id = GETPOSTINT('shipping_method_id');
@@ -1080,7 +1083,7 @@ if ($action == 'create') {
 			print $langs->trans("Weight");
 			print '</td><td colspan="3">';
 			print img_picto('', 'fa-balance-scale', 'class="pictofixedwidth"');
-			print '<input name="weight" size="4" value="'.GETPOSTINT('weight').'"> ';
+			print '<input name="weight" size="4" value="'.dol_escape_htmltag(GETPOST('weight', 'alpha')).'"> ';
 			$text = $formproduct->selectMeasuringUnits("weight_units", "weight", GETPOSTINT('weight_units'), 0, 2);
 			$htmltext = $langs->trans("KeepEmptyForAutoCalculation");
 			print $form->textwithpicto($text, $htmltext);
@@ -1357,8 +1360,8 @@ if ($action == 'create') {
 							// Quantity to send
 							print '<td class="center">';
 							if ($line->product_type == Product::TYPE_PRODUCT || getDolGlobalString('STOCK_SUPPORTS_SERVICES') || ($line->product_type == Product::TYPE_SERVICE && getDolGlobalString('SHIPMENT_SUPPORTS_SERVICES'))) {
-								if (GETPOSTINT('qtyl'.$indiceAsked)) {
-									$deliverableQty = GETPOSTINT('qtyl'.$indiceAsked);
+								if (GETPOSTISSET('qtyl'.$indiceAsked) && GETPOST('qtyl'.$indiceAsked) !== '') {
+									$deliverableQty = (float) price2num(GETPOST('qtyl'.$indiceAsked, 'alpha'), 'MS');
 								}
 								print '<input name="idl'.$indiceAsked.'" type="hidden" value="'.$line->id.'">';
 								print '<input name="qtyl'.$indiceAsked.'" id="qtyl'.$indiceAsked.'" class="qtyl right" type="text" size="4" value="'.$deliverableQty.'">';


### PR DESCRIPTION
htdocs/expedition/card.php read weight, sizeH/sizeW/sizeS, the four trueX fields and the per-line shipped quantity with GETPOSTINT(). All are physical quantities that routinely use decimals (1.6 kg parcel, 0.25 m edge, 0.5 unit of service). GETPOSTINT silently truncates so 1.6 kg was stored as 1 kg and a 0.25 line quantity was stored as 0, breaking the link with the source order line.

Replace GETPOSTINT with GETPOST + price2num float casts at the six save sites (initial create, four inline settrueX actions, per-line qtyl input) and on the displayed weight value, mirroring the float handling in commande/card.php. weight_units / size_units stay GETPOSTINT since they are dictionary ids.

Reproduced on PHP 8.2 in Docker: GETPOSTINT('1.6') -> 1, (float) price2num('1.6') -> 1.6; GETPOSTINT('0.25') -> 0, patched -> 0.25.