### PR TITLE
Fix #38212 skip approver balance warning when leave type does not deduct

### DIFF
--- a/htdocs/holiday/card.php
+++ b/htdocs/holiday/card.php
@@ -520,12 +520,18 @@ if (empty($reshook)) {
 					}
 				}
 
-				// option to notify the validator if the balance is less than the request
+				// option to notify the validator if the balance is less than the request.
+				// Skip the warning when the leave type has affect=0 in c_holiday_types,
+				// i.e. the type is configured not to deduct days from the balance, so a
+				// shortage is irrelevant (see issue #38212).
 				if (!getDolGlobalString('HOLIDAY_HIDE_APPROVER_ABOUT_NEGATIVE_BALANCE')) {
-					$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday);
+					$typeaffectsbalance = (int) getDictionaryValue('c_holiday_types', 'affect', $object->fk_type, true);
+					if ($typeaffectsbalance) {
+						$nbopenedday = num_open_day($object->date_debut_gmt, $object->date_fin_gmt, 0, 1, $object->halfday);
 
-					if ($nbopenedday > $object->getCPforUser($object->fk_user, $object->fk_type)) {
-						$message .= "<p>".$langs->transnoentities("HolidaysToValidateAlertSolde")."</p>\n";
+						if ($nbopenedday > $object->getCPforUser($object->fk_user, $object->fk_type)) {
+							$message .= "<p>".$langs->transnoentities("HolidaysToValidateAlertSolde")."</p>\n";
+						}
 					}
 				}
 


### PR DESCRIPTION
holiday/card.php emitted HolidaysToValidateAlertSolde on the approval email whenever requested open days exceeded the current balance, even when the leave type was configured in c_holiday_types with affect=0 (the type does not deduct from the balance). For non-deducted types the balance cannot drop, so the warning is bogus and misleading.

Look up c_holiday_types.affect via getDictionaryValue and only compute the balance comparison when affect=1. HOLIDAY_HIDE_APPROVER_ABOUT_NEGATIVE_BALANCE keeps its existing effect of silencing the warning entirely.

Reproduced on PHP 8.2 in Docker: LEAVE_SICK and LEAVE_OTHER have affect=0 in the seeded c_holiday_types, vanilla path warns when nb > balance, patched path stays silent. LEAVE_PAID has affect=1, vanilla and patched both warn under shortage so the original behaviour is preserved.