### PR TITLE
FIX #33491 supplier proposal line edit cancel redirect

### DIFF
--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -171,7 +171,7 @@ if (empty($reshook)) {
 		}
 	}
 
-	if ($cancel) {
+	if ($cancel && !($action == 'updateline' && $usercancreate)) {
 		if (!empty($backtopageforcancel)) {
 			header("Location: ".$backtopageforcancel);
 			exit;
@@ -1147,7 +1147,7 @@ if (empty($reshook)) {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
-	} elseif ($action == 'updateline' && $usercancreate && GETPOST('cancel', 'alpha') == $langs->trans("Cancel")) {
+	} elseif ($action == 'updateline' && $usercancreate && $cancel) {
 		header('Location: '.$_SERVER['PHP_SELF'].'?id='.$object->id); //  To re-display card in edit mode
 		exit();
 	} elseif ($action == 'classin' && $usercancreate) {
@@ -1967,7 +1967,7 @@ if ($action == 'create') {
 		<input type="hidden" name="action" value="' . (($action != 'editline') ? 'addline' : 'updateline').'">
 		<input type="hidden" name="mode" value="">
 		<input type="hidden" name="id" value="' . $object->id.'">
-		<input type="hidden" name="backtopage" value="'.$backtopage.'">
+		<input type="hidden" name="backtopage" value="'.dol_escape_htmltag($backtopage).'">
 		';
 
 		if (!empty($conf->use_javascript_ajax) && $object->status == SupplierProposal::STATUS_DRAFT) {


### PR DESCRIPTION
# FIX #33491 supplier proposal line edit cancel redirect

When editing a line on a supplier proposal, clicking the Cancel button could be handled by the generic cancel flow before the dedicated `updateline` cancel handler.

In this case the posted `backtopage` value could be reused and lead to a broken redirect such as `/supplier_proposal/3D1` instead of returning to the supplier proposal card.

This patch keeps the generic cancel handler from processing `updateline` cancellations, lets the dedicated line-edit cancel handler redirect back to `card.php?id=<id>`, and escapes the hidden `backtopage` value rendered in the line form.

Tests:
- `git diff --check upstream/23.0...HEAD`