### PR TITLE
Fix #38497 keep scale=0 of c_units row through CUnits hydration

### DIFF
--- a/htdocs/core/class/cunits.class.php
+++ b/htdocs/core/class/cunits.class.php
@@ -208,7 +208,13 @@ class CUnits extends CommonDict
 				$this->code = $obj->code;
 				$this->label = $obj->label;
 				$this->short_label = $obj->short_label;
-				$this->scale = $obj->scale ? (int) $obj->scale : null;
+				// Preserve scale=0 (e.g. the kg row). A truthy test on $obj->scale would
+				// collapse the legitimate scale of "0" into null and, downstream, the
+				// "weight unit" dropdown comparison in selectMeasuringUnits would no
+				// longer match the stored value under PHP 8 strict numeric-string
+				// rules, silently switching saved products to the first option (see
+				// issue #38497).
+				$this->scale = isset($obj->scale) ? (int) $obj->scale : null;
 				$this->unit_type = $obj->unit_type;
 				$this->active = (int) $obj->active;
 			}
@@ -302,7 +308,8 @@ class CUnits extends CommonDict
 					$record->label = $obj->label;
 					$record->short_label = $obj->short_label;
 					$record->unit_type = $obj->unit_type;
-					$record->scale = $obj->scale ? (int) $obj->scale : null;
+					// Same scale-preservation as in fetch(): see issue #38497.
+					$record->scale = isset($obj->scale) ? (int) $obj->scale : null;
 					$record->active = (int) $obj->active;
 
 					$this->records[$record->id] = $record;


### PR DESCRIPTION
CUnits::fetch() and CUnits::fetchAll() read the c_units scale column with \`\$obj->scale ? (int) \$obj->scale : null\`, collapsing the legitimate scale of 0 (kg, kilogram, second, ...) into null. selectMeasuringUnits in htdocs/product/class/html.formproduct.class.php then renders that row as \`<option value="">\` and the loose comparison \`\$lines->scale == \$selected\` becomes \`null == "0"\`, which was true on PHP 7 but is **false on PHP 8**.

So a product with weight_units=0 stored loses the selected attribute on the kg option, the browser falls back to the first option (mg, scale=-6 in the default seed), and a plain save of the form posts -6 even though the user only changed the name or description. Same path for net_measure_units when the saved unit has scale=0 (kilogram), giving the "piece" symptom the reporter showed in the issue.

Switch both reads to \`isset(\$obj->scale) ? (int) \$obj->scale : null\`, the same form already used by create() and update() at lines 113 and 357, so scale=0 is preserved and only a truly missing column maps to null.

Reproduced on PHP 8.2 in Docker (21.0):
- Created product with weight_units=0 (kg), reloaded -> \$obj->weight_units = '0'.
- Vanilla selectMeasuringUnits(..., '0', 0, 2) renders no \`selected\` attribute on any option. With the fix, kg is selected.
- Same behaviour on net_measure_units when stored unit has scale=0.

Same code path on 22.0 (where the reporter saw it on 22.0.4), 23.0 and develop.

Reported by @daxitsolutions.