### PR TITLE
Fix #38279 add POST-friendly aliases on GET subscriptions response

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -543,6 +543,16 @@ class Members extends DolibarrApi
 		// phpcs:enable
 		$object = parent::_cleanObjectDatas($object);
 
+		// Add POST-friendly aliases so the output of GET /members/{id}/subscriptions
+		// can be fed back into POST /members/{id}/subscriptions without renaming
+		// fields client-side (see issue #38279). The original dateh / datef fields
+		// are kept for backward compatibility with existing consumers.
+		if ($object instanceof Subscription) {
+			$object->start_date = $object->dateh;
+			$object->end_date = $object->datef;
+			$object->label = $object->note_public;
+		}
+
 		// Remove the subscriptions because they are handled as a subresource.
 		if ($object instanceof Adherent) {
 			unset($object->subscriptions);

--- a/htdocs/adherents/class/subscription.class.php
+++ b/htdocs/adherents/class/subscription.class.php
@@ -78,6 +78,31 @@ class Subscription extends CommonObject
 	public $datef;
 
 	/**
+	 * Alias of $dateh exposed by the REST API GET response so the same payload
+	 * can be sent back to POST /members/{id}/subscriptions without renaming
+	 * (see issue #38279). Not persisted.
+	 *
+	 * @var integer
+	 */
+	public $start_date;
+
+	/**
+	 * Alias of $datef exposed by the REST API GET response (see issue #38279).
+	 * Not persisted.
+	 *
+	 * @var integer
+	 */
+	public $end_date;
+
+	/**
+	 * Alias of $note_public exposed by the REST API GET response (see
+	 * issue #38279). Not persisted.
+	 *
+	 * @var string
+	 */
+	public $label;
+
+	/**
 	 * @var int ID
 	 */
 	public $fk_type;


### PR DESCRIPTION
GET /api/index.php/members/{id}/subscriptions returned the raw Subscription object fields (dateh, datef, note_public, amount) while POST /api/index.php/members/{id}/subscriptions takes start_date, end_date, amount, label. A client that fetches existing subscriptions to push them back (or to derive a new one from the fetched data) has to translate the field names by hand.

Add start_date / end_date / label aliases on the Subscription cleanup branch of api_members::_cleanObjectDatas so the GET response now carries the POST field names alongside the originals. The original dateh / datef / note_public fields stay in the response for backward compatibility with consumers that already parse them. amount was already aligned between the two endpoints.

Reproduced on PHP 8.2 in Docker against the running install: created a member with one subscription, queried GET /members/{id}/subscriptions with the patched code -> response now contains start_date, end_date, label populated alongside dateh, datef, note_public. Vanilla path leaves them undefined.