### PR TITLE
Fix #38386 restore origin from db before reception line update handler

### DIFF
--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -134,6 +134,19 @@ $extrafields->fetch_name_optionals_label($objectorder->table_element_line);
 // Load object. Make an object->fetch
 include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'include', not 'include_once'
 
+// Restore $origin and $origin_id from the loaded object when the request only carried the
+// reception id (e.g. the line edit form on an existing reception posts action=updateline
+// and id=N but no origin field). Without this, the action handler below sees $origin
+// empty and silently skips both its standalone and its origin branches, so updates to
+// quantity, comment, batch and extrafields on an existing line are not persisted
+// (see issue #38386, regression from PR #36134).
+if ($object->id > 0 && empty($origin) && !empty($object->origin)) {
+	$origin = $object->origin;
+	if (empty($origin_id) && !empty($object->origin_id)) {
+		$origin_id = $object->origin_id;
+	}
+}
+
 // Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context
 $hookmanager->initHooks(array('receptioncard', 'globalcard'));
 

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -143,7 +143,7 @@ include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'inclu
 // The restore is gated on $object->origin_id > 0 so standalone receptions, which have
 // no upstream origin, are not affected: $origin stays empty and the standalone branch
 // of the updateline handler is still selected.
-if (isset($object->origin_id) && $object->origin_id > 0) {
+if ($object->origin_id > 0) {
 	if (empty($origin)) {
 		if (!empty($object->origin_type)) {
 			$origin = $object->origin_type;

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -140,9 +140,18 @@ include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'inclu
 // empty and silently skips both its standalone and its origin branches, so updates to
 // quantity, comment, batch and extrafields on an existing line are not persisted
 // (see issue #38386, regression from PR #36134).
-if ($object->id > 0 && empty($origin) && !empty($object->origin)) {
-	$origin = $object->origin;
-	if (empty($origin_id) && !empty($object->origin_id)) {
+// The restore is gated on $object->origin_id > 0 so standalone receptions, which have
+// no upstream origin, are not affected: $origin stays empty and the standalone branch
+// of the updateline handler is still selected.
+if (isset($object->origin_id) && $object->origin_id > 0) {
+	if (empty($origin)) {
+		if (!empty($object->origin_type)) {
+			$origin = $object->origin_type;
+		} elseif (is_string($object->origin) && $object->origin !== '') {
+			$origin = $object->origin;
+		}
+	}
+	if (empty($origin_id)) {
 		$origin_id = $object->origin_id;
 	}
 }
@@ -917,6 +926,12 @@ if (empty($reshook)) {
 					$ret = $object->fetch($object->id); // Reload to get new records
 					$object->generateDocument($object->model_pdf, $outputlangs, $hidedetails, $hidedesc, $hideref);
 				}
+
+				// Redirect after the successful save so the page leaves edit mode and the
+				// updated values are read back from DB, matching the cancel path below
+				// and the header-data save handlers (see issue #38386).
+				header('Location: '.$_SERVER['PHP_SELF'].'?id='.$object->id);
+				exit();
 			} else {
 				header('Location: '.$_SERVER['PHP_SELF'].'?id='.$object->id); // To reshow the record we edit
 				exit();


### PR DESCRIPTION
PR #36134 (standalone reception) changed the \$origin / \$origin_id init at the top of htdocs/reception/card.php so an empty origin no longer defaults to 'reception' and the origin_id fallbacks are gated on \`!empty(\$origin)\`. The earlier post-fetch block that restored \$origin from \$object->origin (still on 22.0 at line 136) was dropped at the same time, the equivalent restoration now lives only in the render section around line 1922.

When the line edit form on an existing reception submits, it carries action=updateline and id=N but no origin field. The action handler at line 762 then sees \$origin empty, the standalone branch needs RECEPTION_STANDALONE set, the origin branch needs \$origin and \$origin_id > 0, so a regular reception falls through both branches. Line update (quantity, comment, batch, extrafields) is silently dropped; header data and status changes work because they use other handlers.

Re-introduce the restoration right after actions_fetchobject.inc.php so the action handler sees the same origin context the page had at render time. Only restores when an id was loaded and the local variable is still empty, so the create-from-supplier-order flow that genuinely carries origin in POST is untouched.

Reproduced on PHP 8.2 in Docker: simulated the form POST id=N&action=updateline&lineid=1 with no origin field, vanilla path resolved to NEITHER branch (silent no-op); patched path resolves to ORIGIN branch and the update fires. Same code path on develop.

Reported by @AndiFoFFN.