### PR TITLE
Fix #38559 reset lifecycle timestamps when cloning a ticket

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1278,6 +1278,13 @@ class Ticket extends CommonObject
 		$object->ref = $object->getDefaultRef();
 		$object->track_id = generate_random_id(16);
 		$object->progress = 0;
+		// Reset lifecycle timestamps so the clone starts fresh: datec is filled by
+		// create() with dol_now() when empty, date_read and date_close stay null
+		// because the new ticket has not been read or closed yet (see issue #38559).
+		$object->datec = null;
+		$object->date_read = null;
+		$object->date_close = null;
+		$object->resolution = null;
 
 		// Create clone
 		$object->context['createfromclone'] = 'createfromclone';

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1281,10 +1281,16 @@ class Ticket extends CommonObject
 		// Reset lifecycle timestamps so the clone starts fresh: datec is filled by
 		// create() with dol_now() when empty, date_read and date_close stay null
 		// because the new ticket has not been read or closed yet (see issue #38559).
-		$object->datec = null;
-		$object->date_read = null;
-		$object->date_close = null;
-		$object->resolution = null;
+		// Reset lifecycle timestamps and resolution so the clone starts fresh.
+		// datec stays at 0 so Ticket::create()'s `if (empty($this->datec))` guard
+		// fills it with dol_now(). date_read / date_close / resolution are unset
+		// so the SQL writers' `!isset` checks emit NULL. We use these forms
+		// rather than `= null` so phpstan stays happy with the int-typed
+		// property declarations.
+		$object->datec = 0;
+		unset($object->date_read);
+		unset($object->date_close);
+		unset($object->resolution);
 
 		// Create clone
 		$object->context['createfromclone'] = 'createfromclone';


### PR DESCRIPTION
Ticket::createFromClone resets id, status, ref, track_id and progress but leaves datec, date_read, date_close and resolution carrying over from the source. The clone is then persisted with the source's creation timestamp (Ticket::create only fills datec via dol_now() when empty, line 494-495), the source's date_read, the source's date_close and the source's resolution, even though the clone is a brand new ticket that has never been read, closed or resolved.

For workflows that duplicate a closed ticket to open a fresh request (the use case in the issue: a Purchasing queue reusing past tickets as templates), the duplicate appears as if it was opened months ago and closed at duplication time.

Set the four properties to null before create(). create() then fills datec with dol_now() and writes date_read, date_close and resolution as SQL NULL.

Reproduced on PHP 8.2 in Docker against 23.0:
- vanilla clone of a source with datec=2026-01-01, date_read=2026-01-02, date_close=2026-01-05, resolution=1 -> clone keeps all four (bug).
- patched clone -> datec=now, date_read=NULL, date_close=NULL, resolution=NULL (status reset to 0 already worked).