### PR TITLE
FIX Fix #38199 Normalize sellist "0" to "" in actions_addupdatedelete to restore notnull validation on PHP 8.0+

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -173,6 +173,9 @@ if ($action == 'add' && !empty($permissiontoadd)) {
 		if (!empty($object->fields[$key]['foreignkey']) && $value == '-1') {
 			$value = ''; // This is an explicit foreign key field
 		}
+		if (preg_match('/^sellist:/i', $object->fields[$key]['type']) && $value == '0') {
+			$value = ''; // sellist blank option posts "0"; normalize to '' so notnull check works on PHP 8.0+ (see github.com/Dolibarr/dolibarr/issues/38199)
+		}
 
 		//var_dump($key.' '.$value.' '.$object->fields[$key]['type'].' '.$object->fields[$key]['notnull']);
 
@@ -334,6 +337,9 @@ if ($action == 'update' && !empty($permissiontoadd)) {
 		}
 		if (!empty($object->fields[$key]['foreignkey']) && $value == '-1') {
 			$value = ''; // This is an explicit foreign key field
+		}
+		if (preg_match('/^sellist:/i', $object->fields[$key]['type']) && $value == '0') {
+			$value = ''; // sellist blank option posts "0"; normalize to '' so notnull check works on PHP 8.0+ (see github.com/Dolibarr/dolibarr/issues/38199)
 		}
 
 		$object->$key = $value;


### PR DESCRIPTION
# FIX Fix #38199 Normalize sellist "0" to "" in actions_addupdatedelete to restore notnull validation on PHP 8.0+
When a field is declared with `type = 'sellist:...'` and `notnull => 1`, leaving the dropdown blank on a create or edit form did not trigger the native `ErrorFieldRequired` message. Instead, the INSERT/UPDATE reached the database and returned a raw SQL foreign key constraint error.


**Root cause:** The `sellist` type has no dedicated branch in the field-type dispatch block of `actions_addupdatedelete.inc.php`, so it falls through to the `else` clause which calls `GETPOST($key, 'alphanohtml')`. When nothing is selected,  
  the HTML `<select>` posts `"0"` (the blank option value hardcoded in `showInputField`).
The existing normalization only converts `-1 → ''` for `integer:` and `foreignkey` typed fields. `sellist` was not covered.
The mandatory check then does:
  ```php
  if (!empty($val['notnull']) && $val['notnull'] > 0 && $object->$key == '' ...)
  - PHP < 8.0: 0 == "" → true (loose comparison — error was caught accidentally)
  - PHP 8.0+: 0 == "" → false (https://www.php.net/manual/en/migration80.incompatible.php) → check bypassed silently → SQL FK error


Fix: Add a normalization block for sellist: fields in both the add and update sections, converting "0" to "" so the existing notnull guard catches the missing value correctly:
if (preg_match('/^sellist:/i', $object->fields[$key]['type']) && $value == '0') {
      $value = ''; // sellist blank option posts "0"; normalize to '' so notnull check works on PHP 8.0+
  }