### PR TITLE
Fix/task get tasks array missing search options pattern

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1266,6 +1266,7 @@ class Task extends CommonObjectLine
 		// Add where from extra fields
 		$extrafieldsobjectkey = 'projet_task';
 		$extrafieldsobjectprefix = 'efpt.';
+		$search_options_pattern = 'search_task_options_'; // Aligned with perweek.php/perday.php that build $search_array_options with this prefix (via extrafields->getOptionalsFromPost('projet_task', '', 'search_task_')). Without it, the SQL template falls back to 'search_options_' and the preg_replace fails to strip the actual prefix, generating phantom column names like efpt.search_task_options_<field>.
 		global $db, $conf; // needed for extrafields_list_search_sql.tpl
 		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 


### PR DESCRIPTION
# FIX|Fix #[* get tasks array missing search options pattern*]

When perweek.php / perday.php submit a filter form on a Dolibarr instance
that has any extrafield declared on the projet_task element type (e.g.
via a third-party module such as ATM doc2project which declares
fk_product), the SQL produced by Task::getTasksArray() contains a phantom
WHERE clause:

    AND (efpt.search_task_options_<field> LIKE '%-1%')

which triggers DB_ERROR_NOSUCHFIELD and prevents the timesheet from
loading.

