### PR TITLE
Fix #38563 skip task-driven project load when allprojects view fetch returns no row

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -942,7 +942,13 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 			$projectstatic->fetch_thirdparty();
 		}
 		$res = $projectstatic->fetch_optionals();
-	} elseif ($object->fetch($id, $ref) >= 0) {
+	} elseif ($object->fetch($id, $ref) > 0) {
+		// Use > 0 (not >= 0): when the outer block is entered only because
+		// $allprojectforuser is set (id=0, ref=''), fetch returns 0 and Task::fetch
+		// leaves prior properties (set earlier by the updateline handler at
+		// line 302) untouched, so $object->fk_project would carry the task of
+		// the edited line. $projectstatic would then load that project and the
+		// per-row massaction checkboxes render on the all-projects list (see #38563).
 		if (getDolGlobalString('PROJECT_ALLOW_COMMENT_ON_TASK') && empty($object->comments)) {
 			$object->fetchComments();
 		}

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -943,12 +943,6 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 		}
 		$res = $projectstatic->fetch_optionals();
 	} elseif ($object->fetch($id, $ref) > 0) {
-		// Use > 0 (not >= 0): when the outer block is entered only because
-		// $allprojectforuser is set (id=0, ref=''), fetch returns 0 and Task::fetch
-		// leaves prior properties (set earlier by the updateline handler at
-		// line 302) untouched, so $object->fk_project would carry the task of
-		// the edited line. $projectstatic would then load that project and the
-		// per-row massaction checkboxes render on the all-projects list (see #38563).
 		if (getDolGlobalString('PROJECT_ALLOW_COMMENT_ON_TASK') && empty($object->comments)) {
 			$object->fetchComments();
 		}


### PR DESCRIPTION
The updateline handler at htdocs/projet/tasks/time.php line 302 populates \$object via Task::fetch(\$id_temp) where \$id_temp is the edited line's task id. After the save, the page falls through to the render block at line 937. In the all-projects view (\$id=0, \$ref=''), the outer if is entered only because \$allprojectforuser is set, then the elseif tests \`\$object->fetch(\$id, \$ref) >= 0\`. Task::fetch returns 0 for no row but leaves prior properties untouched, so \$object->fk_project carries the edited task's project. \$projectstatic loads that project, \$arrayofmassactions gets filled, and the per-row toselect[] checkbox renders on every row of the all-projects list.

Tighten the guard to \`> 0\` so the body only runs when fetch actually returned a row. Same code path on develop; 22.0 has a different structure for this block and is not affected.

Reproduced on PHP 8.2 in Docker: created a project + task, called \$object->fetch(\$tid) (simulating the updateline handler), then \$object->fetch(0, ''). Vanilla >= 0 entered the body with \$object->fk_project still=19; patched > 0 skipped.

Reported by @priojk.