### PR TITLE
Fix #38429 validate recruitment API candidature payload against candidature model

### DIFF
--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -682,6 +682,7 @@ class Recruitments extends DolibarrApi
 	 * Validate fields before create or update object
 	 *
 	 * @param	?array<string,mixed>		$data   Array of data to validate
+	 * @param	CommonObject				$object Object to validate against
 	 * @return	array<string,mixed>
 	 *
 	 * @throws	RestException

--- a/htdocs/recruitment/class/api_recruitments.class.php
+++ b/htdocs/recruitment/class/api_recruitments.class.php
@@ -372,7 +372,7 @@ class Recruitments extends DolibarrApi
 		}
 
 		// Check mandatory fields
-		$result = $this->_validate($request_data);
+		$result = $this->_validate($request_data, $this->jobposition);
 
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {
@@ -411,8 +411,10 @@ class Recruitments extends DolibarrApi
 			throw new RestException(403);
 		}
 
-		// Check mandatory fields
-		$result = $this->_validate($request_data);
+		// Check mandatory fields. Validate against the candidature model so the API
+		// rejects with the actual missing candidature fields (e.g. email) instead of
+		// the unrelated job position fields (see issue #38429).
+		$result = $this->_validate($request_data, $this->candidature);
 
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {
@@ -684,21 +686,21 @@ class Recruitments extends DolibarrApi
 	 *
 	 * @throws	RestException
 	 */
-	private function _validate($data)
+	private function _validate($data, $object)
 	{
 		if ($data === null) {
 			$data = array();
 		}
-		$jobposition = array();
-		foreach ($this->jobposition->fields as $field => $propfield) {
+		$result = array();
+		foreach ($object->fields as $field => $propfield) {
 			if (in_array($field, array('rowid', 'entity', 'date_creation', 'tms', 'fk_user_creat')) || empty($propfield['notnull']) || $propfield['notnull'] != 1) {
 				continue; // Not a mandatory field
 			}
 			if (!isset($data[$field])) {
 				throw new RestException(400, "$field field missing");
 			}
-			$jobposition[$field] = $data[$field];
+			$result[$field] = $data[$field];
 		}
-		return $jobposition;
+		return $result;
 	}
 }


### PR DESCRIPTION
api_recruitments::_validate hard-coded \$this->jobposition->fields, so postCandidature rejected payloads missing the jobposition mandatory fields (ref, label, qty, fk_user_recruiter) instead of the candidature ones (ref, email, status). A client posting a valid candidature with just ref + email + status got "400 label field missing" first, then "500 Field EMail is required" once they added the irrelevant fields.

Take the target model as second argument and pass \$this->candidature from postCandidature, \$this->jobposition from postJobPosition. Same shape as the fix already in develop (forward-port).

Verified on PHP 8.2 in Docker via the _validate method called by reflection with both \$this->jobposition and \$this->candidature: a candidature payload {ref, email, status} validates against candidature, rejects against jobposition with "label field missing" - matching the reported symptom exactly. Same bug on 23.0.

Reported and diagnosed by the issue author.