### PR TITLE
Fix #38478 prefix bookkeeping card backtopage default with DOL_URL_ROOT

### DIFF
--- a/htdocs/accountancy/bookkeeping/card.php
+++ b/htdocs/accountancy/bookkeeping/card.php
@@ -56,7 +56,10 @@ $confirm = GETPOST('confirm', 'alpha');
 $type = GETPOST('type', 'alpha');
 $backtopage = GETPOST('backtopage', 'alpha');
 if (empty($backtopage)) {
-	$backtopage = '/accountancy/bookkeeping/list.php';
+	// Prefix with DOL_URL_ROOT so the redirect works when Dolibarr is installed
+	// under a subpath (e.g. https://host/dolibarr/). A bare /accountancy/...
+	// lands the browser at host root and breaks the redirect (see issue #38478).
+	$backtopage = DOL_URL_ROOT.'/accountancy/bookkeeping/list.php';
 }
 
 $optioncss = GETPOST('optioncss', 'aZ'); // Option for the css output (always '' except when 'print')


### PR DESCRIPTION
When no backtopage POST is provided, htdocs/accountancy/bookkeeping/card.php defaulted to the bare path \`/accountancy/bookkeeping/list.php\`. On installs served under a subpath (https://host/dolibarr/...) the browser interprets a relative Location starting with \`/\` as host-root, so the redirect after the "Transaction validated" button lands on host/accountancy/... instead of host/dolibarr/accountancy/... and the user gets a 404.

Prefix the default with DOL_URL_ROOT, the convention used by every other card.php in the codebase (expedition, holiday, adherents, contact, ...). No effect on installs at host root (DOL_URL_ROOT='').

Same code path applies to both Location uses in the file (lines 135 and 383). Reported by @ddiegop with the same fix suggestion.