### PR TITLE
fix(stripe): bypass paymentoksessioncode check for confirmPayment() redirect (mode STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2)

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -390,7 +390,9 @@ if (isModEnabled('stripe') && $paymentmethod === 'stripe') {
 	}
 
 	// Check we are coming from the newpaymentpage
-	if (GETPOST('paymentoksessioncode') !== $_SESSION['paymentoksessioncode']) {
+	// Bypass session check when returning from Stripe confirmPayment() (mode STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2)
+	// In that case, payment_intent is passed in GET by Stripe and PaymentIntent::retrieve() below acts as verification
+	if (empty(GETPOST('payment_intent', 'alphanohtml')) && GETPOST('paymentoksessioncode') !== $_SESSION['paymentoksessioncode']) {
 		$error++;
 		$errmsg = 'Attempted direct access to the paymentok page without a valid session.';
 		dol_syslog($errmsg, LOG_ERR, 0, '_payment');


### PR DESCRIPTION
When STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION is set to 2, the payment flow uses
the Stripe JS confirmPayment() API which redirects the customer directly to paymentok.php
after a successful payment.

In this flow, Stripe appends payment_intent, payment_intent_client_secret and redirect_status
to the return_url — but does NOT append paymentoksessioncode, as this is an internal Dolibarr
session parameter that Stripe has no knowledge of.

This caused paymentok.php to systematically reject valid Stripe payments with:
"Stripe payment verification failed: TRANSACTIONID is not set or session key does not match"

The fix bypasses the paymentoksessioncode session check when a payment_intent parameter
is present in GET, which is the reliable indicator of a Stripe confirmPayment() redirect.
Security is maintained: the PaymentIntent is subsequently verified against the Stripe API
via PaymentIntent::retrieve(), which confirms the payment amount, currency and status.

This unblocks the use of PaymentElement (multi-payment methods: Klarna, Bancontact, iDEAL, etc.)
via STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2, which was broken since v22 due to
the reinforced session verification introduced in paymentok.php.

Fixes: "Stripe payment verification failed: TRANSACTIONID is not set or session key does not match"
Related forum thread: https://www.dolibarr.fr/forum/t/stripe-use-new-checkout-ne-fonctionne-plus/50090

Related to #34974