### PR TITLE
fix(stripe): use automatic_payment_methods when STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2

### DIFF
--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -486,28 +486,28 @@ class Stripe extends CommonObject
 			$paymentmethodtypes = array("card");
 			$descriptor = dol_trunc($tag, 10, 'right', 'UTF-8', 1);
 			if (getDolGlobalInt('STRIPE_SEPA_DIRECT_DEBIT')) {
-			    $paymentmethodtypes[] = "sepa_debit";
+				$paymentmethodtypes[] = "sepa_debit";
 			}
 			if (getDolGlobalInt('STRIPE_KLARNA')) {
-			    $paymentmethodtypes[] = "klarna";
+				$paymentmethodtypes[] = "klarna";
 			}
 			if (getDolGlobalInt('STRIPE_BANCONTACT')) {
-			    $paymentmethodtypes[] = "bancontact";
+				$paymentmethodtypes[] = "bancontact";
 			}
 			if (getDolGlobalInt('STRIPE_IDEAL')) {
-			    $paymentmethodtypes[] = "ideal";
+				$paymentmethodtypes[] = "ideal";
 			}
 			if (getDolGlobalInt('STRIPE_GIROPAY')) {
-			    $paymentmethodtypes[] = "giropay";
+				$paymentmethodtypes[] = "giropay";
 			}
 			if (getDolGlobalInt('STRIPE_SOFORT')) {
-			    $paymentmethodtypes[] = "sofort";
+				$paymentmethodtypes[] = "sofort";
 			}
 			if ($mode == 'terminal') {
-			    if (getDolGlobalInt('STRIPE_CARD_PRESENT')) {
-			        $paymentmethodtypes = array("card_present");
-			    }
-			    $stripemode = 'manual';
+				if (getDolGlobalInt('STRIPE_CARD_PRESENT')) {
+					$paymentmethodtypes = array("card_present");
+				}
+				$stripemode = 'manual';
 			}
 			global $dolibarr_main_url_root;
 			$descriptioninpaymentintent = $description;

--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -510,14 +510,13 @@ class Stripe extends CommonObject
 				$stripemode = 'manual';
 			}
 			global $dolibarr_main_url_root;
-			$descriptioninpaymentintent = $description;
+			$descriptioninpaymentintent = $description;	
 			
 			// When STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2, use automatic_payment_methods
 			// so Stripe Dashboard controls active methods (Klarna, Bancontact, Link, etc.)
 			// and return_url redirect flow works correctly.
 			// In terminal mode, automatic methods are not supported — fallback to manual list.
 			$useautomaticmethods = (getDolGlobalInt('STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION') == 2 && $mode != 'terminal');
-			
 			$dataforintent = array_merge(
 				array(
 					"confirm"     => $confirmnow,

--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -484,52 +484,57 @@ class Stripe extends CommonObject
 
 			// list of payment method types
 			$paymentmethodtypes = array("card");
+			$descriptor = dol_trunc($tag, 10, 'right', 'UTF-8', 1);
 			if (getDolGlobalInt('STRIPE_SEPA_DIRECT_DEBIT')) {
-				$paymentmethodtypes[] = "sepa_debit"; //&& ($object->thirdparty->isInEEC())
+			    $paymentmethodtypes[] = "sepa_debit";
 			}
 			if (getDolGlobalInt('STRIPE_KLARNA')) {
-				$paymentmethodtypes[] = "klarna";
+			    $paymentmethodtypes[] = "klarna";
 			}
 			if (getDolGlobalInt('STRIPE_BANCONTACT')) {
-				$paymentmethodtypes[] = "bancontact";
+			    $paymentmethodtypes[] = "bancontact";
 			}
 			if (getDolGlobalInt('STRIPE_IDEAL')) {
-				$paymentmethodtypes[] = "ideal";
+			    $paymentmethodtypes[] = "ideal";
 			}
 			if (getDolGlobalInt('STRIPE_GIROPAY')) {
-				$paymentmethodtypes[] = "giropay";
+			    $paymentmethodtypes[] = "giropay";
 			}
 			if (getDolGlobalInt('STRIPE_SOFORT')) {
-				$paymentmethodtypes[] = "sofort";
+			    $paymentmethodtypes[] = "sofort";
 			}
 			if ($mode == 'terminal') {
-				if (getDolGlobalInt('STRIPE_CARD_PRESENT')) {
-					$paymentmethodtypes = array("card_present");
-				}
-				$stripemode = 'manual';
+			    if (getDolGlobalInt('STRIPE_CARD_PRESENT')) {
+			        $paymentmethodtypes = array("card_present");
+			    }
+			    $stripemode = 'manual';
 			}
-
 			global $dolibarr_main_url_root;
-
 			$descriptioninpaymentintent = $description;
-
-			$dataforintent = array(
-				"confirm" => $confirmnow, // try to confirm immediately after create (if conditions are ok)
-				"confirmation_method" => $stripemode,
-				"amount" => $stripeamount,
-				"currency" => $currency_code,
-				"payment_method_types" => $paymentmethodtypes,	// When payment_method_types is set, return_url is not required but payment mode can't be managed from dashboard
-				/*
-				'return_url' => $dolibarr_main_url_root.'/public/payment/paymentok.php',
-				'automatic_payment_methods' => array(
-					'enabled' => true,
-					'allow_redirects' => 'never',
-				),
-				*/
-				"description" => $descriptioninpaymentintent,
-				//"save_payment_method" => true,
-				"setup_future_usage" => "on_session",
-				"metadata" => $metadata
+			
+			// When STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2, use automatic_payment_methods
+			// so Stripe Dashboard controls active methods (Klarna, Bancontact, Link, etc.)
+			// and return_url redirect flow works correctly.
+			// In terminal mode, automatic methods are not supported — fallback to manual list.
+			$useautomaticmethods = (getDolGlobalInt('STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION') == 2 && $mode != 'terminal');
+			
+			$dataforintent = array_merge(
+			    array(
+			        "confirm"     => $confirmnow,
+			        "amount"      => $stripeamount,
+			        "currency"    => $currency_code,
+			        "description" => $descriptioninpaymentintent,
+			        "metadata"    => $metadata,
+			    ),
+			    $useautomaticmethods ? array(
+			        'automatic_payment_methods' => array(
+			            'enabled' => true,
+			        ),
+			    ) : array(
+			        'confirmation_method'  => $stripemode,
+			        'payment_method_types' => $paymentmethodtypes,
+			        'setup_future_usage'   => 'on_session',
+			    )
 			);
 			if ($tag) {
 				$dataforintent["statement_descriptor_suffix"] = dol_trunc($tag, 12, 'right', 'UTF-8', 1); 	// For card payment, 22 chars that appears on bank receipt (prefix into stripe setup + this suffix)

--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -519,22 +519,22 @@ class Stripe extends CommonObject
 			$useautomaticmethods = (getDolGlobalInt('STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION') == 2 && $mode != 'terminal');
 			
 			$dataforintent = array_merge(
-			    array(
-			        "confirm"     => $confirmnow,
-			        "amount"      => $stripeamount,
-			        "currency"    => $currency_code,
-			        "description" => $descriptioninpaymentintent,
-			        "metadata"    => $metadata,
-			    ),
-			    $useautomaticmethods ? array(
-			        'automatic_payment_methods' => array(
-			            'enabled' => true,
-			        ),
-			    ) : array(
-			        'confirmation_method'  => $stripemode,
-			        'payment_method_types' => $paymentmethodtypes,
-			        'setup_future_usage'   => 'on_session',
-			    )
+				array(
+					"confirm"     => $confirmnow,
+					"amount"      => $stripeamount,
+					"currency"    => $currency_code,
+					"description" => $descriptioninpaymentintent,
+					"metadata"    => $metadata,
+				),
+				$useautomaticmethods ? array(
+					'automatic_payment_methods' => array(
+						'enabled' => true,
+					),
+				) : array(
+					'confirmation_method'  => $stripemode,
+					'payment_method_types' => $paymentmethodtypes,
+					'setup_future_usage'   => 'on_session',
+				)
 			);
 			if ($tag) {
 				$dataforintent["statement_descriptor_suffix"] = dol_trunc($tag, 12, 'right', 'UTF-8', 1); 	// For card payment, 22 chars that appears on bank receipt (prefix into stripe setup + this suffix)

--- a/htdocs/stripe/class/stripe.class.php
+++ b/htdocs/stripe/class/stripe.class.php
@@ -510,8 +510,7 @@ class Stripe extends CommonObject
 				$stripemode = 'manual';
 			}
 			global $dolibarr_main_url_root;
-			$descriptioninpaymentintent = $description;	
-			
+			$descriptioninpaymentintent = $description;
 			// When STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2, use automatic_payment_methods
 			// so Stripe Dashboard controls active methods (Klarna, Bancontact, Link, etc.)
 			// and return_url redirect flow works correctly.


### PR DESCRIPTION
When using PaymentElement (mode 2), building PaymentIntent with an explicit
payment_method_types list (card only) and setup_future_usage=on_session
prevents redirect-based methods (Klarna, Bancontact, iDEAL, etc.) from appearing.

Switch to automatic_payment_methods: {enabled: true} in this mode so Stripe
respects Dashboard payment method settings. Terminal mode is explicitly excluded
as it is incompatible with automatic methods.

No new constant introduced — behavior is derived from the existing
STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION setting.

Related to #38577 — both PRs are part of the same fix:
- #38577 fixes the `paymentoksessioncode` check in `paymentok.php` that 
  caused Stripe to reject valid return redirects in mode 2
- This PR enables `automatic_payment_methods` in `stripe.class.php` so 
  redirect-based methods (Klarna, Bancontact, etc.) are actually presented 
  to the customer

Both changes are required for a fully functional PaymentElement flow 
with STRIPE_USE_INTENT_WITH_AUTOMATIC_CONFIRMATION=2.