### PR TITLE
FIX PDF generation on multi-page subtotals title

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2895,6 +2895,17 @@ function pdf_render_subtotals(
 	} else {
 		$pdf->MultiCell($width, $pdf->getPageHeight() - $pdf->getBreakMargin() - $curY, '', 0, '', true);
 
+		// rollbackTransaction() removed extra pages; recreate them before setPage().
+		while ($pdf->getNumPages() < $pageAfter) {
+			$pdf->AddPage();
+		}
+
+		for ($p = $savePage + 1; $p < $pageAfter; $p++) {
+			$pdf->setPage($p);
+			$pdf->SetXY($generator->marge_gauche, $pdf->getMargins()['top']);
+			$pdf->MultiCell($width, $pdf->getPageHeight() - $pdf->getBreakMargin() - $pdf->getMargins()['top'], '', 0, '', true);
+		}
+
 		$pdf->setPage($pageAfter);
 		$pdf->SetXY($generator->marge_gauche, $pdf->getMargins()['top']);
 		$pdf->MultiCell($width, max(0, $yAfter - $pdf->getMargins()['top']), '', 0, '', true);


### PR DESCRIPTION
Fixes PDF generation failure (`TCPDF ERROR: Wrong page number on setPage() function: N`) when a subtotals title line has a long description that spans multiple pages.

After `rollbackTransaction()`, recreate missing pages with `AddPage()` before any `setPage($pageAfter)` call. Also paint the colored background on intermediate pages when the title spans more than two pages.

