### PR TITLE
FIX: API categories/objects returns empty array for ticket type Add m…

### DIFF
--- a/htdocs/categories/class/api_categories.class.php
+++ b/htdocs/categories/class/api_categories.class.php
@@ -30,6 +30,7 @@ require_once DOL_DOCUMENT_ROOT.'/product/class/api_products.class.php';
 require_once DOL_DOCUMENT_ROOT.'/societe/class/api_contacts.class.php';
 require_once DOL_DOCUMENT_ROOT.'/societe/class/api_thirdparties.class.php';
 require_once DOL_DOCUMENT_ROOT.'/projet/class/api_projects.class.php';
+require_once DOL_DOCUMENT_ROOT.'/ticket/class/api_tickets.class.php';
 
 /**
  * API class for categories
@@ -839,6 +840,8 @@ class Categories extends DolibarrApi
 			$objects_api = new Contacts();
 		} elseif ($type == 'project') {
 			$objects_api = new Projects();
+		} elseif ($type == 'ticket') {
+			$objects_api = new Tickets();
 		}
 
 		if (is_object($objects_api)) {


### PR DESCRIPTION
Fix API categories/objects returns empty array for ticket type
                                                                                                                                                                             
Description :                                                                                                                                                                                                               

Problem :
Calling GET /api/index.php/categories/{id}/objects?type=ticket always returns an empty array [], even when tickets are correctly linked to the category in the database.                                                    

Root cause
In htdocs/categories/class/api_categories.class.php, the getObjects() method handles the $objects_api instantiation for each type (member, customer, supplier, product, contact, project) but the ticket type is missing    
from the list.                                                                                                                                                                                                              
                                                                                                                                                                                                                              
As a result, $objects_api stays null, the cleaning loop is skipped, and an empty array is returned despite getObjectsInCateg() fetching the correct data.                                                                   
                                                                                                                                                                                                                              
Fix :
Two changes in htdocs/categories/class/api_categories.class.php:                                                                                                                                                            
                                                                                                                                                                                                                              
1. Add missing require_once with the other API imports:                                                                                                                                                                     
`require_once DOL_DOCUMENT_ROOT.'/ticket/class/api_tickets.class.php';`
2. Add the missing ticket case in getObjects():                                                                                                                                                                             
```
  } elseif ($type == 'ticket') {
     $objects_api = new Tickets();    
  }
```