### PR TITLE
FIX: Invoice clone ignores target entity when multicompany sharing is…

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -257,7 +257,7 @@ if (empty($reshook)) {
 
 			$objectutil->date = dol_mktime(12, 0, 0, GETPOSTINT('newdatemonth'), GETPOSTINT('newdateday'), GETPOSTINT('newdateyear'));
 			$objectutil->socid = $socid;
-			$result = $objectutil->createFromClone($user, $id);
+			$result = $objectutil->createFromClone($user, $id, (GETPOSTISSET('entity') ? GETPOSTINT('entity') : null));
 			if ($result > 0) {
 				$warningMsgLineList = array();
 				// check all product lines are to sell otherwise add a warning message for each product line is not to sell

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1253,9 +1253,10 @@ class Facture extends CommonInvoice
 	 *
 	 *	@param      User	$user        	User that clone
 	 *  @param  	int 	$fromid         Id of object to clone
+	 *  @param		int		$forceentity	Entity id to force (used by multicompany to clone into another entity)
 	 * 	@return		int					    New id of clone
 	 */
-	public function createFromClone(User $user, $fromid = 0)
+	public function createFromClone(User $user, $fromid = 0, $forceentity = null)
 	{
 		global $conf, $hookmanager;
 
@@ -1284,6 +1285,8 @@ class Facture extends CommonInvoice
 
 			// TODO Change product price if multi-prices
 		}
+
+		$object->entity = (!empty($forceentity) ? $forceentity : $object->entity);
 
 		$object->id = 0;
 		$object->statut = self::STATUS_DRAFT;


### PR DESCRIPTION
# FIX | Invoice clone ignores target entity when multicompany sharing is enabled
   
When cloning an invoice to another entity via the multicompany entity selector,
the cloned invoice was always created in the source entity instead of the selected one.

The multicompany module correctly displays an entity selector in the clone confirmation                                                      
dialog (formConfirm hook), but the core `confirm_clone` handler in `card.php` never                                                    
read the posted `entity` parameter. `Facture::createFromClone()` also lacked a                                   
`$forceentity` parameter, unlike `Propal::createFromClone()` which already handled                           
this case correctly.

Changes:  
- Add `$forceentity = null` parameter to `Facture::createFromClone()`
- Apply `forceentity` to the cloned object after fetch, before `create()` 
- Pass `GETPOST('entity')` from `card.php` `confirm_clone` handler to `createFromClone()`