### PR TITLE
Fix: Remove invalid #if syntax in moderation workflow

### DIFF
--- a/.github/workflows/moderation.yml
+++ b/.github/workflows/moderation.yml
@@ -48,7 +48,7 @@ jobs:
 
             console.log('Detected language:', isEnglish ? 'english' : 'not english')
 
-            #if (hasYoutubeMusic || !isEnglish) {
+            if (hasYoutubeMusic || !isEnglish) {
             if (hasYoutubeMusic) {
               console.log('Deleting comment...')
 


### PR DESCRIPTION
## Description
Fixes a SyntaxError in the moderation workflow that prevents the GitHub Action from running.

## Problem
The workflow file `.github/workflows/moderation.yml` contains an invalid `#if` statement on line 51, which causes:

SyntaxError: Private field '#if' must be declared in an enclosing class


## Solution
Changed `#if (hasYoutubeMusic || !isEnglish) {` to valid JavaScript syntax: if (hasYoutubeMusic || !isEnglish) {


## Changes Made
- Fixed invalid `#if` syntax to `if` statement in `.github/workflows/moderation.yml`

## Type of Change
- [x] Bug fix
