### PR TITLE
FIX : propal card should be reloaded after validation.

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -370,6 +370,10 @@ if (empty($reshook)) {
 			$result = $object->closeProposal($user, $object::STATUS_SIGNED);
 		}
 		if ($result >= 0) {
+			$ret = $object->fetch($id);	// Reload to get new records
+			if ($ret > 0) {
+				$object->fetch_thirdparty();
+			}
 			if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
 				$outputlangs = $langs;
 				$newlang = '';
@@ -384,10 +388,6 @@ if (empty($reshook)) {
 					$outputlangs->setDefaultLang($newlang);
 				}
 				$model = $object->model_pdf;
-				$ret = $object->fetch($id); // Reload to get new records
-				if ($ret > 0) {
-					$object->fetch_thirdparty();
-				}
 
 				$object->generateDocument($model, $outputlangs, $hidedetails, $hidedesc, $hideref);
 			}


### PR DESCRIPTION
# Fix When validating a propal, the status label is not updated

When MAIN_DISABLE_PDF_AUTOUPDATE is enabled and the user validates a propal, the status and buttons are not updated. They stay related to a "draft" status while status is "validated" in DB. The user needs to reload the page to see the changes.

This does not happen when MAIN_DISABLE_PDF_AUTOUPDATE is disabled.

Reason: we fetch the object before generating the PDF, and this action sets the right status.

Solution : fetch the object before testing MAIN_DISABLE_PDF_AUTOUPDATE
