### PR TITLE
FIX reception/note.php and contact.php: wrong object passed to restrictedArea causing random access denied

### DIFF
--- a/htdocs/reception/contact.php
+++ b/htdocs/reception/contact.php
@@ -83,11 +83,11 @@ if ($user->socid > 0) {
 
 // TODO Test on reception module on only
 $result = -1;
-if ($origin == 'reception') {
-	$result = restrictedArea($user, $origin, $object->id);
+if (isModEnabled("reception") || $origin == 'reception' || empty($origin)) {
+	$result = restrictedArea($user, 'reception', $object->id);
 } else {
 	if ($origin == 'supplierorder' || $origin == 'order_supplier') {
-		$result = restrictedArea($user, 'fournisseur', $object, 'commande_fournisseur', 'commande');
+		$result = restrictedArea($user, 'fournisseur', $object->origin_id, 'commande_fournisseur', 'commande');
 	} elseif (!$user->hasRight($origin, 'lire') && !$user->hasRight($origin, 'read')) {
 		accessforbidden();
 	}

--- a/htdocs/reception/note.php
+++ b/htdocs/reception/note.php
@@ -97,11 +97,11 @@ if (isModEnabled("reception")) {
 $permissionnote = $user->hasRight('reception', 'creer'); // Used by the include of actions_setnotes.inc.php
 
 // TODO Test on reception module on only
-if ($origin == 'reception') {
-	$result = restrictedArea($user, $origin, $object->id);
+if (isModEnabled("reception") || $origin == 'reception' || empty($origin)) {
+	$result = restrictedArea($user, 'reception', $object->id);
 } else {
 	if ($origin == 'supplierorder' || $origin == 'order_supplier') {
-		$result = restrictedArea($user, 'fournisseur', $object, 'commande_fournisseur', 'commande');
+		$result = restrictedArea($user, 'fournisseur', $object->origin_id, 'commande_fournisseur', 'commande');
 	} elseif (!$user->hasRight($origin, 'lire') && !$user->hasRight($origin, 'read')) {
 		accessforbidden();
 	}


### PR DESCRIPTION
# FIX reception/note.php and contact.php: wrong object passed to restrictedArea causing random access denied

In `reception/note.php` and `reception/contact.php`, the security check was passing the `Reception` object directly to `restrictedArea()` when the origin is `order_supplier`.

Since `restrictedArea()` extracts `$object->id` from any object, it was using the **Reception ID** to query the `commande_fournisseur` table instead of the **supplier order ID**. This caused a random "Access denied" error depending on whether a supplier order happened to share the same ID as the reception in the database.

Additionally, the main condition was missing `isModEnabled("reception") || empty($origin)`, causing access denied when the reception module is enabled or when the reception has no linked origin.

Fix aligns `note.php` and `contact.php` with the correct logic already present in `card.php`:
  - Use `restrictedArea($user, 'reception', $object->id)` when the reception module is enabled                                                                                                                                                 
  - Use `$object->origin_id` (supplier order ID) instead of `$object` when checking `order_supplier`