### PR TITLE
FIX customer price : default VAT was not used

### DIFF
--- a/htdocs/societe/price.php
+++ b/htdocs/societe/price.php
@@ -396,7 +396,7 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 
 		// VAT
 		print '<tr><td>'.$langs->trans("VATRate").'</td><td>';
-		print $form->load_tva("tva_tx", GETPOST("tva_tx", "alpha"), $mysoc, null, $object->id, 0, '', false, 1);
+		print $form->load_tva("tva_tx", GETPOST("tva_tx", "alpha"), $mysoc, $object, 0, 0, '', false, 1);
 		print '</td></tr>';
 
 		// Price base


### PR DESCRIPTION
# FIX : customer prices : default VAT was not used

On the "customer prices" tab, when creating a new customer price, the default VAT rate was not used.

The call to $form->load_tva() did not provide the right parameters (in this page, `$object` is an instance of `Societe` class, not `Product`)

seen from 22.0 to develop.