### PR TITLE
FIX Accountancy - Closure - Income and deficit accounts should not prevent the closing process if they contain data

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -489,16 +489,7 @@ class BookKeeping extends CommonObject
 				$this->error = 'BookkeepingRecordAlreadyExists';
 				$this->errors[] = $langs->trans('WarningBookkeepingRecordAlreadyExists', $this->doc_type, $this->fk_doc, $this->fk_docdet);
 
-				dol_syslog(__METHOD__ . ' duplicate record detected: '
-					. 'doc_type=' . $this->doc_type
-					. ', doc_ref=' . $this->doc_ref
-					. ', fk_doc=' . ((int) $this->fk_doc)
-					. ', fk_docdet=' . ((int) $this->fk_docdet)
-					. ', numero_compte=' . $this->numero_compte
-					. ', label_operation=' . $this->label_operation
-					. ', subledger_account=' . ($this->subledger_account ?? '(null)'),
-					LOG_WARNING
-				);
+				dol_syslog(__METHOD__ . ' duplicate record detected: doc_type={$this->doc_type}, doc_ref={$this->doc_ref}, fk_doc={(int) $this->fk_doc}, fk_docdet={(int) $this->fk_docdet}', LOG_WARNING);
 			}
 		} else {
 			$result = -5;

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -489,7 +489,7 @@ class BookKeeping extends CommonObject
 				$this->error = 'BookkeepingRecordAlreadyExists';
 				$this->errors[] = $langs->trans('WarningBookkeepingRecordAlreadyExists', $this->doc_type, $this->fk_doc, $this->fk_docdet);
 
-				dol_syslog(__METHOD__ . ' duplicate record detected: doc_type={$this->doc_type}, doc_ref={$this->doc_ref}, fk_doc={(int) $this->fk_doc}, fk_docdet={(int) $this->fk_docdet}', LOG_WARNING);
+				dol_syslog(get_class($this).":: duplicate record detected: doc_type=" . $this->doc_type.", doc_ref=" . $this->doc_ref . ", fk_doc=" . ((int) $this->fk_doc) . ", fk_docdet=" . ((int) $this->fk_docdet), LOG_WARNING);
 			}
 		} else {
 			$result = -5;

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -352,6 +352,16 @@ class BookKeeping extends CommonObject
 		}
 		$sql .= " AND entity = ".$conf->entity; // Do not use getEntity for accounting features
 
+		// Allow duplicates in incomes or loss statements
+		$accountProfit = getDolGlobalString('ACCOUNTING_RESULT_PROFIT');
+		$accountLoss   = getDolGlobalString('ACCOUNTING_RESULT_LOSS');
+
+		if (($accountProfit && $this->numero_compte === trim($accountProfit)) ||
+			($accountLoss   && $this->numero_compte === trim($accountLoss))) {
+			// If the account being processed corresponds to the “Profit” or “Loss” constant, the detection is bypassed
+			$sql .= " AND 1 = 2";
+		}
+
 		$resql = $this->db->query($sql);
 
 		if ($resql) {
@@ -477,7 +487,18 @@ class BookKeeping extends CommonObject
 				$result = -3;
 				$error++;
 				$this->error = 'BookkeepingRecordAlreadyExists';
-				dol_syslog(__METHOD__.' '.$this->error, LOG_WARNING);
+				$this->errors[] = $langs->trans('WarningBookkeepingRecordAlreadyExists', $this->doc_type, $this->fk_doc, $this->fk_docdet);
+
+				dol_syslog(__METHOD__ . ' duplicate record detected: '
+					. 'doc_type=' . $this->doc_type
+					. ', doc_ref=' . $this->doc_ref
+					. ', fk_doc=' . ((int) $this->fk_doc)
+					. ', fk_docdet=' . ((int) $this->fk_docdet)
+					. ', numero_compte=' . $this->numero_compte
+					. ', label_operation=' . $this->label_operation
+					. ', subledger_account=' . ($this->subledger_account ?? '(null)'),
+					LOG_WARNING
+				);
 			}
 		} else {
 			$result = -5;

--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -489,7 +489,7 @@ class BookKeeping extends CommonObject
 				$this->error = 'BookkeepingRecordAlreadyExists';
 				$this->errors[] = $langs->trans('WarningBookkeepingRecordAlreadyExists', $this->doc_type, $this->fk_doc, $this->fk_docdet);
 
-				dol_syslog(get_class($this).":: duplicate record detected: doc_type=" . $this->doc_type.", doc_ref=" . $this->doc_ref . ", fk_doc=" . ((int) $this->fk_doc) . ", fk_docdet=" . ((int) $this->fk_docdet), LOG_WARNING);
+				dol_syslog(get_class($this).":: create duplicate record detected: doc_type={$this->doc_type}, doc_ref={$this->doc_ref}, fk_doc={((int) $this->fk_doc)}, fk_docdet={((int) $this->fk_docdet)}", LOG_WARNING);
 			}
 		} else {
 			$result = -5;


### PR DESCRIPTION
Description:

During the fiscal year closing process (doc_type = 'closure'), Dolibarr was failing with a BookKeeping::create duplicate detected error and rolling back the transaction.

This occurred because an initial minimal entry (e.g., rounding adjustment) was written to the accounting result account (12000000), blocking any subsequent legitimate closing entries on that same account within the same transaction due to the strict duplicate-check constraint.

Changes:

Modified BookKeeping::create() in bookkeeping.class.php.

Bypassed the duplicate check validation specifically when the processed account matches either the ACCOUNTING_RESULT_PROFIT or ACCOUNTING_RESULT_LOSS global constants.

This ensures that multiple entries can coexist on the result accounts during closing without throwing a false-positive duplicate error.