### PR TITLE
Fix Email events in agenda created with wrong type "Other" and status "N/A"

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1024,7 +1024,7 @@ if (empty($reshook)) {
 	include DOL_DOCUMENT_ROOT . '/core/actions_printing.inc.php';
 
 	// Actions to send emails
-	$actiontypecode = 'AC_OTH_AUTO';
+	$actiontypecode = 'AC_EMAIL';
 	$triggersendname = 'PROPAL_SENTBYMAIL';
 	$autocopy = 'MAIN_MAIL_AUTOCOPY_PROPOSAL_TO';
 	$trackid = 'pro' . $object->id;

--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -448,7 +448,7 @@ if (($action == 'send' || $action == 'relance') && !GETPOST('addfile') && !GETPO
 						$db->begin();	// Transaction for post action must start after sending email to avoid lock when sending email that may be long
 
 						if (empty($actiontypecode)) {
-							$actiontypecode = 'AC_OTH_AUTO'; // Event inserted into agenda automatically
+							$actiontypecode = 'AC_EMAIL'; // Event inserted into agenda automatically
 						}
 
 						$object->socid = $sendtosocid; // To link to a company

--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -1621,7 +1621,7 @@ class InterfaceActionsAuto extends DolibarrTriggers
 		$actioncomm->datep       = $now;
 		$actioncomm->datef       = $now;
 		$actioncomm->durationp   = 0;
-		$actioncomm->percentage  = -1; // Not applicable
+		$actioncomm->percentage  = ($actioncomm->type_code === 'AC_EMAIL') ? 100 : -1; // 100 = Done for sent emails, -1 = Not applicable otherwise
 		$actioncomm->socid       = $societeforactionid;
 		$actioncomm->contact_id  = $contactforactionid; // deprecated, now managed by setting $actioncomm->socpeopleassigned later
 		$actioncomm->authorid    = $user->id; // User saving action


### PR DESCRIPTION
# FIX|Fix Email events in agenda created with wrong type "Other" and status "N/A"

When sending an email from any module (order, invoice, proposal, etc.), the agenda event was created with type "Other (automatic)" instead of "Send Email", and with status "N/A" instead of "Done".

Root cause 1: `actions_sendmails.inc.php` used `AC_OTH_AUTO` as fallback when `$actiontypecode` was not set, and `comm/propal/card.php` also set it explicitly to`AC_OTH_AUTO` before the include. Both should use `AC_EMAIL`.


Root cause 2: `interface_50_modAgenda_ActionsAuto.class.php` hardcoded `percentage = -1` (N/A) for all automatic events. For sent emails (`AC_EMAIL`), the percentage should be `100` (Done) since the email was successfully delivered.