### PR TITLE
Add setting to allow tls bad cert

### DIFF
--- a/htdocs/admin/ldap.php
+++ b/htdocs/admin/ldap.php
@@ -101,6 +101,9 @@ if (empty($reshook)) {
 		if (!dolibarr_set_const($db, 'LDAP_SERVER_USE_TLS', GETPOST("usetls", 'aZ09'), 'chaine', 0, '', $conf->entity)) {
 			$error++;
 		}
+		if (!dolibarr_set_const($db, 'LDAP_SERVER_TLS_IGNORE_CERT', GETPOST("tlsignorecert", 'aZ09'), 'chaine', 0, '', $conf->entity)) {
+			$error++;
+		}
 		if (!dolibarr_set_const($db, 'LDAP_SYNCHRO_ACTIVE', GETPOST("activesynchro", 'aZ09'), 'chaine', 0, '', $conf->entity)) {
 			$error++;
 		}
@@ -243,6 +246,10 @@ print '</td><td><span class="opacitymedium">'.$langs->trans("LDAPServerDnExample
 print '<tr class="oddeven"><td>'.$langs->trans("LDAPServerUseTLS").'</td><td>';
 print $form->selectyesno('usetls', getDolGlobalInt('LDAP_SERVER_USE_TLS'), 1);
 print '</td><td><span class="opacitymedium">'.$langs->trans("LDAPServerUseTLSExample").'</span></td></tr>';
+
+// Ignore SSL Certs
+print '<tr class="oddeven"><td>'.$langs->trans("LDAPServerTLSIgnoreCert").'</td><td>';
+print $form->selectyesno('tlsignorecert', getDolGlobalInt('LDAP_SERVER_TLS_IGNORE_CERT'), 1);
 
 // Password hash type
 print '<tr class="oddeven"><td>'.$langs->trans("LDAPPasswordHashType").'</td><td>';

--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -397,6 +397,10 @@ class Ldap
 						//ldap_set_option($this->connection, LDAP_OPT_PROTOCOL_VERSION, 3);
 						//ldap_set_option($this->connection, LDAP_OPT_REFERRALS, 0);
 
+                        if (getDolGlobalString('LDAP_SERVER_TLS_IGNORE_CERT')) {
+							dol_syslog(get_class($this)."::connectBind ignoring tls cert", LOG_WARNING);
+                            ldap_set_option($this->connection, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_ALLOW);
+                        }
 						$resulttls = ldap_start_tls($this->connection);
 						if (!$resulttls) {
 							dol_syslog(get_class($this)."::connectBind failed to start tls", LOG_WARNING);

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1656,6 +1656,7 @@ LDAPServerPort=Server port
 LDAPServerPortExample=Standard or StartTLS: 389, LDAPs: 636
 LDAPServerProtocolVersion=Protocol version
 LDAPServerUseTLS=Use TLS
+LDAPServerTLSIgnoreCert=Ignore server TLS certificate
 LDAPServerUseTLSExample=Your LDAP server use StartTLS
 LDAPServerDn=Server DN
 LDAPAdminDn=Administrator DN

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -1656,6 +1656,7 @@ LDAPServerPort=Port du serveur
 LDAPServerPortExample=Standard ou StartTLS: 389, LDAP: 636
 LDAPServerProtocolVersion=Version du protocole
 LDAPServerUseTLS=Utiliser TLS
+LDAPServerTLSIgnoreCert=Ignorer le certificat TLS du serveur
 LDAPServerUseTLSExample=Votre serveur LDAP utilise StartTLS
 LDAPServerDn=DN du serveur
 LDAPAdminDn=DN de l'administrateur


### PR DESCRIPTION
# New Add a LDAP setting to allow start tls with ldap and self signed certificate

In some case, as a LDAP is a backend service it might use self signed certificate, in such case the admin want to be able to allow to trust any certificate to connect the LDAP via start tls.

It is less secure than having a trusted certificate but still better than clear connexion.