### PR TITLE
fix: correct wrong constant name for PayPal payment type in donation block

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -1321,7 +1321,7 @@ if ($ispaymentok) {
 				$paymentTypeId = getDolGlobalInt('PAYBOX_PAYMENT_MODE_FOR_PAYMENTS');
 			}
 			if ($paymentmethod == 'paypal') {
-				$paymentTypeId = getDolGlobalInt('global->PAYPAL_PAYMENT_MODE_FOR_PAYMENTS');
+				$paymentTypeId = getDolGlobalInt('PAYPAL_PAYMENT_MODE_FOR_PAYMENTS');
 			}
 			if ($paymentmethod == 'stripe') {
 				$paymentTypeId = getDolGlobalInt('STRIPE_PAYMENT_MODE_FOR_PAYMENTS');


### PR DESCRIPTION
# FIX Fix wrong constant name for PayPal payment type in donation block

In the `DON` payment block, the PayPal payment type resolution was broken due to a copy-paste gone wrong.

When Dolibarr moved away from `$conf->global->CONSTANT` toward `getDolGlobalInt('CONSTANT')`, the `global->` prefix was accidentally carried into the string argument:

```php
// Wrong — residue of the old $conf->global->PAYPAL_... syntax
$paymentTypeId = getDolGlobalInt('global->PAYPAL_PAYMENT_MODE_FOR_PAYMENTS');

// Fixed
$paymentTypeId = getDolGlobalInt('PAYPAL_PAYMENT_MODE_FOR_PAYMENTS');
```

As a result, `getDolGlobalInt` was looking for a constant literally named `global->PAYPAL_PAYMENT_MODE_FOR_PAYMENTS`, which never resolves, leaving `$paymentTypeId` at `0` and causing PayPal donations to always fall back to the hardcoded `CB` payment type.

All other payment objects in the same file (MEM, INV, ORD, ATT, BOO, CON) use the correct form.
