### PR TITLE
Simplify dom parsing

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9330,15 +9330,13 @@ function dol_string_onlythesehtmlattributes($stringtoclean, $allowed_attributes 
 	}
 
 	if (class_exists('DOMDocument') && !empty($stringtoclean)) {
-		//$stringtoclean = '<?xml encoding="UTF-8"><html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body>'.$stringtoclean.'</body></html>';
-		$stringtoclean = '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body>' . $stringtoclean . '</body></html>';
-
 		// Warning: loadHTML does not support HTML5 on old libxml versions.
 		$dom = new DOMDocument('', 'UTF-8');
 		// If $stringtoclean is wrong, it will generates warnings. So we disable warnings and restore them later.
 		$savwarning = error_reporting();
 		error_reporting(E_ALL & ~E_WARNING & ~E_NOTICE);
-		$dom->loadHTML($stringtoclean, LIBXML_ERR_NONE | LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD | LIBXML_NONET | LIBXML_NOWARNING | LIBXML_NOXMLDECL);
+		$wrapperId = "dol_string_onlythesehtmlattributes___wrapper";
+		$dom->loadHTML('<?xml encoding="UTF-8"><div id="' . $wrapperId . '">' . $stringtoclean . '</div>', LIBXML_HTML_NODEFDTD | LIBXML_ERR_NONE | LIBXML_HTML_NOIMPLIED | LIBXML_NONET | LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_NOXMLDECL);
 		error_reporting($savwarning);
 
 		if ($dom instanceof DOMDocument) {
@@ -9383,13 +9381,11 @@ function dol_string_onlythesehtmlattributes($stringtoclean, $allowed_attributes 
 		}
 
 		$dom->encoding = 'UTF-8';
-
-		$return = $dom->saveHTML();	// This may add a LF at end of lines, so we will trim later
-		//$return = '<html><body>aaaa</p>bb<p>ssdd</p>'."\n<p>aaa</p>aa<p>bb</p>";
-
-		//$return = preg_replace('/^'.preg_quote('<?xml encoding="UTF-8">', '/').'/', '', $return);
-		$return = preg_replace('/^' . preg_quote('<html><head><', '/') . '[^<>]*' . preg_quote('></head><body>', '/') . '/', '', $return);
-		$return = preg_replace('/' . preg_quote('</body></html>', '/') . '$/', '', trim($return));
+		$wrapper = $dom->getElementById($wrapperId);
+		$return = '';
+		foreach ($wrapper->childNodes as $child) {
+			$return .= $dom->saveHTML($child);
+		}
 
 		return trim($return);
 	} else {
@@ -9568,14 +9564,8 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 					//  like 'abc' that wrongly ends up, without the trick, with '<p>abc</p>'
 					// Add also a trick <html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"> to solve utf8 lost.
 					// I don't know what the xml encoding is the trick for
-					if ($outishtml) {
-						//$out = '<?xml encoding="UTF-8"><html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">'.$out.'</div></body></html>';
-						$out = '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">' . $out . '</div></body></html>';
-						//$out = '<html><head><meta charset="utf-8"></head><body><div class="tricktoremove">'.$out.'</div></body></html>';
-					} else {
-						//$out = '<?xml encoding="UTF-8"><html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">'.dol_nl2br($out).'</div></body></html>';
-						$out = '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">' . dol_nl2br($out) . '</div></body></html>';
-						//$out = '<html><head><meta charset="utf-8"></head><body><div class="tricktoremove">'.dol_nl2br($out).'</div></body></html>';
+					if (!$outishtml) {
+						$out = dol_nl2br($out);
 					}
 
 					// Note: <a href="https://__[aaa]__/aaa.html"> is transformed into <a href="https://__[aaa]__/aaa.html">
@@ -9591,8 +9581,8 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 						},
 						$out
 					);
-
-					$dom->loadHTML($out, LIBXML_HTML_NODEFDTD | LIBXML_ERR_NONE | LIBXML_HTML_NOIMPLIED | LIBXML_NONET | LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_NOXMLDECL);
+					$wrapperId = "dol_htmlwithnojs___wrapper___toremove";
+					$dom->loadHTML('<?xml encoding="UTF-8"><div id="' . $wrapperId . '">' . $out . '</div>', LIBXML_HTML_NODEFDTD | LIBXML_ERR_NONE | LIBXML_HTML_NOIMPLIED | LIBXML_NONET | LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_NOXMLDECL);
 
 					$dom->encoding = 'UTF-8';
 
@@ -9630,7 +9620,12 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 						}
 					}
 
-					$out = trim($dom->saveHTML());
+					$wrapper = $dom->getElementById($wrapperId);
+					$result = '';
+					foreach ($wrapper->childNodes as $child) {
+						$result .= $dom->saveHTML($child);
+					}
+					$out = trim($result);
 
 					// Restore [ and ] that were protected before loadHTML
 					$out = preg_replace_callback(
@@ -9644,16 +9639,8 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 						},
 						$out
 					);
-
-					// Remove the trick added to solve pb with text in utf8 and text without parent tag
-					//$out = preg_replace('/^'.preg_quote('<?xml encoding="UTF-8">', '/').'/', '', $out);
-					$out = preg_replace('/^' . preg_quote('<html><head><', '/') . '[^<>]+' . preg_quote('></head><body><div class="tricktoremove">', '/') . '/', '', $out);
-					$out = preg_replace('/' . preg_quote('</div></body></html>', '/') . '$/', '', trim($out));
-					//$out = preg_replace('/^<\?xml encoding="UTF-8"><div class="tricktoremove">/', '', $out);
-					//$out = preg_replace('/<\/div>$/', '', $out);
-
-					if (!$outishtml) {		// If $out was not HTML content we made before a dol_nl2br so we must do the opposite operation now
-						$out = str_replace('<br>', '', $out);
+					if (!$outishtml) {        // If $out was not HTML content we made before a dol_nl2br so we must do the opposite operation now
+						$out = preg_replace('/<br\s*\/?>/i', "\n", $out);
 					}
 				} catch (Exception $e) {
 					// If error, invalid HTML string with no way to clean it


### PR DESCRIPTION
### QUAL Simplify DOMDocument HTML parsing in dol_htmlwithnoexternalresource and dol_string_onlythesehtmlattributes

Replace full HTML document wrapper (`<html><head><meta ...></head><body>`) with a simple
`<div>` wrapper and `<?xml encoding="UTF-8">` declaration to preserve UTF-8 encoding.
Extract inner content by iterating over child nodes with `saveHTML()` instead of stripping
the wrapper with fragile regex.

Also fix `str_replace('<br>', '', $out)` which was incorrectly removing line breaks instead
of restoring them when converting back from `dol_nl2br()`.

Tested with UTF-8 content (accents, special characters, emojis, mixed HTML entities) to
confirm no character corruption.