### PR TITLE
FIX: use multidir_output fallback for multi-entity HRM PDF generation

### DIFF
--- a/htdocs/core/modules/hrm/doc/pdf_standard.modules.php
+++ b/htdocs/core/modules/hrm/doc/pdf_standard.modules.php
@@ -161,14 +161,14 @@ class pdf_standard extends ModelePDFEvaluation
 
 		if ($conf->hrm->dir_output) {
 			// Definition of $dir and $file
+			$entity = isset($object->entity) ? $object->entity : 1;
+			$basedir = empty($conf->hrm->multidir_output[$entity]) ? $conf->hrm->dir_output : $conf->hrm->multidir_output[$entity];
 			if ($object->specimen) {
-				//$dir = $conf->hrm->dir_output;
-				$dir = $conf->hrm->multidir_output[isset($object->entity) ? $object->entity : 1].'/evaluation';
+				$dir = $basedir.'/evaluation';
 				$file = $dir."/SPECIMEN.pdf";
 			} else {
 				$objectref = dol_sanitizeFileName($object->ref);
-				//$dir = $conf->hrm->dir_output."/".$objectref;
-				$dir = $conf->hrm->multidir_output[isset($object->entity) ? $object->entity : 1].'/evaluation'."/".$objectref;
+				$dir = $basedir.'/evaluation'."/".$objectref;
 				$file = $dir."/".$objectref.".pdf";
 			}
 


### PR DESCRIPTION

# FIX|Fix #[*use multidir_output fallback for multi-entity HRM PDF generation*]

- When generating a PDF for an `Evaluation` object on an entity other than entity 1, `$conf->hrm->multidir_output[$entity]` was used without any fallback to `$conf->hrm->dir_output`
- If `multidir_output` for the target entity is empty/unset, the resulting path was `/evaluation/<ref>` (missing base directory), causing `dol_mkdir()` to fail with "Impossible de créer le répertoire /evaluation/EVAL..."
- This only affects multi-entity setups; entity 1 is not impacted

Apply the same fallback pattern already used in other PDF modules (e.g. `pdf_crabe.modules.php` for invoices, lines 268–272):

```php
$entity = isset($object->entity) ? $object->entity : 1;
$basedir = empty($conf->hrm->multidir_output[$entity]) ? $conf->hrm->dir_output : $conf->hrm->multidir_output[$entity];