### PR TITLE
FIX : use get_exdir to compute holiday upload path in prepare_head

### DIFF
--- a/htdocs/core/lib/holiday.lib.php
+++ b/htdocs/core/lib/holiday.lib.php
@@ -43,7 +43,7 @@ function holiday_prepare_head($object)
 	// Attachments
 	require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
 	require_once DOL_DOCUMENT_ROOT.'/core/class/link.class.php';
-	$upload_dir = $conf->holiday->multidir_output[$object->entity].'/'.dol_sanitizeFileName($object->ref);
+	$upload_dir = $conf->holiday->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, 'holiday');
 	$nbFiles = count(dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));
 	$nbLinks = Link::count($db, $object->element, $object->id);
 	$head[$h][0] = DOL_URL_ROOT.'/holiday/document.php?id='.$object->id;


### PR DESCRIPTION
# FIX|Fix #[*use get_exdir to compute holiday upload path in prepare_head*]

The attachment badge count on the "Documents" tab of a leave request
always shows nothing, even after adding an attachment.

In holiday_prepare_head(), the upload directory is computed as:

$upload_dir = $conf->holiday->multidir_output[$object->entity].'/'.dol_sanitizeFileName($object->ref);

However, the holiday module stores files using an ID-based 2-level hierarchy (it is listed in $arrayforoldpath in get_exdir with level 2).
The actual storage path looks like 0/1/ (based on object ID), not the ref string. The mismatch means dol_dir_list() always scans an empty or non-existent directory, so the badge count is always 0.

Fix

Use get_exdir() consistently with the rest of the holiday module (same call used in holiday/document.php):

$upload_dir = $conf->holiday->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, 'holiday');