### PR TITLE
Fix MEMBER_NEWFORM_FORCECOUNTRYCODE ignored when set to a country ISO code string

### DIFF
--- a/htdocs/public/members/new.php
+++ b/htdocs/public/members/new.php
@@ -309,7 +309,8 @@ if (empty($reshook) && $action == 'add') {	// Test on permission not required he
 	$firstname = GETPOST("firstname", 'alphanohtml');
 	$societe = GETPOST("societe", 'alphanohtml');
 	$email = preg_replace('/\s+/', '', GETPOST("member_email", 'aZ09arobase'));
-	$country_id = getDolGlobalInt("MEMBER_NEWFORM_FORCECOUNTRYCODE", GETPOSTINT('country_id'));
+	$forcecountry = getDolGlobalString('MEMBER_NEWFORM_FORCECOUNTRYCODE');
+	$country_id = $forcecountry ? (int) getCountry($forcecountry, '3', $db, $langs) : GETPOSTINT('country_id');
 
 	if (!in_array($morphy, array('mor', 'phy'))) {
 		$error++;
@@ -426,7 +427,7 @@ if (empty($reshook) && $action == 'add') {	// Test on permission not required he
 			$adh->pass = GETPOST('pass1', 'password');
 		}
 		$adh->photo       = GETPOST('photo');
-		$adh->country_id  = getDolGlobalInt("MEMBER_NEWFORM_FORCECOUNTRYCODE", GETPOSTINT('country_id'));
+		$adh->country_id  = $country_id;
 		$adh->state_id    = GETPOSTINT('state_id');
 		$adh->typeid      = getDolGlobalInt("MEMBER_NEWFORM_FORCETYPE", GETPOSTINT('typeid'));
 		$adh->note_private = GETPOST('note_private');
@@ -911,7 +912,7 @@ if (getDolGlobalString('MEMBER_SKIP_TABLE') || getDolGlobalString('MEMBER_NEWFOR
 	print '<tr><td class="fieldrequired">'.$langs->trans('Country').'</td><td>';
 	print img_picto('', 'country', 'class="pictofixedwidth paddingright"');
 	if (!$country_id && getDolGlobalString('MEMBER_NEWFORM_FORCECOUNTRYCODE')) {
-		$country_id = getCountry(getDolGlobalString('MEMBER_NEWFORM_FORCECOUNTRYCODE'), '2', $db, $langs);
+		$country_id = (int) getCountry(getDolGlobalString('MEMBER_NEWFORM_FORCECOUNTRYCODE'), '3', $db, $langs);
 	}
 	if (!$country_id && !empty($conf->geoipmaxmind->enabled)) {
 		$country_code = dol_user_country();


### PR DESCRIPTION
## Problem

When `MEMBER_NEWFORM_FORCECOUNTRYCODE` is set to a country ISO code string (e.g. `'ET'` for Ethiopia), the public member registration form (`/public/members/new.php`) incorrectly raises a **"Country is required"** validation error, even though the constant is properly configured.

### Root cause

Two bugs in the same file:

**Bug 1 — action section (lines 312 & 429):**
```php
$country_id = getDolGlobalInt("MEMBER_NEWFORM_FORCECOUNTRYCODE", GETPOSTINT('country_id'));
```
`getDolGlobalInt()` converts `'ET'` to `(int)'ET'` = `0`. Since the constant *is* defined (even if its integer value is 0), the fallback `GETPOSTINT('country_id')` is never used. Result: `$country_id = 0` → validation failure.

**Bug 2 — view section (line 914):**
```php
$country_id = getCountry(getDolGlobalString('MEMBER_NEWFORM_FORCECOUNTRYCODE'), '2', $db, $langs);
```
`getCountry()` mode `'2'` returns the ISO **code** string (e.g. `'ET'`), not the numeric rowid. `select_country()` expects an integer rowid, so the country is not pre-selected in the dropdown.

## Fix

Both the action and view sections now use `getCountry(..., '3', ...)` which returns the numeric `rowid` and correctly resolves both ISO code strings (`'ET'`) and numeric IDs (`90`):

```php
// Action section
$forcecountry = getDolGlobalString('MEMBER_NEWFORM_FORCECOUNTRYCODE');
$country_id = $forcecountry ? (int) getCountry($forcecountry, '3', $db, $langs) : GETPOSTINT('country_id');

// View section
$country_id = (int) getCountry(getDolGlobalString('MEMBER_NEWFORM_FORCECOUNTRYCODE'), '3', $db, $langs);
```

The duplicate resolution on line 429 is replaced by a direct reuse of the already-resolved `$country_id`.

## Impact

Any instance using `MEMBER_NEWFORM_FORCECOUNTRYCODE` with an ISO code string (the documented format) will see the "Country is required" error on every public membership form submission. This is a regression introduced when the server-side country validation was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)