### PR TITLE
Fix supplier order stuck in "Partially received" status when STOCK_SUPPORTS_SERVICES is enabled and all stockable lines are received

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -656,7 +656,7 @@ class CommandeFournisseur extends CommonOrder
 		$sql .= " l.vat_src_code, l.tva_tx, l.remise_percent, l.subprice, l.subprice_ttc,";
 		$sql .= " l.localtax1_tx, l. localtax2_tx, l.localtax1_type, l. localtax2_type, l.total_localtax1, l.total_localtax2,";
 		$sql .= " l.total_ht, l.total_tva, l.total_ttc, l.info_bits, l.special_code, l.fk_parent_line, l.rang,";
-		$sql .= " p.rowid as product_id, p.ref as product_ref, p.label as product_label, p.description as product_desc, p.tobatch as product_tobatch, p.barcode as product_barcode,";
+		$sql .= " p.rowid as product_id, p.ref as product_ref, p.label as product_label, p.description as product_desc, p.tobatch as product_tobatch, p.barcode as product_barcode, p.stockable_product,";
 		$sql .= " l.fk_unit, l.extraparams,";
 		$sql .= " l.date_start, l.date_end,";
 		$sql .= ' l.fk_multicurrency, l.multicurrency_code, l.multicurrency_subprice, l.multicurrency_subprice_ttc, l.multicurrency_total_ht, l.multicurrency_total_tva, l.multicurrency_total_ttc';
@@ -712,6 +712,7 @@ class CommandeFournisseur extends CommonOrder
 				$line->product_desc        = $objp->product_desc;
 				$line->product_tobatch     = $objp->product_tobatch;
 				$line->product_barcode     = $objp->product_barcode;
+				$line->stockable_product   = $objp->stockable_product;
 
 				$line->ref                 = $objp->product_ref; // Ref of product
 				$line->product_ref         = $objp->product_ref; // Ref of product
@@ -3788,7 +3789,7 @@ class CommandeFournisseur extends CommonOrder
 					}
 					foreach ($this->lines as $line) {
 						// Exclude lines not qualified for shipment, similar code is found into interface_20_modWrokflow for customers
-						if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $line->product_type > 0) {
+						if ($line->product_type > 0 && (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') || empty($line->stockable_product))) {
 							continue;
 						}
 						if (array_key_exists($line->fk_product, $qtywished)) {

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -900,7 +900,7 @@ class Reception extends CommonObject
 				// qty wished in origin (purchase order, ...)
 				foreach ($this->origin_object->lines as $origin_line) {
 					// exclude lines not qualified for reception
-					if ((!getDolGlobalInt('STOCK_SUPPORTS_SERVICES') && $origin_line->product_type > 0) || $origin_line->product_type > 1) {
+					if (($origin_line->product_type > 0 && (!getDolGlobalInt('STOCK_SUPPORTS_SERVICES') || empty($origin_line->stockable_product))) || $origin_line->product_type > 1) {
 						continue;
 					}
 					if (array_key_exists($origin_line->fk_product, $qty_wished)) {


### PR DESCRIPTION
# FIX|Fix Fix supplier order stuck in "Partially received" status when STOCK_SUPPORTS_SERVICES is enabled and all stockable lines are received


When a supplier order contains lines with `stockable_product=0` (products or services not managed in stock), fully receiving all stockable lines left the order stuck in "Partially received" status because Dolibarr also waited for non-stockable lines to be dispatched.

The root cause: `getStatusDispatch()` (reception.class.php) and `calcAndSetStatusDispatch()` (fournisseur.commande.class.php) only excluded services when `STOCK_SUPPORTS_SERVICES` was disabled.

Non-stockable products (`product_type=0`, `stockable_product=0`) were never excluded, and non-stockable services were included whenever `STOCK_SUPPORTS_SERVICES` was active, regardless of their individual `stockable_product` flag.
Fix: `fetch_lines()` now selects `p.stockable_product` from the product table, and both status calculation methods exclude any line where `stockable_product=0`, while still respecting the `STOCK_SUPPORTS_SERVICES` setting at runtime for services.