### PR TITLE
FIX setCategoriesCommon() warnings when containing() returns -1 (non-array)

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -11557,15 +11557,15 @@ abstract class CommonObject
 		// Get current categories
 		$c = new Categorie($this->db);
 		$existing = $c->containing($this->id, $type_categ, 'id');
+		// containing() returns an integer < 0 on error (e.g. when the categorie_xxx table does not exist).
+		// Normalize to an empty array to avoid array_diff()/foreach() warnings below.
+		if (!is_array($existing)) {
+			$existing = array();
+		}
 		if ($remove_existing) {
 			// Diff
-			if (is_array($existing)) {
-				$to_del = array_diff($existing, $categories);
-				$to_add = array_diff($categories, $existing);
-			} else {
-				$to_del = array(); // Nothing to delete
-				$to_add = $categories;
-			}
+			$to_del = array_diff($existing, $categories);
+			$to_add = array_diff($categories, $existing);
 		} else {
 			$to_del = array(); // Nothing to delete
 			$to_add = array_diff($categories, $existing);


### PR DESCRIPTION
## What this PR does

Fixes PHP warnings (fatal `TypeError` on PHP 8) raised by `CommonObject::setCategoriesCommon()` during object creation when the related category table is missing.

## Root cause

`Categorie::containing()` returns an integer `-1` when its SQL query fails — for example when the `llx_categorie_xxx` table for that category type does not exist (missing/late module migration).

In `setCategoriesCommon()`, the `$remove_existing = true` branch already guards with `is_array($existing)`, but the `$remove_existing = false` branch passes `$existing` straight to `array_diff()`:

```php
} else {
    $to_del = array(); // Nothing to delete
    $to_add = array_diff($categories, $existing); // $existing can be int -1
}
```

This produces, on PHP 7.x:

```
PHP Warning: array_diff(): Expected parameter 2 to be an array, int given in .../commonobject.class.php
PHP Warning: Invalid argument supplied for foreach() in .../commonobject.class.php
PHP Warning: Cannot modify header information - headers already sent ... in actions_addupdatedelete.inc.php
```

and a fatal `array_diff(): Argument #2 must be of type array, int given` `TypeError` on PHP 8. The warnings are echoed before the post-creation redirect, which then fails with "headers already sent".

## Fix

Normalize `$existing` to an empty array right after the `containing()` call, so both branches are safe, and drop the now-redundant inner `is_array()` guard. No behavioural change when `containing()` returns an array.

## How to reproduce

Create an object whose class manages categories (`setCategories()` called with `remove_existing = false`) while its `llx_categorie_xxx` table is absent — e.g. a module object after a partial upgrade. Without the patch the creation redirect breaks with the warnings above; with the patch the object is created cleanly.