### PR TITLE
NEW clone supplier prices when cloning a product (#31495)

### DIFF
--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1016,6 +1016,15 @@ if (empty($reshook)) {
 							}
 						}
 
+						if (!$error && GETPOST('clone_supplier_prices')) {
+							$result = $clone->clone_fournisseurs($object->id, $id);
+							if ($result < 1) {
+								setEventMessages($langs->trans('ErrorProductClone'), null, 'errors');
+								setEventMessages($clone->error, $clone->errors, 'errors');
+								$error++;
+							}
+						}
+
 						if (!$error && isModEnabled('bom') && $user->hasRight('bom', 'write')) {
 							$defbomidac = 0; // to avoid cloning same BOM twice
 							if (GETPOST('clone_defbom') && $object->fk_default_bom > 0) {
@@ -1053,7 +1062,6 @@ if (empty($reshook)) {
 								}
 							}
 						}
-						// $clone->clone_fournisseurs($object->id, $id);
 					} else {
 						if ($clone->error == 'ErrorProductAlreadyExists') {
 							$refalreadyexists++;
@@ -3078,6 +3086,7 @@ if (($action == 'clone' && (empty($conf->use_javascript_ajax) || !empty($conf->d
 	if (getDolGlobalString('PRODUIT_MULTIPRICES')) {
 		$formquestionclone[] = array('type' => 'checkbox', 'name' => 'clone_prices', 'label' => $langs->trans("ClonePricesProduct").' ('.$langs->trans("CustomerPrices").')', 'value' => 0);
 	}
+	$formquestionclone[] = array('type' => 'checkbox', 'name' => 'clone_supplier_prices', 'label' => $langs->trans("ClonePricesProduct").' ('.$langs->trans("SupplierPrices").')', 'value' => 0);
 	if (getDolGlobalString('PRODUIT_SOUSPRODUITS')) {
 		$formquestionclone[] = array('type' => 'checkbox', 'name' => 'clone_composition', 'label' => $langs->trans('CloneCompositionProduct'), 'value' => 1);
 	}


### PR DESCRIPTION
The product clone form already exposes a "Clone prices (Customer prices)" checkbox that drives Product::clone_price(). The matching supplier-side helper Product::clone_fournisseurs() existed in product.class.php but was only invoked through a dead commented-out call in product/card.php, so users who cloned a product or service lost all their vendor prices silently.

Add a second "Clone prices (Vendor prices)" checkbox, default off to preserve current behaviour, and call clone_fournisseurs() when it is ticked using the same error-handling pattern as the customer-side clone. Remove the misleading commented-out call that has been confusing contributors for years.

clone_fournisseurs() itself copies into llx_product_fournisseur_price (price, quantity, fk_user, tva_tx, fk_soc). It does not copy the ref_fourn / vendor SKU because that field is part of a separate INSERT block in the same method that is intentionally commented out (it would conflict with the unique key on the supplier-ref row). Surfacing the SKU clone is a separate scope.

Develop-branch version of PR #38533 (closed): @eldy requested that since this adds a new user-facing option, it should go to develop as a new implemented feature rather than to 21.0 as a bug fix.