### PR TITLE
FIX generate_random_id() collisions (Duplicate entry on uk_ticket_track_id)

### DIFF
--- a/htdocs/core/lib/ticket.lib.php
+++ b/htdocs/core/lib/ticket.lib.php
@@ -209,9 +209,9 @@ function generate_random_id($car = 16)
 {
 	$string = "";
 	$chaine = "abcdefghijklmnopqrstuvwxyz123456789";
-	mt_srand((int) ((float) microtime() * 1000000));
+	$max = strlen($chaine) - 1;
 	for ($i = 0; $i < $car; $i++) {
-		$string .= $chaine[mt_rand() % strlen($chaine)];
+		$string .= $chaine[random_int(0, $max)];
 	}
 	return $string;
 }


### PR DESCRIPTION
# FIX generate_random_id() produces colliding ids (Duplicate entry on uk_ticket_track_id)

## Problem

`generate_random_id()` (`htdocs/core/lib/ticket.lib.php`) reseeds the PRNG on **every** call:

```php
mt_srand((int) ((float) microtime() * 1000000));
...
$string .= $chaine[mt_rand() % strlen($chaine)];
```

PHP masks the `mt_srand` seed to **uint32**, so the effective seed is `(microtime()*1e6) mod 2^32`. Two consequences:

- the seed **repeats roughly every ~71 minutes** of wall-clock time;
- two calls in the **same microsecond** get the **same seed**, therefore the **same id**.

The usable id space is effectively ~2^32 and time-correlated, not 35^16. (There is also a small modulo bias from `mt_rand() % strlen(...)`.)

In production this makes ticket creation fail under concurrency / bursts (REST API, public ticket interface) with:

```
DB_ERROR_RECORD_ALREADY_EXISTS Duplicate entry 'xxxxxxxxxxxxxxxx' for key 'uk_ticket_track_id'
```

We observed a freshly created ticket collide with the `track_id` of a ticket created **two months earlier**; the citizen-facing creation failed until a later retry happened to produce a different id.

## Fix

Use the CSPRNG `random_int()` (unbiased) and stop reseeding `mt_srand` on each call. Same charset and length, so the generated id format is unchanged. `random_int()` has been available since PHP 7.0.

```php
$max = strlen($chaine) - 1;
for ($i = 0; $i < $car; $i++) {
    $string .= $chaine[random_int(0, $max)];
}
```
