### PR TITLE
Fix #38279 expose Subscription dates and note under documented names in API

### DIFF
--- a/htdocs/adherents/class/api_members.class.php
+++ b/htdocs/adherents/class/api_members.class.php
@@ -614,6 +614,17 @@ class Members extends DolibarrApi
 			unset($object->total_ttc);
 		}
 
+		// Expose POST-friendly aliases on the Subscription GET response so the
+		// payload returned by GET /members/{id}/subscriptions matches the field
+		// names POST /members/{id}/subscriptions expects (see issue #38279).
+		// $dateh / $datef stay in the response for backward compatibility with
+		// existing consumers; date_start / date_end are the documented names
+		// used by the rest of the codebase (e.g. tasks, expenses, holidays).
+		if ($object instanceof Subscription) {
+			$object->date_start = $object->dateh;
+			$object->date_end = $object->datef;
+		}
+
 		return $object;
 	}
 

--- a/htdocs/adherents/class/subscription.class.php
+++ b/htdocs/adherents/class/subscription.class.php
@@ -78,6 +78,33 @@ class Subscription extends CommonObject
 	public $datef;
 
 	/**
+	 * Alias of $dateh exposed by the REST API GET response so the same payload
+	 * can be sent back to POST /members/{id}/subscriptions without renaming
+	 * client-side. Matches the date_start / date_end naming convention used by
+	 * other Dolibarr objects. Not persisted (see issue #38279).
+	 *
+	 * @var integer
+	 */
+	public $date_start;
+
+	/**
+	 * Alias of $datef exposed by the REST API GET response (see issue #38279).
+	 * Not persisted.
+	 *
+	 * @var integer
+	 */
+	public $date_end;
+
+	/**
+	 * Public note exposed under the documented field name. Already populated by
+	 * fetch() but not declared as a real property; declared here so phpstan and
+	 * phan stop flagging the API setter as touching a dynamic property.
+	 *
+	 * @var string
+	 */
+	public $note_public;
+
+	/**
 	 * @var int ID
 	 */
 	public $fk_type;


### PR DESCRIPTION
GET /api/index.php/members/{id}/subscriptions returned the raw Subscription object fields (dateh, datef, note_public, amount) while POST /api/index.php/members/{id}/subscriptions takes start_date, end_date, amount, label. A client that fetches existing subscriptions to push them back has to translate the field names by hand.

Per @eldy review on PR #38556 (closed), this PR addresses the three points raised:

1. Add date_start / date_end aliases on the Subscription class. The date_start / date_end naming convention is already used by other Dolibarr objects (task, expense, holiday), so the alias matches the existing contract instead of introducing a new pair of names.
2. Do not introduce a 'label' alias. note_public is already the documented field on v24; declare it as a real public property so phpstan / phan stop flagging the dynamic-property write that triggered the original review note.
3. Push the change against develop, not 21.0 - the renaming surface is wider than what a maintenance branch should carry.

The dateh / datef raw fields stay in the response for backward compatibility with existing API consumers.