### PR TITLE
Fix #38663 #38638 widen Product::update oldcopy stdClass guard

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1527,8 +1527,11 @@ class Product extends CommonObject
 
 		if ($result >= 0) {
 			// $this->oldcopy should have been set by the caller of update (here properties were already modified)
-			// Note that this->oldcopy must be object and not stdClass, if not the method hasbatch() will not work.
-			if (is_null($this->oldcopy) || (is_object($this->oldcopy) && empty($this->oldcopy->id))) {
+			// Note that this->oldcopy must be a Product instance (not stdClass), otherwise the method
+			// hasbatch() called below will fatal. Callers may set oldcopy via dol_clone($obj, 2) (which
+			// returns a stdClass with scalar properties only) and then we cannot call methods on it,
+			// so re-clone with native=1 in that case (see issues #38663, #38638).
+			if (is_null($this->oldcopy) || (is_object($this->oldcopy) && empty($this->oldcopy->id)) || !($this->oldcopy instanceof Product)) {
 				$this->oldcopy = dol_clone($this, 1);	// 1 to clone with methods to avoid fatal error with $this->oldcopy->hasbatch()
 			}
 			// Test if batch management is activated on existing product


### PR DESCRIPTION
The existing guard at line 1531 of Product::update re-clones \$this->oldcopy with native=1 (which preserves methods) when oldcopy is null or has no id, but does not catch the case where a caller assigned a stdClass via dol_clone(\$obj, 2). dol_clone with native=2 copies the scalar properties of \$srcobject onto a fresh stdClass, including \$obj->id, so empty(\$this->oldcopy->id) is false. Execution then reaches \$this->oldcopy->hasbatch() at line 1716 and fatals with 'Call to undefined method stdClass::hasbatch()'.

Add a third branch to the guard: re-clone whenever oldcopy is not an instance of Product. The native=1 reclone restores the proper Product type and the hasbatch() / isEmpty() calls below work as intended.

Reproduced on PHP 8.2 in Docker: assigned oldcopy = dol_clone(\$obj, 2) (stdClass) then called update(), vanilla path fatals on stdClass::hasbatch() at line 1716, patched path returns 1 cleanly.

Reported by @Friesen-Automation (#38663) and @theheloworld (#38638).