### PR TITLE
Fix #38636 set supplier line unit from product default fk_unit

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -1141,6 +1141,23 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 								$('#buying_price').hide();
 							}
 						});
+
+						<?php if (getDolGlobalString('PRODUCT_USE_UNITS')) { ?>
+						// Sync the measuring unit dropdown with the product's default fk_unit
+						// for the supplier-side line picker (issue #38636), mirroring the
+						// customer-side behaviour from issue #34610. Look at the first
+						// non-pmp/non-cost row of the AJAX response (all rows for a given
+						// product carry the same fk_unit since it comes from llx_product).
+						var firstFkUnit = null;
+						$(data).each(function() {
+							if (this.id != 'pmpprice' && this.id != 'costprice' && typeof this.fk_unit != 'undefined' && this.fk_unit != null && firstFkUnit === null) {
+								firstFkUnit = this.fk_unit;
+							}
+						});
+						if (firstFkUnit !== null && $("#units").length) {
+							$("#units").val(firstFkUnit).trigger('change');
+						}
+						<?php } ?>
 					}
 				},
 				'json');

--- a/htdocs/fourn/ajax/getSupplierPrices.php
+++ b/htdocs/fourn/ajax/getSupplierPrices.php
@@ -120,7 +120,17 @@ if ($idprod > 0) {
 				$label .= ' ('.$productSupplier->fourn_ref.')';
 			}
 
-			$prices[] = array("id" => $productSupplier->product_fourn_price_id, "price" => price2num($price, '', 0), "label" => $label, "title" => $title); // For price field, we must use price2num(), for label or title, price()
+			$prices[] = array(
+				"id" => $productSupplier->product_fourn_price_id,
+				"price" => price2num($price, '', 0),
+				"label" => $label,
+				"title" => $title,
+				// Carry the product's default unit so the line form can preselect
+				// #units like the customer side already does for idprod (see
+				// issues #34610 for the customer side and #38636 for the
+				// supplier side).
+				"fk_unit" => $productSupplier->fk_unit,
+			); // For price field, we must use price2num(), for label or title, price()
 		}
 	}
 

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -832,7 +832,7 @@ class ProductFournisseur extends Product
 	public function list_product_fournisseur_price($prodid, $sortfield = '', $sortorder = '', $limit = 0, $offset = 0, $socid = 0)
 	{
 		// phpcs:enable
-		$sql = "SELECT s.nom as supplier_name, s.rowid as fourn_id, p.ref as product_ref, p.tosell as status, p.tobuy as status_buy, ";
+		$sql = "SELECT s.nom as supplier_name, s.rowid as fourn_id, p.ref as product_ref, p.tosell as status, p.tobuy as status_buy, p.fk_unit as product_fk_unit, ";
 		$sql .= " pfp.rowid as product_fourn_pri_id, pfp.entity, pfp.ref_fourn, pfp.desc_fourn, pfp.fk_product as product_fourn_id, pfp.fk_supplier_price_expression,";
 		$sql .= " pfp.price, pfp.quantity, pfp.unitprice, pfp.remise_percent, pfp.remise, pfp.tva_tx, pfp.fk_availability, pfp.charges, pfp.info_bits, pfp.delivery_time_days, pfp.supplier_reputation,";
 		$sql .= " pfp.multicurrency_price, pfp.multicurrency_unitprice, pfp.multicurrency_tx, pfp.fk_multicurrency, pfp.multicurrency_code, pfp.datec, pfp.tms,";
@@ -885,6 +885,11 @@ class ProductFournisseur extends Product
 				$prodfourn->supplier_reputation = $record["supplier_reputation"];
 				$prodfourn->fourn_date_creation = $this->db->jdate($record['datec']);
 				$prodfourn->fourn_date_modification = $this->db->jdate($record['tms']);
+				// Carry the product's default measuring unit so the AJAX caller
+				// (getSupplierPrices.php) can return it to the line form, which
+				// then preselects #units like the customer side already does for
+				// idprod (see issues #34610 client-side and #38636 supplier-side).
+				$prodfourn->fk_unit = $record["product_fk_unit"];
 
 				$prodfourn->fourn_multicurrency_price = $record["multicurrency_price"];
 				$prodfourn->fourn_multicurrency_unitprice = $record["multicurrency_unitprice"];


### PR DESCRIPTION
The customer-side line picker preselects the product's default measuring unit when a product is chosen, via /product/ajax/products.php returning fk_unit and a small jQuery snippet in objectline_create.tpl.php (added for issue #34610). The supplier-side line picker, which uses /fourn/ajax/getSupplierPrices.php and a separate \$.post callback, never received fk_unit on the wire, so the #units dropdown was always left at its default and the reporter's products with a configured unit showed the wrong unit on save.

Three coordinated edits:
- list_product_fournisseur_price() now selects p.fk_unit alongside the other product columns and assigns it on the returned ProductFournisseur instance as \$prodfourn->fk_unit.
- getSupplierPrices.php exposes \$productSupplier->fk_unit on each row of the JSON response so the client can read it.
- objectline_create.tpl.php (the supplier callback after the fournprice_predef rebuild) walks the response, picks the first non-pmp/non-costprice row's fk_unit, and sets #units to that value when PRODUCT_USE_UNITS is on. Mirrors the customer-side logic already in place for issue #34610.

Verified on PHP 8.2 in Docker: created a product with fk_unit=2, added a supplier price, called list_product_fournisseur_price() - returned row carries fk_unit=2. The same value lands in the JSON response and reaches the JS side.

Reported by @vanyolai.