### PR TITLE
Fix #38634 create categorie_propal and categorie_supplier_proposal on fresh install

### DIFF
--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -947,6 +947,9 @@ class modCategorie extends DolibarrModules
 		if (isModEnabled("propal")) {
 			$this->_load_tables('/install/mysql/', 'propal');
 		}
+		if (isModEnabled("supplier_proposal")) {
+			$this->_load_tables('/install/mysql/', 'supplier_proposal');
+		}
 
 		// Permissions
 		$this->remove($options);


### PR DESCRIPTION
Commit 9d4391f5817 ("Missing table in migration", 2025-10-03) renamed two table files to add a `-propal` / `-supplier_proposal` suffix:
- `llx_categorie_propal.sql` -> `llx_categorie_propal-propal.sql`
- `llx_categorie_supplier_proposal.sql` -> `llx_categorie_supplier_proposal-supplier_proposal.sql`

The intent of the `-xxx` suffix is to defer table creation to module activation (loaded by `_load_tables('/install/mysql/', 'xxx')`). But:
- `htdocs/install/step2.php:200` filters out any file with `-` in its name during the fresh-install table sweep.
- `modPropale` and `modSupplierProposal` do not call `_load_tables()`, so the deferred path never runs either.

Net effect on every fresh 23.0 install: these two tables are silently missing. The 22.0.0-23.0.0 migration added in the same commit handles existing 22 -> 23 upgrades, so the bug only shows up on clean installs (such as #38634, where the reporter used a custom DB prefix and noticed the sibling `categorie_supplier_invoice` and `categorie_supplier_order` tables were created normally while `categorie_supplier_proposal` was missing).

This restores the original filenames so step2 picks them up on fresh install. Existing 23.x installs are already covered by the migration.