### PR TITLE
Fix #38358 guard cache_availability lookup in form_availability

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -9988,10 +9988,10 @@ class Form
 						$out .= ' disabled="disabled"';
 					}
 					if (!empty($tmplabelhtml)) {
-						$out .= ' data-html="' . dolPrintHTMLForAttribute($tmplabelhtml, 0, 0, '', 0, 1) . '"';
+						$out .= ' data-html="' . dolPrintHTMLForAttribute($tmplabelhtml) . '"';
 					} else {
 						$tmplabelhtml = ($tmppicto ? img_picto('', $tmppicto, 'class="pictofixedwidth" style="color: #' . $tmpcolor . '"') : '') . $newval;
-						$out .= ' data-html="' . dolPrintHTMLForAttribute($tmplabelhtml, 0, 0, '', 0, 1) . '"';
+						$out .= ' data-html="' . dolPrintHTMLForAttribute($tmplabelhtml) . '"';
 					}
 					$out .= '>';
 					$out .= dol_htmlentitiesbr($newval);

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6690,7 +6690,11 @@ class Form
 		} else {
 			if ($selected) {
 				$this->load_cache_availability();
-				print $this->cache_availability[$selected]['label'];
+				if (isset($this->cache_availability[$selected])) {
+					print $this->cache_availability[$selected]['label'];
+				} else {
+					print "&nbsp;";
+				}
 			} else {
 				print "&nbsp;";
 			}


### PR DESCRIPTION
form_availability() prints `$this->cache_availability[$selected]['label']` whenever `$selected` is truthy, but only positive c_availability rowids are loaded into the cache. When `$selected` is a non-zero non-cached value such as `-1` (legacy 'not set' sentinel still found on some old propal/order rows), PHP 8 emits the exact pair of warnings from the issue:

- Undefined array key -1
- Trying to access array offset on value of type null

Reproduced in Docker with an empty cache and `$selected = '-1'`. The patch checks isset() before printing and falls back to nbsp, mirroring the `$selected == 0` branch.