### PR TITLE
Fix #34338 don't show late warning on expense report when delay is unset

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2652,11 +2652,12 @@ class ExpenseReport extends CommonObject
 		}
 
 		$now = dol_now();
-		if ($option == 'toapprove') {
-			return (!empty($this->datevalid) ? $this->datevalid : $this->date_valid) < ($now - $conf->expensereport->approve->warning_delay);
-		} else {
-			return (!empty($this->datevalid) ? $this->datevalid : $this->date_valid) < ($now - $conf->expensereport->payment->warning_delay);
+		$warning_delay = (int) ($option == 'toapprove' ? $conf->expensereport->approve->warning_delay : $conf->expensereport->payment->warning_delay);
+		if ($warning_delay <= 0) {
+			// No delay configured (MAIN_DELAY_EXPENSEREPORTS / MIN_DELAY_EXPENSEREPORTS_TO_PAY not set), so nothing is late.
+			return false;
 		}
+		return (!empty($this->datevalid) ? $this->datevalid : $this->date_valid) < ($now - $warning_delay);
 	}
 
 	/**


### PR DESCRIPTION
ExpenseReport::hasDelay() compares the validation date to (now - warning_delay). When MAIN_DELAY_EXPENSEREPORTS or MIN_DELAY_EXPENSEREPORTS_TO_PAY is not set in the global setup, the corresponding $conf->expensereport->approve->warning_delay (or ->payment->warning_delay) is 0, so the test becomes "date_valid < now" and any validated expense report older than a moment is flagged as late. That matches what the reporter saw - every validated row in the list shows the warning icon.

Treat warning_delay <= 0 as "no threshold configured" and return false in that case, so an unconfigured delay no longer marks the whole list as overdue.

Verified in Docker:
- delay=0: hasDelay('toapprove') returns false (was true)
- delay=7 days, validation 8 days ago: returns true
- delay=7 days, validation 3 days ago: returns false