### PR TITLE
Fix #35103 require confirm='yes' before deleting in confirm_delete

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -465,7 +465,7 @@ if ($action == "update_extras" && GETPOSTINT('id') > 0 && !empty($permissiontoed
 }
 
 // Action to delete
-if ($action == 'confirm_delete' && !empty($permissiontodelete)) {
+if ($action == 'confirm_delete' && $confirm == 'yes' && !empty($permissiontodelete)) {
 	if (!($object->id > 0)) {
 		dol_print_error(null, 'Error, object must be fetched before being deleted');
 		exit;


### PR DESCRIPTION
The shared confirm_delete branch at htdocs/core/actions_addupdatedelete.inc.php:468 fired on $action == 'confirm_delete' && !empty($permissiontodelete), but never checked $confirm. Every other confirm_* branch in the same file (confirm_deleteline, confirm_validate, confirm_close, confirm_setdraft, confirm_reopen, confirm_clone) checks `$confirm == 'yes'`. As a result, a card.php using the standard `$form->formconfirm()` flow without the ajax handler would actually delete the object when the user clicks "No" on the confirmation dialog - exactly the path the reporter showed.

Align with the rest of the file by adding the missing `$confirm == 'yes'` check. One-char-equivalent fix; no behavior change for callers using the ajax confirm modal (where only "yes" submits anyway).