### PR TITLE
Fix #34630 keep existing fk_user on timespent update when 'by' column is hidden

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -313,7 +313,10 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 				$object->timespent_date = $timespent_date;
 				$object->timespent_withhour = 0;
 			}
-			$object->timespent_fk_user = GETPOSTINT("userid_line");
+			// If column "by" is hidden, no userid_line is posted; keep the existing fk_user instead of resetting it to 0.
+			if (GETPOSTISSET("userid_line")) {
+				$object->timespent_fk_user = GETPOSTINT("userid_line");
+			}
 			$object->timespent_fk_product = GETPOSTINT("fk_product");
 			$object->timespent_invoiceid = GETPOSTINT("invoiceid");
 			$object->timespent_invoicelineid = GETPOSTINT("invoicelineid");
@@ -348,7 +351,10 @@ if (($action == 'updateline' || $action == 'updatesplitline') && !$cancel && $us
 				$object->timespent_withhour = 0;
 			}
 
-			$object->timespent_fk_user = GETPOSTINT("userid_line");
+			// If column "by" is hidden, no userid_line is posted; keep the existing fk_user instead of resetting it to 0.
+			if (GETPOSTISSET("userid_line")) {
+				$object->timespent_fk_user = GETPOSTINT("userid_line");
+			}
 			$object->timespent_fk_product = GETPOSTINT("fk_product");
 			$object->timespent_invoiceid = GETPOSTINT("invoiceid");
 			$object->timespent_invoicelineid = GETPOSTINT("invoicelineid");


### PR DESCRIPTION
When the 'by' column is hidden in the project timespent list, the form does not emit a `userid_line` input. The `updateline` / `updatesplitline` handler then read `GETPOSTINT('userid_line')` as `0` and overwrote `timespent_fk_user`. The downstream `in_array($object->timespent_fk_user, $childids)` guard with fk_user=0 blocked the update path entirely, and the user saw a confusing "Field User is required" for an assignment they never touched.

Only overwrite `timespent_fk_user` when the form actually posted `userid_line`. Both branches already call `fetchTimeSpent($lineid)` so the existing fk_user is loaded before the assignment.

Mirrors the sibling fix #34511 (date column hidden), same pattern in the same file.