### PR TITLE
Fix #36232 drop reference to non-existent fk_user_done in upcoming-events box

### DIFF
--- a/htdocs/core/boxes/box_actions_future.php
+++ b/htdocs/core/boxes/box_actions_future.php
@@ -107,7 +107,7 @@ class box_actions_future extends ModeleBoxes
 				$sql .= " AND s.rowid = ".((int) $user->socid);
 			}
 			if (!$user->hasRight('agenda', 'allactions', 'read')) {
-				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id)." OR a.fk_user_done = ".((int) $user->id).")";
+				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id).")";
 			}
 			$sql .= " AND a.datep > '".$this->db->idate($now)."'";
 			$sql .= " ORDER BY a.datep ASC";


### PR DESCRIPTION
`llx_actioncomm` has no `fk_user_done` column - it was migrated to `fk_user_action` by the 3.5 -> 3.6 schema change (see `htdocs/install/mysql/migration/3.5.0-3.6.0.sql:1704` which does `UPDATE ... SET fk_user_action = fk_user_done`). The 2023 introduction of the upcoming-events box (commit e0ef2870a42e) added a third predicate `a.fk_user_done = $user->id` to the visibility WHERE clause at `htdocs/core/boxes/box_actions_future.php:110`, which fails with "Unknown column 'a.fk_user_done'" on both MySQL and PostgreSQL. PG surfaces it visibly; MySQL just makes the box silently empty for non-admin users.

Reproduced in Docker:
- Vanilla `OR a.fk_user_done = 1`: ERROR Unknown column.
- Patched (column removed): OK.

`fk_user_action` already covers the "owner of action" semantic that `fk_user_done` used to mean, so no functionality is lost.