### PR TITLE
Fix #36795 persist rang on Task::create so cloned project tasks keep order

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -453,6 +453,7 @@ class Task extends CommonObjectLine
 		$sql .= ", priority";
 		$sql .= ", billable";
 		$sql .= ", fk_statut";
+		$sql .= ", rang";
 		$sql .= ") VALUES (";
 		$sql .= (!empty($this->entity) ? (int) $this->entity : (int) $conf->entity);
 		$sql .= ", ".((int) $this->fk_project);
@@ -472,6 +473,7 @@ class Task extends CommonObjectLine
 		$sql .= ", ".(($this->priority != '' && $this->priority >= 0) ? (int) $this->priority : 'null');
 		$sql .= ", ".((int) $this->billable);
 		$sql .= ", ".((int) $this->status);
+		$sql .= ", ".((!empty($this->rang)) ? ((int) $this->rang) : "0");
 		$sql .= ")";
 
 		$this->db->begin();


### PR DESCRIPTION
`Task::create()`'s INSERT statement omitted the `rang` column. Project clone flows (`Project::createFromClone` -> `Task::createFromClone` -> `Task::create`) copy `rang` onto the clone with `$clone_task->rang = $origin_task->rang;` (htdocs/projet/class/task.class.php:2368), but because the INSERT never wrote the column, the new tasks always ended up with `rang = 0` (the schema default), and the duplicated project lost the drag/drop ordering.

Include `rang` in the INSERT, mirroring the `update()` statement at line 692 that already does `((!empty($this->rang)) ? ((int) $this->rang) : "0")`.