### PR TITLE
fix: warehouse API access checks on update/delete

### DIFF
--- a/htdocs/product/stock/class/api_warehouses.class.php
+++ b/htdocs/product/stock/class/api_warehouses.class.php
@@ -276,7 +276,7 @@ class Warehouses extends DolibarrApi
 			throw new RestException(404, 'warehouse not found');
 		}
 
-		if (!DolibarrApi::_checkAccessToResource('stock', $this->warehouse->id)) {
+		if (!DolibarrApi::_checkAccessToResource('stock', $this->warehouse->id, 'entrepot')) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 
@@ -346,7 +346,7 @@ class Warehouses extends DolibarrApi
 			throw new RestException(404, 'warehouse not found');
 		}
 
-		if (!DolibarrApi::_checkAccessToResource('stock', $this->warehouse->id)) {
+		if (!DolibarrApi::_checkAccessToResource('stock', $this->warehouse->id, 'entrepot')) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 


### PR DESCRIPTION
# FIX: warehouse API access checks on update/delete
`api_warehouses.class.php` checks warehouse access against `entrepot` in `GET`, but `PUT` and `DELETE` call `_checkAccessToResource('stock', $id)` without the warehouse table name.

For warehouses, that fallback is wrong: the access checker defaults to `stock`, while it should be `entrepot`. As a result, a valid warehouse update will be rejected with `403`.

This PR makes `PUT` and `DELETE` use the same `entrepot` access check as `GET`, so warehouse API operations are checked consistently.