### PR TITLE
Fix #37409 guard ykey lookup in DolGraph::draw_chart

### DIFF
--- a/htdocs/core/class/dolgraph.class.php
+++ b/htdocs/core/class/dolgraph.class.php
@@ -1229,9 +1229,10 @@ class DolGraph
 				$legends[$x] = (array_key_exists('label', $valarray) ? $valarray['label'] : $valarray[0]);
 				$array_of_ykeys = array_keys($valarray);
 				$alabelexists = 1;
-				$tmpykey = explode('_', (string) ($array_of_ykeys[$i + ($alabelexists ? 1 : 0)]), 3);
+				$ykeyindex = $i + ($alabelexists ? 1 : 0);
+				$tmpykey = isset($array_of_ykeys[$ykeyindex]) ? explode('_', (string) $array_of_ykeys[$ykeyindex], 3) : array();
 				if (isset($tmpykey[2]) && (!empty($tmpykey[2]) || $tmpykey[2] == '0')) {		// This is a 'Group by' array
-					$tmpvalue = (array_key_exists('y_' . $tmpykey[1] . '_' . $tmpykey[2], $valarray) ? $valarray['y_' . $tmpykey[1] . '_' . $tmpykey[2]] : $valarray[$i + 1]);
+					$tmpvalue = (array_key_exists('y_' . $tmpykey[1] . '_' . $tmpykey[2], $valarray) ? $valarray['y_' . $tmpykey[1] . '_' . $tmpykey[2]] : ($valarray[$i + 1] ?? null));
 					$values[$x] = (is_numeric($tmpvalue) ? $tmpvalue : null);
 					$arrayofgroupslegend[$i] = array(
 						'stacknum' => (int) $tmpykey[1],
@@ -1239,7 +1240,7 @@ class DolGraph
 						'legendwithgroup' => ($this->Legend[$tmpykey[1]] ?? '') . ' - ' . $tmpykey[2]
 					);
 				} else {
-					$tmpvalue = (array_key_exists('y_' . $i, $valarray) ? $valarray['y_' . $i] : $valarray[$i + 1]);
+					$tmpvalue = (array_key_exists('y_' . $i, $valarray) ? $valarray['y_' . $i] : ($valarray[$i + 1] ?? null));
 					//var_dump($i.'_'.$x.'_'.$tmpvalue);
 					$values[$x] = (is_numeric($tmpvalue) ? $tmpvalue : null);
 				}


### PR DESCRIPTION
`draw_chart()` built `$tmpykey` by indexing `$array_of_ykeys[$i + 1]` without checking the key existed first, and the `y_<i>` fallback used `$valarray[$i + 1]` the same way. Both fire PHP 8.2 "Undefined array key" warnings whenever a row in `$this->data` is shorter than the longest one (custom modules like ScrumBoard feed sparse rows).

Patch:
- Resolve the ykey via `isset()` before exploding; fall back to an empty array when missing (the downstream `isset($tmpykey[2])` check already handles that).
- Add a `?? null` fallback on the `$valarray[$i + 1]` value lookup so it stops warning too.

Reproduced in PHP 8.2 with a single-element row; vanilla emits two "Undefined array key 1" warnings, patched emits none.