### PR TITLE
Fix #38199 normalize blank sellist/select to empty for notnull check

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -39,6 +39,9 @@
 @phan-var-force string $hidedetails
 @phan-var-force string $hidedesc
 @phan-var-force string $hideref
+@phan-var-force ?string $confirm
+@phan-var-force ?int $lineid
+@phan-var-force ?int $id
 ';
 /**
  * @var Conf $conf

--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -173,8 +173,8 @@ if ($action == 'add' && !empty($permissiontoadd)) {
 		if (!empty($object->fields[$key]['foreignkey']) && $value == '-1') {
 			$value = ''; // This is an explicit foreign key field
 		}
-		if (preg_match('/^sellist:/i', $object->fields[$key]['type']) && $value == '0') {
-			$value = ''; // sellist blank option posts "0"; normalize to '' so notnull check works on PHP 8.0+ (see github.com/Dolibarr/dolibarr/issues/38199)
+		if ((preg_match('/^sellist/i', $object->fields[$key]['type']) || $object->fields[$key]['type'] == 'select') && $value === '0') {
+			$value = ''; // sellist / select blank option posts "0"; normalize to '' so notnull check works on PHP 8.0+ (see github.com/Dolibarr/dolibarr/issues/38199)
 		}
 
 		//var_dump($key.' '.$value.' '.$object->fields[$key]['type'].' '.$object->fields[$key]['notnull']);
@@ -338,8 +338,8 @@ if ($action == 'update' && !empty($permissiontoadd)) {
 		if (!empty($object->fields[$key]['foreignkey']) && $value == '-1') {
 			$value = ''; // This is an explicit foreign key field
 		}
-		if (preg_match('/^sellist:/i', $object->fields[$key]['type']) && $value == '0') {
-			$value = ''; // sellist blank option posts "0"; normalize to '' so notnull check works on PHP 8.0+ (see github.com/Dolibarr/dolibarr/issues/38199)
+		if ((preg_match('/^sellist/i', $object->fields[$key]['type']) || $object->fields[$key]['type'] == 'select') && $value === '0') {
+			$value = ''; // sellist / select blank option posts "0"; normalize to '' so notnull check works on PHP 8.0+ (see github.com/Dolibarr/dolibarr/issues/38199)
 		}
 
 		$object->$key = $value;


### PR DESCRIPTION
Per eldy's review on #38500 (asked to re-target develop, not the older branch).

The existing `preg_match('/^sellist:/i', ...) && $value == '0'` guard only catches the qualified `sellist:tablename` form on 22.0/23.0. Plain `sellist` and the `select` field type both also post `"0"` for the blank option and skip the notnull check on PHP 8+, surfacing the raw SQL FK constraint error from the original report.

Widen to `preg_match('/^sellist/i', ...) || type == 'select'`, with strict `=== '0'` to avoid PHP 8 loose-compare side effects.