### PR TITLE
FIX EmailCollector: one failing email aborts the whole collector run

### DIFF
--- a/dev/tools/codespell/codespell-lines-ignore.txt
+++ b/dev/tools/codespell/codespell-lines-ignore.txt
@@ -6,11 +6,11 @@
 						$sql .= " SET reponses = '0".$db->escape($obj->reponses)."'";
 						$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.od(s|t)$', '', 'name', SORT_ASC, 0);
 						print '<td class="center"><a href="'.DOL_URL_ROOT.'/product/stock/product.php?dwid='.$object->id.'&id='.$objp->rowid.'&action=transfert&token='.newToken().'&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$id).'">';
-					$dateemail = dol_stringtotime((string) $overview[0]->udate, 'gmt');
+						$dateemail = dol_stringtotime((string) $overview[0]->udate, 'gmt');
 					$pice = '<i class="fas fa-briefcase inline-block"></i>';
 					$typea = ($data[$j]->typea == 'birth') ? $picb : $pice;
 					GETPOSTINT("mouvement"),
-					dol_syslog("msgid=".$overview[0]->message_id." date=".dol_print_date($overview[0]->udate, 'dayrfc', 'gmt')." from=".$overview[0]->from." to=".$overview[0]->to." subject=".$overview[0]->subject);
+						dol_syslog("msgid=".$overview[0]->message_id." date=".dol_print_date($overview[0]->udate, 'dayrfc', 'gmt')." from=".$overview[0]->from." to=".$overview[0]->to." subject=".$overview[0]->subject);
 					jQuery("#mouvement option").removeAttr("selected").change();
 					jQuery("#mouvement option[value=0]").attr("selected","selected").trigger("change");
 					jQuery("#mouvement option[value=1]").attr("selected","selected").trigger("change");

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1776,1941 +1776,1959 @@ class EmailCollector extends CommonObject
 
 			$iforemailloop = 0;
 			foreach ($richarrayofemail as $tmpval) {
-				$iforemailloop++;
+				// Guard the processing of each email: on PHP 8, mysqli throws on a query error
+				// instead of returning false, so a single "poison" email (duplicate key, invalid
+				// date, ...) used to abort the whole collector run before datelastresult and the
+				// processing lock were updated. See the matching catch at the end of the loop.
+				try {
+					$iforemailloop++;
 
-				$imapemail = $tmpval['imapemail'];
-				$header = $tmpval['header'];
-				$overview = $tmpval['overview'];
-				$headers = $tmpval['headers'];
+					$imapemail = $tmpval['imapemail'];
+					$header = $tmpval['header'];
+					$overview = $tmpval['overview'];
+					$headers = $tmpval['headers'];
 
-				if (!empty($headers['in-reply-to']) && empty($headers['In-Reply-To'])) {
-					$headers['In-Reply-To'] = $headers['in-reply-to'];
-				}
-				if (!empty($headers['references']) && empty($headers['References'])) {
-					$headers['References'] = $headers['references'];
-				}
-				if (!empty($headers['message-id']) && empty($headers['Message-ID'])) {
-					$headers['Message-ID'] = $headers['message-id'];
-				}
-				if (!empty($headers['subject']) && empty($headers['Subject'])) {
-					$headers['Subject'] = $headers['subject'];
-				}
-
-				$headers['Subject'] = $this->decodeSMTPSubject($headers['Subject']);
-
-				if (getDolGlobalInt('MAIN_IMAP_USE_PHPIMAP')) {
-					$emailto = (string) $overview['to'];
-				} else {
-					$emailto = $this->decodeSMTPSubject($overview[0]->to);
-				}
-				//var_dump($headers);
-				//var_dump($overview);exit;
-
-				$operationslog .= '<br>** Process email #'.dol_escape_htmltag((string) $iforemailloop);
-
-				if (getDolGlobalInt('MAIN_IMAP_USE_PHPIMAP')) {
-					/** @var Webklex\PHPIMAP\Message $imapemail */
-					'@phan-var-force Webklex\PHPIMAP\Message $imapemail';
-					// $operationslog .= " - ".dol_escape_htmltag((string) $imapemail);
-					$msgid = str_replace(array('<', '>'), '', $overview['message_id']);
-				} else {
-					$operationslog .= " - ".dol_escape_htmltag((string) $imapemail);
-					$msgid = str_replace(array('<', '>'), '', $overview[0]->message_id);
-				}
-				$operationslog .= " - MsgId: ".$msgid;
-				$operationslog .= " - Date: ".($headers['Date'] ?? $langs->transnoentitiesnoconv("NotFound"));
-				$operationslog .= " - References: ".dol_escape_htmltag($headers['References'] ?? $langs->transnoentitiesnoconv("NotFound"))." - Subject: ".dol_escape_htmltag($headers['Subject']);
-
-				dol_syslog("-- Process email #".$iforemailloop.", MsgId: ".$msgid.", Date: ".($headers['Date'] ?? '').", References: ".($headers['References'] ?? '').", Subject: ".$headers['Subject']);
-
-
-				$trackidfoundintorecipienttype = '';
-				$trackidfoundintorecipientid = 0;
-				$reg = array();
-				// See also later list of all supported tags...
-				// Note: "th[i]" to avoid matching a codespell suggestion to convert to "this".
-				// TODO Add host after the @'.preg_quote($host, '/')
-				if (preg_match('/\+(th[i]|ctc|use|mem|sub|proj|tas|con|tic|pro|ord|inv|spro|sor|sin|leav|stockinv|job|surv|salary)([0-9]+)@/', $emailto, $reg)) {
-					$trackidfoundintorecipienttype = $reg[1];
-					$trackidfoundintorecipientid = $reg[2];
-				} elseif (preg_match('/\+emailing-(\w+)@/', $emailto, $reg)) {	// Can be 'emailing-test' or 'emailing-IdMailing-IdRecipient'
-					$trackidfoundintorecipienttype = 'emailing';
-					$trackidfoundintorecipientid = $reg[1];
-				}
-
-				$trackidfoundintomsgidtype = '';
-				$trackidfoundintomsgidid = 0;
-				$reg = array();
-				// See also later list of all supported tags...
-				// Note: "th[i]" to avoid matching a codespell suggestion to convert to "this".
-				// TODO Add host after the @
-				if (preg_match('/(?:[\+\-])(th[i]|ctc|use|mem|sub|proj|tas|con|tic|pro|ord|inv|spro|sor|sin|leav|stockinv|job|surv|salary)([0-9]+)@/', $msgid, $reg)) {
-					$trackidfoundintomsgidtype = $reg[1];
-					$trackidfoundintomsgidid = $reg[2];
-				} elseif (preg_match('/(?:[\+\-])emailing-(\w+)@/', $msgid, $reg)) {	// Can be 'emailing-test' or 'emailing-IdMailing-IdRecipient'
-					$trackidfoundintomsgidtype = 'emailing';
-					$trackidfoundintomsgidid = $reg[1];
-				}
-
-				// Now apply some filters.
-
-				//If there is an emailcollector filter on trackid
-				if ($searchfilterdoltrackid > 0) {
-					if (empty($trackidfoundintorecipienttype) && empty($trackidfoundintomsgidtype)) {
-						if (empty($headers['References']) || !preg_match('/@'.preg_quote($host, '/').'/', $headers['References'])) {
-							$nbemailprocessed++;
-							dol_syslog(" Discarded - No suffix in email recipient and no Header References found matching the signature of the application, so with a trackid coming from the application");
-							continue; // Exclude email
-						}
+					if (!empty($headers['in-reply-to']) && empty($headers['In-Reply-To'])) {
+						$headers['In-Reply-To'] = $headers['in-reply-to'];
 					}
-				}
-				if ($searchfilternodoltrackid > 0) {
-					if (!empty($trackidfoundintorecipienttype) || !empty($trackidfoundintomsgidtype) || (!empty($headers['References']) && preg_match('/@'.preg_quote($host, '/').'/', $headers['References']))) {
-						$nbemailprocessed++;
-						dol_syslog(" Discarded - Suffix found into email or Header References found and matching signature of application so with a trackid");
-						continue; // Exclude email
+					if (!empty($headers['references']) && empty($headers['References'])) {
+						$headers['References'] = $headers['references'];
 					}
-				}
-
-				if ($searchfilterisanswer > 0) {
-					$referencesforanswer = '';
-					if (!empty($headers['References'])) {
-						$referencesforanswer .= $headers['References'].' ';
+					if (!empty($headers['message-id']) && empty($headers['Message-ID'])) {
+						$headers['Message-ID'] = $headers['message-id'];
 					}
-					if (!empty($headers['In-Reply-To'])) {
-						$referencesforanswer .= $headers['In-Reply-To'];
+					if (!empty($headers['subject']) && empty($headers['Subject'])) {
+						$headers['Subject'] = $headers['subject'];
 					}
 
-					$hasdolibarrreference = 0;
-					if (!empty($referencesforanswer)) {
-						if (preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote($host, '/').'/', $referencesforanswer)) {
-							$hasdolibarrreference = 1;
-						} elseif (getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE')) {
-							if (preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote(getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE'), '/').'/', $referencesforanswer)) {
-								$hasdolibarrreference = 1;
+					$headers['Subject'] = $this->decodeSMTPSubject($headers['Subject']);
+
+					if (getDolGlobalInt('MAIN_IMAP_USE_PHPIMAP')) {
+						$emailto = (string) $overview['to'];
+					} else {
+						$emailto = $this->decodeSMTPSubject($overview[0]->to);
+					}
+					//var_dump($headers);
+					//var_dump($overview);exit;
+
+					$operationslog .= '<br>** Process email #'.dol_escape_htmltag((string) $iforemailloop);
+
+					if (getDolGlobalInt('MAIN_IMAP_USE_PHPIMAP')) {
+						/** @var Webklex\PHPIMAP\Message $imapemail */
+						'@phan-var-force Webklex\PHPIMAP\Message $imapemail';
+						// $operationslog .= " - ".dol_escape_htmltag((string) $imapemail);
+						$msgid = str_replace(array('<', '>'), '', $overview['message_id']);
+					} else {
+						$operationslog .= " - ".dol_escape_htmltag((string) $imapemail);
+						$msgid = str_replace(array('<', '>'), '', $overview[0]->message_id);
+					}
+					$operationslog .= " - MsgId: ".$msgid;
+					$operationslog .= " - Date: ".($headers['Date'] ?? $langs->transnoentitiesnoconv("NotFound"));
+					$operationslog .= " - References: ".dol_escape_htmltag($headers['References'] ?? $langs->transnoentitiesnoconv("NotFound"))." - Subject: ".dol_escape_htmltag($headers['Subject']);
+
+					dol_syslog("-- Process email #".$iforemailloop.", MsgId: ".$msgid.", Date: ".($headers['Date'] ?? '').", References: ".($headers['References'] ?? '').", Subject: ".$headers['Subject']);
+
+
+					$trackidfoundintorecipienttype = '';
+					$trackidfoundintorecipientid = 0;
+					$reg = array();
+					// See also later list of all supported tags...
+					// Note: "th[i]" to avoid matching a codespell suggestion to convert to "this".
+					// TODO Add host after the @'.preg_quote($host, '/')
+					if (preg_match('/\+(th[i]|ctc|use|mem|sub|proj|tas|con|tic|pro|ord|inv|spro|sor|sin|leav|stockinv|job|surv|salary)([0-9]+)@/', $emailto, $reg)) {
+						$trackidfoundintorecipienttype = $reg[1];
+						$trackidfoundintorecipientid = $reg[2];
+					} elseif (preg_match('/\+emailing-(\w+)@/', $emailto, $reg)) {	// Can be 'emailing-test' or 'emailing-IdMailing-IdRecipient'
+						$trackidfoundintorecipienttype = 'emailing';
+						$trackidfoundintorecipientid = $reg[1];
+					}
+
+					$trackidfoundintomsgidtype = '';
+					$trackidfoundintomsgidid = 0;
+					$reg = array();
+					// See also later list of all supported tags...
+					// Note: "th[i]" to avoid matching a codespell suggestion to convert to "this".
+					// TODO Add host after the @
+					if (preg_match('/(?:[\+\-])(th[i]|ctc|use|mem|sub|proj|tas|con|tic|pro|ord|inv|spro|sor|sin|leav|stockinv|job|surv|salary)([0-9]+)@/', $msgid, $reg)) {
+						$trackidfoundintomsgidtype = $reg[1];
+						$trackidfoundintomsgidid = $reg[2];
+					} elseif (preg_match('/(?:[\+\-])emailing-(\w+)@/', $msgid, $reg)) {	// Can be 'emailing-test' or 'emailing-IdMailing-IdRecipient'
+						$trackidfoundintomsgidtype = 'emailing';
+						$trackidfoundintomsgidid = $reg[1];
+					}
+
+					// Now apply some filters.
+
+					//If there is an emailcollector filter on trackid
+					if ($searchfilterdoltrackid > 0) {
+						if (empty($trackidfoundintorecipienttype) && empty($trackidfoundintomsgidtype)) {
+							if (empty($headers['References']) || !preg_match('/@'.preg_quote($host, '/').'/', $headers['References'])) {
+								$nbemailprocessed++;
+								dol_syslog(" Discarded - No suffix in email recipient and no Header References found matching the signature of the application, so with a trackid coming from the application");
+								continue; // Exclude email
 							}
 						}
 					}
-
-					if (empty($headers['In-Reply-To']) && empty($hasdolibarrreference)) {
-						$nbemailprocessed++;
-						dol_syslog(" Discarded - Email is not an answer (no In-Reply-To header and no Dolibarr reference)");
-						continue; // Exclude email
-					}
-					$isanswer = 0;
-					if (preg_match('/^(Re|AW)\s*:\s+/i', $headers['Subject'])) {
-						$isanswer = 1;
-					}
-					if (getDolGlobalString('EMAILCOLLECTOR_USE_IN_REPLY_TO_TO_DETECT_ANSWERS')) {
-						// Note: "In-Reply-To" to detect if mail is an answer of another mail is not reliable because we can have:
-						// Message-ID=A, In-Reply-To=B, References=B and message can BE an answer but may be NOT (for example a transfer of an email rewritten)
-						if (!empty($headers['In-Reply-To'])) {
-							$isanswer = 1;
+					if ($searchfilternodoltrackid > 0) {
+						if (!empty($trackidfoundintorecipienttype) || !empty($trackidfoundintomsgidtype) || (!empty($headers['References']) && preg_match('/@'.preg_quote($host, '/').'/', $headers['References']))) {
+							$nbemailprocessed++;
+							dol_syslog(" Discarded - Suffix found into email or Header References found and matching signature of application so with a trackid");
+							continue; // Exclude email
 						}
 					}
-					if ($hasdolibarrreference) {
-						$isanswer = 1;
-					}
-					//if ($headers['In-Reply-To'] != $headers['Message-ID'] && empty($headers['References'])) $isanswer = 1;	// If in-reply-to differs of message-id, this is a reply
-					//if ($headers['In-Reply-To'] != $headers['Message-ID'] && !empty($headers['References']) && strpos($headers['References'], $headers['Message-ID']) !== false) $isanswer = 1;
 
-					if (!$isanswer) {
-						$nbemailprocessed++;
-						dol_syslog(" Discarded - Email is not an answer (no RE prefix in subject)");
-						continue; // Exclude email
-					}
-				}
-				if ($searchfilterisnotanswer > 0) {
-					if (!empty($headers['In-Reply-To'])) {
-						// Note: we can have
-						// Message-ID=A, In-Reply-To=B, References=B and message can BE an answer or NOT (a transfer rewritten)
+					if ($searchfilterisanswer > 0) {
+						$referencesforanswer = '';
+						if (!empty($headers['References'])) {
+							$referencesforanswer .= $headers['References'].' ';
+						}
+						if (!empty($headers['In-Reply-To'])) {
+							$referencesforanswer .= $headers['In-Reply-To'];
+						}
+
+						$hasdolibarrreference = 0;
+						if (!empty($referencesforanswer)) {
+							if (preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote($host, '/').'/', $referencesforanswer)) {
+								$hasdolibarrreference = 1;
+							} elseif (getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE')) {
+								if (preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote(getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE'), '/').'/', $referencesforanswer)) {
+									$hasdolibarrreference = 1;
+								}
+							}
+						}
+
+						if (empty($headers['In-Reply-To']) && empty($hasdolibarrreference)) {
+							$nbemailprocessed++;
+							dol_syslog(" Discarded - Email is not an answer (no In-Reply-To header and no Dolibarr reference)");
+							continue; // Exclude email
+						}
 						$isanswer = 0;
-						if (preg_match('/^(回复|回覆|SV|Antw|VS|RE|Re|AW|Aw|ΑΠ|השב| תשובה | הועבר|Vá|R|RIF|BLS|Atb|RES|Odp|பதில்|YNT|ATB)\s*:\s+/i', $headers['Subject'])) {
+						if (preg_match('/^(Re|AW)\s*:\s+/i', $headers['Subject'])) {
+							$isanswer = 1;
+						}
+						if (getDolGlobalString('EMAILCOLLECTOR_USE_IN_REPLY_TO_TO_DETECT_ANSWERS')) {
+							// Note: "In-Reply-To" to detect if mail is an answer of another mail is not reliable because we can have:
+							// Message-ID=A, In-Reply-To=B, References=B and message can BE an answer but may be NOT (for example a transfer of an email rewritten)
+							if (!empty($headers['In-Reply-To'])) {
+								$isanswer = 1;
+							}
+						}
+						if ($hasdolibarrreference) {
 							$isanswer = 1;
 						}
 						//if ($headers['In-Reply-To'] != $headers['Message-ID'] && empty($headers['References'])) $isanswer = 1;	// If in-reply-to differs of message-id, this is a reply
 						//if ($headers['In-Reply-To'] != $headers['Message-ID'] && !empty($headers['References']) && strpos($headers['References'], $headers['Message-ID']) !== false) $isanswer = 1;
-						if ($isanswer) {
+
+						if (!$isanswer) {
 							$nbemailprocessed++;
-							dol_syslog(" Discarded - Email is an answer");
+							dol_syslog(" Discarded - Email is not an answer (no RE prefix in subject)");
 							continue; // Exclude email
 						}
 					}
-				}
-				if ($searchfilterreplyto > 0) {
-					if (!empty($headers['Reply-To'])) {
-						$isreplytook = 0;
-						foreach ($rulesreplyto as $key => $rulereplyto) {
-							if (preg_match('/'.preg_quote($rulereplyto, '/').'/', $headers['Reply-To'])) {
-								$isreplytook++;
+					if ($searchfilterisnotanswer > 0) {
+						if (!empty($headers['In-Reply-To'])) {
+							// Note: we can have
+							// Message-ID=A, In-Reply-To=B, References=B and message can BE an answer or NOT (a transfer rewritten)
+							$isanswer = 0;
+							if (preg_match('/^(回复|回覆|SV|Antw|VS|RE|Re|AW|Aw|ΑΠ|השב| תשובה | הועבר|Vá|R|RIF|BLS|Atb|RES|Odp|பதில்|YNT|ATB)\s*:\s+/i', $headers['Subject'])) {
+								$isanswer = 1;
+							}
+							//if ($headers['In-Reply-To'] != $headers['Message-ID'] && empty($headers['References'])) $isanswer = 1;	// If in-reply-to differs of message-id, this is a reply
+							//if ($headers['In-Reply-To'] != $headers['Message-ID'] && !empty($headers['References']) && strpos($headers['References'], $headers['Message-ID']) !== false) $isanswer = 1;
+							if ($isanswer) {
+								$nbemailprocessed++;
+								dol_syslog(" Discarded - Email is an answer");
+								continue; // Exclude email
 							}
 						}
+					}
+					if ($searchfilterreplyto > 0) {
+						if (!empty($headers['Reply-To'])) {
+							$isreplytook = 0;
+							foreach ($rulesreplyto as $key => $rulereplyto) {
+								if (preg_match('/'.preg_quote($rulereplyto, '/').'/', $headers['Reply-To'])) {
+									$isreplytook++;
+								}
+							}
 
-						if (!$isreplytook || $isreplytook != count($rulesreplyto)) {
-							$nbemailprocessed++;
-							dol_syslog(" Discarded - Reply-to does not match");
-							continue; // Exclude email
+							if (!$isreplytook || $isreplytook != count($rulesreplyto)) {
+								$nbemailprocessed++;
+								dol_syslog(" Discarded - Reply-to does not match");
+								continue; // Exclude email
+							}
 						}
 					}
-				}
 
-				//print "Process mail ".$iforemailloop." Subject: ".dol_escape_htmltag($headers['Subject'])." selected<br>\n";
+					//print "Process mail ".$iforemailloop." Subject: ".dol_escape_htmltag($headers['Subject'])." selected<br>\n";
 
-				$thirdpartystatic = new Societe($this->db);
-				$contactstatic = new Contact($this->db);
-				$projectstatic = new Project($this->db);
+					$thirdpartystatic = new Societe($this->db);
+					$contactstatic = new Contact($this->db);
+					$projectstatic = new Project($this->db);
 
-				$nbactiondoneforemail = 0;
-				$errorforemail = 0;
-				$errorforactions = 0;
-				$thirdpartyfoundby = '';
-				$contactfoundby = '';
-				$projectfoundby = '';
-				$ticketfoundby = '';
-				$candidaturefoundby = '';
+					$nbactiondoneforemail = 0;
+					$errorforemail = 0;
+					$errorforactions = 0;
+					$thirdpartyfoundby = '';
+					$contactfoundby = '';
+					$projectfoundby = '';
+					$ticketfoundby = '';
+					$candidaturefoundby = '';
 
 
-				if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-					$dateformated = dol_print_date($overview['date'], 'dayrfc', 'gmt');		// May generate a warning "dol_print_date($overview['date'], 'dayrfc', 'gmt')" in log
-					dol_syslog("msgid=".$overview['message_id']." date=".$dateformated." from=".$overview['from']." to=".$overview['to']." subject=".$overview['subject']);
+					if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+						$dateformated = dol_print_date($overview['date'], 'dayrfc', 'gmt');		// May generate a warning "dol_print_date($overview['date'], 'dayrfc', 'gmt')" in log
+						dol_syslog("msgid=".$overview['message_id']." date=".$dateformated." from=".$overview['from']." to=".$overview['to']." subject=".$overview['subject']);
 
-					// Removed emojis
-					$overview['subject'] = removeEmoji($overview['subject'], getDolGlobalInt('MAIN_EMAIL_COLLECTOR_ACCEPT_EMOJIS', 1));
-				} else {
-					dol_syslog("msgid=".$overview[0]->message_id." date=".dol_print_date($overview[0]->udate, 'dayrfc', 'gmt')." from=".$overview[0]->from." to=".$overview[0]->to." subject=".$overview[0]->subject);
-
-					$overview[0]->subject = $this->decodeSMTPSubject($overview[0]->subject);
-
-					$overview[0]->from = $this->decodeSMTPSubject($overview[0]->from);
-
-					// Removed emojis
-					$overview[0]->subject = removeEmoji($overview[0]->subject, getDolGlobalInt('MAIN_EMAIL_COLLECTOR_ACCEPT_EMOJIS', 1));
-				}
-				// GET IMAP email structure/content
-				global $htmlmsg, $plainmsg, $charset, $attachments;
-
-				if (getDolGlobalInt('MAIN_IMAP_USE_PHPIMAP')) {
-					/** @var Webklex\PHPIMAP\Message $imapemail */
-					'@phan-var-force Webklex\PHPIMAP\Message $imapemail';
-					if ($imapemail->hasHTMLBody()) {
-						$htmlmsg = $imapemail->getHTMLBody();
-					}
-					if ($imapemail->hasTextBody() && $imapemail->getTextBody() != "\n") {
-						$plainmsg = $imapemail->getTextBody();
-					}
-					if ($imapemail->hasAttachments()) {
-						$attachments = $imapemail->getAttachments()->all();
+						// Removed emojis
+						$overview['subject'] = removeEmoji($overview['subject'], getDolGlobalInt('MAIN_EMAIL_COLLECTOR_ACCEPT_EMOJIS', 1));
 					} else {
-						$attachments = [];
+						dol_syslog("msgid=".$overview[0]->message_id." date=".dol_print_date($overview[0]->udate, 'dayrfc', 'gmt')." from=".$overview[0]->from." to=".$overview[0]->to." subject=".$overview[0]->subject);
+
+						$overview[0]->subject = $this->decodeSMTPSubject($overview[0]->subject);
+
+						$overview[0]->from = $this->decodeSMTPSubject($overview[0]->from);
+
+						// Removed emojis
+						$overview[0]->subject = removeEmoji($overview[0]->subject, getDolGlobalInt('MAIN_EMAIL_COLLECTOR_ACCEPT_EMOJIS', 1));
 					}
-				} else {
-					$getMsg = $this->getmsg($connection, $imapemail); // This set global var $charset, $htmlmsg, $plainmsg, $attachments
-					if ($getMsg < 0) {
-						$this->errors = array_merge($this->errors, [$this->error]);
-						return $getMsg;
-					}
-				}
-				'@phan-var-force Webklex\PHPIMAP\Attachment[] $attachments';
+					// GET IMAP email structure/content
+					global $htmlmsg, $plainmsg, $charset, $attachments;
 
-				//print $plainmsg;
-				//var_dump($plainmsg); exit;
-
-				//$htmlmsg,$plainmsg,$charset,$attachments
-				$messagetext = $plainmsg ? $plainmsg : dol_string_nohtmltag((string) $htmlmsg, 0);
-				// Removed emojis
-
-				if (utf8_valid($messagetext)) {
-					$messagetext = removeEmoji($messagetext, getDolGlobalInt('MAIN_EMAIL_COLLECTOR_ACCEPT_EMOJIS', 1));
-				} else {
-					$operationslog .= '<br>Discarded - Email body is not valid utf8';
-					dol_syslog(" Discarded - Email body is not valid utf8");
-					continue; // Exclude email
-				}
-
-				if (!empty($searchfilterexcludebodyarray)) {
-					foreach ($searchfilterexcludebodyarray as $searchfilterexcludebody) {
-						if (preg_match('/'.preg_quote($searchfilterexcludebody, '/').'/ms', $messagetext)) {
-							$nbemailprocessed++;
-							$operationslog .= '<br>Discarded - Email body contains string '.$searchfilterexcludebody;
-							dol_syslog(" Discarded - Email body contains string ".$searchfilterexcludebody);
-							continue 2; // Exclude email
+					if (getDolGlobalInt('MAIN_IMAP_USE_PHPIMAP')) {
+						/** @var Webklex\PHPIMAP\Message $imapemail */
+						'@phan-var-force Webklex\PHPIMAP\Message $imapemail';
+						if ($imapemail->hasHTMLBody()) {
+							$htmlmsg = $imapemail->getHTMLBody();
 						}
-					}
-				}
-
-				//var_dump($plainmsg);
-				//var_dump($htmlmsg);
-				//var_dump($messagetext);
-				//var_dump($charset);
-				//var_dump($attachments);
-				//exit;
-
-				// Parse IMAP email structure
-				/*
-				 $structure = imap_fetchstructure($connection, $imapemail, FT_UID);
-
-				 $partplain = $parthtml = -1;
-				 $encodingplain = $encodinghtml = '';
-
-				 $result = createPartArray($structure, '');
-
-				 foreach($result as $part)
-				 {
-				 // $part['part_object']->type seems 0 for content
-				 // $part['part_object']->type seems 5 for attachment
-				 if (empty($part['part_object'])) continue;
-				 if ($part['part_object']->subtype == 'HTML')
-				 {
-				 $parthtml=$part['part_number'];
-				 if ($part['part_object']->encoding == 4)
-				 {
-				 $encodinghtml = 'aaa';
-				 }
-				 }
-				 if ($part['part_object']->subtype == 'PLAIN')
-				 {
-				 $partplain=$part['part_number'];
-				 if ($part['part_object']->encoding == 4)
-				 {
-				 $encodingplain = 'rr';
-				 }
-				 }
-				 }
-				 //var_dump($result);
-				 //var_dump($partplain);
-				 //var_dump($parthtml);
-
-				 //var_dump($structure);
-				 //var_dump($parthtml);
-				 //var_dump($partplain);
-
-				 $messagetext = imap_fetchbody($connection, $imapemail, ($parthtml != '-1' ? $parthtml : ($partplain != '-1' ? $partplain : 1)), FT_PEEK|FTP_UID);
-				 */
-
-				//var_dump($messagetext);
-				//var_dump($structure->parts[0]->parts);
-				//print $header;
-				//print $messagetext;
-				//exit;
-
-				$fromstring = '';
-				$replytostring = '';
-
-				if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-					$fromstring = $overview['from'];
-					$replytostring = empty($overview['in_reply-to']) ? $headers['Reply-To'] : $overview['in_reply-to'];
-
-					$sender = $overview['sender'];
-					$to = $overview['to'];
-					$sendtocc = empty($overview['cc']) ? '' : $overview['cc'];
-					$sendtobcc = empty($overview['bcc']) ? '' : $overview['bcc'];
-
-					$tmpdate = $overview['date']->toDate();  // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
-					$tmptimezone = $tmpdate->getTimezone()->getName();  // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
-
-					$dateemail = dol_stringtotime((string) $overview['date'], 'gmt');    // if $overview['timezone'] is "+00:00"
-					if (preg_match('/^([+\-])(\d\d):(\d\d)/', $tmptimezone, $reg)) {
-						if ($reg[1] == '+' && ($reg[2] != '00' || $reg[3] != '00')) {
-							$dateemail -= (3600 * (int) $reg[2]);
-							$dateemail -= (60 * (int) $reg[3]);
+						if ($imapemail->hasTextBody() && $imapemail->getTextBody() != "\n") {
+							$plainmsg = $imapemail->getTextBody();
 						}
-						if ($reg[1] == '-' && ($reg[2] != '00' || $reg[3] != '00')) {
-							$dateemail += (3600 * (int) $reg[2]);
-							$dateemail += (60 * (int) $reg[3]);
+						if ($imapemail->hasAttachments()) {
+							$attachments = $imapemail->getAttachments()->all();
+						} else {
+							$attachments = [];
 						}
-					}
-					$subject = $overview['subject'];
-				} else {
-					$fromstring = $overview[0]->from;
-					$replytostring = (!empty($overview['in_reply-to']) ? $overview['in_reply-to'] : (!empty($headers['Reply-To']) ? $headers['Reply-To'] : "")) ;
-
-					$sender = !empty($overview[0]->sender) ? $overview[0]->sender : '';
-					$to = $overview[0]->to;
-					$sendtocc = !empty($overview[0]->cc) ? $overview[0]->cc : '';
-					$sendtobcc = !empty($overview[0]->bcc) ? $overview[0]->bcc : '';
-					$dateemail = dol_stringtotime((string) $overview[0]->udate, 'gmt');
-					$subject = $overview[0]->subject;
-					//var_dump($msgid);exit;
-				}
-
-				if (!empty($searchfilterexcludesubjectarray)) {
-					foreach ($searchfilterexcludesubjectarray as $searchfilterexcludesubject) {
-						if (preg_match('/'.preg_quote($searchfilterexcludesubject, '/').'/ms', $subject)) {
-							$nbemailprocessed++;
-							$operationslog .= '<br>Discarded - Email subject contains string '.$searchfilterexcludesubject;
-							dol_syslog(" Discarded - Email subject contains string ".$searchfilterexcludesubject);
-							continue 2; // Exclude email
-						}
-					}
-				}
-
-				$reg = array();
-				if (preg_match('/^(.*)<(.*)>$/', $fromstring, $reg)) {
-					$from = $reg[2];
-					$fromtext = $reg[1];
-				} else {
-					$from = $fromstring;
-					$fromtext = '';
-				}
-				if (preg_match('/^(.*)<(.*)>$/', $replytostring, $reg)) {
-					$replyto = $reg[2];
-					$replytotext = $reg[1];
-				} else {
-					$replyto = $replytostring;
-					$replytotext = '';
-				}
-				$fk_element_id = 0;
-				$fk_element_type = '';
-
-
-				$this->db->begin();
-
-				$contactid = 0;
-				$thirdpartyid = 0;
-				$projectid = 0;
-				$ticketid = 0;
-
-				// Analyze TrackId in field References (already analyzed previously into the "To:" and "Message-Id").
-				// For example:
-				// References: <1542377954.SMTPs-dolibarr-thi649@8f6014fde11ec6cdec9a822234fc557e>
-				// References: <1542377954.SMTPs-dolibarr-tic649@8f6014fde11ec6cdec9a822234fc557e>
-				// References: <1542377954.SMTPs-dolibarr-abc649@8f6014fde11ec6cdec9a822234fc557e>
-				$trackid = '';
-				$objectid = 0;
-				$objectemail = null;
-
-				$reg = array();
-				$arrayofreferences = array();
-				if (!empty($headers['References'])) {
-					$arrayofreferences = preg_split('/(,|\s+)/', $headers['References']);
-				}
-				if (!in_array('<'.$msgid.'>', $arrayofreferences)) {
-					$arrayofreferences = array_merge($arrayofreferences, array('<'.$msgid.'>'));
-				}
-				// var_dump($headers['References']);
-				// var_dump($arrayofreferences);
-
-				// We loop on References, but as soon as we found one that allow us to find an existing object,
-				// we do a break (See line with comment "Exit loop of references").
-				foreach ($arrayofreferences as $reference) {
-					//print "Process mail ".$iforemailloop." email_msgid ".$msgid.", date ".dol_print_date($dateemail, 'dayhour', 'gmt').", subject ".$subject.", reference ".dol_escape_htmltag($reference)."<br>\n";
-					if (!empty($trackidfoundintorecipienttype)) {
-						$resultsearchtrackid = -1;		// trackid found
-						$reg[1] = $trackidfoundintorecipienttype;
-						$reg[2] = $trackidfoundintorecipientid;
-					} elseif (!empty($trackidfoundintomsgidtype)) {
-						$resultsearchtrackid = -1;		// trackid found
-						$reg[1] = $trackidfoundintomsgidtype;
-						$reg[2] = $trackidfoundintomsgidid;
 					} else {
-						$resultsearchtrackid = preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote($host, '/').'/', $reference, $reg);	// trackid found or not
-						if (empty($resultsearchtrackid) && getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE')) {
-							$resultsearchtrackid = preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote(getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE'), '/').'/', $reference, $reg);	// trackid found
+						$getMsg = $this->getmsg($connection, $imapemail); // This set global var $charset, $htmlmsg, $plainmsg, $attachments
+						if ($getMsg < 0) {
+							$this->errors = array_merge($this->errors, [$this->error]);
+							return $getMsg;
 						}
 					}
+					'@phan-var-force Webklex\PHPIMAP\Attachment[] $attachments';
 
-					if (!empty($resultsearchtrackid)) {
-						// We found a tracker (in recipient email or msgid or into a Reference matching the Dolibarr server)
-						$trackid = $reg[1].$reg[2];
+					//print $plainmsg;
+					//var_dump($plainmsg); exit;
 
-						$objectid = $reg[2];
-						// See also list into interface_50_modAgenda_ActionsAuto
-						if ($reg[1] == 'thi') {   // Third-party
-							$objectemail = new Societe($this->db);
-						}
-						if ($reg[1] == 'ctc') {   // Contact
-							$objectemail = new Contact($this->db);
-						}
-						if ($reg[1] == 'inv') {   // Customer Invoice
-							$objectemail = new Facture($this->db);
-						}
-						if ($reg[1] == 'sinv') {   // Supplier Invoice
-							$objectemail = new FactureFournisseur($this->db);
-						}
-						if ($reg[1] == 'pro') {   // Customer Proposal
-							$objectemail = new Propal($this->db);
-						}
-						if ($reg[1] == 'ord') {   // Sale Order
-							$objectemail = new Commande($this->db);
-						}
-						if ($reg[1] == 'shi') {   // Shipment
-							$objectemail = new Expedition($this->db);
-						}
-						if ($reg[1] == 'spro') {   // Supplier Proposal
-							$objectemail = new SupplierProposal($this->db);
-						}
-						if ($reg[1] == 'sord') {   // Supplier Order
-							$objectemail = new CommandeFournisseur($this->db);
-						}
-						if ($reg[1] == 'rec') {   // Reception
-							$objectemail = new Reception($this->db);
-						}
-						if ($reg[1] == 'proj') {   // Project
-							$objectemail = new Project($this->db);
-							$projectfoundby = 'TrackID dolibarr-'.$trackid.'@...';
-						}
-						if ($reg[1] == 'tas') {   // Task
-							$objectemail = new Task($this->db);
-						}
-						if ($reg[1] == 'con') {   // Contact
-							$objectemail = new Contact($this->db);
-						}
-						if ($reg[1] == 'use') {   // User
-							$objectemail = new User($this->db);
-						}
-						if ($reg[1] == 'tic') {   // Ticket
-							$objectemail = new Ticket($this->db);
-							$ticketfoundby = 'TrackID dolibarr-'.$trackid.'@...';
-						}
-						if ($reg[1] == 'recruitmentcandidature') {   // Recruiting Candidate
-							$objectemail = new RecruitmentCandidature($this->db);
-							$candidaturefoundby = 'TrackID dolibarr-'.$trackid.'@...';
-						}
-						if ($reg[1] == 'mem') {   // Member
-							$objectemail = new Adherent($this->db);
-						}
-						/*if ($reg[1] == 'leav') {   // Leave / Holiday
-							$objectemail = new Holiday($db);
-						}
-						if ($reg[1] == 'exp') {   // ExpenseReport
-							$objectemail = new ExpenseReport($db);
-						}*/
-					} elseif (preg_match('/<(.*@.*)>/', $reference, $reg)) {
-						// This is an external reference, we check if we have it in our database
-						if (is_null($objectemail) && isModEnabled('ticket')) {
-							$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."ticket";
-							$sql .= " WHERE email_msgid = '".$this->db->escape($reg[1])."' OR origin_references LIKE '%".$this->db->escape($this->db->escapeforlike($reg[1]))."%'";
-							$resql = $this->db->query($sql);
-							if ($resql) {
-								$obj = $this->db->fetch_object($resql);
-								if ($obj) {
-									$objectid = $obj->rowid;
-									$objectemail = new Ticket($this->db);
-									$ticketfoundby = $langs->transnoentitiesnoconv("EmailMsgID").' ('.$reg[1].')';
-								}
-							} else {
-								$errorforemail++;
-							}
-						}
+					//$htmlmsg,$plainmsg,$charset,$attachments
+					$messagetext = $plainmsg ? $plainmsg : dol_string_nohtmltag((string) $htmlmsg, 0);
+					// Removed emojis
 
-						if (!is_object($objectemail) && isModEnabled('project')) {
-							$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."projet where email_msgid = '".$this->db->escape($reg[1])."'";
-							$resql = $this->db->query($sql);
-							if ($resql) {
-								$obj = $this->db->fetch_object($resql);
-								if ($obj) {
-									$objectid = $obj->rowid;
-									$objectemail = new Project($this->db);
-									$projectfoundby = $langs->transnoentitiesnoconv("EmailMsgID").' ('.$reg[1].')';
-								}
-							} else {
-								$errorforemail++;
-							}
-						}
+					if (utf8_valid($messagetext)) {
+						$messagetext = removeEmoji($messagetext, getDolGlobalInt('MAIN_EMAIL_COLLECTOR_ACCEPT_EMOJIS', 1));
+					} else {
+						$operationslog .= '<br>Discarded - Email body is not valid utf8';
+						dol_syslog(" Discarded - Email body is not valid utf8");
+						continue; // Exclude email
+					}
 
-						if (!is_object($objectemail) && isModEnabled('recruitment')) {
-							$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."recruitment_recruitmentcandidature where email_msgid = '".$this->db->escape($reg[1])."'";
-							$resql = $this->db->query($sql);
-							if ($resql) {
-								$obj = $this->db->fetch_object($resql);
-								if ($obj) {
-									$objectid = $obj->rowid;
-									$objectemail = new RecruitmentCandidature($this->db);
-									$candidaturefoundby = $langs->transnoentitiesnoconv("EmailMsgID").' ('.$reg[1].')';
-								}
-							} else {
-								$errorforemail++;
+					if (!empty($searchfilterexcludebodyarray)) {
+						foreach ($searchfilterexcludebodyarray as $searchfilterexcludebody) {
+							if (preg_match('/'.preg_quote($searchfilterexcludebody, '/').'/ms', $messagetext)) {
+								$nbemailprocessed++;
+								$operationslog .= '<br>Discarded - Email body contains string '.$searchfilterexcludebody;
+								dol_syslog(" Discarded - Email body contains string ".$searchfilterexcludebody);
+								continue 2; // Exclude email
 							}
 						}
 					}
 
-					// Load object linked to email
-					if (is_object($objectemail)) {
-						$result = $objectemail->fetch($objectid);
-						if ($result > 0) {
-							$fk_element_id = $objectemail->id;
-							$fk_element_type = $objectemail->element;
-							// Fix fk_element_type
-							if ($fk_element_type == 'facture') {
-								$fk_element_type = 'invoice';
+					//var_dump($plainmsg);
+					//var_dump($htmlmsg);
+					//var_dump($messagetext);
+					//var_dump($charset);
+					//var_dump($attachments);
+					//exit;
+
+					// Parse IMAP email structure
+					/*
+					 $structure = imap_fetchstructure($connection, $imapemail, FT_UID);
+
+					 $partplain = $parthtml = -1;
+					 $encodingplain = $encodinghtml = '';
+
+					 $result = createPartArray($structure, '');
+
+					 foreach($result as $part)
+					 {
+					 // $part['part_object']->type seems 0 for content
+					 // $part['part_object']->type seems 5 for attachment
+					 if (empty($part['part_object'])) continue;
+					 if ($part['part_object']->subtype == 'HTML')
+					 {
+					 $parthtml=$part['part_number'];
+					 if ($part['part_object']->encoding == 4)
+					 {
+					 $encodinghtml = 'aaa';
+					 }
+					 }
+					 if ($part['part_object']->subtype == 'PLAIN')
+					 {
+					 $partplain=$part['part_number'];
+					 if ($part['part_object']->encoding == 4)
+					 {
+					 $encodingplain = 'rr';
+					 }
+					 }
+					 }
+					 //var_dump($result);
+					 //var_dump($partplain);
+					 //var_dump($parthtml);
+
+					 //var_dump($structure);
+					 //var_dump($parthtml);
+					 //var_dump($partplain);
+
+					 $messagetext = imap_fetchbody($connection, $imapemail, ($parthtml != '-1' ? $parthtml : ($partplain != '-1' ? $partplain : 1)), FT_PEEK|FTP_UID);
+					 */
+
+					//var_dump($messagetext);
+					//var_dump($structure->parts[0]->parts);
+					//print $header;
+					//print $messagetext;
+					//exit;
+
+					$fromstring = '';
+					$replytostring = '';
+
+					if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+						$fromstring = $overview['from'];
+						$replytostring = empty($overview['in_reply-to']) ? $headers['Reply-To'] : $overview['in_reply-to'];
+
+						$sender = $overview['sender'];
+						$to = $overview['to'];
+						$sendtocc = empty($overview['cc']) ? '' : $overview['cc'];
+						$sendtobcc = empty($overview['bcc']) ? '' : $overview['bcc'];
+
+						$tmpdate = $overview['date']->toDate();  // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
+						$tmptimezone = $tmpdate->getTimezone()->getName();  // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
+
+						$dateemail = dol_stringtotime((string) $overview['date'], 'gmt');    // if $overview['timezone'] is "+00:00"
+						if (preg_match('/^([+\-])(\d\d):(\d\d)/', $tmptimezone, $reg)) {
+							if ($reg[1] == '+' && ($reg[2] != '00' || $reg[3] != '00')) {
+								$dateemail -= (3600 * (int) $reg[2]);
+								$dateemail -= (60 * (int) $reg[3]);
 							}
-
-							if (get_class($objectemail) != 'Societe') {
-								$thirdpartyid = $objectemail->fk_soc ?? $objectemail->socid;
-							} else {
-								$thirdpartyid = $objectemail->id;
+							if ($reg[1] == '-' && ($reg[2] != '00' || $reg[3] != '00')) {
+								$dateemail += (3600 * (int) $reg[2]);
+								$dateemail += (60 * (int) $reg[3]);
 							}
+						}
+						$subject = $overview['subject'];
+					} else {
+						$fromstring = $overview[0]->from;
+						$replytostring = (!empty($overview['in_reply-to']) ? $overview['in_reply-to'] : (!empty($headers['Reply-To']) ? $headers['Reply-To'] : "")) ;
 
-							if (get_class($objectemail) != 'Contact') {
-								$contactid = $objectemail->fk_socpeople;
-							} else {
-								$contactid = $objectemail->id;
+						$sender = !empty($overview[0]->sender) ? $overview[0]->sender : '';
+						$to = $overview[0]->to;
+						$sendtocc = !empty($overview[0]->cc) ? $overview[0]->cc : '';
+						$sendtobcc = !empty($overview[0]->bcc) ? $overview[0]->bcc : '';
+						$dateemail = dol_stringtotime((string) $overview[0]->udate, 'gmt');
+						$subject = $overview[0]->subject;
+						//var_dump($msgid);exit;
+					}
+
+					if (!empty($searchfilterexcludesubjectarray)) {
+						foreach ($searchfilterexcludesubjectarray as $searchfilterexcludesubject) {
+							if (preg_match('/'.preg_quote($searchfilterexcludesubject, '/').'/ms', $subject)) {
+								$nbemailprocessed++;
+								$operationslog .= '<br>Discarded - Email subject contains string '.$searchfilterexcludesubject;
+								dol_syslog(" Discarded - Email subject contains string ".$searchfilterexcludesubject);
+								continue 2; // Exclude email
 							}
+						}
+					}
 
-							if (get_class($objectemail) != 'Project') {
-								$projectid = isset($objectemail->fk_project) ? $objectemail->fk_project : $objectemail->fk_projet;
-							} else {
-								$projectid = $objectemail->id;
+					$reg = array();
+					if (preg_match('/^(.*)<(.*)>$/', $fromstring, $reg)) {
+						$from = $reg[2];
+						$fromtext = $reg[1];
+					} else {
+						$from = $fromstring;
+						$fromtext = '';
+					}
+					if (preg_match('/^(.*)<(.*)>$/', $replytostring, $reg)) {
+						$replyto = $reg[2];
+						$replytotext = $reg[1];
+					} else {
+						$replyto = $replytostring;
+						$replytotext = '';
+					}
+					$fk_element_id = 0;
+					$fk_element_type = '';
+
+
+					$this->db->begin();
+
+					$contactid = 0;
+					$thirdpartyid = 0;
+					$projectid = 0;
+					$ticketid = 0;
+
+					// Analyze TrackId in field References (already analyzed previously into the "To:" and "Message-Id").
+					// For example:
+					// References: <1542377954.SMTPs-dolibarr-thi649@8f6014fde11ec6cdec9a822234fc557e>
+					// References: <1542377954.SMTPs-dolibarr-tic649@8f6014fde11ec6cdec9a822234fc557e>
+					// References: <1542377954.SMTPs-dolibarr-abc649@8f6014fde11ec6cdec9a822234fc557e>
+					$trackid = '';
+					$objectid = 0;
+					$objectemail = null;
+
+					$reg = array();
+					$arrayofreferences = array();
+					if (!empty($headers['References'])) {
+						$arrayofreferences = preg_split('/(,|\s+)/', $headers['References']);
+					}
+					if (!in_array('<'.$msgid.'>', $arrayofreferences)) {
+						$arrayofreferences = array_merge($arrayofreferences, array('<'.$msgid.'>'));
+					}
+					// var_dump($headers['References']);
+					// var_dump($arrayofreferences);
+
+					// We loop on References, but as soon as we found one that allow us to find an existing object,
+					// we do a break (See line with comment "Exit loop of references").
+					foreach ($arrayofreferences as $reference) {
+						//print "Process mail ".$iforemailloop." email_msgid ".$msgid.", date ".dol_print_date($dateemail, 'dayhour', 'gmt').", subject ".$subject.", reference ".dol_escape_htmltag($reference)."<br>\n";
+						if (!empty($trackidfoundintorecipienttype)) {
+							$resultsearchtrackid = -1;		// trackid found
+							$reg[1] = $trackidfoundintorecipienttype;
+							$reg[2] = $trackidfoundintorecipientid;
+						} elseif (!empty($trackidfoundintomsgidtype)) {
+							$resultsearchtrackid = -1;		// trackid found
+							$reg[1] = $trackidfoundintomsgidtype;
+							$reg[2] = $trackidfoundintomsgidid;
+						} else {
+							$resultsearchtrackid = preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote($host, '/').'/', $reference, $reg);	// trackid found or not
+							if (empty($resultsearchtrackid) && getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE')) {
+								$resultsearchtrackid = preg_match('/dolibarr-([a-z]+)([0-9]+)@'.preg_quote(getDolGlobalString('EMAIL_ALTERNATIVE_HOST_SIGNATURE'), '/').'/', $reference, $reg);	// trackid found
 							}
+						}
 
-							if ($objectemail instanceof Ticket) {	// For tickets, we have a column to store all met references, so we complete it if we need to.
-								$ticketid = $objectemail->id;
+						if (!empty($resultsearchtrackid)) {
+							// We found a tracker (in recipient email or msgid or into a Reference matching the Dolibarr server)
+							$trackid = $reg[1].$reg[2];
 
-								$changeonticket_references = false;
-								if (empty($trackid)) {
-									$trackid = $objectemail->track_id;
-								}
-								if (empty($objectemail->origin_references)) {
-									$objectemail->origin_references = !empty($headers['References']) ? $headers['References'] : null;
-									$changeonticket_references = true;
+							$objectid = $reg[2];
+							// See also list into interface_50_modAgenda_ActionsAuto
+							if ($reg[1] == 'thi') {   // Third-party
+								$objectemail = new Societe($this->db);
+							}
+							if ($reg[1] == 'ctc') {   // Contact
+								$objectemail = new Contact($this->db);
+							}
+							if ($reg[1] == 'inv') {   // Customer Invoice
+								$objectemail = new Facture($this->db);
+							}
+							if ($reg[1] == 'sinv') {   // Supplier Invoice
+								$objectemail = new FactureFournisseur($this->db);
+							}
+							if ($reg[1] == 'pro') {   // Customer Proposal
+								$objectemail = new Propal($this->db);
+							}
+							if ($reg[1] == 'ord') {   // Sale Order
+								$objectemail = new Commande($this->db);
+							}
+							if ($reg[1] == 'shi') {   // Shipment
+								$objectemail = new Expedition($this->db);
+							}
+							if ($reg[1] == 'spro') {   // Supplier Proposal
+								$objectemail = new SupplierProposal($this->db);
+							}
+							if ($reg[1] == 'sord') {   // Supplier Order
+								$objectemail = new CommandeFournisseur($this->db);
+							}
+							if ($reg[1] == 'rec') {   // Reception
+								$objectemail = new Reception($this->db);
+							}
+							if ($reg[1] == 'proj') {   // Project
+								$objectemail = new Project($this->db);
+								$projectfoundby = 'TrackID dolibarr-'.$trackid.'@...';
+							}
+							if ($reg[1] == 'tas') {   // Task
+								$objectemail = new Task($this->db);
+							}
+							if ($reg[1] == 'con') {   // Contact
+								$objectemail = new Contact($this->db);
+							}
+							if ($reg[1] == 'use') {   // User
+								$objectemail = new User($this->db);
+							}
+							if ($reg[1] == 'tic') {   // Ticket
+								$objectemail = new Ticket($this->db);
+								$ticketfoundby = 'TrackID dolibarr-'.$trackid.'@...';
+							}
+							if ($reg[1] == 'recruitmentcandidature') {   // Recruiting Candidate
+								$objectemail = new RecruitmentCandidature($this->db);
+								$candidaturefoundby = 'TrackID dolibarr-'.$trackid.'@...';
+							}
+							if ($reg[1] == 'mem') {   // Member
+								$objectemail = new Adherent($this->db);
+							}
+							/*if ($reg[1] == 'leav') {   // Leave / Holiday
+								$objectemail = new Holiday($db);
+							}
+							if ($reg[1] == 'exp') {   // ExpenseReport
+								$objectemail = new ExpenseReport($db);
+							}*/
+						} elseif (preg_match('/<(.*@.*)>/', $reference, $reg)) {
+							// This is an external reference, we check if we have it in our database
+							if (is_null($objectemail) && isModEnabled('ticket')) {
+								$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."ticket";
+								$sql .= " WHERE email_msgid = '".$this->db->escape($reg[1])."' OR origin_references LIKE '%".$this->db->escape($this->db->escapeforlike($reg[1]))."%'";
+								$resql = $this->db->query($sql);
+								if ($resql) {
+									$obj = $this->db->fetch_object($resql);
+									if ($obj) {
+										$objectid = $obj->rowid;
+										$objectemail = new Ticket($this->db);
+										$ticketfoundby = $langs->transnoentitiesnoconv("EmailMsgID").' ('.$reg[1].')';
+									}
 								} else {
-									foreach ($arrayofreferences as $key => $referencetmp) {
-										if (!str_contains($objectemail->origin_references, $referencetmp)) {
-											$objectemail->origin_references .= " ".$referencetmp;
-											$changeonticket_references = true;
+									$errorforemail++;
+								}
+							}
+
+							if (!is_object($objectemail) && isModEnabled('project')) {
+								$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."projet where email_msgid = '".$this->db->escape($reg[1])."'";
+								$resql = $this->db->query($sql);
+								if ($resql) {
+									$obj = $this->db->fetch_object($resql);
+									if ($obj) {
+										$objectid = $obj->rowid;
+										$objectemail = new Project($this->db);
+										$projectfoundby = $langs->transnoentitiesnoconv("EmailMsgID").' ('.$reg[1].')';
+									}
+								} else {
+									$errorforemail++;
+								}
+							}
+
+							if (!is_object($objectemail) && isModEnabled('recruitment')) {
+								$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."recruitment_recruitmentcandidature where email_msgid = '".$this->db->escape($reg[1])."'";
+								$resql = $this->db->query($sql);
+								if ($resql) {
+									$obj = $this->db->fetch_object($resql);
+									if ($obj) {
+										$objectid = $obj->rowid;
+										$objectemail = new RecruitmentCandidature($this->db);
+										$candidaturefoundby = $langs->transnoentitiesnoconv("EmailMsgID").' ('.$reg[1].')';
+									}
+								} else {
+									$errorforemail++;
+								}
+							}
+						}
+
+						// Load object linked to email
+						if (is_object($objectemail)) {
+							$result = $objectemail->fetch($objectid);
+							if ($result > 0) {
+								$fk_element_id = $objectemail->id;
+								$fk_element_type = $objectemail->element;
+								// Fix fk_element_type
+								if ($fk_element_type == 'facture') {
+									$fk_element_type = 'invoice';
+								}
+
+								if (get_class($objectemail) != 'Societe') {
+									$thirdpartyid = $objectemail->fk_soc ?? $objectemail->socid;
+								} else {
+									$thirdpartyid = $objectemail->id;
+								}
+
+								if (get_class($objectemail) != 'Contact') {
+									$contactid = $objectemail->fk_socpeople;
+								} else {
+									$contactid = $objectemail->id;
+								}
+
+								if (get_class($objectemail) != 'Project') {
+									$projectid = isset($objectemail->fk_project) ? $objectemail->fk_project : $objectemail->fk_projet;
+								} else {
+									$projectid = $objectemail->id;
+								}
+
+								if ($objectemail instanceof Ticket) {	// For tickets, we have a column to store all met references, so we complete it if we need to.
+									$ticketid = $objectemail->id;
+
+									$changeonticket_references = false;
+									if (empty($trackid)) {
+										$trackid = $objectemail->track_id;
+									}
+									if (empty($objectemail->origin_references)) {
+										$objectemail->origin_references = !empty($headers['References']) ? $headers['References'] : null;
+										$changeonticket_references = true;
+									} else {
+										foreach ($arrayofreferences as $key => $referencetmp) {
+											if (!str_contains($objectemail->origin_references, $referencetmp)) {
+												$objectemail->origin_references .= " ".$referencetmp;
+												$changeonticket_references = true;
+											}
 										}
 									}
+									if ($changeonticket_references) {
+										$operationslog .= '<br>We complete ticket ID='.$ticketid.' with property origin_references='.$objectemail->origin_references;
+										$objectemail->update($user, 1);		// We complete the references field with all references mentioned into this email. This field is for technical tracking purpose, not a user field, so no need to execute triggers
+									}
 								}
-								if ($changeonticket_references) {
-									$operationslog .= '<br>We complete ticket ID='.$ticketid.' with property origin_references='.$objectemail->origin_references;
-									$objectemail->update($user, 1);		// We complete the references field with all references mentioned into this email. This field is for technical tracking purpose, not a user field, so no need to execute triggers
+							}
+						}
+
+						// Project
+						if ($projectid > 0) {
+							$result = $projectstatic->fetch($projectid);
+							if ($result <= 0) {
+								$projectstatic->id = 0;
+							} else {
+								$projectid = $projectstatic->id;
+								if ($trackid) {
+									$projectfoundby = 'trackid ('.$trackid.')';
+								}
+								if (empty($contactid)) {
+									$contactid = $projectstatic->fk_contact;
+								}
+								if (empty($thirdpartyid)) {
+									$thirdpartyid = $projectstatic->fk_soc;
 								}
 							}
 						}
-					}
-
-					// Project
-					if ($projectid > 0) {
-						$result = $projectstatic->fetch($projectid);
-						if ($result <= 0) {
-							$projectstatic->id = 0;
-						} else {
-							$projectid = $projectstatic->id;
-							if ($trackid) {
-								$projectfoundby = 'trackid ('.$trackid.')';
-							}
-							if (empty($contactid)) {
-								$contactid = $projectstatic->fk_contact;
-							}
-							if (empty($thirdpartyid)) {
-								$thirdpartyid = $projectstatic->fk_soc;
+						// Contact
+						if ($contactid > 0) {
+							$result = $contactstatic->fetch($contactid);
+							if ($result <= 0) {
+								$contactstatic->id = 0;
+							} else {
+								$contactid = $contactstatic->id;
+								if ($trackid) {
+									$contactfoundby = 'trackid ('.$trackid.')';
+								}
+								if (empty($thirdpartyid)) {
+									$thirdpartyid = $contactstatic->fk_soc;
+								}
 							}
 						}
-					}
-					// Contact
-					if ($contactid > 0) {
-						$result = $contactstatic->fetch($contactid);
-						if ($result <= 0) {
-							$contactstatic->id = 0;
-						} else {
-							$contactid = $contactstatic->id;
-							if ($trackid) {
-								$contactfoundby = 'trackid ('.$trackid.')';
-							}
-							if (empty($thirdpartyid)) {
-								$thirdpartyid = $contactstatic->fk_soc;
-							}
-						}
-					}
-					// Thirdparty
-					if ($thirdpartyid > 0) {
-						$result = $thirdpartystatic->fetch($thirdpartyid);
-						if ($result <= 0) {
-							$thirdpartystatic->id = 0;
-						} else {
-							$thirdpartyid = $thirdpartystatic->id;
-							if ($trackid) {
-								$thirdpartyfoundby = 'trackid ('.$trackid.')';
-							}
-						}
-					}
-
-					if (is_object($objectemail)) {
-						break; // Exit loop of references. We already found an accurate reference
-					}
-				}
-
-				if (empty($contactid)) {		// Try to find contact using email
-					$result = $contactstatic->fetch(0, null, '', $from);
-
-					if ($result > 0) {
-						dol_syslog("We found a contact with the email ".$from);
-						$contactid = $contactstatic->id;
-						$contactfoundby = 'email of contact ('.$from.')';
-						if (empty($thirdpartyid) && $contactstatic->socid > 0) {
-							$result = $thirdpartystatic->fetch($contactstatic->socid);
-							if ($result > 0) {
+						// Thirdparty
+						if ($thirdpartyid > 0) {
+							$result = $thirdpartystatic->fetch($thirdpartyid);
+							if ($result <= 0) {
+								$thirdpartystatic->id = 0;
+							} else {
 								$thirdpartyid = $thirdpartystatic->id;
-								$thirdpartyfoundby = 'email of contact ('.$from.')';
+								if ($trackid) {
+									$thirdpartyfoundby = 'trackid ('.$trackid.')';
+								}
+							}
+						}
+
+						if (is_object($objectemail)) {
+							break; // Exit loop of references. We already found an accurate reference
+						}
+					}
+
+					if (empty($contactid)) {		// Try to find contact using email
+						$result = $contactstatic->fetch(0, null, '', $from);
+
+						if ($result > 0) {
+							dol_syslog("We found a contact with the email ".$from);
+							$contactid = $contactstatic->id;
+							$contactfoundby = 'email of contact ('.$from.')';
+							if (empty($thirdpartyid) && $contactstatic->socid > 0) {
+								$result = $thirdpartystatic->fetch($contactstatic->socid);
+								if ($result > 0) {
+									$thirdpartyid = $thirdpartystatic->id;
+									$thirdpartyfoundby = 'email of contact ('.$from.')';
+								}
 							}
 						}
 					}
-				}
 
-				if (empty($thirdpartyid)) {		// Try to find thirdparty using email
-					$result = $thirdpartystatic->fetch(0, '', '', '', '', '', '', '', '', '', $from);
-					if ($result > 0) {
-						dol_syslog("We found a thirdparty with the email ".$from);
-						$thirdpartyid = $thirdpartystatic->id;
-						$thirdpartyfoundby = 'email ('.$from.')';
+					if (empty($thirdpartyid)) {		// Try to find thirdparty using email
+						$result = $thirdpartystatic->fetch(0, '', '', '', '', '', '', '', '', '', $from);
+						if ($result > 0) {
+							dol_syslog("We found a thirdparty with the email ".$from);
+							$thirdpartyid = $thirdpartystatic->id;
+							$thirdpartyfoundby = 'email ('.$from.')';
+						}
 					}
-				}
 
-				/*
-				 if ($replyto) {
-				 if (empty($contactid)) {		// Try to find contact using email
-				 $result = $contactstatic->fetch(0, null, '', $replyto);
+					/*
+					 if ($replyto) {
+					 if (empty($contactid)) {		// Try to find contact using email
+					 $result = $contactstatic->fetch(0, null, '', $replyto);
 
-				 if ($result > 0) {
-				 dol_syslog("We found a contact with the email ".$replyto);
-				 $contactid = $contactstatic->id;
-				 $contactfoundby = 'email of contact ('.$replyto.')';
-				 if (empty($thirdpartyid) && $contactstatic->socid > 0) {
-				 $result = $thirdpartystatic->fetch($contactstatic->socid);
-				 if ($result > 0) {
-				 $thirdpartyid = $thirdpartystatic->id;
-				 $thirdpartyfoundby = 'email of contact ('.$replyto.')';
-				 }
-				 }
-				 }
-				 }
+					 if ($result > 0) {
+					 dol_syslog("We found a contact with the email ".$replyto);
+					 $contactid = $contactstatic->id;
+					 $contactfoundby = 'email of contact ('.$replyto.')';
+					 if (empty($thirdpartyid) && $contactstatic->socid > 0) {
+					 $result = $thirdpartystatic->fetch($contactstatic->socid);
+					 if ($result > 0) {
+					 $thirdpartyid = $thirdpartystatic->id;
+					 $thirdpartyfoundby = 'email of contact ('.$replyto.')';
+					 }
+					 }
+					 }
+					 }
 
-				 if (empty($thirdpartyid)) {		// Try to find thirdparty using email
-				 $result = $thirdpartystatic->fetch(0, '', '', '', '', '', '', '', '', '', $replyto);
-				 if ($result > 0) {
-				 dol_syslog("We found a thirdparty with the email ".$replyto);
-				 $thirdpartyid = $thirdpartystatic->id;
-				 $thirdpartyfoundby = 'email ('.$replyto.')';
-				 }
-				 }
-				 }
-				 */
+					 if (empty($thirdpartyid)) {		// Try to find thirdparty using email
+					 $result = $thirdpartystatic->fetch(0, '', '', '', '', '', '', '', '', '', $replyto);
+					 if ($result > 0) {
+					 dol_syslog("We found a thirdparty with the email ".$replyto);
+					 $thirdpartyid = $thirdpartystatic->id;
+					 $thirdpartyfoundby = 'email ('.$replyto.')';
+					 }
+					 }
+					 }
+					 */
 
 
-				// Now do all operations for the email (extract variables and creating data)
-				if ($mode < 2) {	// 0=Mode production, 1=Mode test (read IMAP and try SQL update then rollback), 2=Mode test with no SQL updates
-					foreach ($this->actions as $operation) {
-						$errorforthisaction = 0;
-						$ticketalreadyexists = 0;
-						if ($errorforactions) {
-							break;
-						}
-						if (empty($operation['status'])) {
-							continue;
-						}
+					// Now do all operations for the email (extract variables and creating data)
+					if ($mode < 2) {	// 0=Mode production, 1=Mode test (read IMAP and try SQL update then rollback), 2=Mode test with no SQL updates
+						foreach ($this->actions as $operation) {
+							$errorforthisaction = 0;
+							$ticketalreadyexists = 0;
+							if ($errorforactions) {
+								break;
+							}
+							if (empty($operation['status'])) {
+								continue;
+							}
 
-						$operationslog .= '<br>* Process operation '.$operation['type'];
+							$operationslog .= '<br>* Process operation '.$operation['type'];
 
-						// Make Operation
-						dol_syslog("Execute action ".$operation['type']." actionparam=".$operation['actionparam'].' thirdpartystatic->id='.$thirdpartystatic->id.' contactstatic->id='.$contactstatic->id.' projectstatic->id='.$projectstatic->id);
-						dol_syslog("Execute action fk_element_id=".$fk_element_id." fk_element_type=".$fk_element_type);	// If a Dolibarr tracker id is found, we should now the id of object
+							// Make Operation
+							dol_syslog("Execute action ".$operation['type']." actionparam=".$operation['actionparam'].' thirdpartystatic->id='.$thirdpartystatic->id.' contactstatic->id='.$contactstatic->id.' projectstatic->id='.$projectstatic->id);
+							dol_syslog("Execute action fk_element_id=".$fk_element_id." fk_element_type=".$fk_element_type);	// If a Dolibarr tracker id is found, we should now the id of object
 
-						// Try to guess if this is an email in or out.
-						$actioncode = 'EMAIL_IN';
-						// If we scan the Sent box, we use the code for out email
-						if (preg_match('/Sent$/', $sourcedir) || preg_match('/envoyés$/i', $sourcedir)) {
-							$actioncode = 'EMAIL';
-						}
-						// If sender is in the list MAIL_FROM_EMAILS_TO_CONSIDER_SENDING
-						$arrayofemailtoconsideresender = explode(',', getDolGlobalString('MAIL_FROM_EMAILS_TO_CONSIDER_SENDING'));
-						foreach ($arrayofemailtoconsideresender as $emailtoconsidersender) {
-							if (preg_match('/'.preg_quote($emailtoconsidersender, '/').'/', $fromstring)) {
+							// Try to guess if this is an email in or out.
+							$actioncode = 'EMAIL_IN';
+							// If we scan the Sent box, we use the code for out email
+							if (preg_match('/Sent$/', $sourcedir) || preg_match('/envoyés$/i', $sourcedir)) {
 								$actioncode = 'EMAIL';
 							}
-						}
-						$operationslog .= '<br>Email will have actioncode='.$actioncode;
-
-						$description = $descriptiontitle = $descriptionmeta = $descriptionfull = '';
-
-						$descriptiontitle = $langs->transnoentitiesnoconv("RecordCreatedByEmailCollector", $this->ref);
-
-						$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("EmailMsgID").' : '.dol_escape_htmltag($msgid));
-						$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailTopic").' : '.dol_escape_htmltag($subject));
-						$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailDate").($langs->trans("MailDate") != 'Date' ? ' (Date)' : '').' : '.dol_escape_htmltag(dol_print_date($dateemail, "dayhourtext", "gmt")));
-						$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailFrom").($langs->trans("MailFrom") != 'From' ? ' (From)' : '').' : '.dol_escape_htmltag($fromstring));
-						if ($sender) {
-							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("Sender").($langs->trans("Sender") != 'Sender' ? ' (Sender)' : '').' : '.dol_escape_htmltag($sender));
-						}
-						$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailTo").($langs->trans("MailTo") != 'To' ? ' (To)' : '').' : '.dol_escape_htmltag($to));
-						if ($replyto) {
-							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailReply").($langs->trans("MailReply") != 'Reply to' ? ' (Reply to)' : '').' : '.dol_escape_htmltag($replyto));
-						}
-						if ($sendtocc) {
-							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailCC").($langs->trans("MailCC") != 'CC' ? ' (CC)' : '').' : '.dol_escape_htmltag($sendtocc));
-						}
-
-						if ($operation['type'] == 'ticket') {
-							// Verify if ticket already exists to fall back on the right operation
-							$tickettocreate = new Ticket($this->db);
-							$errorfetchticket = 0;
-							$alreadycreated = 0;
-							if ($ticketid > 0) {
-								$alreadycreated = $tickettocreate->fetch($ticketid);
-							}
-							if ($alreadycreated == 0 && !empty($trackid)) {
-								$alreadycreated = $tickettocreate->fetch(0, '', $trackid);
-							}
-							if ($alreadycreated == 0 && !empty($msgid)) {
-								$alreadycreated = $tickettocreate->fetch(0, '', '', $msgid);
-							}
-							if ($alreadycreated < 0) {
-								$errorfetchticket++;
-							}
-							if (empty($errorfetchticket)) {
-								if ($alreadycreated == 0) {
-									$operationslog .= '<br>Ticket not found using trackid='.$trackid.' or msgid='.$msgid;
-									$ticketalreadyexists = 0;
-								} else {
-									$operationslog .= '<br>Ticket already found using trackid='.$trackid.' or msgid='.$msgid.", we replace operation 'ticket' with 'recordevent' to add a new message";	// We change the operation type to do
-									$ticketalreadyexists = 1;
-									$operation['type'] = 'recordevent';
+							// If sender is in the list MAIL_FROM_EMAILS_TO_CONSIDER_SENDING
+							$arrayofemailtoconsideresender = explode(',', getDolGlobalString('MAIL_FROM_EMAILS_TO_CONSIDER_SENDING'));
+							foreach ($arrayofemailtoconsideresender as $emailtoconsidersender) {
+								if (preg_match('/'.preg_quote($emailtoconsidersender, '/').'/', $fromstring)) {
+									$actioncode = 'EMAIL';
 								}
-							} else {
-								$ticketalreadyexists = -1;
 							}
-						}
+							$operationslog .= '<br>Email will have actioncode='.$actioncode;
 
-						// Process now the operation according to its type
+							$description = $descriptiontitle = $descriptionmeta = $descriptionfull = '';
 
-						// Search and create thirdparty
-						if ($operation['type'] == 'loadthirdparty' || $operation['type'] == 'loadandcreatethirdparty') {
-							if ($thirdpartyid > 0) {
-								// We already have found the thirdparty id to load, so we bypass the action loadthirdparty
-								$idtouseforthirdparty = $thirdpartyid;
-								$operationslog .= '<br>We already have found a related thirdparty id, so we bypass the action loadthirdparty and use idtouseforthirdparty='.$idtouseforthirdparty;
-							} elseif (empty($operation['actionparam'])) {
-								$errorforactions++;
-								$this->error = "Action loadthirdparty or loadandcreatethirdparty has empty parameter. Must be a rule like 'name=HEADER:^From:(.*);' or 'name=SET:xxx' or 'name=EXTRACT:(body|subject):regex where 'name' can be replaced with 'id' or 'email' to define how to set or extract data. More properties can also be set, for example client=SET:2;";
-								$this->errors[] = $this->error;
-							} else {
-								$actionparam = $operation['actionparam'];
-								$idtouseforthirdparty = '';
-								$nametouseforthirdparty = '';
-								$emailtouseforthirdparty = '';
-								$namealiastouseforthirdparty = '';
+							$descriptiontitle = $langs->transnoentitiesnoconv("RecordCreatedByEmailCollector", $this->ref);
 
-								$operationslog .= '<br>Loop on each property to set into actionparam';
+							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("EmailMsgID").' : '.dol_escape_htmltag($msgid));
+							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailTopic").' : '.dol_escape_htmltag($subject));
+							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailDate").($langs->trans("MailDate") != 'Date' ? ' (Date)' : '').' : '.dol_escape_htmltag(dol_print_date($dateemail, "dayhourtext", "gmt")));
+							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailFrom").($langs->trans("MailFrom") != 'From' ? ' (From)' : '').' : '.dol_escape_htmltag($fromstring));
+							if ($sender) {
+								$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("Sender").($langs->trans("Sender") != 'Sender' ? ' (Sender)' : '').' : '.dol_escape_htmltag($sender));
+							}
+							$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailTo").($langs->trans("MailTo") != 'To' ? ' (To)' : '').' : '.dol_escape_htmltag($to));
+							if ($replyto) {
+								$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailReply").($langs->trans("MailReply") != 'Reply to' ? ' (Reply to)' : '').' : '.dol_escape_htmltag($replyto));
+							}
+							if ($sendtocc) {
+								$descriptionmeta = dol_concatdesc($descriptionmeta, $langs->trans("MailCC").($langs->trans("MailCC") != 'CC' ? ' (CC)' : '').' : '.dol_escape_htmltag($sendtocc));
+							}
 
-								// $actionparam = 'param=SET:aaa' or 'param=EXTRACT:BODY:....'
-								$arrayvaluetouse = dolExplodeIntoArray($actionparam, '(\n\r|\r|\n|;)', '=');
-								foreach ($arrayvaluetouse as $propertytooverwrite => $valueforproperty) {
-									$sourcestring = '';
-									$sourcefield = '';
-									$regexstring = '';
-									$regforregex = array();
-
-									if (preg_match('/^EXTRACT:([a-zA-Z0-9_]+):(.*)$/', $valueforproperty, $regforregex)) {
-										$sourcefield = $regforregex[1];
-										$regexstring = $regforregex[2];
-									}
-
-									if (!empty($sourcefield) && !empty($regexstring)) {
-										if (strtolower($sourcefield) == 'body') {
-											$sourcestring = $messagetext;
-										} elseif (strtolower($sourcefield) == 'subject') {
-											$sourcestring = $subject;
-										} elseif (strtolower($sourcefield) == 'header') {
-											$sourcestring = $header;
-										}
-
-										if ($sourcestring) {
-											$regforval = array();
-											//var_dump($regexstring);var_dump($sourcestring);
-											if (preg_match('/'.$regexstring.'/ms', $sourcestring, $regforval)) {
-												//var_dump($regforval[count($regforval)-1]);exit;
-												// Overwrite param $tmpproperty
-												if ($propertytooverwrite == 'id') {
-													$idtouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
-
-													$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found idtouseforthirdparty='.dol_escape_htmltag($idtouseforthirdparty);
-												} elseif ($propertytooverwrite == 'email') {
-													$emailtouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
-
-													$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found emailtouseforthirdparty='.dol_escape_htmltag($emailtouseforthirdparty);
-												} elseif ($propertytooverwrite == 'name') {
-													$nametouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
-
-													$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found nametouseforthirdparty='.dol_escape_htmltag($nametouseforthirdparty);
-												} elseif ($propertytooverwrite == 'name_alias') {
-													$namealiastouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
-
-													$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found namealiastouseforthirdparty='.dol_escape_htmltag($namealiastouseforthirdparty);
-												} else {
-													$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> We discard this, not a field used to search an existing thirdparty';
-												}
-											} else {
-												// Regex not found
-												if (in_array($propertytooverwrite, array('id', 'email', 'name', 'name_alias'))) {
-													$idtouseforthirdparty = null;
-													$nametouseforthirdparty = null;
-													$emailtouseforthirdparty = null;
-													$namealiastouseforthirdparty = null;
-
-													$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Not found. Property searched is critical so we cancel the search.';
-												} else {
-													$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Not found';
-												}
-											}
-											//var_dump($object->$tmpproperty);exit;
-										} else {
-											// Nothing can be done for this param
-											$errorforactions++;
-											$this->error = 'The extract rule to use to load thirdparty for email '.$msgid.' has an unknown source (must be HEADER, SUBJECT or BODY)';
-											$this->errors[] = $this->error;
-
-											$operationslog .= '<br>'.$this->error;
-										}
-									} elseif (preg_match('/^(SET|SETIFEMPTY):(.*)$/', $valueforproperty, $reg)) {
-										//if (preg_match('/^options_/', $tmpproperty)) $object->array_options[preg_replace('/^options_/', '', $tmpproperty)] = $reg[1];
-										//else $object->$tmpproperty = $reg[1];
-										// Example: id=SETIFEMPTY:123
-										if ($propertytooverwrite == 'id') {
-											$idtouseforthirdparty = $reg[2];
-
-											$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property idtouseforthrdparty='.dol_escape_htmltag($idtouseforthirdparty);
-										} elseif ($propertytooverwrite == 'email') {
-											$emailtouseforthirdparty = $reg[2];
-
-											$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property emailtouseforthrdparty='.dol_escape_htmltag($emailtouseforthirdparty);
-										} elseif ($propertytooverwrite == 'name') {
-											$nametouseforthirdparty = $reg[2];
-
-											$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property nametouseforthirdparty='.dol_escape_htmltag($nametouseforthirdparty);
-										} elseif ($propertytooverwrite == 'name_alias') {
-											$namealiastouseforthirdparty = $reg[2];
-
-											$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property namealiastouseforthirdparty='.dol_escape_htmltag($namealiastouseforthirdparty);
-										}
+							if ($operation['type'] == 'ticket') {
+								// Verify if ticket already exists to fall back on the right operation
+								$tickettocreate = new Ticket($this->db);
+								$errorfetchticket = 0;
+								$alreadycreated = 0;
+								if ($ticketid > 0) {
+									$alreadycreated = $tickettocreate->fetch($ticketid);
+								}
+								if ($alreadycreated == 0 && !empty($trackid)) {
+									$alreadycreated = $tickettocreate->fetch(0, '', $trackid);
+								}
+								if ($alreadycreated == 0 && !empty($msgid)) {
+									$alreadycreated = $tickettocreate->fetch(0, '', '', $msgid);
+								}
+								if ($alreadycreated < 0) {
+									$errorfetchticket++;
+								}
+								if (empty($errorfetchticket)) {
+									if ($alreadycreated == 0) {
+										$operationslog .= '<br>Ticket not found using trackid='.$trackid.' or msgid='.$msgid;
+										$ticketalreadyexists = 0;
 									} else {
-										$errorforactions++;
-										$this->error = 'Bad syntax for description of action parameters: '.$actionparam;
-										$this->errors[] = $this->error;
-										break;
+										$operationslog .= '<br>Ticket already found using trackid='.$trackid.' or msgid='.$msgid.", we replace operation 'ticket' with 'recordevent' to add a new message";	// We change the operation type to do
+										$ticketalreadyexists = 1;
+										$operation['type'] = 'recordevent';
 									}
+								} else {
+									$ticketalreadyexists = -1;
 								}
+							}
 
-								if (!$errorforactions && ($idtouseforthirdparty || $emailtouseforthirdparty || $nametouseforthirdparty || $namealiastouseforthirdparty)) {
-									// We make another search on thirdparty
-									$operationslog .= '<br>We have this initial main data to search thirdparty: id='.$idtouseforthirdparty.', email='.$emailtouseforthirdparty.', name='.$nametouseforthirdparty.', name_alias='.$namealiastouseforthirdparty.'.';
+							// Process now the operation according to its type
 
-									$tmpobject = new stdClass();
-									$tmpobject->element = 'generic';
-									$tmpobject->id = $idtouseforthirdparty;
-									$tmpobject->name = $nametouseforthirdparty;
-									$tmpobject->name_alias = $namealiastouseforthirdparty;
-									$tmpobject->email = $emailtouseforthirdparty;
+							// Search and create thirdparty
+							if ($operation['type'] == 'loadthirdparty' || $operation['type'] == 'loadandcreatethirdparty') {
+								if ($thirdpartyid > 0) {
+									// We already have found the thirdparty id to load, so we bypass the action loadthirdparty
+									$idtouseforthirdparty = $thirdpartyid;
+									$operationslog .= '<br>We already have found a related thirdparty id, so we bypass the action loadthirdparty and use idtouseforthirdparty='.$idtouseforthirdparty;
+								} elseif (empty($operation['actionparam'])) {
+									$errorforactions++;
+									$this->error = "Action loadthirdparty or loadandcreatethirdparty has empty parameter. Must be a rule like 'name=HEADER:^From:(.*);' or 'name=SET:xxx' or 'name=EXTRACT:(body|subject):regex where 'name' can be replaced with 'id' or 'email' to define how to set or extract data. More properties can also be set, for example client=SET:2;";
+									$this->errors[] = $this->error;
+								} else {
+									$actionparam = $operation['actionparam'];
+									$idtouseforthirdparty = '';
+									$nametouseforthirdparty = '';
+									$emailtouseforthirdparty = '';
+									$namealiastouseforthirdparty = '';
 
-									$this->overwritePropertiesOfObject($tmpobject, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+									$operationslog .= '<br>Loop on each property to set into actionparam';
 
-									$idtouseforthirdparty = $tmpobject->id;
-									$nametouseforthirdparty = $tmpobject->name;
-									$namealiastouseforthirdparty = $tmpobject->name_alias;
-									$emailtouseforthirdparty = $tmpobject->email;
+									// $actionparam = 'param=SET:aaa' or 'param=EXTRACT:BODY:....'
+									$arrayvaluetouse = dolExplodeIntoArray($actionparam, '(\n\r|\r|\n|;)', '=');
+									foreach ($arrayvaluetouse as $propertytooverwrite => $valueforproperty) {
+										$sourcestring = '';
+										$sourcefield = '';
+										$regexstring = '';
+										$regforregex = array();
 
-									$operationslog .= '<br>We try to search existing thirdparty with idtouseforthirdparty='.$idtouseforthirdparty.' emailtouseforthirdparty='.$emailtouseforthirdparty.' nametouseforthirdparty='.$nametouseforthirdparty.' namealiastouseforthirdparty='.$namealiastouseforthirdparty;
+										if (preg_match('/^EXTRACT:([a-zA-Z0-9_]+):(.*)$/', $valueforproperty, $regforregex)) {
+											$sourcefield = $regforregex[1];
+											$regexstring = $regforregex[2];
+										}
 
-									// Try to find the thirdparty that match the most the information we have
-									$result = $thirdpartystatic->findNearest((int) $idtouseforthirdparty, (string) $nametouseforthirdparty, '', '', '', '', '', '', '', '', (string) $emailtouseforthirdparty, (string) $namealiastouseforthirdparty);
+										if (!empty($sourcefield) && !empty($regexstring)) {
+											if (strtolower($sourcefield) == 'body') {
+												$sourcestring = $messagetext;
+											} elseif (strtolower($sourcefield) == 'subject') {
+												$sourcestring = $subject;
+											} elseif (strtolower($sourcefield) == 'header') {
+												$sourcestring = $header;
+											}
 
-									if ($result < 0) {
-										$errorforactions++;
-										$this->error = 'Error when getting thirdparty with name '.$nametouseforthirdparty.' (may be 2 record exists with same name ?)';
-										$this->errors[] = $this->error;
-										break;
-									} elseif ($result == 0) {	// No thirdparty found
-										if ($operation['type'] == 'loadthirdparty') {
-											dol_syslog("Third party with id=".$idtouseforthirdparty." email=".$emailtouseforthirdparty." name=".$nametouseforthirdparty." name_alias=".$namealiastouseforthirdparty." was not found");
+											if ($sourcestring) {
+												$regforval = array();
+												//var_dump($regexstring);var_dump($sourcestring);
+												if (preg_match('/'.$regexstring.'/ms', $sourcestring, $regforval)) {
+													//var_dump($regforval[count($regforval)-1]);exit;
+													// Overwrite param $tmpproperty
+													if ($propertytooverwrite == 'id') {
+														$idtouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
 
-											// Search into contacts of thirdparties to try to guess the thirdparty to use
-											$resultContact = $contactstatic->findNearest(0, '', '', '', (string) $emailtouseforthirdparty, '', 0);
-											if ($resultContact > 0) {
-												$contactstatic->fetch($resultContact);
-												$idtouseforthirdparty = $contactstatic->socid;
-												$result = $thirdpartystatic->fetch($idtouseforthirdparty);
-												if ($result > 0) {
-													dol_syslog("Third party with id=".$idtouseforthirdparty." email=".$emailtouseforthirdparty." name=".$nametouseforthirdparty." name_alias=".$namealiastouseforthirdparty." was found thanks to linked contact search");
+														$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found idtouseforthirdparty='.dol_escape_htmltag($idtouseforthirdparty);
+													} elseif ($propertytooverwrite == 'email') {
+														$emailtouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
+
+														$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found emailtouseforthirdparty='.dol_escape_htmltag($emailtouseforthirdparty);
+													} elseif ($propertytooverwrite == 'name') {
+														$nametouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
+
+														$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found nametouseforthirdparty='.dol_escape_htmltag($nametouseforthirdparty);
+													} elseif ($propertytooverwrite == 'name_alias') {
+														$namealiastouseforthirdparty = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
+
+														$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Found namealiastouseforthirdparty='.dol_escape_htmltag($namealiastouseforthirdparty);
+													} else {
+														$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> We discard this, not a field used to search an existing thirdparty';
+													}
+												} else {
+													// Regex not found
+													if (in_array($propertytooverwrite, array('id', 'email', 'name', 'name_alias'))) {
+														$idtouseforthirdparty = null;
+														$nametouseforthirdparty = null;
+														$emailtouseforthirdparty = null;
+														$namealiastouseforthirdparty = null;
+
+														$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Not found. Property searched is critical so we cancel the search.';
+													} else {
+														$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' Regex /'.dol_escape_htmltag($regexstring).'/ms into '.strtoupper($sourcefield).' -> Not found';
+													}
+												}
+												//var_dump($object->$tmpproperty);exit;
+											} else {
+												// Nothing can be done for this param
+												$errorforactions++;
+												$this->error = 'The extract rule to use to load thirdparty for email '.$msgid.' has an unknown source (must be HEADER, SUBJECT or BODY)';
+												$this->errors[] = $this->error;
+
+												$operationslog .= '<br>'.$this->error;
+											}
+										} elseif (preg_match('/^(SET|SETIFEMPTY):(.*)$/', $valueforproperty, $reg)) {
+											//if (preg_match('/^options_/', $tmpproperty)) $object->array_options[preg_replace('/^options_/', '', $tmpproperty)] = $reg[1];
+											//else $object->$tmpproperty = $reg[1];
+											// Example: id=SETIFEMPTY:123
+											if ($propertytooverwrite == 'id') {
+												$idtouseforthirdparty = $reg[2];
+
+												$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property idtouseforthrdparty='.dol_escape_htmltag($idtouseforthirdparty);
+											} elseif ($propertytooverwrite == 'email') {
+												$emailtouseforthirdparty = $reg[2];
+
+												$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property emailtouseforthrdparty='.dol_escape_htmltag($emailtouseforthirdparty);
+											} elseif ($propertytooverwrite == 'name') {
+												$nametouseforthirdparty = $reg[2];
+
+												$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property nametouseforthirdparty='.dol_escape_htmltag($nametouseforthirdparty);
+											} elseif ($propertytooverwrite == 'name_alias') {
+												$namealiastouseforthirdparty = $reg[2];
+
+												$operationslog .= '<br>propertytooverwrite='.$propertytooverwrite.' We set property namealiastouseforthirdparty='.dol_escape_htmltag($namealiastouseforthirdparty);
+											}
+										} else {
+											$errorforactions++;
+											$this->error = 'Bad syntax for description of action parameters: '.$actionparam;
+											$this->errors[] = $this->error;
+											break;
+										}
+									}
+
+									if (!$errorforactions && ($idtouseforthirdparty || $emailtouseforthirdparty || $nametouseforthirdparty || $namealiastouseforthirdparty)) {
+										// We make another search on thirdparty
+										$operationslog .= '<br>We have this initial main data to search thirdparty: id='.$idtouseforthirdparty.', email='.$emailtouseforthirdparty.', name='.$nametouseforthirdparty.', name_alias='.$namealiastouseforthirdparty.'.';
+
+										$tmpobject = new stdClass();
+										$tmpobject->element = 'generic';
+										$tmpobject->id = $idtouseforthirdparty;
+										$tmpobject->name = $nametouseforthirdparty;
+										$tmpobject->name_alias = $namealiastouseforthirdparty;
+										$tmpobject->email = $emailtouseforthirdparty;
+
+										$this->overwritePropertiesOfObject($tmpobject, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+
+										$idtouseforthirdparty = $tmpobject->id;
+										$nametouseforthirdparty = $tmpobject->name;
+										$namealiastouseforthirdparty = $tmpobject->name_alias;
+										$emailtouseforthirdparty = $tmpobject->email;
+
+										$operationslog .= '<br>We try to search existing thirdparty with idtouseforthirdparty='.$idtouseforthirdparty.' emailtouseforthirdparty='.$emailtouseforthirdparty.' nametouseforthirdparty='.$nametouseforthirdparty.' namealiastouseforthirdparty='.$namealiastouseforthirdparty;
+
+										// Try to find the thirdparty that match the most the information we have
+										$result = $thirdpartystatic->findNearest((int) $idtouseforthirdparty, (string) $nametouseforthirdparty, '', '', '', '', '', '', '', '', (string) $emailtouseforthirdparty, (string) $namealiastouseforthirdparty);
+
+										if ($result < 0) {
+											$errorforactions++;
+											$this->error = 'Error when getting thirdparty with name '.$nametouseforthirdparty.' (may be 2 record exists with same name ?)';
+											$this->errors[] = $this->error;
+											break;
+										} elseif ($result == 0) {	// No thirdparty found
+											if ($operation['type'] == 'loadthirdparty') {
+												dol_syslog("Third party with id=".$idtouseforthirdparty." email=".$emailtouseforthirdparty." name=".$nametouseforthirdparty." name_alias=".$namealiastouseforthirdparty." was not found");
+
+												// Search into contacts of thirdparties to try to guess the thirdparty to use
+												$resultContact = $contactstatic->findNearest(0, '', '', '', (string) $emailtouseforthirdparty, '', 0);
+												if ($resultContact > 0) {
+													$contactstatic->fetch($resultContact);
+													$idtouseforthirdparty = $contactstatic->socid;
+													$result = $thirdpartystatic->fetch($idtouseforthirdparty);
+													if ($result > 0) {
+														dol_syslog("Third party with id=".$idtouseforthirdparty." email=".$emailtouseforthirdparty." name=".$nametouseforthirdparty." name_alias=".$namealiastouseforthirdparty." was found thanks to linked contact search");
+													} else {
+														$errorforactions++;
+														$langs->load("errors");
+														$this->error = $langs->trans('ErrorFailedToLoadThirdParty', $idtouseforthirdparty, (string) $emailtouseforthirdparty, (string) $nametouseforthirdparty, (string) $namealiastouseforthirdparty);
+														$this->errors[] = $this->error;
+													}
 												} else {
 													$errorforactions++;
 													$langs->load("errors");
 													$this->error = $langs->trans('ErrorFailedToLoadThirdParty', $idtouseforthirdparty, (string) $emailtouseforthirdparty, (string) $nametouseforthirdparty, (string) $namealiastouseforthirdparty);
 													$this->errors[] = $this->error;
 												}
-											} else {
-												$errorforactions++;
-												$langs->load("errors");
-												$this->error = $langs->trans('ErrorFailedToLoadThirdParty', $idtouseforthirdparty, (string) $emailtouseforthirdparty, (string) $nametouseforthirdparty, (string) $namealiastouseforthirdparty);
-												$this->errors[] = $this->error;
-											}
-										} elseif ($operation['type'] == 'loadandcreatethirdparty') {
-											dol_syslog("Third party with id=".$idtouseforthirdparty." email=".$emailtouseforthirdparty." name=".$nametouseforthirdparty." name_alias=".$namealiastouseforthirdparty." was not found. We try to create it.");
+											} elseif ($operation['type'] == 'loadandcreatethirdparty') {
+												dol_syslog("Third party with id=".$idtouseforthirdparty." email=".$emailtouseforthirdparty." name=".$nametouseforthirdparty." name_alias=".$namealiastouseforthirdparty." was not found. We try to create it.");
 
-											// Create thirdparty
-											$thirdpartystatic = new Societe($db);
-											$thirdpartystatic->name = (string) $nametouseforthirdparty;
-											if (!empty($namealiastouseforthirdparty)) {
-												if ($namealiastouseforthirdparty != $nametouseforthirdparty) {
-													$thirdpartystatic->name_alias = $namealiastouseforthirdparty;
+												// Create thirdparty
+												$thirdpartystatic = new Societe($db);
+												$thirdpartystatic->name = (string) $nametouseforthirdparty;
+												if (!empty($namealiastouseforthirdparty)) {
+													if ($namealiastouseforthirdparty != $nametouseforthirdparty) {
+														$thirdpartystatic->name_alias = $namealiastouseforthirdparty;
+													}
+												} else {
+													$thirdpartystatic->name_alias = (empty($replytostring) ? (empty($fromtext) ? '' : $fromtext) : $replytostring);
 												}
-											} else {
-												$thirdpartystatic->name_alias = (empty($replytostring) ? (empty($fromtext) ? '' : $fromtext) : $replytostring);
+												$thirdpartystatic->email = (empty($emailtouseforthirdparty) ? (empty($replyto) ? (empty($from) ? '' : $from) : $replyto) : $emailtouseforthirdparty);
+
+												// Overwrite values with values extracted from source email
+												$errorforthisaction = $this->overwritePropertiesOfObject($thirdpartystatic, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+
+												if ($thirdpartystatic->client && empty($thirdpartystatic->code_client)) {
+													$thirdpartystatic->code_client = 'auto';
+												}
+												if ($thirdpartystatic->fournisseur && empty($thirdpartystatic->code_fournisseur)) {
+													$thirdpartystatic->code_fournisseur = 'auto';
+												}
+
+												if ($errorforthisaction) {
+													$errorforactions++;
+												} else {
+													$result = $thirdpartystatic->create($user);
+													if ($result <= 0) {
+														$errorforactions++;
+														$this->error = $thirdpartystatic->error;
+														$this->errors = $thirdpartystatic->errors;
+													} else {
+														$operationslog .= '<br>Thirdparty created -> id = '.dol_escape_htmltag((string) $thirdpartystatic->id);
+													}
+												}
 											}
-											$thirdpartystatic->email = (empty($emailtouseforthirdparty) ? (empty($replyto) ? (empty($from) ? '' : $from) : $replyto) : $emailtouseforthirdparty);
+										} else {	// $result > 0 is ID of thirdparty
+											dol_syslog("One and only one existing third party has been found");
+
+											$thirdpartystatic->fetch($result);
+
+											$operationslog .= '<br>Thirdparty already exists with id = '.dol_escape_htmltag((string) $thirdpartystatic->id)." and name ".dol_escape_htmltag($thirdpartystatic->name);
+										}
+									}
+								}
+							} elseif ($operation['type'] == 'loadandcreatecontact') { // Search and create contact
+								if (empty($operation['actionparam'])) {
+									$errorforactions++;
+									$this->error = "Action loadandcreatecontact has empty parameter. Must be 'SET:xxx' or 'EXTRACT:(body|subject):regex' to define how to extract data";
+									$this->errors[] = $this->error;
+								} else {
+									$contact_static = new Contact($this->db);
+									// Overwrite values with values extracted from source email
+									$errorforthisaction = $this->overwritePropertiesOfObject($contact_static, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+									if ($errorforthisaction) {
+										$errorforactions++;
+									} else {
+										if (!empty($contact_static->email) && $contact_static->email != $from) {
+											$from = $contact_static->email;
+										}
+
+										$result = $contactstatic->fetch(0, null, '', $from);
+										if ($result < 0) {
+											$errorforactions++;
+											$this->error = 'Error when getting contact with email ' . $from;
+											$this->errors[] = $this->error;
+											break;
+										} elseif ($result == 0) {
+											dol_syslog("Contact with email " . $from . " was not found. We try to create it.");
+											$contactstatic = new Contact($this->db);
+
+											// Create contact
+											$contactstatic->email = $from;
+											$operationslog .= '<br>We set property email='.dol_escape_htmltag($from);
 
 											// Overwrite values with values extracted from source email
-											$errorforthisaction = $this->overwritePropertiesOfObject($thirdpartystatic, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
-
-											if ($thirdpartystatic->client && empty($thirdpartystatic->code_client)) {
-												$thirdpartystatic->code_client = 'auto';
-											}
-											if ($thirdpartystatic->fournisseur && empty($thirdpartystatic->code_fournisseur)) {
-												$thirdpartystatic->code_fournisseur = 'auto';
-											}
+											$errorforthisaction = $this->overwritePropertiesOfObject($contactstatic, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
 
 											if ($errorforthisaction) {
 												$errorforactions++;
 											} else {
-												$result = $thirdpartystatic->create($user);
-												if ($result <= 0) {
-													$errorforactions++;
-													$this->error = $thirdpartystatic->error;
-													$this->errors = $thirdpartystatic->errors;
-												} else {
-													$operationslog .= '<br>Thirdparty created -> id = '.dol_escape_htmltag((string) $thirdpartystatic->id);
+												// Search country by name or code
+												if (!empty($contactstatic->country)) {
+													require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+													$result = getCountry('', '3', $this->db, null, 1, $contactstatic->country);
+													if ($result == 'NotDefined') {
+														$errorforactions++;
+														$this->error = "Error country not found by this name '" . $contactstatic->country . "'";
+													} elseif (!($result > 0)) {
+														$errorforactions++;
+														$this->error = "Error when search country by this name '" . $contactstatic->country . "'";
+														$this->errors[] = $this->db->lasterror();
+													} else {
+														$contactstatic->country_id = $result;
+														$operationslog .= '<br>We set property country_id='.dol_escape_htmltag($result);
+													}
+												} elseif (!empty($contactstatic->country_code)) {
+													require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
+													$result = getCountry($contactstatic->country_code, '3', $this->db);
+													if ($result == 'NotDefined') {
+														$errorforactions++;
+														$this->error = "Error country not found by this code '" . $contactstatic->country_code . "'";
+													} elseif (!($result > 0)) {
+														$errorforactions++;
+														$this->error = "Error when search country by this code '" . $contactstatic->country_code . "'";
+														$this->errors[] = $this->db->lasterror();
+													} else {
+														$contactstatic->country_id = $result;
+														$operationslog .= '<br>We set property country_id='.dol_escape_htmltag($result);
+													}
+												}
+
+												if (!$errorforactions) {
+													// Search state by name or code (for country if defined)
+													if (!empty($contactstatic->state)) {
+														require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
+														$result = dol_getIdFromCode($this->db, $contactstatic->state, 'c_departements', 'nom', 'rowid');
+														if (empty($result)) {
+															$errorforactions++;
+															$this->error = "Error state not found by this name '" . $contactstatic->state . "'";
+														} elseif (!($result > 0)) {
+															$errorforactions++;
+															$this->error = "Error when search state by this name '" . $contactstatic->state . "'";
+															$this->errors[] = $this->db->lasterror();
+														} else {
+															$contactstatic->state_id = $result;
+															$operationslog .= '<br>We set property state_id='.dol_escape_htmltag($result);
+														}
+													} elseif (!empty($contactstatic->state_code)) {
+														require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
+														$result = dol_getIdFromCode($this->db, $contactstatic->state_code, 'c_departements', 'code_departement', 'rowid');
+														if (empty($result)) {
+															$errorforactions++;
+															$this->error = "Error state not found by this code '" . $contactstatic->state_code . "'";
+														} elseif (!($result > 0)) {
+															$errorforactions++;
+															$this->error = "Error when search state by this code '" . $contactstatic->state_code . "'";
+															$this->errors[] = $this->db->lasterror();
+														} else {
+															$contactstatic->state_id = $result;
+															$operationslog .= '<br>We set property state_id='.dol_escape_htmltag($result);
+														}
+													}
+												}
+
+												if (!$errorforactions) {
+													$result = $contactstatic->create($user);
+													if ($result <= 0) {
+														$errorforactions++;
+														$this->error = $contactstatic->error;
+														$this->errors = $contactstatic->errors;
+													} else {
+														$operationslog .= '<br>Contact created -> id = '.dol_escape_htmltag((string) $contactstatic->id);
+													}
 												}
 											}
 										}
-									} else {	// $result > 0 is ID of thirdparty
-										dol_syslog("One and only one existing third party has been found");
-
-										$thirdpartystatic->fetch($result);
-
-										$operationslog .= '<br>Thirdparty already exists with id = '.dol_escape_htmltag((string) $thirdpartystatic->id)." and name ".dol_escape_htmltag($thirdpartystatic->name);
 									}
 								}
-							}
-						} elseif ($operation['type'] == 'loadandcreatecontact') { // Search and create contact
-							if (empty($operation['actionparam'])) {
-								$errorforactions++;
-								$this->error = "Action loadandcreatecontact has empty parameter. Must be 'SET:xxx' or 'EXTRACT:(body|subject):regex' to define how to extract data";
-								$this->errors[] = $this->error;
-							} else {
-								$contact_static = new Contact($this->db);
-								// Overwrite values with values extracted from source email
-								$errorforthisaction = $this->overwritePropertiesOfObject($contact_static, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
-								if ($errorforthisaction) {
-									$errorforactions++;
-								} else {
-									if (!empty($contact_static->email) && $contact_static->email != $from) {
-										$from = $contact_static->email;
+							} elseif ($operation['type'] == 'recordevent') {
+								// Create event
+								$actioncomm = new ActionComm($this->db);
+
+								$alreadycreated = $actioncomm->fetch(0, '', '', $msgid);
+								if ($alreadycreated == 0) {
+									$operationslog .= '<br>We did not find existing actioncomm with msgid='.$msgid;
+
+									if ($projectstatic->id > 0) {
+										if ($projectfoundby) {
+											$descriptionmeta = dol_concatdesc($descriptionmeta, 'Project found from '.$projectfoundby);
+										}
+									}
+									if ($thirdpartystatic->id > 0) {
+										if ($thirdpartyfoundby) {
+											$descriptionmeta = dol_concatdesc($descriptionmeta, 'Third party found from '.$thirdpartyfoundby);
+										}
+									}
+									if ($contactstatic->id > 0) {
+										if ($contactfoundby) {
+											$descriptionmeta = dol_concatdesc($descriptionmeta, 'Contact/address found from '.$contactfoundby);
+										}
 									}
 
-									$result = $contactstatic->fetch(0, null, '', $from);
-									if ($result < 0) {
+									$description = $descriptiontitle;
+
+									$description = dol_concatdesc($description, $descriptionmeta);
+									$description = dol_concatdesc($description, "-----");
+									$description = dol_concatdesc($description, $messagetext);
+
+									$descriptionfull = $description;
+									if (!getDolGlobalString('MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER')) {
+										$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
+										$descriptionfull = dol_concatdesc($descriptionfull, $header);
+									}
+
+									// Insert record of emails sent
+									$actioncomm->type_code   = 'AC_OTH_AUTO'; // Type of event ('AC_OTH', 'AC_OTH_AUTO', 'AC_XXX'...)
+									$actioncomm->code        = 'AC_'.$actioncode;
+									$actioncomm->label       = $langs->trans("ActionAC_".$actioncode).' - '.$langs->trans("MailFrom").' '.$from;
+									$actioncomm->note_private = $descriptionfull;
+									$actioncomm->fk_project  = $projectstatic->id;
+									$actioncomm->datep       = $dateemail;	// date of email
+									$actioncomm->datef       = $dateemail;	// date of email
+									$actioncomm->percentage  = -1; // Not applicable
+									$actioncomm->socid       = $thirdpartystatic->id;
+									$actioncomm->contact_id = $contactstatic->id;
+									$actioncomm->socpeopleassigned = (!empty($contactstatic->id) ? array($contactstatic->id) : array());
+									$actioncomm->authorid    = $user->id; // User saving action
+									$actioncomm->userownerid = $user->id; // Owner of action
+									// Fields when action is an email (content should be added into note)
+									$actioncomm->email_msgid = $msgid;
+									$actioncomm->email_from  = $fromstring;
+									$actioncomm->email_sender = $sender;
+									$actioncomm->email_to    = $to;
+									$actioncomm->email_tocc  = $sendtocc;
+									$actioncomm->email_tobcc = $sendtobcc;
+									$actioncomm->email_subject = $subject;
+									$actioncomm->errors_to   = '';
+
+									if (!in_array($fk_element_type, array('societe', 'contact', 'project', 'user'))) {
+										$actioncomm->fk_element  = $fk_element_id;
+										$actioncomm->elementid = $fk_element_id;
+										$actioncomm->elementtype = $fk_element_type;
+										if (is_object($objectemail) && $objectemail->module) {
+											$actioncomm->elementtype .= '@'.$objectemail->module;
+										}
+									}
+
+									//$actioncomm->extraparams = $extraparams;
+
+									// Overwrite values with values extracted from source email
+									$errorforthisaction = $this->overwritePropertiesOfObject($actioncomm, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+
+									if ($errorforthisaction) {
 										$errorforactions++;
-										$this->error = 'Error when getting contact with email ' . $from;
-										$this->errors[] = $this->error;
-										break;
-									} elseif ($result == 0) {
-										dol_syslog("Contact with email " . $from . " was not found. We try to create it.");
-										$contactstatic = new Contact($this->db);
-
-										// Create contact
-										$contactstatic->email = $from;
-										$operationslog .= '<br>We set property email='.dol_escape_htmltag($from);
-
-										// Overwrite values with values extracted from source email
-										$errorforthisaction = $this->overwritePropertiesOfObject($contactstatic, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
-
-										if ($errorforthisaction) {
+									} else {
+										$result = $actioncomm->create($user);
+										if ($result <= 0) {
 											$errorforactions++;
+											$this->errors = $actioncomm->errors;
 										} else {
-											// Search country by name or code
-											if (!empty($contactstatic->country)) {
-												require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
-												$result = getCountry('', '3', $this->db, null, 1, $contactstatic->country);
-												if ($result == 'NotDefined') {
-													$errorforactions++;
-													$this->error = "Error country not found by this name '" . $contactstatic->country . "'";
-												} elseif (!($result > 0)) {
-													$errorforactions++;
-													$this->error = "Error when search country by this name '" . $contactstatic->country . "'";
-													$this->errors[] = $this->db->lasterror();
-												} else {
-													$contactstatic->country_id = $result;
-													$operationslog .= '<br>We set property country_id='.dol_escape_htmltag($result);
-												}
-											} elseif (!empty($contactstatic->country_code)) {
-												require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
-												$result = getCountry($contactstatic->country_code, '3', $this->db);
-												if ($result == 'NotDefined') {
-													$errorforactions++;
-													$this->error = "Error country not found by this code '" . $contactstatic->country_code . "'";
-												} elseif (!($result > 0)) {
-													$errorforactions++;
-													$this->error = "Error when search country by this code '" . $contactstatic->country_code . "'";
-													$this->errors[] = $this->db->lasterror();
-												} else {
-													$contactstatic->country_id = $result;
-													$operationslog .= '<br>We set property country_id='.dol_escape_htmltag($result);
-												}
-											}
-
-											if (!$errorforactions) {
-												// Search state by name or code (for country if defined)
-												if (!empty($contactstatic->state)) {
-													require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
-													$result = dol_getIdFromCode($this->db, $contactstatic->state, 'c_departements', 'nom', 'rowid');
-													if (empty($result)) {
-														$errorforactions++;
-														$this->error = "Error state not found by this name '" . $contactstatic->state . "'";
-													} elseif (!($result > 0)) {
-														$errorforactions++;
-														$this->error = "Error when search state by this name '" . $contactstatic->state . "'";
-														$this->errors[] = $this->db->lasterror();
+											if ($fk_element_type == "ticket" && is_object($objectemail)) {
+												if ($objectemail->status == Ticket::STATUS_CLOSED || $objectemail->status == Ticket::STATUS_CANCELED || $objectemail->status == Ticket::STATUS_NEED_MORE_INFO || $objectemail->status == Ticket::STATUS_WAITING) {
+													if ($objectemail->fk_user_assign != null) {
+														$res = $objectemail->setStatut(Ticket::STATUS_ASSIGNED);
 													} else {
-														$contactstatic->state_id = $result;
-														$operationslog .= '<br>We set property state_id='.dol_escape_htmltag($result);
+														$res = $objectemail->setStatut(Ticket::STATUS_NOT_READ);
 													}
-												} elseif (!empty($contactstatic->state_code)) {
-													require_once DOL_DOCUMENT_ROOT . '/core/lib/functions.lib.php';
-													$result = dol_getIdFromCode($this->db, $contactstatic->state_code, 'c_departements', 'code_departement', 'rowid');
-													if (empty($result)) {
-														$errorforactions++;
-														$this->error = "Error state not found by this code '" . $contactstatic->state_code . "'";
-													} elseif (!($result > 0)) {
-														$errorforactions++;
-														$this->error = "Error when search state by this code '" . $contactstatic->state_code . "'";
-														$this->errors[] = $this->db->lasterror();
+
+													if ($res) {
+														$operationslog .= '<br>Ticket Re-Opened successfully -> ref='.$objectemail->ref;
 													} else {
-														$contactstatic->state_id = $result;
-														$operationslog .= '<br>We set property state_id='.dol_escape_htmltag($result);
+														$errorforactions++;
+														$this->error = 'Error while changing the ticket status -> ref='.$objectemail->ref;
+														$this->errors[] = $this->error;
+													}
+												}
+												if (!empty($attachments)) {
+													// There is an attachment for the ticket -> store attachment
+													$ticket = new Ticket($this->db);
+													$ticket->fetch($fk_element_id);
+													$destdir = $conf->ticket->dir_output.'/'.$ticket->ref;
+													if (!dol_is_dir($destdir)) {
+														dol_mkdir($destdir);
+													}
+													if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+														foreach ($attachments as $attachment) {
+															$attachment->save($destdir.'/');
+														}
+													} else {
+														$this->getmsg($connection, $imapemail, $destdir);
 													}
 												}
 											}
 
-											if (!$errorforactions) {
-												$result = $contactstatic->create($user);
-												if ($result <= 0) {
+											$operationslog .= '<br>Event created -> id='.dol_escape_htmltag((string) $actioncomm->id);
+										}
+									}
+								} else {
+									$operationslog .= '<br>An event in actioncomm table already exists for the msgid = '.$msgid.' so we bypass this action.';
+								}
+							} elseif ($operation['type'] == 'recordjoinpiece') {
+								$data = [];
+								if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+									foreach ($attachments as $attachment) {
+										if ($attachment->getName() === 'undefined') {
+											continue;
+										}
+										$data[$attachment->getName()] = $attachment->getContent();
+									}
+								} else {
+									$pj = getAttachments($imapemail, $connection);
+									foreach ($pj as $key => $val) {
+										$data[$val['filename']] = getFileData($imapemail, (string) $val['pos'], $val['type'], $connection);
+									}
+								}
+								if (count($data) > 0) {
+									$sql = "SELECT rowid as id FROM ".MAIN_DB_PREFIX."user WHERE email LIKE '%".$this->db->escape($from)."%'";
+									$resql = $this->db->query($sql);
+									if ($this->db->num_rows($resql) == 0) {
+										$this->errors[] = "User Not allowed to add documents ({$from})";
+									}
+									$arrayobject = array(
+										'propale' => array('table' => 'propal',
+											'fields' => array('ref'),
+											'class' => 'comm/propal/class/propal.class.php',
+											'object' => 'Propal'),
+										'holiday' => array('table' => 'holiday',
+											'fields' => array('ref'),
+											'class' => 'holiday/class/holiday.class.php',
+											'object' => 'Holiday'),
+										'expensereport' => array('table' => 'expensereport',
+											'fields' => array('ref'),
+											'class' => 'expensereport/class/expensereport.class.php',
+											'object' => 'ExpenseReport'),
+										'recruitment/recruitmentjobposition' => array('table' => 'recruitment_recruitmentjobposition',
+											'fields' => array('ref'),
+											'class' => 'recruitment/class/recruitmentjobposition.class.php',
+											'object' => 'RecruitmentJobPosition'),
+										'recruitment/recruitmentcandidature' => array('table' => 'recruitment_recruitmentcandidature',
+											'fields' => array('ref'),
+											'class' => 'recruitment/class/recruitmentcandidature.class.php',
+											'object' => 'RecruitmentCandidature'),
+										'societe' => array('table' => 'societe',
+											'fields' => array('code_client', 'code_fournisseur'),
+											'class' => 'societe/class/societe.class.php',
+											'object' => 'Societe'),
+										'commande' => array('table' => 'commande',
+											'fields' => array('ref'),
+											'class' => 'commande/class/commande.class.php',
+											'object' => 'Commande'),
+										'expedition' => array('table' => 'expedition',
+											'fields' => array('ref'),
+											'class' => 'expedition/class/expedition.class.php',
+											'object' => 'Expedition'),
+										'contract' => array('table' => 'contrat',
+											'fields' => array('ref'),
+											'class' => 'contrat/class/contrat.class.php',
+											'object' => 'Contrat'),
+										'fichinter' => array('table' => 'fichinter',
+											'fields' => array('ref'),
+											'class' => 'fichinter/class/fichinter.class.php',
+											'object' => 'Fichinter'),
+										'ticket' => array('table' => 'ticket',
+											'fields' => array('ref'),
+											'class' => 'ticket/class/ticket.class.php',
+											'object' => 'Ticket'),
+										'knowledgemanagement' => array('table' => 'knowledgemanagement_knowledgerecord',
+											'fields' => array('ref'),
+											'class' => 'knowledgemanagement/class/knowledgemanagement.class.php',
+											'object' => 'KnowledgeRecord'),
+										'supplier_proposal' => array('table' => 'supplier_proposal',
+											'fields' => array('ref'),
+											'class' => 'supplier_proposal/class/supplier_proposal.class.php',
+											'object' => 'SupplierProposal'),
+										'fournisseur/commande' => array('table' => 'commande_fournisseur',
+											'fields' => array('ref', 'ref_supplier'),
+											'class' => 'fourn/class/fournisseur.commande.class.php',
+											'object' => 'SupplierProposal'),
+										'facture' => array('table' => 'facture',
+											'fields' => array('ref'),
+											'class' => 'compta/facture/class/facture.class.php',
+											'object' => 'Facture'),
+										'fournisseur/facture' => array('table' => 'facture_fourn',
+											'fields' => array('ref', 'ref_client'),
+											'class' => 'fourn/class/fournisseur.facture.class.php',
+											'object' => 'FactureFournisseur'),
+										'produit' => array('table' => 'product',
+											'fields' => array('ref'),
+											'class' => 'product/class/product.class.php',
+											'object' => 'Product'),
+										'productlot' => array('table' => 'product_lot',
+											'fields' => array('batch'),
+											'class' => 'product/stock/class/productlot.class.php',
+											'object' => 'Productlot'),
+										'projet' => array('table' => 'projet',
+											'fields' => array('ref'),
+											'class' => 'projet/class/projet.class.php',
+											'object' => 'Project'),
+										'projet_task' => array('table' => 'projet_task',
+											'fields' => array('ref'),
+											'class' => 'projet/class/task.class.php',
+											'object' => 'Task'),
+										'ressource' => array('table' => 'resource',
+											'fields' => array('ref'),
+											'class' => 'ressource/class/dolressource.class.php',
+											'object' => 'Dolresource'),
+										'bom' => array('table' => 'bom_bom',
+											'fields' => array('ref'),
+											'class' => 'bom/class/bom.class.php',
+											'object' => 'BOM'),
+										'mrp' => array('table' => 'mrp_mo',
+											'fields' => array('ref'),
+											'class' => 'mrp/class/mo.class.php',
+											'object' => 'Mo'),
+									);
+
+									if (!is_object($hookmanager)) {
+										include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
+										$hookmanager = new HookManager($this->db);
+									}
+									$hookmanager->initHooks(array('emailcolector'));
+									$parameters = array('arrayobject' => $arrayobject);
+									$reshook = $hookmanager->executeHooks('addmoduletoeamailcollectorjoinpiece', $parameters);    // Note that $action and $object may have been modified by some hooks
+									if ($reshook > 0) {
+										$arrayobject = $hookmanager->resArray;
+									}
+
+									$resultobj = array();
+
+									foreach ($arrayobject as $key => $objectdesc) {
+										$sql = 'SELECT DISTINCT t.rowid ';
+										$sql .= ' FROM ' . MAIN_DB_PREFIX . $this->db->sanitize($objectdesc['table']) . ' AS t';
+										$sql .= ' WHERE ';
+										foreach ($objectdesc['fields'] as $field) {
+											$sql .= "('" .$this->db->escape($subject) . "'  LIKE CONCAT('%',  t." . $this->db->sanitize($field) . ", '%') AND t." . $this->db->sanitize($field) . " <> '') OR ";
+										}
+										$sql = substr($sql, 0, -4);
+
+										$ressqlobj = $this->db->query($sql);
+										if ($ressqlobj) {
+											while ($obj = $this->db->fetch_object($ressqlobj)) {
+												$resultobj[$key][] = $obj->rowid;
+											}
+										}
+									}
+									$dirs = array();
+									foreach ($resultobj as $mod => $ids) {
+										$moddesc = $arrayobject[$mod];
+										$elementpath = $mod;
+										dol_include_once($moddesc['class']);
+										$objectmanaged = new $moddesc['object']($this->db);
+										'@phan-var-force CommonObject $objectmanaged';
+										foreach ($ids as $val) {
+											$res = $objectmanaged->fetch($val);
+											if ($res) {
+												$path = ($objectmanaged->entity > 1 ? "/" . $objectmanaged->entity : '');
+												$dirs[] = DOL_DATA_ROOT . $path . "/" . $elementpath . '/' . dol_sanitizeFileName($objectmanaged->ref) . '/';
+											} else {
+												$this->errors[] = 'object not found';
+											}
+										}
+									}
+									foreach ($dirs as $target) {
+										$prefix = $this->actions[$this->id]['actionparam'];
+										foreach ($data as $filename => $content) {
+											$resr = saveAttachment($target, $prefix . '_' . $filename, $content);
+											if ($resr == -1) {
+												$this->errors[] = 'Doc not saved';
+											}
+										}
+									}
+
+									$operationslog .= '<br>Save attachment files on disk';
+								} else {
+									$this->errors[] = 'no joined piece';
+
+									$operationslog .= '<br>No joinded files';
+								}
+							} elseif ($operation['type'] == 'project') {
+								// Create project / lead
+								$projecttocreate = new Project($this->db);
+								$alreadycreated = $projecttocreate->fetch(0, '', '', $msgid);
+								if ($alreadycreated == 0) {
+									if ($thirdpartystatic->id > 0) {
+										$projecttocreate->socid = $thirdpartystatic->id;
+										if ($thirdpartyfoundby) {
+											$descriptionmeta = dol_concatdesc($descriptionmeta, 'Third party found from '.$thirdpartyfoundby);
+										}
+									}
+									if ($contactstatic->id > 0) {
+										$projecttocreate->contact_id = $contactstatic->id;
+										if ($contactfoundby) {
+											$descriptionmeta = dol_concatdesc($descriptionmeta, 'Contact/address found from '.$contactfoundby);
+										}
+									}
+
+									$description = $descriptiontitle;
+
+									$description = dol_concatdesc($description, $descriptionmeta);
+									$description = dol_concatdesc($description, "-----");
+									$description = dol_concatdesc($description, $messagetext);
+
+									$descriptionfull = $description;
+									if (!getDolGlobalString('MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER')) {
+										$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
+										$descriptionfull = dol_concatdesc($descriptionfull, $header);
+									}
+
+									$id_opp_status = dol_getIdFromCode($this->db, 'PROSP', 'c_lead_status', 'code', 'rowid');
+									$percent_opp_status = dol_getIdFromCode($this->db, 'PROSP', 'c_lead_status', 'code', 'percent');
+
+									$projecttocreate->title = $subject;
+									$projecttocreate->date_start = $dateemail;	// date of email
+									$projecttocreate->date_end = 0;
+									$projecttocreate->opp_status = $id_opp_status;
+									$projecttocreate->opp_percent = $percent_opp_status;
+									$projecttocreate->description = dol_concatdesc(dolGetFirstLineOfText(dol_string_nohtmltag($description, 2), 10), '...'.$langs->transnoentities("SeePrivateNote").'...');
+									$projecttocreate->note_private = $descriptionfull;
+									$projecttocreate->entity = $conf->entity;
+									// Fields when action is an email (content should be added into agenda event)
+									$projecttocreate->email_date    = $dateemail;
+									$projecttocreate->email_msgid   = $msgid;
+									$projecttocreate->email_from    = $fromstring;
+									$projecttocreate->email_sender  = $sender;
+									$projecttocreate->email_to      = $to;
+									$projecttocreate->email_tocc    = $sendtocc;
+									$projecttocreate->email_tobcc   = $sendtobcc;
+									$projecttocreate->email_subject = $subject;
+									$projecttocreate->errors_to     = '';
+
+									$savesocid = $projecttocreate->socid;
+
+									// Overwrite values with values extracted from source email.
+									// This may overwrite any $projecttocreate->xxx properties.
+									$errorforthisaction = $this->overwritePropertiesOfObject($projecttocreate, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+									$modele = null;
+
+									// Set project ref if not yet defined
+									if (empty($projecttocreate->ref)) {
+										// Get next Ref
+										$defaultref = '';
+										$modele = getDolGlobalString('PROJECT_ADDON', 'mod_project_simple');
+
+										// Search template files
+										$file = '';
+										$classname = '';
+										$reldir = '';
+										$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
+										foreach ($dirmodels as $reldir) {
+											$file = dol_buildpath($reldir."core/modules/project/".$modele.'.php', 0);
+											if (file_exists($file)) {
+												$classname = $modele;
+												break;
+											}
+										}
+
+										if ($classname !== '') {
+											if ($savesocid > 0) {
+												if ($savesocid != $projecttocreate->socid) {
 													$errorforactions++;
-													$this->error = $contactstatic->error;
-													$this->errors = $contactstatic->errors;
+													setEventMessages('You loaded a thirdparty (id='.$savesocid.') and you force another thirdparty id (id='.$projecttocreate->socid.') by setting socid in operation with a different value', null, 'errors');
+												}
+											} else {
+												if ($projecttocreate->socid > 0) {
+													$thirdpartystatic->fetch($projecttocreate->socid);
+												}
+											}
+
+											$result = dol_include_once($reldir."core/modules/project/".$modele.'.php');
+											$modModuleToUseForNextValue = new $classname();
+											'@phan-var-force ModeleNumRefProjects $modModuleToUseForNextValue';
+											$defaultref = $modModuleToUseForNextValue->getNextValue(($thirdpartystatic->id > 0 ? $thirdpartystatic : null), $projecttocreate);
+										}
+										$projecttocreate->ref = $defaultref;
+									}
+
+
+									if ($errorforthisaction) {
+										$errorforactions++;
+									} else {
+										if (empty($projecttocreate->ref) || (is_numeric($projecttocreate->ref) && $projecttocreate->ref <= 0)) {
+											$errorforactions++;
+											$this->error = 'Failed to create project: Can\'t get a valid value for the field ref with numbering template = '.$modele.', thirdparty id = '.$thirdpartystatic->id;
+
+											$operationslog .= '<br>'.$this->error;
+										} else {
+											// Create project
+											$result = $projecttocreate->create($user);
+											if ($result <= 0) {
+												$errorforactions++;
+												$this->error = 'Failed to create project: '.$langs->trans($projecttocreate->error);
+												$this->errors = $projecttocreate->errors;
+
+												$operationslog .= '<br>'.$this->error;
+											} else {
+												if ($attachments) {
+													$destdir = $conf->project->dir_output.'/'.$projecttocreate->ref;
+													if (!dol_is_dir($destdir)) {
+														dol_mkdir($destdir);
+													}
+													if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+														foreach ($attachments as $attachment) {
+															// $attachment->save($destdir.'/');
+															$typeattachment = (string) $attachment->getDisposition();
+															$filename = $attachment->getFilename();
+															$content = $attachment->getContent();
+															$this->saveAttachment($destdir, $filename, $content);
+														}
+													} else {
+														$getMsg = $this->getmsg($connection, $imapemail, $destdir);
+														if ($getMsg < 0) {
+															$this->errors = array_merge($this->errors, [$this->error]);
+															return $getMsg;
+														}
+													}
+
+													$operationslog .= '<br>Project created with attachments -> id='.dol_escape_htmltag((string) $projecttocreate->id);
 												} else {
-													$operationslog .= '<br>Contact created -> id = '.dol_escape_htmltag((string) $contactstatic->id);
+													$operationslog .= '<br>Project created without attachments -> id='.dol_escape_htmltag((string) $projecttocreate->id);
 												}
 											}
 										}
 									}
+								} else {
+									dol_syslog("Project already exists for msgid = ".dol_escape_htmltag($msgid).", so we do not recreate it.");
+
+									$operationslog .= '<br>Project already exists for msgid ='.dol_escape_htmltag($msgid);
 								}
-							}
-						} elseif ($operation['type'] == 'recordevent') {
-							// Create event
-							$actioncomm = new ActionComm($this->db);
-
-							$alreadycreated = $actioncomm->fetch(0, '', '', $msgid);
-							if ($alreadycreated == 0) {
-								$operationslog .= '<br>We did not find existing actioncomm with msgid='.$msgid;
-
-								if ($projectstatic->id > 0) {
-									if ($projectfoundby) {
-										$descriptionmeta = dol_concatdesc($descriptionmeta, 'Project found from '.$projectfoundby);
+							} elseif ($operation['type'] == 'ticket') {
+								// Create ticket
+								$tickettocreate = new Ticket($this->db);
+								if ($ticketalreadyexists == 0) {
+									if ($thirdpartystatic->id > 0) {
+										$tickettocreate->socid = $thirdpartystatic->id;
+										$tickettocreate->fk_soc = $thirdpartystatic->id;
+										if ($thirdpartyfoundby) {
+											$descriptionmeta = dol_concatdesc($descriptionmeta, 'Third party found from '.$thirdpartyfoundby);
+										}
 									}
-								}
-								if ($thirdpartystatic->id > 0) {
-									if ($thirdpartyfoundby) {
-										$descriptionmeta = dol_concatdesc($descriptionmeta, 'Third party found from '.$thirdpartyfoundby);
+									if ($contactstatic->id > 0) {
+										$tickettocreate->contact_id = $contactstatic->id;
+										if ($contactfoundby) {
+											$descriptionmeta = dol_concatdesc($descriptionmeta, 'Contact/address found from '.$contactfoundby);
+										}
 									}
-								}
-								if ($contactstatic->id > 0) {
-									if ($contactfoundby) {
-										$descriptionmeta = dol_concatdesc($descriptionmeta, 'Contact/address found from '.$contactfoundby);
+
+									$description = $descriptiontitle;
+
+									$description = dol_concatdesc($description, $descriptionmeta);
+									$description = dol_concatdesc($description, "-----");
+									$description = dol_concatdesc($description, $messagetext);
+
+									$descriptionfull = $description;
+									if (!getDolGlobalString('MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER')) {
+										$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
+										$descriptionfull = dol_concatdesc($descriptionfull, $header);
 									}
+
+									$tickettocreate->subject = $subject;
+									$tickettocreate->message = $description;
+									$tickettocreate->type_code = (getDolGlobalString('MAIN_EMAILCOLLECTOR_TICKET_TYPE_CODE', dol_getIdFromCode($this->db, 1, 'c_ticket_type', 'use_default', 'code', 1)));
+									$tickettocreate->category_code = (getDolGlobalString('MAIN_EMAILCOLLECTOR_TICKET_CATEGORY_CODE', dol_getIdFromCode($this->db, 1, 'c_ticket_category', 'use_default', 'code', 1)));
+									$tickettocreate->severity_code = (getDolGlobalString('MAIN_EMAILCOLLECTOR_TICKET_SEVERITY_CODE', dol_getIdFromCode($this->db, 1, 'c_ticket_severity', 'use_default', 'code', 1)));
+									$tickettocreate->origin_email = $from;
+									$tickettocreate->origin_replyto = (!empty($replyto) ? $replyto : null);
+									$tickettocreate->origin_references = (!empty($headers['References']) ? $headers['References'] : null);
+									$tickettocreate->fk_user_create = $user->id;
+									$tickettocreate->datec = dol_now();
+									$tickettocreate->fk_project = $projectstatic->id;
+									$tickettocreate->notify_tiers_at_create = getDolGlobalInt('TICKET_CHECK_NOTIFY_THIRDPARTY_AT_CREATION');
+									$tickettocreate->note_private = $descriptionfull;
+									$tickettocreate->entity = $conf->entity;
+									// Fields when action is an email (content should be added into agenda event)
+									$tickettocreate->email_date    = $dateemail;
+									$tickettocreate->email_msgid   = $msgid;
+									$tickettocreate->email_from    = $fromstring;
+									$tickettocreate->email_sender  = $sender;
+									$tickettocreate->email_to      = $to;
+									$tickettocreate->email_tocc    = $sendtocc;
+									$tickettocreate->email_tobcc   = $sendtobcc;
+									$tickettocreate->email_subject = $subject;
+									$tickettocreate->errors_to     = '';
+
+									//$tickettocreate->fk_contact = $contactstatic->id;
+
+									$savesocid = $tickettocreate->socid;
+
+									// Overwrite values with values extracted from source email.
+									// This may overwrite any $projecttocreate->xxx properties.
+									$errorforthisaction = $this->overwritePropertiesOfObject($tickettocreate, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+
+									$modele = 'UNDEFINED';
+									// Set ticket ref if not yet defined
+									if (empty($tickettocreate->ref)) {
+										// Get next Ref
+										$defaultref = '';
+										$modele = getDolGlobalString('TICKET_ADDON', 'mod_ticket_simple');
+
+										// Search template files
+										$file = '';
+										$classname = '';
+										$reldir = '';
+										$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
+										foreach ($dirmodels as $reldir) {
+											$file = dol_buildpath($reldir."core/modules/ticket/".$modele.'.php', 0);
+											if (file_exists($file)) {
+												$classname = $modele;
+												break;
+											}
+										}
+
+										if ($classname !== '') {
+											if ($savesocid > 0) {
+												if ($savesocid != $tickettocreate->socid) {
+													$errorforactions++;
+													setEventMessages('You loaded a thirdparty (id='.$savesocid.') and you force another thirdparty id (id='.$tickettocreate->socid.') by setting socid in operation with a different value', null, 'errors');
+												}
+											} else {
+												if ($tickettocreate->socid > 0) {
+													$thirdpartystatic->fetch($tickettocreate->socid);
+												}
+											}
+
+											$result = dol_include_once($reldir."core/modules/ticket/".$modele.'.php');
+											$modModuleToUseForNextValue = new $classname();
+											'@phan-var-force ModeleNumRefTicket $modModuleToUseForNextValue';
+											$defaultref = $modModuleToUseForNextValue->getNextValue(($thirdpartystatic->id > 0 ? $thirdpartystatic : null), $tickettocreate);
+										}
+										$tickettocreate->ref = $defaultref;
+									}
+
+									if ($errorforthisaction) {
+										$errorforactions++;
+									} else {
+										if (is_numeric($tickettocreate->ref) && $tickettocreate->ref <= 0) {
+											$errorforactions++;
+											$this->error = 'Failed to create ticket: Can\'t get a valid value for the field ref with numbering template = '.$modele.', thirdparty id = '.$thirdpartystatic->id;
+										} else {
+											// Create ticket
+											$tickettocreate->context['actionmsg2'] = $langs->trans("ActionAC_EMAIL_IN").' - '.$langs->trans("TICKET_CREATEInDolibarr");
+											$tickettocreate->context['actionmsg'] = $langs->trans("ActionAC_EMAIL_IN").' - '.$langs->trans("TICKET_CREATEInDolibarr");
+											//$tickettocreate->email_fields_no_propagate_in_actioncomm = 0;
+
+											// Add sender to context array to make sure that confirmation e-mail can be sent by trigger script
+											$sender_contact = new Contact($this->db);
+											$sender_contact->fetch(0, null, '', $from);
+											if (!empty($sender_contact->id)) {
+												$tickettocreate->context['contact_id'] = $sender_contact->id;
+											}
+
+											$result = $tickettocreate->create($user);
+											if ($result <= 0) {
+												$errorforactions++;
+												$this->error = 'Failed to create ticket: '.$langs->trans($tickettocreate->error);
+												$this->errors = $tickettocreate->errors;
+											} else {
+												if ($attachments) {
+													$destdir = $conf->ticket->dir_output.'/'.$tickettocreate->ref;
+													if (!dol_is_dir($destdir)) {
+														dol_mkdir($destdir);
+													}
+													if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+														foreach ($attachments as $attachment) {
+															// $attachment->save($destdir.'/');
+															$typeattachment = (string) $attachment->getDisposition();
+															$filename = $attachment->getName();
+															$content = $attachment->getContent();
+															$this->saveAttachment($destdir, $filename, $content);
+														}
+													} else {
+														$getMsg = $this->getmsg($connection, $imapemail, $destdir);
+														if ($getMsg < 0) {
+															$this->errors = array_merge($this->errors, [$this->error]);
+															return $getMsg;
+														}
+													}
+
+													$operationslog .= '<br>Ticket created with attachments -> id='.dol_escape_htmltag((string) $tickettocreate->id);
+												} else {
+													$operationslog .= '<br>Ticket created without attachments -> id='.dol_escape_htmltag((string) $tickettocreate->id);
+												}
+											}
+										}
+									}
+								} else {
+									// Do nothing in action ticket if ticket already exists.
+									// Note that if we want to add a new event to a ticket, we should have a collector with action "Record event in agenda" or hope the type of action 'ticket' was
+									// already replaced automatically by operation "recordevent".
+									$operationslog .= '<br>Ticket already exists, so we bypass action "ticket"';
 								}
+							} elseif ($operation['type'] == 'candidature') {
+								// Create candidature
+								$candidaturetocreate = new RecruitmentCandidature($this->db);
 
-								$description = $descriptiontitle;
+								$alreadycreated = $candidaturetocreate->fetch(0, '', $msgid);
+								if ($alreadycreated == 0) {
+									$description = $descriptiontitle;
+									$description = dol_concatdesc($description, "-----");
+									$description = dol_concatdesc($description, $descriptionmeta);
+									$description = dol_concatdesc($description, "-----");
+									$description = dol_concatdesc($description, $messagetext);
 
-								$description = dol_concatdesc($description, $descriptionmeta);
-								$description = dol_concatdesc($description, "-----");
-								$description = dol_concatdesc($description, $messagetext);
-
-								$descriptionfull = $description;
-								if (!getDolGlobalString('MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER')) {
+									$descriptionfull = $description;
 									$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
 									$descriptionfull = dol_concatdesc($descriptionfull, $header);
-								}
 
-								// Insert record of emails sent
-								$actioncomm->type_code   = 'AC_OTH_AUTO'; // Type of event ('AC_OTH', 'AC_OTH_AUTO', 'AC_XXX'...)
-								$actioncomm->code        = 'AC_'.$actioncode;
-								$actioncomm->label       = $langs->trans("ActionAC_".$actioncode).' - '.$langs->trans("MailFrom").' '.$from;
-								$actioncomm->note_private = $descriptionfull;
-								$actioncomm->fk_project  = $projectstatic->id;
-								$actioncomm->datep       = $dateemail;	// date of email
-								$actioncomm->datef       = $dateemail;	// date of email
-								$actioncomm->percentage  = -1; // Not applicable
-								$actioncomm->socid       = $thirdpartystatic->id;
-								$actioncomm->contact_id = $contactstatic->id;
-								$actioncomm->socpeopleassigned = (!empty($contactstatic->id) ? array($contactstatic->id) : array());
-								$actioncomm->authorid    = $user->id; // User saving action
-								$actioncomm->userownerid = $user->id; // Owner of action
-								// Fields when action is an email (content should be added into note)
-								$actioncomm->email_msgid = $msgid;
-								$actioncomm->email_from  = $fromstring;
-								$actioncomm->email_sender = $sender;
-								$actioncomm->email_to    = $to;
-								$actioncomm->email_tocc  = $sendtocc;
-								$actioncomm->email_tobcc = $sendtobcc;
-								$actioncomm->email_subject = $subject;
-								$actioncomm->errors_to   = '';
+									$candidaturetocreate->subject = $subject;
+									$candidaturetocreate->message = $description;
+									$candidaturetocreate->type_code = 0;
+									$candidaturetocreate->category_code = null;
+									$candidaturetocreate->severity_code = null;
+									$candidaturetocreate->email = $from;
+									//$candidaturetocreate->lastname = $langs->trans("Anonymous").' - '.$from;
+									$candidaturetocreate->fk_user_creat = $user->id;
+									$candidaturetocreate->date_creation = dol_now();
+									$candidaturetocreate->fk_project = $projectstatic->id;
+									$candidaturetocreate->description = $description;
+									$candidaturetocreate->note_private = $descriptionfull;
+									$candidaturetocreate->entity = $conf->entity;
+									$candidaturetocreate->email_msgid = $msgid;
+									$candidaturetocreate->email_date = $dateemail;		// date of email
+									$candidaturetocreate->status = $candidaturetocreate::STATUS_DRAFT;
+									//$candidaturetocreate->fk_contact = $contactstatic->id;
 
-								if (!in_array($fk_element_type, array('societe', 'contact', 'project', 'user'))) {
-									$actioncomm->fk_element  = $fk_element_id;
-									$actioncomm->elementid = $fk_element_id;
-									$actioncomm->elementtype = $fk_element_type;
-									if (is_object($objectemail) && $objectemail->module) {
-										$actioncomm->elementtype .= '@'.$objectemail->module;
-									}
-								}
+									// Overwrite values with values extracted from source email.
+									// This may overwrite any $projecttocreate->xxx properties.
+									$errorforthisaction = $this->overwritePropertiesOfObject($candidaturetocreate, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
 
-								//$actioncomm->extraparams = $extraparams;
+									// Set candidature ref if not yet defined
+									/*if (empty($candidaturetocreate->ref))				We do not need this because we create object in draft status
+									 {
+									 // Get next Ref
+									 $defaultref = '';
+									 $modele = empty($conf->global->CANDIDATURE_ADDON) ? 'mod_candidature_simple' : $conf->global->CANDIDATURE_ADDON;
 
-								// Overwrite values with values extracted from source email
-								$errorforthisaction = $this->overwritePropertiesOfObject($actioncomm, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
+									 // Search template files
+									 $file = ''; $classname = ''; $filefound = 0; $reldir = '';
+									 $dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
+									 foreach ($dirmodels as $reldir)
+									 {
+									 $file = dol_buildpath($reldir."core/modules/ticket/".$modele.'.php', 0);
+									 if (file_exists($file)) {
+									 $filefound = 1;
+									 $classname = $modele;
+									 break;
+									 }
+									 }
 
-								if ($errorforthisaction) {
-									$errorforactions++;
-								} else {
-									$result = $actioncomm->create($user);
-									if ($result <= 0) {
+									 if ($filefound) {
+									 if ($savesocid > 0) {
+									 if ($savesocid != $candidaturetocreate->socid) {
+									 $errorforactions++;
+									 setEventMessages('You loaded a thirdparty (id='.$savesocid.') and you force another thirdparty id (id='.$candidaturetocreate->socid.') by setting socid in operation with a different value', null, 'errors');
+									 }
+									 } else {
+									 if ($candidaturetocreate->socid > 0)
+									 {
+									 $thirdpartystatic->fetch($candidaturetocreate->socid);
+									 }
+									 }
+
+									 $result = dol_include_once($reldir."core/modules/ticket/".$modele.'.php');
+									 $modModuleToUseForNextValue = new $classname;
+									'@phan-var-force ModeleNumRefTicket $modModuleToUseForNextValue';
+									 $defaultref = $modModuleToUseForNextValue->getNextValue(($thirdpartystatic->id > 0 ? $thirdpartystatic : null), $tickettocreate);
+									 }
+									 $candidaturetocreate->ref = $defaultref;
+									 }*/
+
+									if ($errorforthisaction) {
 										$errorforactions++;
-										$this->errors = $actioncomm->errors;
 									} else {
-										if ($fk_element_type == "ticket" && is_object($objectemail)) {
-											if ($objectemail->status == Ticket::STATUS_CLOSED || $objectemail->status == Ticket::STATUS_CANCELED || $objectemail->status == Ticket::STATUS_NEED_MORE_INFO || $objectemail->status == Ticket::STATUS_WAITING) {
-												if ($objectemail->fk_user_assign != null) {
-													$res = $objectemail->setStatut(Ticket::STATUS_ASSIGNED);
-												} else {
-													$res = $objectemail->setStatut(Ticket::STATUS_NOT_READ);
-												}
-
-												if ($res) {
-													$operationslog .= '<br>Ticket Re-Opened successfully -> ref='.$objectemail->ref;
-												} else {
-													$errorforactions++;
-													$this->error = 'Error while changing the ticket status -> ref='.$objectemail->ref;
-													$this->errors[] = $this->error;
-												}
-											}
-											if (!empty($attachments)) {
-												// There is an attachment for the ticket -> store attachment
-												$ticket = new Ticket($this->db);
-												$ticket->fetch($fk_element_id);
-												$destdir = $conf->ticket->dir_output.'/'.$ticket->ref;
-												if (!dol_is_dir($destdir)) {
-													dol_mkdir($destdir);
-												}
-												if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-													foreach ($attachments as $attachment) {
-														$attachment->save($destdir.'/');
-													}
-												} else {
-													$this->getmsg($connection, $imapemail, $destdir);
-												}
-											}
+										// Create project
+										$result = $candidaturetocreate->create($user);
+										if ($result <= 0) {
+											$errorforactions++;
+											$this->error = 'Failed to create candidature: '.implode(', ', $candidaturetocreate->errors);
+											$this->errors = $candidaturetocreate->errors;
 										}
 
-										$operationslog .= '<br>Event created -> id='.dol_escape_htmltag((string) $actioncomm->id);
+										$operationslog .= '<br>Candidature created without attachments -> id='.dol_escape_htmltag((string) $candidaturetocreate->id);
 									}
 								}
-							} else {
-								$operationslog .= '<br>An event in actioncomm table already exists for the msgid = '.$msgid.' so we bypass this action.';
-							}
-						} elseif ($operation['type'] == 'recordjoinpiece') {
-							$data = [];
-							if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-								foreach ($attachments as $attachment) {
-									if ($attachment->getName() === 'undefined') {
-										continue;
-									}
-									$data[$attachment->getName()] = $attachment->getContent();
-								}
-							} else {
-								$pj = getAttachments($imapemail, $connection);
-								foreach ($pj as $key => $val) {
-									$data[$val['filename']] = getFileData($imapemail, (string) $val['pos'], $val['type'], $connection);
-								}
-							}
-							if (count($data) > 0) {
-								$sql = "SELECT rowid as id FROM ".MAIN_DB_PREFIX."user WHERE email LIKE '%".$this->db->escape($from)."%'";
-								$resql = $this->db->query($sql);
-								if ($this->db->num_rows($resql) == 0) {
-									$this->errors[] = "User Not allowed to add documents ({$from})";
-								}
-								$arrayobject = array(
-									'propale' => array('table' => 'propal',
-										'fields' => array('ref'),
-										'class' => 'comm/propal/class/propal.class.php',
-										'object' => 'Propal'),
-									'holiday' => array('table' => 'holiday',
-										'fields' => array('ref'),
-										'class' => 'holiday/class/holiday.class.php',
-										'object' => 'Holiday'),
-									'expensereport' => array('table' => 'expensereport',
-										'fields' => array('ref'),
-										'class' => 'expensereport/class/expensereport.class.php',
-										'object' => 'ExpenseReport'),
-									'recruitment/recruitmentjobposition' => array('table' => 'recruitment_recruitmentjobposition',
-										'fields' => array('ref'),
-										'class' => 'recruitment/class/recruitmentjobposition.class.php',
-										'object' => 'RecruitmentJobPosition'),
-									'recruitment/recruitmentcandidature' => array('table' => 'recruitment_recruitmentcandidature',
-										'fields' => array('ref'),
-										'class' => 'recruitment/class/recruitmentcandidature.class.php',
-										'object' => 'RecruitmentCandidature'),
-									'societe' => array('table' => 'societe',
-										'fields' => array('code_client', 'code_fournisseur'),
-										'class' => 'societe/class/societe.class.php',
-										'object' => 'Societe'),
-									'commande' => array('table' => 'commande',
-										'fields' => array('ref'),
-										'class' => 'commande/class/commande.class.php',
-										'object' => 'Commande'),
-									'expedition' => array('table' => 'expedition',
-										'fields' => array('ref'),
-										'class' => 'expedition/class/expedition.class.php',
-										'object' => 'Expedition'),
-									'contract' => array('table' => 'contrat',
-										'fields' => array('ref'),
-										'class' => 'contrat/class/contrat.class.php',
-										'object' => 'Contrat'),
-									'fichinter' => array('table' => 'fichinter',
-										'fields' => array('ref'),
-										'class' => 'fichinter/class/fichinter.class.php',
-										'object' => 'Fichinter'),
-									'ticket' => array('table' => 'ticket',
-										'fields' => array('ref'),
-										'class' => 'ticket/class/ticket.class.php',
-										'object' => 'Ticket'),
-									'knowledgemanagement' => array('table' => 'knowledgemanagement_knowledgerecord',
-										'fields' => array('ref'),
-										'class' => 'knowledgemanagement/class/knowledgemanagement.class.php',
-										'object' => 'KnowledgeRecord'),
-									'supplier_proposal' => array('table' => 'supplier_proposal',
-										'fields' => array('ref'),
-										'class' => 'supplier_proposal/class/supplier_proposal.class.php',
-										'object' => 'SupplierProposal'),
-									'fournisseur/commande' => array('table' => 'commande_fournisseur',
-										'fields' => array('ref', 'ref_supplier'),
-										'class' => 'fourn/class/fournisseur.commande.class.php',
-										'object' => 'SupplierProposal'),
-									'facture' => array('table' => 'facture',
-										'fields' => array('ref'),
-										'class' => 'compta/facture/class/facture.class.php',
-										'object' => 'Facture'),
-									'fournisseur/facture' => array('table' => 'facture_fourn',
-										'fields' => array('ref', 'ref_client'),
-										'class' => 'fourn/class/fournisseur.facture.class.php',
-										'object' => 'FactureFournisseur'),
-									'produit' => array('table' => 'product',
-										'fields' => array('ref'),
-										'class' => 'product/class/product.class.php',
-										'object' => 'Product'),
-									'productlot' => array('table' => 'product_lot',
-										'fields' => array('batch'),
-										'class' => 'product/stock/class/productlot.class.php',
-										'object' => 'Productlot'),
-									'projet' => array('table' => 'projet',
-										'fields' => array('ref'),
-										'class' => 'projet/class/projet.class.php',
-										'object' => 'Project'),
-									'projet_task' => array('table' => 'projet_task',
-										'fields' => array('ref'),
-										'class' => 'projet/class/task.class.php',
-										'object' => 'Task'),
-									'ressource' => array('table' => 'resource',
-										'fields' => array('ref'),
-										'class' => 'ressource/class/dolressource.class.php',
-										'object' => 'Dolresource'),
-									'bom' => array('table' => 'bom_bom',
-										'fields' => array('ref'),
-										'class' => 'bom/class/bom.class.php',
-										'object' => 'BOM'),
-									'mrp' => array('table' => 'mrp_mo',
-										'fields' => array('ref'),
-										'class' => 'mrp/class/mo.class.php',
-										'object' => 'Mo'),
-								);
-
+							} elseif (substr($operation['type'], 0, 4) == 'hook') {
+								// Create event specific on hook
+								// this code action is hook..... for support this call
 								if (!is_object($hookmanager)) {
 									include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
 									$hookmanager = new HookManager($this->db);
 								}
-								$hookmanager->initHooks(array('emailcolector'));
-								$parameters = array('arrayobject' => $arrayobject);
-								$reshook = $hookmanager->executeHooks('addmoduletoeamailcollectorjoinpiece', $parameters);    // Note that $action and $object may have been modified by some hooks
-								if ($reshook > 0) {
-									$arrayobject = $hookmanager->resArray;
+								$hookmanager->initHooks(['emailcolector']);
+
+								$parameters = array(
+									'connection' =>  $connection,
+									'imapemail' => $imapemail,
+									'overview' => $overview,
+
+									'from' => $from,
+									'fromtext' => $fromtext,
+
+									'actionparam' =>  $operation['actionparam'],
+
+									'thirdpartyid' => $thirdpartyid,
+									'objectid' => $objectid,
+									'objectemail' => $objectemail,
+
+									'messagetext' => $messagetext,
+									'subject' => $subject,
+									'header' => $header,
+									'attachments' => $attachments,
+								);
+								$reshook = $hookmanager->executeHooks('doCollectImapOneCollector', $parameters, $this, $operation['type']);
+
+								if ($reshook < 0) {
+									$errorforthisaction++;
+									$this->error = $hookmanager->resPrint;
 								}
-
-								$resultobj = array();
-
-								foreach ($arrayobject as $key => $objectdesc) {
-									$sql = 'SELECT DISTINCT t.rowid ';
-									$sql .= ' FROM ' . MAIN_DB_PREFIX . $this->db->sanitize($objectdesc['table']) . ' AS t';
-									$sql .= ' WHERE ';
-									foreach ($objectdesc['fields'] as $field) {
-										$sql .= "('" .$this->db->escape($subject) . "'  LIKE CONCAT('%',  t." . $this->db->sanitize($field) . ", '%') AND t." . $this->db->sanitize($field) . " <> '') OR ";
-									}
-									$sql = substr($sql, 0, -4);
-
-									$ressqlobj = $this->db->query($sql);
-									if ($ressqlobj) {
-										while ($obj = $this->db->fetch_object($ressqlobj)) {
-											$resultobj[$key][] = $obj->rowid;
-										}
-									}
-								}
-								$dirs = array();
-								foreach ($resultobj as $mod => $ids) {
-									$moddesc = $arrayobject[$mod];
-									$elementpath = $mod;
-									dol_include_once($moddesc['class']);
-									$objectmanaged = new $moddesc['object']($this->db);
-									'@phan-var-force CommonObject $objectmanaged';
-									foreach ($ids as $val) {
-										$res = $objectmanaged->fetch($val);
-										if ($res) {
-											$path = ($objectmanaged->entity > 1 ? "/" . $objectmanaged->entity : '');
-											$dirs[] = DOL_DATA_ROOT . $path . "/" . $elementpath . '/' . dol_sanitizeFileName($objectmanaged->ref) . '/';
-										} else {
-											$this->errors[] = 'object not found';
-										}
-									}
-								}
-								foreach ($dirs as $target) {
-									$prefix = $this->actions[$this->id]['actionparam'];
-									foreach ($data as $filename => $content) {
-										$resr = saveAttachment($target, $prefix . '_' . $filename, $content);
-										if ($resr == -1) {
-											$this->errors[] = 'Doc not saved';
-										}
-									}
-								}
-
-								$operationslog .= '<br>Save attachment files on disk';
-							} else {
-								$this->errors[] = 'no joined piece';
-
-								$operationslog .= '<br>No joinded files';
-							}
-						} elseif ($operation['type'] == 'project') {
-							// Create project / lead
-							$projecttocreate = new Project($this->db);
-							$alreadycreated = $projecttocreate->fetch(0, '', '', $msgid);
-							if ($alreadycreated == 0) {
-								if ($thirdpartystatic->id > 0) {
-									$projecttocreate->socid = $thirdpartystatic->id;
-									if ($thirdpartyfoundby) {
-										$descriptionmeta = dol_concatdesc($descriptionmeta, 'Third party found from '.$thirdpartyfoundby);
-									}
-								}
-								if ($contactstatic->id > 0) {
-									$projecttocreate->contact_id = $contactstatic->id;
-									if ($contactfoundby) {
-										$descriptionmeta = dol_concatdesc($descriptionmeta, 'Contact/address found from '.$contactfoundby);
-									}
-								}
-
-								$description = $descriptiontitle;
-
-								$description = dol_concatdesc($description, $descriptionmeta);
-								$description = dol_concatdesc($description, "-----");
-								$description = dol_concatdesc($description, $messagetext);
-
-								$descriptionfull = $description;
-								if (!getDolGlobalString('MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER')) {
-									$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
-									$descriptionfull = dol_concatdesc($descriptionfull, $header);
-								}
-
-								$id_opp_status = dol_getIdFromCode($this->db, 'PROSP', 'c_lead_status', 'code', 'rowid');
-								$percent_opp_status = dol_getIdFromCode($this->db, 'PROSP', 'c_lead_status', 'code', 'percent');
-
-								$projecttocreate->title = $subject;
-								$projecttocreate->date_start = $dateemail;	// date of email
-								$projecttocreate->date_end = 0;
-								$projecttocreate->opp_status = $id_opp_status;
-								$projecttocreate->opp_percent = $percent_opp_status;
-								$projecttocreate->description = dol_concatdesc(dolGetFirstLineOfText(dol_string_nohtmltag($description, 2), 10), '...'.$langs->transnoentities("SeePrivateNote").'...');
-								$projecttocreate->note_private = $descriptionfull;
-								$projecttocreate->entity = $conf->entity;
-								// Fields when action is an email (content should be added into agenda event)
-								$projecttocreate->email_date    = $dateemail;
-								$projecttocreate->email_msgid   = $msgid;
-								$projecttocreate->email_from    = $fromstring;
-								$projecttocreate->email_sender  = $sender;
-								$projecttocreate->email_to      = $to;
-								$projecttocreate->email_tocc    = $sendtocc;
-								$projecttocreate->email_tobcc   = $sendtobcc;
-								$projecttocreate->email_subject = $subject;
-								$projecttocreate->errors_to     = '';
-
-								$savesocid = $projecttocreate->socid;
-
-								// Overwrite values with values extracted from source email.
-								// This may overwrite any $projecttocreate->xxx properties.
-								$errorforthisaction = $this->overwritePropertiesOfObject($projecttocreate, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
-								$modele = null;
-
-								// Set project ref if not yet defined
-								if (empty($projecttocreate->ref)) {
-									// Get next Ref
-									$defaultref = '';
-									$modele = getDolGlobalString('PROJECT_ADDON', 'mod_project_simple');
-
-									// Search template files
-									$file = '';
-									$classname = '';
-									$reldir = '';
-									$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
-									foreach ($dirmodels as $reldir) {
-										$file = dol_buildpath($reldir."core/modules/project/".$modele.'.php', 0);
-										if (file_exists($file)) {
-											$classname = $modele;
-											break;
-										}
-									}
-
-									if ($classname !== '') {
-										if ($savesocid > 0) {
-											if ($savesocid != $projecttocreate->socid) {
-												$errorforactions++;
-												setEventMessages('You loaded a thirdparty (id='.$savesocid.') and you force another thirdparty id (id='.$projecttocreate->socid.') by setting socid in operation with a different value', null, 'errors');
-											}
-										} else {
-											if ($projecttocreate->socid > 0) {
-												$thirdpartystatic->fetch($projecttocreate->socid);
-											}
-										}
-
-										$result = dol_include_once($reldir."core/modules/project/".$modele.'.php');
-										$modModuleToUseForNextValue = new $classname();
-										'@phan-var-force ModeleNumRefProjects $modModuleToUseForNextValue';
-										$defaultref = $modModuleToUseForNextValue->getNextValue(($thirdpartystatic->id > 0 ? $thirdpartystatic : null), $projecttocreate);
-									}
-									$projecttocreate->ref = $defaultref;
-								}
-
-
 								if ($errorforthisaction) {
 									$errorforactions++;
+									$operationslog .= '<br>Hook doCollectImapOneCollector executed with error';
 								} else {
-									if (empty($projecttocreate->ref) || (is_numeric($projecttocreate->ref) && $projecttocreate->ref <= 0)) {
-										$errorforactions++;
-										$this->error = 'Failed to create project: Can\'t get a valid value for the field ref with numbering template = '.$modele.', thirdparty id = '.$thirdpartystatic->id;
-
-										$operationslog .= '<br>'.$this->error;
-									} else {
-										// Create project
-										$result = $projecttocreate->create($user);
-										if ($result <= 0) {
-											$errorforactions++;
-											$this->error = 'Failed to create project: '.$langs->trans($projecttocreate->error);
-											$this->errors = $projecttocreate->errors;
-
-											$operationslog .= '<br>'.$this->error;
-										} else {
-											if ($attachments) {
-												$destdir = $conf->project->dir_output.'/'.$projecttocreate->ref;
-												if (!dol_is_dir($destdir)) {
-													dol_mkdir($destdir);
-												}
-												if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-													foreach ($attachments as $attachment) {
-														// $attachment->save($destdir.'/');
-														$typeattachment = (string) $attachment->getDisposition();
-														$filename = $attachment->getFilename();
-														$content = $attachment->getContent();
-														$this->saveAttachment($destdir, $filename, $content);
-													}
-												} else {
-													$getMsg = $this->getmsg($connection, $imapemail, $destdir);
-													if ($getMsg < 0) {
-														$this->errors = array_merge($this->errors, [$this->error]);
-														return $getMsg;
-													}
-												}
-
-												$operationslog .= '<br>Project created with attachments -> id='.dol_escape_htmltag((string) $projecttocreate->id);
-											} else {
-												$operationslog .= '<br>Project created without attachments -> id='.dol_escape_htmltag((string) $projecttocreate->id);
-											}
-										}
-									}
-								}
-							} else {
-								dol_syslog("Project already exists for msgid = ".dol_escape_htmltag($msgid).", so we do not recreate it.");
-
-								$operationslog .= '<br>Project already exists for msgid ='.dol_escape_htmltag($msgid);
-							}
-						} elseif ($operation['type'] == 'ticket') {
-							// Create ticket
-							$tickettocreate = new Ticket($this->db);
-							if ($ticketalreadyexists == 0) {
-								if ($thirdpartystatic->id > 0) {
-									$tickettocreate->socid = $thirdpartystatic->id;
-									$tickettocreate->fk_soc = $thirdpartystatic->id;
-									if ($thirdpartyfoundby) {
-										$descriptionmeta = dol_concatdesc($descriptionmeta, 'Third party found from '.$thirdpartyfoundby);
-									}
-								}
-								if ($contactstatic->id > 0) {
-									$tickettocreate->contact_id = $contactstatic->id;
-									if ($contactfoundby) {
-										$descriptionmeta = dol_concatdesc($descriptionmeta, 'Contact/address found from '.$contactfoundby);
-									}
-								}
-
-								$description = $descriptiontitle;
-
-								$description = dol_concatdesc($description, $descriptionmeta);
-								$description = dol_concatdesc($description, "-----");
-								$description = dol_concatdesc($description, $messagetext);
-
-								$descriptionfull = $description;
-								if (!getDolGlobalString('MAIN_EMAILCOLLECTOR_MAIL_WITHOUT_HEADER')) {
-									$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
-									$descriptionfull = dol_concatdesc($descriptionfull, $header);
-								}
-
-								$tickettocreate->subject = $subject;
-								$tickettocreate->message = $description;
-								$tickettocreate->type_code = (getDolGlobalString('MAIN_EMAILCOLLECTOR_TICKET_TYPE_CODE', dol_getIdFromCode($this->db, 1, 'c_ticket_type', 'use_default', 'code', 1)));
-								$tickettocreate->category_code = (getDolGlobalString('MAIN_EMAILCOLLECTOR_TICKET_CATEGORY_CODE', dol_getIdFromCode($this->db, 1, 'c_ticket_category', 'use_default', 'code', 1)));
-								$tickettocreate->severity_code = (getDolGlobalString('MAIN_EMAILCOLLECTOR_TICKET_SEVERITY_CODE', dol_getIdFromCode($this->db, 1, 'c_ticket_severity', 'use_default', 'code', 1)));
-								$tickettocreate->origin_email = $from;
-								$tickettocreate->origin_replyto = (!empty($replyto) ? $replyto : null);
-								$tickettocreate->origin_references = (!empty($headers['References']) ? $headers['References'] : null);
-								$tickettocreate->fk_user_create = $user->id;
-								$tickettocreate->datec = dol_now();
-								$tickettocreate->fk_project = $projectstatic->id;
-								$tickettocreate->notify_tiers_at_create = getDolGlobalInt('TICKET_CHECK_NOTIFY_THIRDPARTY_AT_CREATION');
-								$tickettocreate->note_private = $descriptionfull;
-								$tickettocreate->entity = $conf->entity;
-								// Fields when action is an email (content should be added into agenda event)
-								$tickettocreate->email_date    = $dateemail;
-								$tickettocreate->email_msgid   = $msgid;
-								$tickettocreate->email_from    = $fromstring;
-								$tickettocreate->email_sender  = $sender;
-								$tickettocreate->email_to      = $to;
-								$tickettocreate->email_tocc    = $sendtocc;
-								$tickettocreate->email_tobcc   = $sendtobcc;
-								$tickettocreate->email_subject = $subject;
-								$tickettocreate->errors_to     = '';
-
-								//$tickettocreate->fk_contact = $contactstatic->id;
-
-								$savesocid = $tickettocreate->socid;
-
-								// Overwrite values with values extracted from source email.
-								// This may overwrite any $projecttocreate->xxx properties.
-								$errorforthisaction = $this->overwritePropertiesOfObject($tickettocreate, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
-
-								$modele = 'UNDEFINED';
-								// Set ticket ref if not yet defined
-								if (empty($tickettocreate->ref)) {
-									// Get next Ref
-									$defaultref = '';
-									$modele = getDolGlobalString('TICKET_ADDON', 'mod_ticket_simple');
-
-									// Search template files
-									$file = '';
-									$classname = '';
-									$reldir = '';
-									$dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
-									foreach ($dirmodels as $reldir) {
-										$file = dol_buildpath($reldir."core/modules/ticket/".$modele.'.php', 0);
-										if (file_exists($file)) {
-											$classname = $modele;
-											break;
-										}
-									}
-
-									if ($classname !== '') {
-										if ($savesocid > 0) {
-											if ($savesocid != $tickettocreate->socid) {
-												$errorforactions++;
-												setEventMessages('You loaded a thirdparty (id='.$savesocid.') and you force another thirdparty id (id='.$tickettocreate->socid.') by setting socid in operation with a different value', null, 'errors');
-											}
-										} else {
-											if ($tickettocreate->socid > 0) {
-												$thirdpartystatic->fetch($tickettocreate->socid);
-											}
-										}
-
-										$result = dol_include_once($reldir."core/modules/ticket/".$modele.'.php');
-										$modModuleToUseForNextValue = new $classname();
-										'@phan-var-force ModeleNumRefTicket $modModuleToUseForNextValue';
-										$defaultref = $modModuleToUseForNextValue->getNextValue(($thirdpartystatic->id > 0 ? $thirdpartystatic : null), $tickettocreate);
-									}
-									$tickettocreate->ref = $defaultref;
-								}
-
-								if ($errorforthisaction) {
-									$errorforactions++;
-								} else {
-									if (is_numeric($tickettocreate->ref) && $tickettocreate->ref <= 0) {
-										$errorforactions++;
-										$this->error = 'Failed to create ticket: Can\'t get a valid value for the field ref with numbering template = '.$modele.', thirdparty id = '.$thirdpartystatic->id;
-									} else {
-										// Create ticket
-										$tickettocreate->context['actionmsg2'] = $langs->trans("ActionAC_EMAIL_IN").' - '.$langs->trans("TICKET_CREATEInDolibarr");
-										$tickettocreate->context['actionmsg'] = $langs->trans("ActionAC_EMAIL_IN").' - '.$langs->trans("TICKET_CREATEInDolibarr");
-										//$tickettocreate->email_fields_no_propagate_in_actioncomm = 0;
-
-										// Add sender to context array to make sure that confirmation e-mail can be sent by trigger script
-										$sender_contact = new Contact($this->db);
-										$sender_contact->fetch(0, null, '', $from);
-										if (!empty($sender_contact->id)) {
-											$tickettocreate->context['contact_id'] = $sender_contact->id;
-										}
-
-										$result = $tickettocreate->create($user);
-										if ($result <= 0) {
-											$errorforactions++;
-											$this->error = 'Failed to create ticket: '.$langs->trans($tickettocreate->error);
-											$this->errors = $tickettocreate->errors;
-										} else {
-											if ($attachments) {
-												$destdir = $conf->ticket->dir_output.'/'.$tickettocreate->ref;
-												if (!dol_is_dir($destdir)) {
-													dol_mkdir($destdir);
-												}
-												if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-													foreach ($attachments as $attachment) {
-														// $attachment->save($destdir.'/');
-														$typeattachment = (string) $attachment->getDisposition();
-														$filename = $attachment->getName();
-														$content = $attachment->getContent();
-														$this->saveAttachment($destdir, $filename, $content);
-													}
-												} else {
-													$getMsg = $this->getmsg($connection, $imapemail, $destdir);
-													if ($getMsg < 0) {
-														$this->errors = array_merge($this->errors, [$this->error]);
-														return $getMsg;
-													}
-												}
-
-												$operationslog .= '<br>Ticket created with attachments -> id='.dol_escape_htmltag((string) $tickettocreate->id);
-											} else {
-												$operationslog .= '<br>Ticket created without attachments -> id='.dol_escape_htmltag((string) $tickettocreate->id);
-											}
-										}
-									}
-								}
-							} else {
-								// Do nothing in action ticket if ticket already exists.
-								// Note that if we want to add a new event to a ticket, we should have a collector with action "Record event in agenda" or hope the type of action 'ticket' was
-								// already replaced automatically by operation "recordevent".
-								$operationslog .= '<br>Ticket already exists, so we bypass action "ticket"';
-							}
-						} elseif ($operation['type'] == 'candidature') {
-							// Create candidature
-							$candidaturetocreate = new RecruitmentCandidature($this->db);
-
-							$alreadycreated = $candidaturetocreate->fetch(0, '', $msgid);
-							if ($alreadycreated == 0) {
-								$description = $descriptiontitle;
-								$description = dol_concatdesc($description, "-----");
-								$description = dol_concatdesc($description, $descriptionmeta);
-								$description = dol_concatdesc($description, "-----");
-								$description = dol_concatdesc($description, $messagetext);
-
-								$descriptionfull = $description;
-								$descriptionfull = dol_concatdesc($descriptionfull, "----- Header");
-								$descriptionfull = dol_concatdesc($descriptionfull, $header);
-
-								$candidaturetocreate->subject = $subject;
-								$candidaturetocreate->message = $description;
-								$candidaturetocreate->type_code = 0;
-								$candidaturetocreate->category_code = null;
-								$candidaturetocreate->severity_code = null;
-								$candidaturetocreate->email = $from;
-								//$candidaturetocreate->lastname = $langs->trans("Anonymous").' - '.$from;
-								$candidaturetocreate->fk_user_creat = $user->id;
-								$candidaturetocreate->date_creation = dol_now();
-								$candidaturetocreate->fk_project = $projectstatic->id;
-								$candidaturetocreate->description = $description;
-								$candidaturetocreate->note_private = $descriptionfull;
-								$candidaturetocreate->entity = $conf->entity;
-								$candidaturetocreate->email_msgid = $msgid;
-								$candidaturetocreate->email_date = $dateemail;		// date of email
-								$candidaturetocreate->status = $candidaturetocreate::STATUS_DRAFT;
-								//$candidaturetocreate->fk_contact = $contactstatic->id;
-
-								// Overwrite values with values extracted from source email.
-								// This may overwrite any $projecttocreate->xxx properties.
-								$errorforthisaction = $this->overwritePropertiesOfObject($candidaturetocreate, $operation['actionparam'], $messagetext, $subject, $header, $operationslog);
-
-								// Set candidature ref if not yet defined
-								/*if (empty($candidaturetocreate->ref))				We do not need this because we create object in draft status
-								 {
-								 // Get next Ref
-								 $defaultref = '';
-								 $modele = empty($conf->global->CANDIDATURE_ADDON) ? 'mod_candidature_simple' : $conf->global->CANDIDATURE_ADDON;
-
-								 // Search template files
-								 $file = ''; $classname = ''; $filefound = 0; $reldir = '';
-								 $dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
-								 foreach ($dirmodels as $reldir)
-								 {
-								 $file = dol_buildpath($reldir."core/modules/ticket/".$modele.'.php', 0);
-								 if (file_exists($file)) {
-								 $filefound = 1;
-								 $classname = $modele;
-								 break;
-								 }
-								 }
-
-								 if ($filefound) {
-								 if ($savesocid > 0) {
-								 if ($savesocid != $candidaturetocreate->socid) {
-								 $errorforactions++;
-								 setEventMessages('You loaded a thirdparty (id='.$savesocid.') and you force another thirdparty id (id='.$candidaturetocreate->socid.') by setting socid in operation with a different value', null, 'errors');
-								 }
-								 } else {
-								 if ($candidaturetocreate->socid > 0)
-								 {
-								 $thirdpartystatic->fetch($candidaturetocreate->socid);
-								 }
-								 }
-
-								 $result = dol_include_once($reldir."core/modules/ticket/".$modele.'.php');
-								 $modModuleToUseForNextValue = new $classname;
-								'@phan-var-force ModeleNumRefTicket $modModuleToUseForNextValue';
-								 $defaultref = $modModuleToUseForNextValue->getNextValue(($thirdpartystatic->id > 0 ? $thirdpartystatic : null), $tickettocreate);
-								 }
-								 $candidaturetocreate->ref = $defaultref;
-								 }*/
-
-								if ($errorforthisaction) {
-									$errorforactions++;
-								} else {
-									// Create project
-									$result = $candidaturetocreate->create($user);
-									if ($result <= 0) {
-										$errorforactions++;
-										$this->error = 'Failed to create candidature: '.implode(', ', $candidaturetocreate->errors);
-										$this->errors = $candidaturetocreate->errors;
-									}
-
-									$operationslog .= '<br>Candidature created without attachments -> id='.dol_escape_htmltag((string) $candidaturetocreate->id);
+									$operationslog .= '<br>Hook doCollectImapOneCollector executed without error';
 								}
 							}
-						} elseif (substr($operation['type'], 0, 4) == 'hook') {
-							// Create event specific on hook
-							// this code action is hook..... for support this call
-							if (!is_object($hookmanager)) {
-								include_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
-								$hookmanager = new HookManager($this->db);
+
+							if (!$errorforactions) {
+								$nbactiondoneforemail++;
 							}
-							$hookmanager->initHooks(['emailcolector']);
-
-							$parameters = array(
-								'connection' =>  $connection,
-								'imapemail' => $imapemail,
-								'overview' => $overview,
-
-								'from' => $from,
-								'fromtext' => $fromtext,
-
-								'actionparam' =>  $operation['actionparam'],
-
-								'thirdpartyid' => $thirdpartyid,
-								'objectid' => $objectid,
-								'objectemail' => $objectemail,
-
-								'messagetext' => $messagetext,
-								'subject' => $subject,
-								'header' => $header,
-								'attachments' => $attachments,
-							);
-							$reshook = $hookmanager->executeHooks('doCollectImapOneCollector', $parameters, $this, $operation['type']);
-
-							if ($reshook < 0) {
-								$errorforthisaction++;
-								$this->error = $hookmanager->resPrint;
-							}
-							if ($errorforthisaction) {
-								$errorforactions++;
-								$operationslog .= '<br>Hook doCollectImapOneCollector executed with error';
-							} else {
-								$operationslog .= '<br>Hook doCollectImapOneCollector executed without error';
-							}
-						}
-
-						if (!$errorforactions) {
-							$nbactiondoneforemail++;
 						}
 					}
-				}
 
-				// Error for email or not ?
-				if (!$errorforactions) {
-					if (!empty($targetdir)) {
-						if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-							// Move mail using PHP-IMAP
-							dol_syslog("EmailCollector::doCollectOneCollector move message ".($imapemail->getHeader()->get('subject'))." to ".$targetdir, LOG_DEBUG);
-							$operationslog .= '<br>Move mail '.($this->uidAsString($imapemail)).' - '.$msgid.' - '.$imapemail->getHeader()->get('subject').' to '.$targetdir;
+					// Error for email or not ?
+					if (!$errorforactions) {
+						if (!empty($targetdir)) {
+							if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+								// Move mail using PHP-IMAP
+								dol_syslog("EmailCollector::doCollectOneCollector move message ".($imapemail->getHeader()->get('subject'))." to ".$targetdir, LOG_DEBUG);
+								$operationslog .= '<br>Move mail '.($this->uidAsString($imapemail)).' - '.$msgid.' - '.$imapemail->getHeader()->get('subject').' to '.$targetdir;
 
-							$arrayofemailtodelete[$this->uidAsString($imapemail)] = $imapemail;
-							// Note: Real move is done later using $arrayofemailtodelete
+								$arrayofemailtodelete[$this->uidAsString($imapemail)] = $imapemail;
+								// Note: Real move is done later using $arrayofemailtodelete
+							} else {
+								dol_syslog("EmailCollector::doCollectOneCollector move message ".($this->uidAsString($imapemail))." to ".$connectstringtarget, LOG_DEBUG);
+								$operationslog .= '<br>Move mail '.($this->uidAsString($imapemail)).' - '.$msgid;
+
+								$arrayofemailtodelete[$imapemail] = $msgid;
+								// Note: Real move is done later using $arrayofemailtodelete
+							}
 						} else {
-							dol_syslog("EmailCollector::doCollectOneCollector move message ".($this->uidAsString($imapemail))." to ".$connectstringtarget, LOG_DEBUG);
-							$operationslog .= '<br>Move mail '.($this->uidAsString($imapemail)).' - '.$msgid;
-
-							$arrayofemailtodelete[$imapemail] = $msgid;
-							// Note: Real move is done later using $arrayofemailtodelete
+							if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
+								dol_syslog("EmailCollector::doCollectOneCollector message ".($this->uidAsString($imapemail))." '".($imapemail->getHeader()->get('subject'))."' using this->host=".$this->host.", this->access_type=".$this->acces_type." was set to read", LOG_DEBUG);
+							} else {
+								dol_syslog("EmailCollector::doCollectOneCollector message ".($this->uidAsString($imapemail))." to ".$connectstringtarget." was set to read", LOG_DEBUG);
+							}
 						}
 					} else {
-						if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-							dol_syslog("EmailCollector::doCollectOneCollector message ".($this->uidAsString($imapemail))." '".($imapemail->getHeader()->get('subject'))."' using this->host=".$this->host.", this->access_type=".$this->acces_type." was set to read", LOG_DEBUG);
-						} else {
-							dol_syslog("EmailCollector::doCollectOneCollector message ".($this->uidAsString($imapemail))." to ".$connectstringtarget." was set to read", LOG_DEBUG);
-						}
+						$errorforemail++;
 					}
-				} else {
-					$errorforemail++;
-				}
 
 
-				unset($objectemail);
-				unset($projectstatic);
-				unset($thirdpartystatic);
-				unset($contactstatic);
+					unset($objectemail);
+					unset($projectstatic);
+					unset($thirdpartystatic);
+					unset($contactstatic);
 
-				$nbemailprocessed++;
+					$nbemailprocessed++;
 
-				if (!$errorforemail) {
-					$nbactiondone += $nbactiondoneforemail;
-					$nbemailok++;
+					if (!$errorforemail) {
+						$nbactiondone += $nbactiondoneforemail;
+						$nbemailok++;
 
-					if (empty($mode)) {
-						$this->db->commit();
+						if (empty($mode)) {
+							$this->db->commit();
+						} else {
+							$this->db->rollback();
+						}
+
+						// Stop the loop to process email if we reach maximum collected per collect
+						if ($this->maxemailpercollect > 0 && $nbemailok >= $this->maxemailpercollect) {
+							dol_syslog("EmailCollect::doCollectOneCollector We reach maximum of ".$nbemailok." collected with success, so we stop this collector now.");
+							$datelastok = strtotime($headers['Date']); // Set datetime
+							break;
+						}
 					} else {
+						$error++;
+
 						$this->db->rollback();
 					}
-
-					// Stop the loop to process email if we reach maximum collected per collect
-					if ($this->maxemailpercollect > 0 && $nbemailok >= $this->maxemailpercollect) {
-						dol_syslog("EmailCollect::doCollectOneCollector We reach maximum of ".$nbemailok." collected with success, so we stop this collector now.");
-						$datelastok = strtotime($headers['Date']); // Set datetime
-						break;
+				} catch (Throwable $e) {
+					// One email failed hard (see the try at the top of the loop). Roll back just
+					// this email, log it and continue, so the rest of the batch still drains and
+					// the collector's processing lock is released. Do not bump $error: the other
+					// emails are fine; the poison email is left in the mailbox and re-skipped.
+					try {
+						$this->db->rollback();
+					} catch (Throwable $e2) {
+						// transaction may already be closed; ignore
 					}
-				} else {
-					$error++;
-
-					$this->db->rollback();
+					dol_syslog("EmailCollector::doCollectOneCollector email #".$iforemailloop." skipped due to exception: ".$e->getMessage(), LOG_ERR);
+					continue;
 				}
 			}
 


### PR DESCRIPTION
# FIX EmailCollector: one failing email aborts the whole collector run

## Problem

In `EmailCollector::doCollectOneCollector()`, the per-email loop
`foreach ($richarrayofemail as $tmpval) { … }` has no exception guard.

On PHP 8, mysqli throws on a query error instead of returning `false`. So a single
problematic email — e.g. one whose processing hits a duplicate unique-key constraint, or
an invalid date value — raises an **uncaught exception that aborts the entire collector
run**. Because it aborts mid-loop:

- `datelastresult` is not updated,
- the collector's `processing` lock is not released (it stays stuck/stalled), and
- the remaining emails in the batch are never processed.

A single bad message therefore blocks the whole collector indefinitely.

## Fix

Wrap each iteration body in `try { … } catch (Throwable $e)`: on failure, roll back just
that email, log it (`email #N skipped due to exception`), and `continue`. `$error` is
intentionally **not** incremented, so the other emails in the batch still complete and the
processing lock is released; the failing email is left in the mailbox and harmlessly
re-skipped on the next run.

The only logical change is the added `try {` / `} catch { … }`. The loop body is
re-indented one level for the new scope (required by the code style check), so the diff is
large but mostly whitespace — **review with whitespace hidden (`?w=1`)**.
