### PR TITLE
Fix #38477 build signed PDF for any bank PDF model, not only sepamandate

### DIFF
--- a/htdocs/core/ajax/onlineSign.php
+++ b/htdocs/core/ajax/onlineSign.php
@@ -663,6 +663,13 @@ if ($action == "importSignature") {
 						if ($last_modelpdf == 'sepamandate') {
 							$newpdffilename = $upload_dir . $langs->transnoentitiesnoconv("SepaMandateShort") . ' ' . dol_sanitizeFileName($object->ref) . "-" . dol_sanitizeFileName($object->rum) . "_signed-" . $date . ".pdf";
 							$sourcefile = $upload_dir . $langs->transnoentitiesnoconv("SepaMandateShort") . ' ' . dol_sanitizeFileName($object->ref) . "-" . dol_sanitizeFileName($object->rum) . ".pdf";
+						} else {
+							// Fallback for setups using a non-default bank PDF model (eg. "ban"): take the last
+							// generated main document as source and append "_signed-<date>" before the extension.
+							// Without this the signed PDF is never built and the download link keeps pointing at
+							// the unsigned original.
+							$sourcefile = DOL_DATA_ROOT . '/' . $last_main_doc_file;
+							$newpdffilename = preg_replace('/\.pdf$/i', '_signed-' . $date . '.pdf', $sourcefile);
 						}
 						if (dol_is_file($sourcefile)) {
 							$parameters = array('sourcefile' => $sourcefile, 'newpdffilename' => $newpdffilename);


### PR DESCRIPTION
Split out of #38518 per eldy's "PR to split" label - this PR carries only the SEPA mandate / bank PDF fallback.

The signed-PDF builder in `htdocs/core/ajax/onlineSign.php` only set `$sourcefile` and `$newpdffilename` when `$last_modelpdf == 'sepamandate'`. For any other bank PDF model (eg. `ban`) both stayed empty, the `dol_is_file($sourcefile)` check failed silently, no signed PDF was built, and the public download link kept pointing at the unsigned original.

Add an else branch that derives source from `$last_main_doc_file` and the signed name by appending `_signed-<date>` before the extension.