### PR TITLE
Workstation_extrafields table missing

### DIFF
--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -440,4 +440,15 @@ INSERT INTO llx_accounting_system (fk_country, pcg_version, label, active) VALUE
 -- Rename OIDC enable constant: openidconnect was converted from a module to a config-level feature (#36051)
 UPDATE llx_const SET name = 'MAIN_AUTHENTICATION_OIDC_ON' WHERE name = 'MAIN_MODULE_OPENIDCONNECT';
 
+-- this table was created only during fresh install
+CREATE llx_workstation_workstation_extrafields
+(
+    rowid           integer     AUTO_INCREMENT PRIMARY KEY,
+    tms             timestamp   DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    fk_object       integer     NOT NULL,
+    import_key      varchar(14)                          -- import key
+) ENGINE=innodb;
+
+ALTER TABLE llx_workstation_workstation_extrafields ADD INDEX idx_workstation_workstation_extrafields (fk_object);
+
 -- end of migration


### PR DESCRIPTION
llx_workstation_workstation_extrafields is missing in v23 if this was migrated from precedent dolibarr version

<img width="1718" height="696" alt="image" src="https://github.com/user-attachments/assets/d2c7ad79-8d5b-4276-ac97-ec71e0dd058b" />

