### PR TITLE
NEW add agenda event link to AI request log

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -126,6 +126,7 @@ CREATE TABLE llx_ai_request_log
   entity				        integer DEFAULT 1 NOT NULL,
   date_request			    	datetime,
   fk_user     			    	integer NOT NULL,
+  fk_actioncomm			    	integer,
   query_text        	  		text,
   tool_name     		    	varchar(255),
   provider   			      	varchar(50),
@@ -133,6 +134,9 @@ CREATE TABLE llx_ai_request_log
   confidence        	  		float,
   status            	  		varchar(50),
   error_msg         	  		text,
+  input_hash         	  		varchar(80),
+  output_hash        	  		varchar(80),
+  security_hash      	  		varchar(80),
   raw_request_payload   		MEDIUMTEXT,
   raw_response_payload			MEDIUMTEXT
 )ENGINE=innodb;
@@ -142,7 +146,10 @@ ALTER TABLE llx_prelevement_bons ADD COLUMN tms timestamp DEFAULT CURRENT_TIMEST
 ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_entity (entity);
 ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_date (date_request);
 ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_user (fk_user);
+ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_fk_actioncomm (fk_actioncomm);
 ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_status (status);
+ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_input_hash (input_hash);
+ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_security_hash (security_hash);
 
 -- Add parent group support for usergroup inheritance
 ALTER TABLE llx_usergroup ADD COLUMN fk_parent integer DEFAULT NULL AFTER entity;

--- a/htdocs/install/mysql/tables/llx_ai_request_log-ai.key.sql
+++ b/htdocs/install/mysql/tables/llx_ai_request_log-ai.key.sql
@@ -27,5 +27,14 @@ ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_date (date_request);
 -- Index for searching by user
 ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_user (fk_user);
 
+-- Index for searching by linked agenda event
+ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_fk_actioncomm (fk_actioncomm);
+
 -- Index for filtering by status
 ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_status (status);
+
+-- Index for searching by input hash
+ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_input_hash (input_hash);
+
+-- Index for searching by security hash
+ALTER TABLE llx_ai_request_log ADD INDEX idx_ai_request_log_security_hash (security_hash);

--- a/htdocs/install/mysql/tables/llx_ai_request_log-ai.sql
+++ b/htdocs/install/mysql/tables/llx_ai_request_log-ai.sql
@@ -24,6 +24,7 @@ create table llx_ai_request_log
   entity					integer DEFAULT 1 NOT NULL,
   date_request				datetime,
   fk_user					integer NOT NULL,						-- ID of user
+  fk_actioncomm				integer,								-- Optional linked agenda event
   query_text				text,									-- User prompt
   tool_name					varchar(255),							-- Tool used
   provider					varchar(50),							-- LLM provider
@@ -31,6 +32,9 @@ create table llx_ai_request_log
   confidence				float,									-- LLM confidence
   status					varchar(50),							-- Response status
   error_msg					text,									-- Error message
+  input_hash				varchar(80),							-- Hash of input payload or source content
+  output_hash				varchar(80),							-- Hash of response payload
+  security_hash				varchar(80),							-- Hash linking entity/event/input/output metadata
   raw_request_payload		MEDIUMTEXT,								-- Request payload
   raw_response_payload		MEDIUMTEXT								-- Response payload
 )ENGINE=innodb;


### PR DESCRIPTION
## Summary

This PR reuses and enhances the existing `llx_ai_request_log` table instead of adding a new AI event table.

It replaces the previous proposal from #38698, which introduced `llx_actioncomm_ai`. Following review feedback, the goal is now to keep a single AI audit/log table and add only the missing metadata needed to link an AI request to an agenda event.

## Why reuse `llx_ai_request_log`

`llx_ai_request_log` already stores AI request audit data:

- entity;
- user;
- date;
- prompt/query text;
- tool name;
- provider;
- execution time;
- confidence;
- status/error;
- raw request payload;
- raw response payload.

For EmailCollector / agenda-event AI processing, the missing part is not a new table. The missing part is the ability to link a log entry to the Dolibarr event that represents the original business interaction.

## Added fields

- `fk_actioncomm`: optional link to the agenda event associated with this AI request.
- `input_hash`: hash of the input payload or source content.
- `output_hash`: hash of the AI response payload.
- `security_hash`: integrity hash linking entity/event/input/output metadata.

## Added indexes

- `idx_ai_request_log_fk_actioncomm`
- `idx_ai_request_log_input_hash`
- `idx_ai_request_log_security_hash`

## Use cases

### Email cleaner

An EmailCollector message is recorded as an agenda event. The EmailCleaner can then store its AI preprocessing output in `llx_ai_request_log`:

- `fk_actioncomm`: event id;
- `tool_name`: `email_cleaner`;
- `query_text`: short technical description/message id;
- `raw_request_payload`: collected email metadata;
- `raw_response_payload`: cleaned text, thread metadata, attachment metadata, confidence and handoff payload;
- `input_hash`, `output_hash`, `security_hash`: audit traceability.

### Assistant or MCP tool calls linked to an event

A future assistant action may be related to an agenda event, for example summarizing a meeting note or preparing a follow-up suggestion. The request can be logged in the same table with `fk_actioncomm` set, without introducing another module-specific log table.

## Scope

This PR only enhances the existing AI request log table.

It does not add AI runtime behavior and does not change EmailCollector behavior by itself.

Runtime usage is proposed separately in #38699.
