### PR TITLE
Fix #37619 strip leading and trailing delimiters in isStringVarMatching

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11694,6 +11694,12 @@ function dol_getIdFromCode($db, $key, $tablename, $fieldkey = 'code', $fieldid =
  */
 function isStringVarMatching($var, $regextext, $matchrule = 1)
 {
+	// Tolerate callers (custom modules, older code) that already pass a full regex with delimiters
+	// like '/^(aaa|bbb)/' instead of the bare body. Without this, the function would build
+	// '/^/^(aaa|bbb)//' which trips preg_match() with 'Unknown modifier ^'.
+	$regextext = preg_replace('#^/\^?#', '', (string) $regextext);
+	$regextext = preg_replace('#\$?/[imsxuADSUXJ]*$#', '', $regextext);
+
 	if ($matchrule == 1) {
 		if ($var == 'mainmenu') {
 			global $mainmenu;


### PR DESCRIPTION
`isStringVarMatching($var, $regextext)` wraps the input with `/^` and `/` before `preg_match`, but custom modules and older code sometimes pass the full regex with delimiters (eg. `/^(admintools|all)/`). The double wrap produces `/^/^(admintools|all)//` which trips `preg_match() Unknown modifier '^'` on every page load - exactly what the reporter sees.

Strip a leading `/` (optionally followed by `^`) and any trailing `$?/` plus PCRE flags before reusing the pattern. Both bare (`(admintools|all)`) and already-delimited forms now match the same way.

Verified in Docker on 5 input shapes (bare, `^...`, `/^.../`, `/^.../i`, plain word) - no warnings on any.