### PR TITLE
fix: render imported standalone shipment lines

### DIFF
--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -519,7 +519,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes' && !empty($permissionto
 		if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
 			$newlang = GETPOST('lang_id', 'aZ09');
 		}
-		if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang) && is_object($object->thirdparty)) {
+		if (getDolGlobalInt('MAIN_MULTILANGS') && is_object($object->thirdparty)) {
 			$newlang = $object->thirdparty->default_lang;
 		}
 		if (!empty($newlang)) {
@@ -564,7 +564,7 @@ if ($action == 'confirm_validate' && $confirm == 'yes' && $permissiontoadd) {
 				if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
-				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
+				if (getDolGlobalInt('MAIN_MULTILANGS')) {
 					$newlang = !empty($object->thirdparty->default_lang) ? $object->thirdparty->default_lang : "";
 				}
 				if (!empty($newlang)) {
@@ -601,7 +601,7 @@ if ($action == 'confirm_close' && $confirm == 'yes' && $permissiontoadd) {
 				if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
-				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
+				if (getDolGlobalInt('MAIN_MULTILANGS')) {
 					$newlang = $object->thirdparty->default_lang;
 				}
 				if (!empty($newlang)) {

--- a/htdocs/core/actions_addupdatedelete.inc.php
+++ b/htdocs/core/actions_addupdatedelete.inc.php
@@ -519,7 +519,7 @@ if ($action == 'confirm_deleteline' && $confirm == 'yes' && !empty($permissionto
 		if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
 			$newlang = GETPOST('lang_id', 'aZ09');
 		}
-		if (getDolGlobalInt('MAIN_MULTILANGS') && is_object($object->thirdparty)) {
+		if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang) && is_object($object->thirdparty)) {
 			$newlang = $object->thirdparty->default_lang;
 		}
 		if (!empty($newlang)) {
@@ -564,7 +564,7 @@ if ($action == 'confirm_validate' && $confirm == 'yes' && $permissiontoadd) {
 				if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
-				if (getDolGlobalInt('MAIN_MULTILANGS')) {
+				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
 					$newlang = !empty($object->thirdparty->default_lang) ? $object->thirdparty->default_lang : "";
 				}
 				if (!empty($newlang)) {
@@ -601,7 +601,7 @@ if ($action == 'confirm_close' && $confirm == 'yes' && $permissiontoadd) {
 				if (getDolGlobalInt('MAIN_MULTILANGS') /* && empty($newlang) */ && GETPOST('lang_id', 'aZ09')) {
 					$newlang = GETPOST('lang_id', 'aZ09');
 				}
-				if (getDolGlobalInt('MAIN_MULTILANGS')) {
+				if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
 					$newlang = $object->thirdparty->default_lang;
 				}
 				if (!empty($newlang)) {

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -3104,7 +3104,7 @@ if ($action == 'create' && $usercancreate) {
 			}
 
 			print '<div class="div-table-responsive-no-min">';
-			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline')) {
+			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline' && getDolGlobalString('SHIPMENT_STANDALONE'))) {
 				print '<table id="tablelines" class="noborder noshadow" width="100%">';
 			}
 
@@ -3113,7 +3113,7 @@ if ($action == 'create' && $usercancreate) {
 			}
 
 			// Form to add new line
-			if ($object->status == 0 && $permissiontoadd && $action != 'selectlines') {
+			if ($object->status == 0 && $permissiontoadd && $action != 'selectlines' && getDolGlobalString('SHIPMENT_STANDALONE')) {
 				if ($action != 'editline') {
 					// Add products/services form
 
@@ -3128,7 +3128,7 @@ if ($action == 'create' && $usercancreate) {
 				}
 			}
 
-			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline')) {
+			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline' && getDolGlobalString('SHIPMENT_STANDALONE'))) {
 				print '</table>';
 			}
 			print '</div>';
@@ -3137,8 +3137,11 @@ if ($action == 'create' && $usercancreate) {
 		}
 	}
 
-	// Lines of products of origin
-	if (!empty($object->origin) && $object->origin_id > 0) {
+	$showoriginlines = ($object->origin_id > 0);
+	$showimportedstandalonelines = (empty($object->origin_id) && $object->id > 0 && !empty($object->lines) && !getDolGlobalString('SHIPMENT_STANDALONE'));
+
+	// Lines of products of origin or imported standalone shipments
+	if ($showoriginlines || $showimportedstandalonelines) {
 		if ($action == 'editline') {
 			print '	<form name="updateline" id="updateline" action="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&amp;lineid=' . $line_id . '" method="POST">
 			<input type="hidden" name="token" value="' . newToken() . '">
@@ -3160,8 +3163,8 @@ if ($action == 'create' && $usercancreate) {
 		// Product/Service
 		print '<td  class="linecoldescription" >' . $langs->trans("Products") . '</td>';
 		// Qty
-		print '<td class="center linecolqty">' . $langs->trans("QtyOrdered") . '</td>';
 		if ($origin_id > 0) {
+			print '<td class="center linecolqty">' . $langs->trans("QtyOrdered") . '</td>';
 			print '<td class="center linecolqtyinothershipments">' . $langs->trans("QtyInOtherShipments") . '</td>';
 		}
 		if ($action == 'editline') {
@@ -3370,7 +3373,9 @@ if ($action == 'create' && $usercancreate) {
 				}
 
 				// Qty ordered
-				print '<td class="center linecolqty">' . $lines[$i]->qty_asked . ' ' . $unit_order . '</td>';
+				if ($origin_id > 0) {
+					print '<td class="center linecolqty">' . $lines[$i]->qty_asked . ' ' . $unit_order . '</td>';
+				}
 
 				// Qty in other shipments (with shipment and warehouse used)
 				if ($origin_id > 0) {
@@ -3662,7 +3667,7 @@ if ($action == 'create' && $usercancreate) {
 				// Display lines extrafields.
 				// $line is a line of shipment
 
-				$colspan = 6;
+				$colspan = ($origin_id > 0 ? 6 : 5);
 				if ($origin_id > 0) {
 					$colspan++;
 				}

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -3104,7 +3104,7 @@ if ($action == 'create' && $usercancreate) {
 			}
 
 			print '<div class="div-table-responsive-no-min">';
-			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline' && getDolGlobalString('SHIPMENT_STANDALONE'))) {
+			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline')) {
 				print '<table id="tablelines" class="noborder noshadow" width="100%">';
 			}
 
@@ -3113,7 +3113,7 @@ if ($action == 'create' && $usercancreate) {
 			}
 
 			// Form to add new line
-			if ($object->status == 0 && $permissiontoadd && $action != 'selectlines' && getDolGlobalString('SHIPMENT_STANDALONE')) {
+			if ($object->status == 0 && $permissiontoadd && $action != 'selectlines') {
 				if ($action != 'editline') {
 					// Add products/services form
 
@@ -3128,7 +3128,7 @@ if ($action == 'create' && $usercancreate) {
 				}
 			}
 
-			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline' && getDolGlobalString('SHIPMENT_STANDALONE'))) {
+			if (!empty($object->lines) || ($object->status == $object::STATUS_DRAFT && $permissiontoadd && $action != 'selectlines' && $action != 'editline')) {
 				print '</table>';
 			}
 			print '</div>';

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2349,8 +2349,13 @@ class Expedition extends CommonObject
 		global $mysoc;
 
 		$this->lines = array();
+		$shipmentlinebatch = new ExpeditionLineBatch($this->db);
 
-		$sql = 'SELECT ed.rowid, ed.fk_expedition, ed.fk_entrepot, ed.fk_product, ed.fk_unit, ed.description, ed.fk_elementdet, ed.fk_element, ed.element_type, ed.qty, ed.rang';
+		$sql = 'SELECT ed.rowid, ed.fk_expedition, ed.fk_entrepot, ed.fk_product, ed.fk_unit, ed.description, ed.fk_elementdet, ed.fk_element, ed.element_type, ed.qty, ed.rang, ed.extraparams';
+		$sql .= ', p.ref as product_ref, p.label as product_label, p.description as product_desc, p.fk_product_type, p.barcode as product_barcode';
+		$sql .= ', p.weight, p.weight_units, p.length, p.length_units, p.width, p.width_units, p.height, p.height_units';
+		$sql .= ', p.surface, p.surface_units, p.volume, p.volume_units, p.tosell as product_tosell, p.tobuy as product_tobuy';
+		$sql .= ', p.tobatch as product_tobatch, p.stockable_product';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.$this->table_element_line.' as ed';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON (p.rowid = ed.fk_product)';
 		$sql .= ' WHERE ed.fk_expedition = '.((int) $this->id);
@@ -2370,15 +2375,65 @@ class Expedition extends CommonObject
 				$line->rowid            = $objp->rowid;
 				$line->id				= $objp->rowid;
 				$line->fk_expedition	= $this->id;
+				$line->qty_shipped      = $objp->qty;
+				$line->qty_asked        = $objp->qty;
 				$line->description      = $objp->description;
 				$line->qty              = $objp->qty;
 				$line->fk_entrepot      = $objp->fk_entrepot;
+				$line->entrepot_id      = $objp->fk_entrepot;
 				$line->fk_product       = $objp->fk_product;
+				$line->product_type     = $objp->fk_product_type;
+				$line->fk_product_type  = $objp->fk_product_type;
+				$line->ref              = $objp->product_ref;
+				$line->product_ref      = $objp->product_ref;
+				$line->product_label    = $objp->product_label;
+				$line->libelle          = $objp->product_label;
+				$line->label            = $objp->product_label;
+				$line->product_desc     = $objp->product_desc;
+				$line->desc             = $objp->description;
+				$line->product_barcode  = $objp->product_barcode;
+				$line->product_tosell   = $objp->product_tosell;
+				$line->product_tobuy    = $objp->product_tobuy;
+				$line->product_tobatch  = $objp->product_tobatch;
+				$line->stockable_product = $objp->stockable_product;
+				$line->weight           = $objp->weight;
+				$line->weight_units     = $objp->weight_units;
+				$line->length           = $objp->length;
+				$line->length_units     = $objp->length_units;
+				$line->width            = $objp->width;
+				$line->width_units      = $objp->width_units;
+				$line->height           = $objp->height;
+				$line->height_units     = $objp->height_units;
+				$line->surface          = $objp->surface;
+				$line->surface_units    = $objp->surface_units;
+				$line->volume           = $objp->volume;
+				$line->volume_units     = $objp->volume_units;
 				$line->rang             = $objp->rang;
 				$line->fk_element 		= $objp->fk_element;
+				$line->origin_id        = $objp->fk_element;
 				$line->fk_unit          = $objp->fk_unit;
 				$line->fk_elementdet 	= $objp->fk_elementdet;
-				$line->fk_element_type 	= $objp->element_type;
+				$line->origin_line_id   = $objp->fk_elementdet;
+				$line->element_type 	= $objp->element_type;
+				$line->fk_origin        = $objp->element_type;
+				$line->extraparams      = !empty($objp->extraparams) ? (array) json_decode($objp->extraparams, true) : array();
+
+				$detail_entrepot = new stdClass();
+				$detail_entrepot->entrepot_id = $objp->fk_entrepot;
+				$detail_entrepot->qty_shipped = $objp->qty;
+				$detail_entrepot->line_id = $objp->rowid;
+				$line->details_entrepot = array($detail_entrepot);
+
+				$line->detail_batch = array();
+				if (isModEnabled('productbatch') && $objp->rowid > 0 && $objp->product_tobatch > 0) {
+					$newdetailbatch = $shipmentlinebatch->fetchAll($objp->rowid, $objp->fk_product);
+					if (is_array($newdetailbatch)) {
+						foreach ($newdetailbatch as $detailbatch) {
+							$detailbatch->entrepot_id = $detailbatch->fk_warehouse;
+						}
+						$line->detail_batch = $newdetailbatch;
+					}
+				}
 				$line->fetch_optionals();
 
 				$this->lines[$i] = $line;


### PR DESCRIPTION
# FIX: shipment card display for imported shipments without source link
Imported shipments can have valid rows in `llx_expeditiondet` even when there is no `element_element` header link to a source document.

Those shipments are loaded through `Expedition::fetch_lines_free()`, but that loader currently hydrates only a small subset of fields. When the richer shipment table is used, most cells stay empty because the line object has no shipped qty, warehouse details, product metadata, or lot/batch details.

This patch:
- keeps the standalone add-line block gated behind `SHIPMENT_STANDALONE`
- shows existing no-origin shipments in the richer shipment table even when `SHIPMENT_STANDALONE` is disabled
- hides origin-only columns for those shipments
- enriches `Expedition::fetch_lines_free()` with the fields the shipment renderer already expects, including warehouse and batch data

This only makes existing imported no-origin shipments readable in the card view. It does not introduce a new standalone shipment creation workflow.