### PR TITLE
Fix #36749 verify php-dom at install time

### DIFF
--- a/htdocs/install/check.php
+++ b/htdocs/install/check.php
@@ -255,6 +255,13 @@ if (!class_exists('ZipArchive')) {
 	$extensionok[] = 'ZIP';
 }
 
+// Check if DOM is supported (used by dol_htmlwithnojs/DOMDocument, login.tpl.php fatals otherwise)
+if (!class_exists('DOMDocument')) {
+	$extensionko[] = 'DOM';
+} else {
+	$extensionok[] = 'DOM';
+}
+
 if (!empty($extensionok)) {
 	//print '<img src="../theme/eldy/img/tick.png" alt="Ok" class="valignmiddle pictofixedwidth"> ';
 	print img_picto('', 'tick', 'class="pictofixedwidth"');


### PR DESCRIPTION
The installer's `check.php` already lists mbstring, JSON, GD, Curl, Calendar, Xml, UTF8, Intl, IMAP, ZIP but never tests DOM or Ctype. Without DOM the login page fatals on "Class DOMDocument not found" coming from `dol_htmlwithnojs()` (`htdocs/core/lib/functions.lib.php:8812`) called by `dolPrintHTML()` in `login.tpl.php:272` - exactly the stack from #36749. Without Ctype several html sanitizers surface the same white-page symptom (#36750).

Add both checks alongside the existing ones, using the same warning-not-blocking pattern.