### PR TITLE
Fix #37322 set IPP document-format from file extension in PrintIPP

### DIFF
--- a/htdocs/core/modules/printing/printipp.modules.php
+++ b/htdocs/core/modules/printing/printipp.modules.php
@@ -169,6 +169,23 @@ class printing_printipp extends PrintingDriver
 		}
 		$fileprint .= '/'.$file;
 		$ipp->setData($fileprint);
+		// Tell CUPS what we are sending so it picks the right filter chain (otherwise ODT/PDF arrive as raw and print as ASCII garbage).
+		$extension = strtolower(pathinfo($fileprint, PATHINFO_EXTENSION));
+		$mimebyext = array(
+			'pdf' => 'application/pdf',
+			'odt' => 'application/vnd.oasis.opendocument.text',
+			'ods' => 'application/vnd.oasis.opendocument.spreadsheet',
+			'odp' => 'application/vnd.oasis.opendocument.presentation',
+			'ps' => 'application/postscript',
+			'eps' => 'application/postscript',
+			'txt' => 'text/plain',
+			'png' => 'image/png',
+			'jpg' => 'image/jpeg',
+			'jpeg' => 'image/jpeg',
+		);
+		if (isset($mimebyext[$extension])) {
+			$ipp->setMimeMediaType($mimebyext[$extension]);
+		}
 		try {
 			$ipp->printJob();
 		} catch (Exception $e) {


### PR DESCRIPTION
The PrintIPP driver at `htdocs/core/modules/printing/printipp.modules.php:171` calls `$ipp->setData($fileprint)` and never tells CUPS what the file actually is, so the job arrives with the default `application/octet-stream` and CUPS treats ODT/PDF/PS as raw bytes - the ASCII garbage symptom the reporter described.

Map the file extension to a known MIME (pdf, odt, ods, odp, ps, eps, txt, png, jpg, jpeg) and call `$ipp->setMimeMediaType()` when recognised. Unknown extensions fall through to the existing default behaviour, so existing setups are not affected.