### PR TITLE
Fix #35815 initHooks on payment document.php pages

### DIFF
--- a/htdocs/compta/paiement/document.php
+++ b/htdocs/compta/paiement/document.php
@@ -52,6 +52,8 @@ if (isModEnabled('project')) {
 // Load translation files required by the page
 $langs->loadLangs(array('bills', 'banks', 'companies', 'suppliers', 'other'));
 
+$hookmanager->initHooks(array('paymentdocument', 'globalcard'));
+
 $id = GETPOSTINT('id');
 $ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'aZ09');

--- a/htdocs/fourn/paiement/document.php
+++ b/htdocs/fourn/paiement/document.php
@@ -54,6 +54,8 @@ if (isModEnabled('project')) {
 // Load translation files required by the page
 $langs->loadLangs(array('banks', 'bills', 'companies', 'suppliers', 'other'));
 
+$hookmanager->initHooks(array('paymentsupplierdocument', 'globalcard'));
+
 
 // Get Parameters
 $id = GETPOSTINT('id');


### PR DESCRIPTION
`compta/paiement/document.php` and `fourn/paiement/document.php` expose `$hookmanager` via the @var docblock but never call `initHooks`, so the include of `core/actions_linkedfiles.inc.php` and the rest of the page can't run any custom-module hook context. Sibling files like `commande/document.php` already do this at line 95.

Add `$hookmanager->initHooks(array('paymentdocument', 'globalcard'))` to the customer-payment page and `paymentsupplierdocument` to the supplier-payment page, right after `$langs->loadLangs(...)`.