### PR TITLE
Fix #34931 strip surrounding & from action=reconcile in bank delete link

### DIFF
--- a/htdocs/compta/bank/bankentries_list.php
+++ b/htdocs/compta/bank/bankentries_list.php
@@ -1913,7 +1913,9 @@ if ($resql) {
 				}
 			}
 			if ($user->hasRight('banque', 'modifier')) {
-				$parambis = preg_replace('/action=reconcile/', '', $param);
+				// Strip the surrounding & so the leading action= we put first stays the only action= in the URL.
+				// Without this the URL ends up with two action= params; PHP picks the last one and the page silently switches to 'reconcile' instead of 'delete'.
+				$parambis = preg_replace('/&?action=(reconcile|confirm_deleteonreconcile)(&|$)/', '\2', $param);
 				print '<a href="'.$_SERVER["PHP_SELF"].'?action='.($action == 'reconcile' ? 'confirm_deleteonreconcile&confirm=yes' : 'delete').'&token='.newToken().'&rowid='.$objp->rowid.'&page='.$page.$parambis.($sortfield ? '&sortfield='.$sortfield : '').($sortorder ? '&sortorder='.$sortorder : '').'">';
 				print img_delete('', 'class="marginleftonly"');
 				print '</a>';


### PR DESCRIPTION
The delete-icon link on `htdocs/compta/bank/bankentries_list.php:1916` stripped `action=reconcile` from `$param` but left a stray trailing `&` (and the same string is re-emitted by includes), so the final URL the reporter shared has two `action=` query params: `action=delete&...&action=reconcile&...`. PHP picks the last one, the page silently switches to the reconcile path, and the delete confirm dialog never opens - exactly the symptom.

Widen the `preg_replace` to consume the surrounding `&` (and to also drop a stray `confirm_deleteonreconcile` for symmetry). The leading `action=` we put first becomes the only `action=` in the URL.