### PR TITLE
Fix #38036 keep vat_src_code when converting deposit invoice into discount

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -541,41 +541,47 @@ class Paiement extends CommonObject
 										$discount->fk_facture_source = $invoice->id;
 
 										// Loop on each vat rate
+										// Bucket by tva_tx and vat_src_code so the generated discount keeps the source VAT code
 										$i = 0;
 										foreach ($invoice->lines as $line) {
 											if ($line->product_type != 9 && $line->total_ht != 0) {    // no need to create discount if amount is null or is special product
-												if (!array_key_exists($line->tva_tx, $amount_ht)) {
-													$amount_ht[$line->tva_tx] = 0.0;
-													$amount_tva[$line->tva_tx] = 0.0;
-													$amount_ttc[$line->tva_tx] = 0.0;
-													$multicurrency_amount_ht[$line->tva_tx] = 0.0;
-													$multicurrency_amount_tva[$line->tva_tx] = 0.0;
-													$multicurrency_amount_ttc[$line->tva_tx] = 0.0;
+												$key = $line->tva_tx.'|'.(string) $line->vat_src_code;
+												if (!array_key_exists($key, $amount_ht)) {
+													$amount_ht[$key] = 0.0;
+													$amount_tva[$key] = 0.0;
+													$amount_ttc[$key] = 0.0;
+													$multicurrency_amount_ht[$key] = 0.0;
+													$multicurrency_amount_tva[$key] = 0.0;
+													$multicurrency_amount_ttc[$key] = 0.0;
 												}
-												$amount_ht[$line->tva_tx] += $line->total_ht;
-												$amount_tva[$line->tva_tx] += $line->total_tva;
-												$amount_ttc[$line->tva_tx] += $line->total_ttc;
-												$multicurrency_amount_ht[$line->tva_tx] += $line->multicurrency_total_ht;
-												$multicurrency_amount_tva[$line->tva_tx] += $line->multicurrency_total_tva;
-												$multicurrency_amount_ttc[$line->tva_tx] += $line->multicurrency_total_ttc;
+												$amount_ht[$key] += $line->total_ht;
+												$amount_tva[$key] += $line->total_tva;
+												$amount_ttc[$key] += $line->total_ttc;
+												$multicurrency_amount_ht[$key] += $line->multicurrency_total_ht;
+												$multicurrency_amount_tva[$key] += $line->multicurrency_total_tva;
+												$multicurrency_amount_ttc[$key] += $line->multicurrency_total_ttc;
 												$i++;
 											}
 										}
 
-										foreach ($amount_ht as $tva_tx => $xxx) {
-											$discount->amount_ht = abs($amount_ht[$tva_tx]);
-											$discount->total_ht = abs($amount_ht[$tva_tx]);
-											$discount->amount_tva = abs($amount_tva[$tva_tx]);
-											$discount->total_tva = abs($amount_tva[$tva_tx]);
-											$discount->amount_ttc = abs($amount_ttc[$tva_tx]);
-											$discount->total_ttc = abs($amount_ttc[$tva_tx]);
-											$discount->multicurrency_amount_ht = abs($multicurrency_amount_ht[$tva_tx]);
-											$discount->multicurrency_total_ht = abs($multicurrency_amount_ht[$tva_tx]);
-											$discount->multicurrency_amount_tva = abs($multicurrency_amount_tva[$tva_tx]);
-											$discount->multicurrency_total_tva = abs($multicurrency_amount_tva[$tva_tx]);
-											$discount->multicurrency_amount_ttc = abs($multicurrency_amount_ttc[$tva_tx]);
-											$discount->multicurrency_total_ttc = abs($multicurrency_amount_ttc[$tva_tx]);
+										foreach ($amount_ht as $key => $xxx) {
+											$parts = explode('|', (string) $key, 2);
+											$tva_tx = $parts[0];
+											$vat_src_code = isset($parts[1]) ? $parts[1] : '';
+											$discount->amount_ht = abs($amount_ht[$key]);
+											$discount->total_ht = abs($amount_ht[$key]);
+											$discount->amount_tva = abs($amount_tva[$key]);
+											$discount->total_tva = abs($amount_tva[$key]);
+											$discount->amount_ttc = abs($amount_ttc[$key]);
+											$discount->total_ttc = abs($amount_ttc[$key]);
+											$discount->multicurrency_amount_ht = abs($multicurrency_amount_ht[$key]);
+											$discount->multicurrency_total_ht = abs($multicurrency_amount_ht[$key]);
+											$discount->multicurrency_amount_tva = abs($multicurrency_amount_tva[$key]);
+											$discount->multicurrency_total_tva = abs($multicurrency_amount_tva[$key]);
+											$discount->multicurrency_amount_ttc = abs($multicurrency_amount_ttc[$key]);
+											$discount->multicurrency_total_ttc = abs($multicurrency_amount_ttc[$key]);
 											$discount->tva_tx = abs((float) $tva_tx);
+											$discount->vat_src_code = $vat_src_code;
 
 											$result = $discount->create($user);
 											if ($result < 0) {


### PR DESCRIPTION
Fix #38036.

When a paid deposit invoice is auto-converted into a discount in `Paiement::create()`, the per-rate buckets were keyed on `tva_tx` alone. Lines sharing a rate but with distinct `vat_src_code` values got merged into one bucket, and the generated `societe_remise_except` row was always created with an empty `vat_src_code`.

A later 'Apply discount' on the standard invoice therefore inserts a discount line without the source VAT code, while the deposit lines keep it. The PDF then shows two VAT lines for the same rate (one with the code, one without).

Bucket by `tva_tx . '|' . vat_src_code`, parse both back when looping, and assign `vat_src_code` on the generated discount before `create()`.

Unit-level validation (synthetic invoice lines): 3 lines at 20% CGV20 + 2 lines at 20% no-code + 1 line at 10%. Old code yields 1 bucket at 20% with code='' and ht=190. New code yields 2 buckets at 20% (CGV20 ht=150, no-code ht=40). Total HT identical (220 in both).