### PR TITLE
Fix #37443 avoid null property warning on clientfourn report amounts

### DIFF
--- a/htdocs/compta/resultat/clientfourn.php
+++ b/htdocs/compta/resultat/clientfourn.php
@@ -1183,15 +1183,16 @@ if ($modecompta == 'BOOKKEEPING') {
 				$total_ht_outcome += $obj->amount;
 				$total_ttc_outcome += $obj->amount;
 			}
+			$debit_amount = isset($obj->amount) ? $obj->amount : 0;
 			print '<tr class="oddeven">';
 			print '<td>&nbsp;</td>';
 			print "<td>".$langs->trans("AccountingDebit")."</td>\n";
 			print '<td class="right">';
 			if ($modecompta == 'CREANCES-DETTES') {
-				print '<span class="amount">'.price(-$obj->amount).'</span>';
+				print '<span class="amount">'.price(-$debit_amount).'</span>';
 			}
 			print '</td>';
-			print '<td class="right"><span class="amount">'.price(-$obj->amount)."</span></td>\n";
+			print '<td class="right"><span class="amount">'.price(-$debit_amount)."</span></td>\n";
 			print "</tr>\n";
 
 			// Credit (payment received from customer for example)
@@ -1203,14 +1204,15 @@ if ($modecompta == 'BOOKKEEPING') {
 				$total_ht_income += $obj->amount;
 				$total_ttc_income += $obj->amount;
 			}
+			$credit_amount = isset($obj->amount) ? $obj->amount : 0;
 			print '<tr class="oddeven"><td>&nbsp;</td>';
 			print "<td>".$langs->trans("AccountingCredit")."</td>\n";
 			print '<td class="right">';
 			if ($modecompta == 'CREANCES-DETTES') {
-				print '<span class="amount">'.price($obj->amount).'</span>';
+				print '<span class="amount">'.price($credit_amount).'</span>';
 			}
 			print '</td>';
-			print '<td class="right"><span class="amount">'.price($obj->amount)."</span></td>\n";
+			print '<td class="right"><span class="amount">'.price($credit_amount)."</span></td>\n";
 			print "</tr>\n";
 
 			// Total


### PR DESCRIPTION
Fix #37443.

The various-payments section of `compta/resultat/clientfourn.php` fetches two rows from a `GROUP BY p.sens` query (debit, credit). When one of the two sens has no payment in the period, the corresponding `fetch_object()` returns null. The totals are already guarded by `isset($obj->amount)`, but the subsequent print statements still dereferenced `$obj->amount`, producing the warning reported when clicking an amount in `compta/resultat/index.php`.

Capture the amount into a local that defaults to 0 when the row is absent and print from that local. Behaviour is unchanged when both rows are present; the warning disappears in the missing-row case, and the printed value is 0 instead of an undefined read.