### PR TITLE
FIX : abandoned invoice should not have remaining to pay (invoice list)

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -2371,7 +2371,7 @@ if ($num > 0) {
 		$multicurrency_totalpay = $multicurrency_paiement + $multicurrency_totalcreditnotes + $multicurrency_totaldeposits;
 		$multicurrency_remaintopay = price2num($facturestatic->multicurrency_total_ttc - $multicurrency_totalpay);
 
-		if ($facturestatic->status == Facture::STATUS_CLOSED) {
+		if (in_array($facturestatic->status, [Facture::STATUS_CLOSED, Facture::STATUS_ABANDONED])) {
 			$remaintopay = 0;
 			$multicurrency_remaintopay = 0;
 		}


### PR DESCRIPTION
Fix the bug : in invoice list, abandoned invoices still have a remain to pay amount, also impacting the remain to pay total.