### PR TITLE
fix: respect line element type in stock and stats 

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2972,13 +2972,14 @@ class Expedition extends CommonObject
 
 		// Loop on each product line to add a stock movement
 		$sql = "SELECT";
-		$sql .= " ed.rowid as edid, ed.fk_product, ed.qty, ed.fk_entrepot";
-		$sql .= ", cd.rowid as cdid";
-		$sql .= ", cd.subprice";
+		$sql .= " ed.rowid as edid, COALESCE(cd.fk_product, pd.fk_product, ed.fk_product) as fk_product, ed.qty, ed.fk_entrepot";
+		$sql .= ", COALESCE(cd.rowid, pd.rowid, 0) as src_line_id";
+		$sql .= ", COALESCE(cd.subprice, pd.subprice, 0) as subprice";
 		$sql .= ", edb.rowid as edbrowid, edb.eatby, edb.sellby, edb.batch, edb.qty as edbqty, edb.fk_origin_stock";
 		$sql .= ", e.ref";
 		$sql .= " FROM " . $this->db->prefix() . "expeditiondet as ed";
-		$sql .= " LEFT JOIN " . $this->db->prefix() . "commandedet as cd ON cd.rowid = ed.fk_elementdet";
+		$sql .= " LEFT JOIN " . $this->db->prefix() . "commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
+		$sql .= " LEFT JOIN " . $this->db->prefix() . "propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
 		$sql .= " LEFT JOIN " . $this->db->prefix() . "expeditiondet_batch as edb on edb.fk_expeditiondet = ed.rowid";
 		$sql .= " INNER JOIN " . $this->db->prefix() . "expedition as e ON ed.fk_expedition = e.rowid";
 		$sql .= " WHERE ed.fk_expedition = " . ((int) $this->id);
@@ -3002,7 +3003,7 @@ class Expedition extends CommonObject
 
 				$mouvS = new MouvementStock($this->db);
 				$mouvS->origin = &$this;
-				$mouvS->setOrigin($this->element, $this->id, $obj->cdid, $obj->edid);
+				$mouvS->setOrigin($this->element, $this->id, $obj->src_line_id, $obj->edid);
 
 				if (empty($obj->edbrowid)) {
 					// line without batch detail
@@ -3136,16 +3137,15 @@ class Expedition extends CommonObject
 
 				$langs->load("agenda");
 
-				// Loop on each product line to add a stock movement
-				// TODO possibilite d'expedier a partir d'une propale ou autre origine
-				$sql = "SELECT cd.fk_product, cd.subprice,";
+				// Loop on each product line to revert stock movement
+				$sql = "SELECT COALESCE(cd.fk_product, pd.fk_product, ed.fk_product) as fk_product, COALESCE(cd.subprice, pd.subprice, 0) as subprice,";
 				$sql .= " ed.rowid, ed.qty, ed.fk_entrepot,";
 				$sql .= " edb.rowid as edbrowid, edb.eatby, edb.sellby, edb.batch, edb.qty as edbqty, edb.fk_origin_stock";
-				$sql .= " FROM ".MAIN_DB_PREFIX."commandedet as cd,";
-				$sql .= " ".MAIN_DB_PREFIX."expeditiondet as ed";
+				$sql .= " FROM ".MAIN_DB_PREFIX."expeditiondet as ed";
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
 				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."expeditiondet_batch as edb on edb.fk_expeditiondet = ed.rowid";
 				$sql .= " WHERE ed.fk_expedition = ".((int) $this->id);
-				$sql .= " AND cd.rowid = ed.fk_elementdet";
 
 				dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 				$resql = $this->db->query($sql);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -3867,28 +3867,58 @@ class Product extends CommonObject
 		// phpcs:enable
 		global $user, $hookmanager, $action;
 
-		$sql = "SELECT COUNT(DISTINCT e.fk_soc) as nb_customers, COUNT(DISTINCT e.rowid) as nb,";
-		$sql .= " COUNT(ed.rowid) as nb_rows, SUM(ed.qty) as qty";
-		$sql .= " FROM ".$this->db->prefix()."societe as s";
-		$sql .= " INNER JOIN ".$this->db->prefix()."expedition as e ON e.fk_soc = s.rowid";
-		$sql .= " INNER JOIN ".$this->db->prefix()."expeditiondet as ed ON ed.fk_expedition = e.rowid";
-		$sql .= " LEFT JOIN ".$this->db->prefix()."commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
-		$sql .= " LEFT JOIN ".$this->db->prefix()."commande as c ON c.rowid = cd.fk_commande";
-		$sql .= " LEFT JOIN ".$this->db->prefix()."propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
+		$sqlwhere = " WHERE e.entity IN (".getEntity($forVirtualStock && getDolGlobalString('STOCK_CALCULATE_VIRTUAL_STOCK_TRANSVERSE_MODE') ? 'stock' : 'expedition').")";
 		if (empty($user->fk_soc) && !$user->hasRight('societe', 'client', 'voir') && !$forVirtualStock) {
-			$sql .= " INNER JOIN ".$this->db->prefix()."societe_commerciaux as sc ON sc.fk_soc = e.fk_soc AND sc.fk_user = ".((int) $user->id);
+			$sqljoinrights = " INNER JOIN ".$this->db->prefix()."societe_commerciaux as sc ON sc.fk_soc = e.fk_soc AND sc.fk_user = ".((int) $user->id);
+		} else {
+			$sqljoinrights = "";
 		}
-		$sql .= " WHERE 1 = 1";
-		$sql .= " AND e.entity IN (".getEntity($forVirtualStock && getDolGlobalString('STOCK_CALCULATE_VIRTUAL_STOCK_TRANSVERSE_MODE') ? 'stock' : 'expedition').")";
-		$sql .= " AND COALESCE(cd.fk_product, pd.fk_product, ed.fk_product) = ".((int) $this->id);
 		if ($socid > 0) {
-			$sql .= " AND e.fk_soc = ".((int) $socid);
-		}
-		if ($filtrestatut != '') {
-			$sql .= " AND (c.fk_statut IN (".$this->db->sanitize($filtrestatut).") OR c.rowid IS NULL)";
+			$sqlwhere .= " AND e.fk_soc = ".((int) $socid);
 		}
 		if (!empty($filterShipmentStatus)) {
-			$sql .= " AND e.fk_statut IN (".$this->db->sanitize($filterShipmentStatus).")";
+			$sqlwhere .= " AND e.fk_statut IN (".$this->db->sanitize($filterShipmentStatus).")";
+		}
+
+		$sqlunion = array();
+
+		$sqlcommande = "SELECT e.fk_soc, e.rowid as expeditionid, ed.rowid as edrowid, ed.qty, c.fk_statut as order_status";
+		$sqlcommande .= " FROM ".$this->db->prefix()."societe as s";
+		$sqlcommande .= " INNER JOIN ".$this->db->prefix()."expedition as e ON e.fk_soc = s.rowid";
+		$sqlcommande .= " INNER JOIN ".$this->db->prefix()."expeditiondet as ed ON ed.fk_expedition = e.rowid";
+		$sqlcommande .= " INNER JOIN ".$this->db->prefix()."commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
+		$sqlcommande .= " LEFT JOIN ".$this->db->prefix()."commande as c ON c.rowid = cd.fk_commande";
+		$sqlcommande .= $sqljoinrights;
+		$sqlcommande .= $sqlwhere;
+		$sqlcommande .= " AND cd.fk_product = ".((int) $this->id);
+		$sqlunion[] = $sqlcommande;
+
+		$sqlpropal = "SELECT e.fk_soc, e.rowid as expeditionid, ed.rowid as edrowid, ed.qty, NULL as order_status";
+		$sqlpropal .= " FROM ".$this->db->prefix()."societe as s";
+		$sqlpropal .= " INNER JOIN ".$this->db->prefix()."expedition as e ON e.fk_soc = s.rowid";
+		$sqlpropal .= " INNER JOIN ".$this->db->prefix()."expeditiondet as ed ON ed.fk_expedition = e.rowid";
+		$sqlpropal .= " INNER JOIN ".$this->db->prefix()."propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
+		$sqlpropal .= $sqljoinrights;
+		$sqlpropal .= $sqlwhere;
+		$sqlpropal .= " AND pd.fk_product = ".((int) $this->id);
+		$sqlunion[] = $sqlpropal;
+
+		$sqlfree = "SELECT e.fk_soc, e.rowid as expeditionid, ed.rowid as edrowid, ed.qty, NULL as order_status";
+		$sqlfree .= " FROM ".$this->db->prefix()."societe as s";
+		$sqlfree .= " INNER JOIN ".$this->db->prefix()."expedition as e ON e.fk_soc = s.rowid";
+		$sqlfree .= " INNER JOIN ".$this->db->prefix()."expeditiondet as ed ON ed.fk_expedition = e.rowid";
+		$sqlfree .= $sqljoinrights;
+		$sqlfree .= $sqlwhere;
+		$sqlfree .= " AND (ed.element_type NOT IN ('commande', 'order', 'propal') OR ed.element_type IS NULL OR ed.element_type = '')";
+		$sqlfree .= " AND ed.fk_product = ".((int) $this->id);
+		$sqlunion[] = $sqlfree;
+
+		$sql = "SELECT COUNT(DISTINCT src.fk_soc) as nb_customers, COUNT(DISTINCT src.expeditionid) as nb,";
+		$sql .= " COUNT(src.edrowid) as nb_rows, SUM(src.qty) as qty";
+		$sql .= " FROM (".implode(" UNION ALL ", $sqlunion).") as src";
+		$sql .= " WHERE 1 = 1";
+		if ($filtrestatut != '') {
+			$sql .= " AND (src.order_status IN (".$this->db->sanitize($filtrestatut).") OR src.order_status IS NULL)";
 		}
 
 		$result = $this->db->query($sql);

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -3869,25 +3869,23 @@ class Product extends CommonObject
 
 		$sql = "SELECT COUNT(DISTINCT e.fk_soc) as nb_customers, COUNT(DISTINCT e.rowid) as nb,";
 		$sql .= " COUNT(ed.rowid) as nb_rows, SUM(ed.qty) as qty";
-		$sql .= " FROM ".$this->db->prefix()."expeditiondet as ed";
-		$sql .= ", ".$this->db->prefix()."commandedet as cd";
-		$sql .= ", ".$this->db->prefix()."commande as c";
-		$sql .= ", ".$this->db->prefix()."expedition as e";
-		$sql .= ", ".$this->db->prefix()."societe as s";
-		$sql .= " WHERE e.rowid = ed.fk_expedition";
-		$sql .= " AND c.rowid = cd.fk_commande";
-		$sql .= " AND e.fk_soc = s.rowid";
-		$sql .= " AND e.entity IN (".getEntity($forVirtualStock && getDolGlobalString('STOCK_CALCULATE_VIRTUAL_STOCK_TRANSVERSE_MODE') ? 'stock' : 'expedition').")";
-		$sql .= " AND ed.fk_elementdet = cd.rowid";
-		$sql .= " AND cd.fk_product = ".((int) $this->id);
-		if (empty($user->fk_soc) && !$user->hasRight('societe', 'client', 'voir') && !$forVirtualStock) {	// For external user, restriction is done on filter on fk_soc directly
+		$sql .= " FROM ".$this->db->prefix()."societe as s";
+		$sql .= " INNER JOIN ".$this->db->prefix()."expedition as e ON e.fk_soc = s.rowid";
+		$sql .= " INNER JOIN ".$this->db->prefix()."expeditiondet as ed ON ed.fk_expedition = e.rowid";
+		$sql .= " LEFT JOIN ".$this->db->prefix()."commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
+		$sql .= " LEFT JOIN ".$this->db->prefix()."commande as c ON c.rowid = cd.fk_commande";
+		$sql .= " LEFT JOIN ".$this->db->prefix()."propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
+		if (empty($user->fk_soc) && !$user->hasRight('societe', 'client', 'voir') && !$forVirtualStock) {
 			$sql .= " INNER JOIN ".$this->db->prefix()."societe_commerciaux as sc ON sc.fk_soc = e.fk_soc AND sc.fk_user = ".((int) $user->id);
 		}
+		$sql .= " WHERE 1 = 1";
+		$sql .= " AND e.entity IN (".getEntity($forVirtualStock && getDolGlobalString('STOCK_CALCULATE_VIRTUAL_STOCK_TRANSVERSE_MODE') ? 'stock' : 'expedition').")";
+		$sql .= " AND COALESCE(cd.fk_product, pd.fk_product, ed.fk_product) = ".((int) $this->id);
 		if ($socid > 0) {
 			$sql .= " AND e.fk_soc = ".((int) $socid);
 		}
 		if ($filtrestatut != '') {
-			$sql .= " AND c.fk_statut IN (".$this->db->sanitize($filtrestatut).")";
+			$sql .= " AND (c.fk_statut IN (".$this->db->sanitize($filtrestatut).") OR c.rowid IS NULL)";
 		}
 		if (!empty($filterShipmentStatus)) {
 			$sql .= " AND e.fk_statut IN (".$this->db->sanitize($filterShipmentStatus).")";

--- a/htdocs/product/stats/expedition.php
+++ b/htdocs/product/stats/expedition.php
@@ -149,32 +149,76 @@ if ($id > 0 || !empty($ref)) {
 
 
 		if ($user->hasRight('shipping', 'lire')) {
-			$sql = "SELECT DISTINCT s.nom as name, s.rowid as socid, s.code_client, e.ref, e.ref_customer";
-			$sql .= ", e.date_creation, e.date_delivery, e.fk_statut as statut, e.rowid as expeditionid, ed.rowid";
-			$sql .= ", ed.qty, COALESCE(cd.subprice * (100 - cd.remise_percent) / 100 * ed.qty, pd.subprice * (100 - pd.remise_percent) / 100 * ed.qty, 0) AS total_ht";
+			$sortfieldalias = array(
+				'e.rowid' => 'expeditionid',
+				's.nom' => 'name',
+				's.code_client' => 'code_client',
+				'e.date_creation' => 'date_creation',
+				'e.date_delivery' => 'date_delivery',
+				'ed.qty' => 'qty',
+				'e.fk_statut' => 'statut',
+				'total_ht' => 'total_ht',
+			);
+
+			$sqlunion = array();
+			$sqlselect = "SELECT DISTINCT s.nom as name, s.rowid as socid, s.code_client, e.ref, e.ref_customer";
+			$sqlselect .= ", e.date_creation, e.date_delivery, e.fk_statut as statut, e.rowid as expeditionid, ed.rowid";
+			$sqlselect .= ", ed.qty";
 			if (!$user->hasRight('societe', 'client', 'voir') && !$socid) {
-				$sql .= ", sc.fk_soc, sc.fk_user ";
+				$sqlselect .= ", sc.fk_soc, sc.fk_user";
 			}
-			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
-			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."expedition as e ON e.fk_soc = s.rowid";
-			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."expeditiondet as ed ON ed.fk_expedition = e.rowid";
-			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
-			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
-			if (!$user->hasRight('societe', 'client', 'voir') && !$socid) {
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
-			}
-			$sql .= " WHERE e.entity IN (".getEntity('expedition').")";
-			$sql .= " AND COALESCE(cd.fk_product, pd.fk_product, ed.fk_product) = ".((int) $product->id);
+			$sqlwhere = " WHERE e.entity IN (".getEntity('expedition').")";
 			if (!empty($search_month)) {
-				$sql .= ' AND MONTH(e.date_creation) ='.((int) $search_month);
+				$sqlwhere .= ' AND MONTH(e.date_creation) ='.((int) $search_month);
 			}
 			if (!empty($search_year)) {
-				$sql .= ' AND YEAR(e.date_creation) ='.((int) $search_year);
+				$sqlwhere .= ' AND YEAR(e.date_creation) ='.((int) $search_year);
 			}
 			if ($socid) {
-				$sql .= " AND e.fk_soc = ".((int) $socid);
+				$sqlwhere .= " AND e.fk_soc = ".((int) $socid);
 			}
-			$sql .= $db->order($sortfield, $sortorder);
+
+			$sqlcommande = $sqlselect;
+			$sqlcommande .= ", cd.subprice * (100 - cd.remise_percent) / 100 * ed.qty AS total_ht";
+			$sqlcommande .= " FROM ".MAIN_DB_PREFIX."societe as s";
+			$sqlcommande .= " INNER JOIN ".MAIN_DB_PREFIX."expedition as e ON e.fk_soc = s.rowid";
+			$sqlcommande .= " INNER JOIN ".MAIN_DB_PREFIX."expeditiondet as ed ON ed.fk_expedition = e.rowid";
+			$sqlcommande .= " INNER JOIN ".MAIN_DB_PREFIX."commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
+			if (!$user->hasRight('societe', 'client', 'voir') && !$socid) {
+				$sqlcommande .= " INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+			}
+			$sqlcommande .= $sqlwhere;
+			$sqlcommande .= " AND cd.fk_product = ".((int) $product->id);
+			$sqlunion[] = $sqlcommande;
+
+			$sqlpropal = $sqlselect;
+			$sqlpropal .= ", pd.subprice * (100 - pd.remise_percent) / 100 * ed.qty AS total_ht";
+			$sqlpropal .= " FROM ".MAIN_DB_PREFIX."societe as s";
+			$sqlpropal .= " INNER JOIN ".MAIN_DB_PREFIX."expedition as e ON e.fk_soc = s.rowid";
+			$sqlpropal .= " INNER JOIN ".MAIN_DB_PREFIX."expeditiondet as ed ON ed.fk_expedition = e.rowid";
+			$sqlpropal .= " INNER JOIN ".MAIN_DB_PREFIX."propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
+			if (!$user->hasRight('societe', 'client', 'voir') && !$socid) {
+				$sqlpropal .= " INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+			}
+			$sqlpropal .= $sqlwhere;
+			$sqlpropal .= " AND pd.fk_product = ".((int) $product->id);
+			$sqlunion[] = $sqlpropal;
+
+			$sqlfree = $sqlselect;
+			$sqlfree .= ", 0 AS total_ht";
+			$sqlfree .= " FROM ".MAIN_DB_PREFIX."societe as s";
+			$sqlfree .= " INNER JOIN ".MAIN_DB_PREFIX."expedition as e ON e.fk_soc = s.rowid";
+			$sqlfree .= " INNER JOIN ".MAIN_DB_PREFIX."expeditiondet as ed ON ed.fk_expedition = e.rowid";
+			if (!$user->hasRight('societe', 'client', 'voir') && !$socid) {
+				$sqlfree .= " INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
+			}
+			$sqlfree .= $sqlwhere;
+			$sqlfree .= " AND (ed.element_type NOT IN ('commande', 'order', 'propal') OR ed.element_type IS NULL OR ed.element_type = '')";
+			$sqlfree .= " AND ed.fk_product = ".((int) $product->id);
+			$sqlunion[] = $sqlfree;
+
+			$sql = "SELECT * FROM (".implode(" UNION ALL ", $sqlunion).") as sending_src";
+			$sql .= $db->order($sortfieldalias[$sortfield] ?? 'date_creation', $sortorder);
 
 			//Calcul total qty and amount for global if full scan list
 			$total_ht = 0;

--- a/htdocs/product/stats/expedition.php
+++ b/htdocs/product/stats/expedition.php
@@ -151,19 +151,20 @@ if ($id > 0 || !empty($ref)) {
 		if ($user->hasRight('shipping', 'lire')) {
 			$sql = "SELECT DISTINCT s.nom as name, s.rowid as socid, s.code_client, e.ref, e.ref_customer";
 			$sql .= ", e.date_creation, e.date_delivery, e.fk_statut as statut, e.rowid as expeditionid, ed.rowid";
-			$sql .= ", ed.qty , cd.subprice * (100 - cd.remise_percent) / 100 * ed.qty AS total_ht";
+			$sql .= ", ed.qty, COALESCE(cd.subprice * (100 - cd.remise_percent) / 100 * ed.qty, pd.subprice * (100 - pd.remise_percent) / 100 * ed.qty, 0) AS total_ht";
 			if (!$user->hasRight('societe', 'client', 'voir') && !$socid) {
 				$sql .= ", sc.fk_soc, sc.fk_user ";
 			}
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."expedition as e ON e.fk_soc = s.rowid";
 			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."expeditiondet as ed ON ed.fk_expedition = e.rowid";
-			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."commandedet as cd ON cd.rowid = ed.fk_elementdet AND (ed.element_type = 'commande' OR ed.element_type = 'order')";
+			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commandedet as cd ON cd.rowid = ed.fk_elementdet AND ed.element_type IN ('commande', 'order')";
+			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."propaldet as pd ON pd.rowid = ed.fk_elementdet AND ed.element_type = 'propal'";
 			if (!$user->hasRight('societe', 'client', 'voir') && !$socid) {
 				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."societe_commerciaux as sc ON s.rowid = sc.fk_soc AND sc.fk_user = ".((int) $user->id);
 			}
 			$sql .= " WHERE e.entity IN (".getEntity('expedition').")";
-			$sql .= " AND cd.fk_product = ".((int) $product->id);
+			$sql .= " AND COALESCE(cd.fk_product, pd.fk_product, ed.fk_product) = ".((int) $product->id);
 			if (!empty($search_month)) {
 				$sql .= ' AND MONTH(e.date_creation) ='.((int) $search_month);
 			}


### PR DESCRIPTION
# FIX shipment stock and product stats for non-order shipment lines
This is a follow-up in the same bug family as the shipment line `element_type` fixes (see #38671), but it is **not** technically dependent on them.

Some shipment code paths still assume every shipment line points to `commandedet`:

- stock movements on shipment validation / reopen
- product shipment stats list
- product shipment counters in related items

That breaks or miscounts shipments when lines come from another source such as `propal`, or when the shipment line already carries the product directly.

This patch makes those paths resolve shipment lines through `ed.element_type` instead of always reading `commandedet`:

- `commande` / `order` lines still use `commandedet`
- `propal` lines use `propaldet`
- fallback uses `ed.fk_product` when the shipment line itself carries the product

Tested on 23.0 with proposal-linked shipments and free shipment lines imported directly in the database.
