### PR TITLE
Fix #37543 persist currency on pricecy extrafield

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2914,7 +2914,7 @@ class ExtraFields
 				} elseif (in_array($key_type, array('price', 'double'))) {
 					$value_arr = GETPOST("options_".$key, 'alpha');
 					$value_key = price2num($value_arr);
-				} elseif (in_array($key_type, array('pricecy', 'double'))) {
+				} elseif (in_array($key_type, array('pricecy'))) {
 					$value_key = price2num(GETPOST("options_".$key, 'alpha')).':'.GETPOST("options_".$key."currency_id", 'alpha');
 				} elseif (in_array($key_type, array('html'))) {
 					$value_key = GETPOST("options_".$key, 'restricthtml');
@@ -3069,6 +3069,16 @@ class ExtraFields
 					// Make sure we get an array even if there's only one checkbox
 					$value_arr = (array) $value_arr;
 					$value_key = implode(',', $value_arr);
+				} elseif (in_array($key_type, array('pricecy'))) {
+					if (!GETPOSTISSET($keyprefix."options_".$key.$keysuffix)) {
+						continue; // Value was not provided, we should not set it.
+					}
+					$value_arr = GETPOST($keyprefix."options_".$key.$keysuffix);
+					if ($keyprefix != 'search_') {    // If value is for a search, we must keep complex string like '>100 <=150'
+						$value_key = price2num($value_arr).':'.GETPOST($keyprefix."options_".$key.$keysuffix."currency_id", 'alpha');
+					} else {
+						$value_key = $value_arr;
+					}
 				} elseif (in_array($key_type, array('price', 'double', 'int'))) {
 					if (!GETPOSTISSET($keyprefix."options_".$key.$keysuffix)) {
 						continue; // Value was not provided, we should not set it.


### PR DESCRIPTION
Fix #37543.

`ExtraFields::getOptionalsFromPost()` had no dedicated handler for the `pricecy` (price with currency) type, so the path used by line-level extrafields fell through to the generic else and only read the amount field. The companion `options_<key>currency_id` input was dropped, the saved value was a bare number, and the renderer then treated it as the default currency.

Add a `pricecy` case that concatenates amount and currency_id into the `amount:currency` string the rest of the code already expects (`showOutputField()`, `pdf_writeLineDesc`, etc.).

The legacy `setOptionalsFromPost()` path had the symmetric problem from a different angle: its `pricecy` branch was guarded by `in_array($key_type, array('pricecy', 'double'))`, where `'double'` is dead code because the previous elseif already matches it. Drop `'double'` so the type list reflects the real intent.