### PR TITLE
Fix #37599 require both negative-lines flags to skip abs on credit note update

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4716,7 +4716,7 @@ class Facture extends CommonInvoice
 				$this->line->rang = $rangmax + 1;
 			}
 			$apply_abs_price_on_credit_note = false;
-			if ($this->type == self::TYPE_CREDIT_NOTE  && !getDolGlobalInt('FACTURE_ENABLE_NEGATIVE_LINES') && !getDolGlobalInt('INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN')) {
+			if ($this->type == self::TYPE_CREDIT_NOTE && !(getDolGlobalInt('FACTURE_ENABLE_NEGATIVE_LINES') && getDolGlobalInt('INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN'))) {
 				$apply_abs_price_on_credit_note = true;
 			}
 


### PR DESCRIPTION
Fix #37599. Regression introduced by #33434.

#33434 was meant to allow positive lines on a credit note when both `FACTURE_ENABLE_NEGATIVE_LINES` and `INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN` were enabled together (so origin-negative lines moved as positive into the credit note can be re-edited without being forced back negative).

The actual gate landed as `!A && !B`, which disables the abs forcing whenever **either** flag is set. Sites that enable only `FACTURE_ENABLE_NEGATIVE_LINES` now see credit note totals flip to positive after editing any line.

Use `!(A && B)` instead so the relaxation only kicks in when both flags are set, matching:

- the description on #33434 ("if FACTURE_ENABLE_NEGATIVE_LINES and INVOICE_KEEP_DISCOUNT_LINES_AS_IN_ORIGIN is used together"),
- the symmetric `addline()` path which always forces `-abs` on credit notes (lines 4422-4469 unchanged by #33434).