### PR TITLE
Fix #36905 guard project card thirdparty client check against null

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -365,16 +365,14 @@ if (empty($reshook)) {
 				setEventMessages($langs->trans("ErrorOppStatusRequiredIfAmount"), null, 'errors');
 			}
 
-			if (!$error) {
-				if ((int) $object->thirdparty->client == 0 || (int) $object->thirdparty->client == 2) {		// If not yet customer
-					// Get ID of the special opportunity status code 'WON'
-					$idoppstatuswon = (int) dol_getIdFromCode($db, 'WON', 'c_lead_status', 'code', 'rowid');
+			if (!$error && !is_null($object->thirdparty) && ((int) $object->thirdparty->client == 0 || (int) $object->thirdparty->client == 2)) {		// If not yet customer
+				// Get ID of the special opportunity status code 'WON'
+				$idoppstatuswon = (int) dol_getIdFromCode($db, 'WON', 'c_lead_status', 'code', 'rowid');
 
-					if ($object->opp_status == $idoppstatuswon) {
-						// Switch the thirdparty into a customer (only if thirdparty exists)
-						if (!empty($object->thirdparty) && !empty($object->thirdparty->id)) {
-							$object->thirdparty->setAsCustomer();
-						}
+				if ($object->opp_status == $idoppstatuswon) {
+					// Switch the thirdparty into a customer (only if thirdparty exists)
+					if (!empty($object->thirdparty) && !empty($object->thirdparty->id)) {
+						$object->thirdparty->setAsCustomer();
 					}
 				}
 			}
@@ -465,7 +463,7 @@ if (empty($reshook)) {
 
 			// If opportunities are used and the customer is not yet a customer
 			if (getDolGlobalString('PROJECT_USE_OPPORTUNITIES') && $object->usage_opportunity) {
-				if ((int) $object->thirdparty->client == 0 || (int) $object->thirdparty->client == 2) {		// If not yet customer
+				if (!is_null($object->thirdparty) && ((int) $object->thirdparty->client == 0 || (int) $object->thirdparty->client == 2)) {		// If not yet customer
 					// Get ID of the special opportunity status code 'WON'
 					$idoppstatuswon = (int) dol_getIdFromCode($db, 'WON', 'c_lead_status', 'code', 'rowid');
 


### PR DESCRIPTION
Fix #36905. Backport of 6ce7ba17f4d (already on 23.0 and develop) to 22.0.

When editing a project that has no thirdparty attached, the WON/customer conversion block in `projet/card.php` dereferenced `$object->thirdparty->client` without first checking that the thirdparty was loaded. `$object->fetch_thirdparty()` leaves the property null in that case, so on PHP 8 the request fatals with "Attempt to read property 'client' on null" and "Call to a member function setAsCustomer() on null".

Same guard already lives on 23.0 (commit 6ce7ba17f4d). This PR brings the same fix to 22.0 on both opportunity blocks (create-path and update-path) so 22.x stays stable for the remaining N-1 window.