### PR TITLE
Fix #36847 stable order on Propal::fetch_lines

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -1961,7 +1961,7 @@ class Propal extends CommonObject
 		if ($sqlforgedfilters) {
 			$sql .= $sqlforgedfilters;
 		}
-		$sql .= ' ORDER by d.rang';
+		$sql .= ' ORDER BY d.rang, d.rowid';
 
 		dol_syslog(get_class($this)."::fetch_lines", LOG_DEBUG);
 		$result = $this->db->query($sql);


### PR DESCRIPTION
Fix #36847.

The proposal-to-order create path (`Commande::createFromProposal`) walks `$object->lines` and adds them in the order returned by `Propal::fetch_lines`. The query only sorted by `d.rang`, so two propal lines sharing a rang (legacy data, manual edits, batch imports) came back in MySQL's internal heap order, and the order built from them ended up with lines permuted versus the proposal.

Add `d.rowid` as a tie-breaker, matching the stable pattern `Expedition::fetch_lines` already uses (`ORDER BY rang ASC, rowid ASC`). Behaviour on data with unique rangs is unchanged.