### PR TITLE
Fix #37110 gate variants tables when variants module disabled

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1903,7 +1903,7 @@ class Product extends CommonObject
 				}
 			}
 
-			if (!$error) {
+			if (!$error && isModEnabled('variants')) {
 				include_once DOL_DOCUMENT_ROOT.'/variants/class/ProductCombination.class.php';
 				include_once DOL_DOCUMENT_ROOT.'/variants/class/ProductCombination2ValuePair.class.php';
 
@@ -5601,6 +5601,9 @@ class Product extends CommonObject
 	public function hasVariants()
 	{
 		$nb = 0;
+		if (!isModEnabled('variants')) {
+			return $nb;
+		}
 		$sql = "SELECT count(rowid) as nb FROM ".$this->db->prefix()."product_attribute_combination WHERE fk_product_parent = ".((int) $this->id);
 		$sql .= " AND entity IN (".getEntity('product').")";
 


### PR DESCRIPTION
Fix #37110.

`Product::delete()` and `Product::hasVariants()` queried `llx_product_attribute_combination` unconditionally, even when the variants module was disabled. On PostgreSQL the table only ever exists once the variants module has been activated (it lives in the suffixed `-variants.sql` files loaded via `_load_tables()`), so deleting a freshly created product on a fresh install fatals with:

```
ERREUR: 42P01: la relation llx_product_attribute_combination n'existe pas
```

Wrap the delete-time block in `isModEnabled('variants')` (matching the existing gate in the update path on line 1802) and short-circuit `hasVariants()` when the module is off, mirroring the existing guard in `isVariant()` (line 5611-onwards in 23.0). MySQL is unaffected because the table is created in the same path.