### PR TITLE
Fix #36510 advance pg sequence after forced-rowid dictionary insert

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -1029,6 +1029,12 @@ if (empty($reshook)) {
 			if ($resql) {	// Add is ok
 				setEventMessages($langs->transnoentities("RecordCreatedSuccessfully"), null, 'mesgs');
 
+				// PostgreSQL: when we forced the rowid we must bump the matching <table>_<rowid_col>_seq
+				// so the next auto-increment insert does not collide with our chosen value (#36510).
+				if ($db->type == 'pgsql' && $tabrowid[$id] && !in_array($tabrowid[$id], $listfieldinsert)) {
+					$db->query("SELECT setval(pg_get_serial_sequence('".$db->escape(MAIN_DB_PREFIX.$db->sanitize($tablename))."', '".$db->escape($tabrowid[$id])."'), GREATEST((SELECT MAX(".$db->sanitize($tabrowid[$id]).") FROM ".MAIN_DB_PREFIX.$db->sanitize($tablename)."), 1))");
+				}
+
 				// Clean $_POST array, we keep only id of dictionary
 				if ($id == DICT_TVA && GETPOSTINT('country') > 0) {
 					$search_country_id = GETPOSTINT('country');


### PR DESCRIPTION
Fix #36510. Diagnosis by @hregis.

Dictionary entry creation in `admin/dict.php` computes `$newid = MAX(rowid) + 1` in PHP and INSERTs with that rowid explicitly. On PostgreSQL the matching serial sequence (`<table>_<rowid>_seq`) is never told about the manually chosen value, so the next auto-increment insert hits a duplicate-key error that the dictionary handler surfaces to the user as "already existing record" - even when the code typed is genuinely unique.

Bump the sequence with `setval(pg_get_serial_sequence(...), GREATEST(MAX(rowid), 1))` right after a successful forced-rowid INSERT, gated on `$db->type == 'pgsql'` so MySQL/MariaDB behaviour stays untouched.

This is the short-term targeted fix discussed on the issue. The longer-term move from rowid-based FKs to code-based dictionary references (multicompany sharing direction described by @hregis) is being tracked separately.