### PR TITLE
Fix #36082 make projectfiles and projectcontacts ODT segments optional

### DIFF
--- a/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
+++ b/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
@@ -876,9 +876,13 @@ class doc_generic_project_odt extends ModelePDFProjects
 					}
 					$odfHandler->mergeSegment($listlines);
 				} catch (OdfException $e) {
-					$this->error = $e->getMessage();
-					dol_syslog($this->error, LOG_WARNING);
-					return -1;
+					$ExceptionTrace = $e->getTrace();
+					// no segment defined on ODT is not an error
+					if ($ExceptionTrace[0]['function'] != 'setSegment') {
+						$this->error = $e->getMessage();
+						dol_syslog($this->error, LOG_WARNING);
+						return -1;
+					}
 				}
 
 				// Replace tags of lines for contacts
@@ -921,9 +925,13 @@ class doc_generic_project_odt extends ModelePDFProjects
 						}
 						$odfHandler->mergeSegment($listlines);
 					} catch (OdfException $e) {
-						$this->error = $e->getMessage();
-						dol_syslog($this->error, LOG_WARNING);
-						return -1;
+						$ExceptionTrace = $e->getTrace();
+						// no segment defined on ODT is not an error
+						if ($ExceptionTrace[0]['function'] != 'setSegment') {
+							$this->error = $e->getMessage();
+							dol_syslog($this->error, LOG_WARNING);
+							return -1;
+						}
 					}
 				}
 


### PR DESCRIPTION
Fix #36082.

The `tasks` segment block in `doc_generic_project_odt::write_file` already swallows the missing-segment exception by checking the trace function name (`setSegment`), letting templates omit the `[!-- BEGIN tasks --]` pair without fatal-ing. The `projectfiles` and `projectcontacts` catch blocks just below did not have that check, so a template missing either segment caused an uncaught `OdfExceptionSegmentNotFound` and a 500, even though the surrounding code clearly meant to treat all three the same way.

Apply the same `$ExceptionTrace[0]['function'] != 'setSegment'` check to both catch blocks. Behaviour on templates that include the segments is unchanged; templates that omit them now generate without the fatal.