### PR TITLE
Fix #35979 remove KB record file directory on delete

### DIFF
--- a/htdocs/knowledgemanagement/class/knowledgerecord.class.php
+++ b/htdocs/knowledgemanagement/class/knowledgerecord.class.php
@@ -502,6 +502,8 @@ class KnowledgeRecord extends CommonObject
 	 */
 	public function delete(User $user, $notrigger = 0)
 	{
+		global $conf;
+
 		$error = 0;
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX."categorie_knowledgemanagement WHERE fk_knowledgemanagement = ".((int) $this->id);
 		dol_syslog(get_class($this)."::delete", LOG_DEBUG);
@@ -529,8 +531,20 @@ class KnowledgeRecord extends CommonObject
 			}
 		}
 
-		return $this->deleteCommon($user, $notrigger);
-		//return $this->deleteCommon($user, $notrigger, 1);
+		$result = $this->deleteCommon($user, $notrigger);
+
+		// Remove the linked files directory (uploads attached to the article)
+		if ($result > 0 && !empty($conf->knowledgemanagement->dir_output) && !empty($this->ref)) {
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+			$dir = $conf->knowledgemanagement->dir_output.'/knowledgerecord/'.dol_sanitizeFileName($this->ref);
+			if (file_exists($dir)) {
+				if (!@dol_delete_dir_recursive($dir)) {
+					$this->errors[] = 'ErrorFailToDeleteDir';
+				}
+			}
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
Fix #35979.

`KnowledgeRecord::delete` only ran the SQL DELETE chain through `deleteCommon()` and never touched the filesystem. Uploaded attachments under `documents/knowledgemanagement/knowledgerecord/<ref>/` stayed on disk forever, growing the documents directory whenever a KB article was removed.

After `deleteCommon` succeeds, remove the matching directory with `dol_delete_dir_recursive()`, matching the pattern `Project::delete` (`projet/class/project.class.php:1098-1110`) and `Expedition::delete` (`expedition/class/expedition.class.php:1924-1929`) already use.