### PR TITLE
Fix #35661 drop duplicated ref segment in notify pdf path

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -1269,7 +1269,7 @@ class Notify
 						break;
 				}
 				$ref = dol_sanitizeFileName($newref);
-				$pdf_path = $dir_output."/".$ref."/".$ref.".pdf";
+				$pdf_path = $dir_output."/".$ref.".pdf";
 				if (!dol_is_file($pdf_path)) {
 					// We can't add PDF as it is not generated yet.
 					$filepdf = '';


### PR DESCRIPTION
Fix #35661.

The fixed-target branch of `Notify::send` built the PDF path as `$dir_output/$ref/$ref.pdf` while `$dir_output` already includes the `get_exdir(...)` ref subdirectory (see how it is assembled in every `switch ($notifcode)` case immediately above). The double ref segment made `dol_is_file()` always fail, so the PDF was never attached when a notification was routed to a fixed email address.

The matching block just above for user/group targets (line 979) has always used the correct `$dir_output/$ref.pdf` form. Drop the extra `$ref/` segment on line 1263 so both branches produce the same path.

Reported back to 16.0 and dates back to commit 958b6abdaafa from 2022-03-23.