### PR TITLE
Fix #36353 fresh object instance per iteration in getObjectsInCateg

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -1050,11 +1050,11 @@ class Categorie extends CommonObject
 					if ($onlyids) {
 						$objs[] = $rec['fk_object'];
 					} else {
-						$tmpobj->id = 0;
-						$tmpobj->fetch($rec['fk_object']);	// The fetch will erase $tmpobj->id only if it succeed.
+						$tmpobj = new $classnameforobj($this->db);
+						$tmpobj->fetch($rec['fk_object']);	// The fetch will set $tmpobj->id only if it succeed.
 						// @phpstan-ignore-next-line
 						if ($tmpobj->id > 0) {		// Failing fetch may happen for example when a category supplier was set and third party was moved as customer only. The object supplier can't be loaded.
-							$objs[] = clone $tmpobj;
+							$objs[] = $tmpobj;
 						}
 					}
 				}


### PR DESCRIPTION
Fix #36353.

`Categorie::getObjectsInCateg()` reused a single `$tmpobj` declared before the fetch loop and only reset `$tmpobj->id` before each `fetch()`. Object classes whose `fetch()` does not clear every property left stale data from previous rows. The shallow `clone $tmpobj` then kept nested object references (e.g. `thirdparty`, `extrafields`, loaded children) pointing at whatever the last fetch had populated, so the viewcat list ended up showing duplicates of the last item.

Instantiate a fresh `$tmpobj = new $classnameforobj($this->db);` per row and append it directly. Each returned entry is fully independent and matches its source row.