### PR TITLE
Fix #38456 dedup product_fournisseur_price before merging suppliers

### DIFF
--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -1198,9 +1198,9 @@ class ProductFournisseur extends Product
 		}
 		$dbs->free($resql);
 
-		if (!empty($colliding)) {
+		foreach ($colliding as $rowid) {
 			$sqldel = "DELETE FROM ".$dbs->prefix()."product_fournisseur_price";
-			$sqldel .= " WHERE rowid IN (".$dbs->sanitize(implode(',', $colliding)).")";
+			$sqldel .= " WHERE rowid = ".((int) $rowid);
 			if (!$dbs->query($sqldel)) {
 				return false;
 			}

--- a/htdocs/fourn/class/fournisseur.product.class.php
+++ b/htdocs/fourn/class/fournisseur.product.class.php
@@ -1173,6 +1173,39 @@ class ProductFournisseur extends Product
 	 */
 	public static function replaceThirdparty(DoliDB $dbs, $origin_id, $dest_id)
 	{
+		// llx_product_fournisseur_price has a UNIQUE INDEX uk_product_fournisseur_price_ref
+		// on (ref_fourn, fk_soc, quantity, entity). A blind UPDATE fk_soc = dest on every
+		// origin row fails on rows where dest already has the same (ref_fourn, quantity, entity),
+		// blocking the whole merge with a 1062 Duplicate entry error (see #38456).
+		// Drop the colliding origin rows first - they would become exact duplicates of dest
+		// rows so the merge has nothing to lose by keeping the dest version.
+		$sqlselect = "SELECT pfp_origin.rowid";
+		$sqlselect .= " FROM ".$dbs->prefix()."product_fournisseur_price AS pfp_origin";
+		$sqlselect .= " INNER JOIN ".$dbs->prefix()."product_fournisseur_price AS pfp_dest";
+		$sqlselect .= " ON pfp_dest.fk_soc = ".((int) $dest_id);
+		$sqlselect .= " AND pfp_dest.ref_fourn = pfp_origin.ref_fourn";
+		$sqlselect .= " AND pfp_dest.quantity = pfp_origin.quantity";
+		$sqlselect .= " AND pfp_dest.entity = pfp_origin.entity";
+		$sqlselect .= " WHERE pfp_origin.fk_soc = ".((int) $origin_id);
+
+		$resql = $dbs->query($sqlselect);
+		if (!$resql) {
+			return false;
+		}
+		$colliding = array();
+		while ($obj = $dbs->fetch_object($resql)) {
+			$colliding[] = (int) $obj->rowid;
+		}
+		$dbs->free($resql);
+
+		if (!empty($colliding)) {
+			$sqldel = "DELETE FROM ".$dbs->prefix()."product_fournisseur_price";
+			$sqldel .= " WHERE rowid IN (".$dbs->sanitize(implode(',', $colliding)).")";
+			if (!$dbs->query($sqldel)) {
+				return false;
+			}
+		}
+
 		$tables = array(
 			'product_fournisseur_price'
 		);


### PR DESCRIPTION
Fix #38456.

When merging two supplier thirdparties via `Societe::mergeCompany`, the `ProductFournisseur::replaceThirdparty` path delegated to `CommonObject::commonReplaceThirdparty` which runs a blind `UPDATE fk_soc = dest` on every origin row. The UNIQUE INDEX `uk_product_fournisseur_price_ref(ref_fourn, fk_soc, quantity, entity)` rejects rows where dest already has the same `(ref_fourn, quantity, entity)`, so the whole merge aborts with a 1062 Duplicate entry error and no user-facing message.

Override `replaceThirdparty` locally on `ProductFournisseur` to first drop the colliding origin rows (they would become exact duplicates of dest rows so nothing useful is lost by keeping the dest version), then run the normal `commonReplaceThirdparty` path on what is left.

Uses a portable SELECT-then-DELETE-by-rowid pattern to avoid MySQL-only `DELETE/JOIN` and PostgreSQL-incompatible self-reference in `DELETE`.