### PR TITLE
Fix #38597 stop TakePOS popup from firing again after cash control close

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1101,11 +1101,14 @@ $( document ).ready(function() {
 	}
 
 	if (getDolGlobalString('TAKEPOS_CONTROL_CASH_OPENING')) {
+		// Look for any cash control fence created today on this terminal, regardless of its status,
+		// so the auto-open popup only fires on the first cash control of a calendar day. Without this,
+		// refreshing the browser the same day after closing a fence used to immediately re-fire the
+		// popup because the closed fences were filtered out by the status check (#38597).
 		$sql = "SELECT rowid, status FROM ".MAIN_DB_PREFIX."pos_cash_fence WHERE";
 		$sql .= " entity = ".((int) $conf->entity)." AND ";
 		$sql .= " posnumber = ".((int) $_SESSION["takeposterminal"])." AND ";
 		$sql .= " date_creation > '".$db->idate(dol_get_first_hour(dol_now()))."'";
-		$sql .= " AND status = 0 ";
 		$resql = $db->query($sql);
 		if ($resql) {
 			$obj = $db->fetch_object($resql);


### PR DESCRIPTION
Fix #38597.

The TakePOS auto-open cash control popup at `htdocs/takepos/index.php:1103-1117` ran:

```sql
SELECT rowid, status FROM llx_pos_cash_fence
WHERE entity = X AND posnumber = Y AND date_creation > today_first_hour AND status = 0
```

After a fence was closed, its status no longer equals 0, so the SQL returned no rows. The popup was then triggered on every browser refresh until midnight, even though a cash control had already been opened and closed earlier in the same day.

Drop the `status = 0` filter so any fence created today (open or closed) counts as "already had a cash control today" and the popup stays suppressed for the rest of the day. The first open of a new calendar day still fires it because no row from today exists yet. Matches the historical legacy behavior referenced in the report.