### PR TITLE
Fix #37744 do not auto-close draft invoice when full deposit covers remain_to_pay

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -704,9 +704,15 @@ if (empty($reshook)) {
 			}
 
 			if (!$error) {
-				$newremaintopay = $object->getRemainToPay(0);
-				if ($newremaintopay == 0) {
-					$object->setPaid($user);
+				// Only mark as paid when the invoice is already validated. On a still-draft
+				// invoice the discount link reduces the remain_to_pay but the invoice is not
+				// yet a legally issued document (ref is still PROV-...), so closing it would
+				// leave it stuck as paid+PROV (see #37744).
+				if ($object->status == Facture::STATUS_VALIDATED) {
+					$newremaintopay = $object->getRemainToPay(0);
+					if ($newremaintopay == 0) {
+						$object->setPaid($user);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Closes #37744.

In htdocs/compta/facture/card.php the setabsolutediscount action has two branches: remise_id (line 657+) and remise_id_for_payment (line 683+). The first branch already guards setPaid behind a STATUS_VALIDATED check (line 675), the second branch did not.

When a 100% deposit-converted-to-discount is applied on a still-draft invoice via the second branch, the new remain_to_pay reaches 0 and setPaid runs on a PROV-ref invoice. The invoice then sits as paid with a temporary reference because validation never happened.

Mirror the same STATUS_VALIDATED guard onto the remise_id_for_payment branch.