### PR TITLE
Fix #37582 run sql query in stockatdate.php csv branch too

### DIFF
--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -380,10 +380,10 @@ if ($date && $dateIsValid) {	// We avoid a heavy sql if mandatory parameter date
 	//print $sql;
 	if ($ext != 'csv') {
 		$sql .= $db->plimit($limit + 1, $offset);
-		$resql = $db->query($sql);
 	} else {
 		$limit = 0;
 	}
+	$resql = $db->query($sql);
 	if (empty($resql)) {
 		dol_print_error($db);
 		exit;


### PR DESCRIPTION
Closes #37582.

In htdocs/product/stock/stockatdate.php the SQL query is only executed when the page is rendered as HTML (`$ext != 'csv'`, line 381). When the user clicks the 'Download CSV' link, `$ext` is 'csv' so `$resql` is never assigned, the empty($resql) check immediately below triggers `dol_print_error($db); exit`, and the response is HTTP 500 with a header-only CSV.

Move `$db->query($sql)` out of the if/else and run it in both branches. The plimit skip stays inside the if so the CSV export is not paginated.