### PR TITLE
Fix #37120 honor LDAP_FILTER_CONNECTION in Ldap::getAttribute lookup

### DIFF
--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -1105,6 +1105,13 @@ class Ldap
 			return -3;
 		}
 
+		// Honor the admin-configured user search filter (LDAP_FILTER_CONNECTION)
+		// so an identifier match outside the configured scope does not leak
+		// attributes for an unrelated LDAP user (see #37120).
+		if (!empty($this->filter) && !preg_match('/^\s*\(\s*&\s*\(/', $filter)) {
+			$filter = '(&(' . $this->filter . ')' . $filter . ')';
+		}
+
 		$search = @ldap_search($this->connection, $dn, $filter);
 
 		// Only one entry should ever be returned


### PR DESCRIPTION
Closes #37120.

The user/ldap.php attribute viewer calls `$ldap->getAttribute($dn, $search)` where `$search` is built from the user identifier alone (e.g. `(uid=jdoe)`). `getAttribute()` forwards that filter to `ldap_search()` unchanged, so the admin-configured `LDAP_FILTER_CONNECTION` (which `getRecords()` honors via activefilter=1) is bypassed.

A local Dolibarr user renamed to a uid that matches an LDAP entry sitting outside the configured search-filter scope will then leak that entry's attributes back to the UI.

AND `$this->filter` with the caller-supplied filter when set, unless the filter is already a conjunctive expression starting with `(&(` (avoids double-wrapping when called from getRecords).