### PR TITLE
Fix #37205 pass selectedline to invoice.php addline so supplements attach to parent

### DIFF
--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -587,7 +587,7 @@ function ClickProduct(position, qty = 1) {
 			return;
 		}
 		// Call page invoice.php to generate the section with product lines
-		$("#poslines").load("invoice.php?action=addline&token=<?php echo newToken(); ?>&place="+place+"&idproduct="+idproduct+"&qty="+qty+"&invoiceid="+invoiceid, function() {
+		$("#poslines").load("invoice.php?action=addline&token=<?php echo newToken(); ?>&place="+place+"&idproduct="+idproduct+"&selectedline="+selectedline+"&qty="+qty+"&invoiceid="+invoiceid, function() {
 			<?php if (getDolGlobalString('TAKEPOS_CUSTOMER_DISPLAY')) {
 				echo "CustomerDisplay();";
 			}?>


### PR DESCRIPTION
Closes #37205.

TakePOS supplement handling needs the rowid of the previously selected line so the new line can be attached as a child via fk_parent_line. `htdocs/takepos/invoice.php:837` reads `$selectedline = GETPOSTINT('selectedline')` and `SELECT fk_parent_line FROM facturedet WHERE rowid = $selectedline` to find the parent.

The JS in `htdocs/takepos/index.php:590` had dropped the `selectedline` query parameter (regression since 19.x), so GETPOSTINT returned 0, the parent lookup matched nothing, fk_parent_line stayed null and the supplement was added as a standalone line.

Restore the `&selectedline=` parameter to the AJAX URL. Reporter pinpointed both the symptom and the missing param.