### PR TITLE
Fix #36743 guard getExecutableContent() call against partial-upgrade undefined function

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -2074,8 +2074,11 @@ function dol_add_file_process($upload_dir, $allowoverwrite = 0, $updatesessionor
 				$info = pathinfo($destfile);
 				$destfile = dol_sanitizeFileName($info['filename'].($info['extension'] != '' ? ('.'.strtolower($info['extension'])) : ''));
 
-				// Check extension is allowed for upload
-				$fileextensionrestriction = getDolGlobalString("MAIN_FILE_EXTENSION_UPLOAD_RESTRICTION", implode(',', getExecutableContent()));
+				// Check extension is allowed for upload.
+				// Guard against partial upgrades where files.lib.php has been refreshed
+				// but functions.lib.php has not been reloaded with getExecutableContent() yet.
+				$defaultexecutableextensions = function_exists('getExecutableContent') ? implode(',', getExecutableContent()) : 'htm,html,shtml,js,phar,php,php3,php4,php5,phtml,pht,pl,py,cgi,ksh,sh,bash,bat,cmd,wpk,exe';
+				$fileextensionrestriction = getDolGlobalString("MAIN_FILE_EXTENSION_UPLOAD_RESTRICTION", $defaultexecutableextensions);
 				if (!empty($fileextensionrestriction)) {
 					$arrayofregexextension = explode(",", $fileextensionrestriction);
 


### PR DESCRIPTION
Closes #36743.

`dol_add_file_process()` builds the default MAIN_FILE_EXTENSION_UPLOAD_RESTRICTION value via `implode(',', getExecutableContent())` inline. `getExecutableContent()` was added to `core/lib/functions.lib.php` in 22.0.0. On installs where files.lib.php has been refreshed but functions.lib.php still ships an older copy (partial upgrade, mixed deploy), the upload path crashes with `Fatal Error: Call to undefined function getExecutableContent()` at files.lib.php:2078.

Guard the call with `function_exists()` and fall back to a static copy of the current executable-extension list. The fallback matches the function output exactly so the security check is preserved; once functions.lib.php is also upgraded the function-based branch takes over again.