### PR TITLE
Fix #37317 22.0 backport: include actions_printing.inc.php in ticket card

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -680,6 +680,9 @@ if (empty($reshook)) {
 	$permissiondellink = $user->hasRight('ticket', 'write');
 	include DOL_DOCUMENT_ROOT . '/core/actions_dellink.inc.php'; // Must be 'include', not 'include_once'
 
+	// Actions when printing a doc from card
+	include DOL_DOCUMENT_ROOT . '/core/actions_printing.inc.php';
+
 	// Actions to build doc
 	include DOL_DOCUMENT_ROOT . '/core/actions_builddoc.inc.php';
 


### PR DESCRIPTION
Closes #37317 on 22.0.

The Ticket card at htdocs/ticket/card.php never handled action=print_file because it never included htdocs/core/actions_printing.inc.php. Clicking the printer icon on a Ticket hit the URL with that action, the handler that dispatches to Direct Printing / PrintIPP was never loaded, and the page rendered as a blank response.

23.0 and develop already include the file (commit dc85a6756b7, shipped in 23.0.0+). This is a one-line backport to keep the printer icon working on 22.0.