### PR TITLE
Fix #34680 store DATABASE_PWD_ENCRYPTED with entity=0 like admin/security.php

### DIFF
--- a/htdocs/install/step5.php
+++ b/htdocs/install/step5.php
@@ -273,7 +273,11 @@ if ($action == "set" || empty($action) || preg_match('/upgrade/i', $action)) {
 				$numrows = $db->num_rows($resql);
 				if ($numrows == 0) {
 					// Define default setup for password encryption
-					dolibarr_set_const($db, "DATABASE_PWD_ENCRYPTED", "1", 'chaine', 0, '', $conf->entity);
+					// DATABASE_PWD_ENCRYPTED is shared across all entities (admin/security.php:75
+					// stores it with entity=0). Use entity 0 here too, otherwise an install only
+					// records the flag for entity 1 and later created entities default to
+					// unencrypted passwords until an admin re-toggles the setting (#34680).
+					dolibarr_set_const($db, "DATABASE_PWD_ENCRYPTED", "1", 'chaine', 0, '', 0);
 					dolibarr_set_const($db, "MAIN_SECURITY_SALT", dol_print_date(dol_now(), 'dayhourlog'), 'chaine', 0, '', 0); // All entities
 					if (function_exists('password_hash')) {
 						dolibarr_set_const($db, "MAIN_SECURITY_HASH_ALGO", 'password_hash', 'chaine', 0, '', 0); // All entities


### PR DESCRIPTION
Closes #34680.

htdocs/admin/security.php:75 stores DATABASE_PWD_ENCRYPTED with entity 0 (the inline comment says 'DATABASE_PWD_ENCRYPTED is a setup into conf file, so always shared for everybody'). htdocs/install/step5.php was instead writing it with `$conf->entity` (= 1 on a first install), so the flag landed in llx_const for entity 1 only. Any later created entity then defaulted to no password encryption until an admin manually flipped the setting in admin/security.