### PR TITLE
Fix #34775 map facturerec/facture_fourn_rec to facture-rec.class.php in contract creation

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -319,6 +319,7 @@ if (empty($reshook)) {
 				}
 
 				// For compatibility
+				$classname = '';
 				if ($element == 'order') {
 					$element = $subelement = 'commande';
 				}
@@ -329,6 +330,17 @@ if (empty($reshook)) {
 				if ($element == 'invoice' || $element == 'facture') {
 					$element = 'compta/facture';
 					$subelement = 'facture';
+				}
+				if ($element == 'facturerec' || $element == 'facture_rec') {
+					// FactureRec lives in compta/facture/class/facture-rec.class.php (#34775)
+					$element = 'compta/facture';
+					$subelement = 'facture-rec';
+					$classname = 'FactureRec';
+				}
+				if ($element == 'facture_fourn_rec' || $element == 'invoice_supplier_rec') {
+					$element = 'fourn';
+					$subelement = 'fournisseur.facture-rec';
+					$classname = 'FactureFournisseurRec';
 				}
 
 				$object->origin    = $origin;
@@ -344,7 +356,9 @@ if (empty($reshook)) {
 				if ($id > 0) {
 					dol_include_once('/'.$element.'/class/'.$subelement.'.class.php');
 
-					$classname = ucfirst($subelement);
+					if (empty($classname)) {
+						$classname = ucfirst($subelement);
+					}
 					$srcobject = new $classname($db);
 					'@phan-var-force Commande|Propal|Facture $srcobject';  // Can be other class, but CommonObject is too Generic
 
@@ -1188,10 +1202,23 @@ if ($action == 'create') {
 				$element = 'compta/facture';
 				$subelement = 'facture';
 			}
+			$classname = '';
+			if ($element == 'facturerec' || $element == 'facture_rec') {
+				$element = 'compta/facture';
+				$subelement = 'facture-rec';
+				$classname = 'FactureRec';
+			}
+			if ($element == 'facture_fourn_rec' || $element == 'invoice_supplier_rec') {
+				$element = 'fourn';
+				$subelement = 'fournisseur.facture-rec';
+				$classname = 'FactureFournisseurRec';
+			}
 
 			dol_include_once('/'.$element.'/class/'.$subelement.'.class.php');
 
-			$classname = ucfirst($subelement);
+			if (empty($classname)) {
+				$classname = ucfirst($subelement);
+			}
 			$objectsrc = new $classname($db);
 			'@phan-var-force Commande|Propal|Facture $objectsrc';
 			$objectsrc->fetch($originid);


### PR DESCRIPTION
Closes #34775.

htdocs/contrat/card.php builds the source-class path from $element/$subelement parsed out of `GETPOST('origin')`. When a contract is created from a recurring invoice, origin = `facturerec` (or `facture_fourn_rec`), so the include path becomes `/facturerec/class/facturerec.class.php` while the real file is `htdocs/compta/facture/class/facture-rec.class.php`. dol_include_once silently logs the missing file, the source object is never instantiated, the contract is created without source lines and the link to the original invoice template breaks.

Add the same compatibility branches for facturerec / facture_fourn_rec as exist for facture / invoice. Because the file name now contains a hyphen, `ucfirst($subelement)` would yield `Facture-rec` (not a valid PHP identifier), so the new branches pin $classname explicitly to `FactureRec` / `FactureFournisseurRec` and the existing fallback only runs when no branch set it.