### PR TITLE
FIX Missing comma in ExpenseReportLine::fetch SQL

### DIFF
--- a/htdocs/expensereport/class/expensereportline.class.php
+++ b/htdocs/expensereport/class/expensereportline.class.php
@@ -254,7 +254,7 @@ class ExpenseReportLine extends CommonObjectLine
 		$sql = 'SELECT fde.rowid, fde.fk_expensereport, fde.fk_c_type_fees, fde.fk_c_exp_tax_cat, fde.fk_projet as fk_project, fde.date,';
 		$sql .= ' fde.tva_tx as vatrate, fde.vat_src_code, fde.comments, fde.qty, fde.value_unit, fde.total_ht, fde.total_tva, fde.total_ttc, fde.fk_ecm_files,';
 		$sql .= ' fde.localtax1_tx, fde.localtax2_tx, fde.localtax1_type, fde.localtax2_type, fde.total_localtax1, fde.total_localtax2, fde.rule_warning_message,';
-		$sql .= ' ctf.code as type_fees_code, ctf.label as type_fees_libelle, tcheck_file';
+		$sql .= ' ctf.code as type_fees_code, ctf.label as type_fees_libelle, fde.tcheck_file,';
 		$sql .= ' pjt.rowid as projet_id, pjt.title as projet_title, pjt.ref as projet_ref';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'expensereport_det as fde';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_type_fees as ctf ON fde.fk_c_type_fees=ctf.id'; // Sometimes type of expense report has been removed, so we use a left join here.

--- a/test/phpunit/ExpenseReportTest.php
+++ b/test/phpunit/ExpenseReportTest.php
@@ -237,4 +237,40 @@ class ExpenseReportTest extends CommonClassTest
 		$this->assertGreaterThan(0, $result);
 		return $result;
 	}
+
+	/**
+	 * testExpenseReportLineFetch
+	 *
+	 * @return	void
+	 */
+	public function testExpenseReportLineFetch()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$expensereport = new ExpenseReport($db);
+		$expensereport->initAsSpecimen();
+		$expensereport->status = 0;
+		$expensereport->fk_statut = 0;
+		$createresult = $expensereport->create($user);
+		$this->assertGreaterThan(0, $createresult, "Setup failed, cannot create expense report: ".$expensereport->error);
+
+		$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."expensereport_det WHERE fk_expensereport = ".((int) $expensereport->id)." ORDER BY rowid ASC";
+		$resql = $db->query($sql);
+		$lineobj = ($resql ? $db->fetch_object($resql) : null);
+		$this->assertNotNull($lineobj, "Setup failed, no line created for the expense report");
+		$lineid = (int) $lineobj->rowid;
+
+		$line = new ExpenseReportLine($db);
+		$fetchresult = $line->fetch($lineid);
+		print __METHOD__." lineid=".$lineid." result=".$fetchresult."\n";
+
+		$this->assertGreaterThan(0, $fetchresult, "ExpenseReportLine::fetch() must succeed for an existing line");
+		$this->assertEquals($lineid, $line->id, "Fetched line id does not match the requested one");
+
+		$expensereport->delete($user);
+	}
 }


### PR DESCRIPTION
# FIX Missing comma in ExpenseReportLine::fetch SQL

The `SELECT` of `ExpenseReportLine::fetch()` was missing a comma after the `tcheck_file` column. After concatenation the SQL became:

```
... ctf.label as type_fees_libelle, tcheck_file pjt.rowid as projet_id ...
```

which is a syntax error (`DB_ERROR_SYNTAX`), so the query always failed and `fetch()` returned `-1`.

This broke loading a single expense report line, both:
- in the UI — confirm "delete line" in `expensereport/card.php`, and
- in the REST API — `PUT /expensereports/{id}/lines/{lineid}`.

The column is now also qualified with its table alias (`fde.`) for consistency with the other columns of the `SELECT`.

### Test

A PHPUnit test `ExpenseReportTest::testExpenseReportLineFetch` is added. It creates an expense report with a line and reloads the line. It **fails before** the fix (SQL syntax error, `fetch()` returns `-1`) and **passes after**.

```
OK (1 test, 4 assertions)
```
