### PR TITLE
FIX API extrafield type check

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2016	    Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2020-2025  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2025	    William Mead			<william@m34d.com>
+ * Copyright (C) 2025-2026	William Mead			<william@m34d.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -200,10 +200,10 @@ class DolibarrApi
 				if (strpos($typeOfExtraField, 'int') || strpos($typeOfExtraField, 'double') || in_array($typeOfExtraField, array('real', 'price', 'stock'))) {
 					return sanitizeVal($value, 'int');
 				}
-				if ($object->array_options[$field]['type'] == 'html') {
+				if ($typeOfExtraField == 'html') {
 					return sanitizeVal($value, 'restricthtml');
 				}
-				if ($object->array_options[$field]['type'] == 'select') {
+				if ($typeOfExtraField == 'select') {
 					// TODO Check values are in the list of possible 'options'
 					return sanitizeVal($value, 'alphanohtml');
 				}


### PR DESCRIPTION
# FIX API extrafield type check
When updating html extrafields through API, HTML tags were being removed. Type check on `html` and also `select` where actually defaulting to `alphanothtml` type check.
