### PR TITLE
Qual: Fix PHPStan warning (undefined variable $s) in bank.lib.php

### DIFF
--- a/htdocs/core/lib/bank.lib.php
+++ b/htdocs/core/lib/bank.lib.php
@@ -457,7 +457,8 @@ function checkBanForAccount($account)
 		// Separation du rib en 3 groups de 7 + 1 group de 2.
 		// Multiplication of each group by the coefficients in the array.
 
-		for ($i = 0, $s = 0; $i < 3; $i++) {
+		$s = 0;
+		for ($i = 0; $i < 3; $i++) {
 			$code = substr($rib, 7 * $i, 7);
 			$s += ((int) $code) * $coef[$i];
 		}


### PR DESCRIPTION
## Context

PHPStan level 9 (the `dev/tools/phpstan/phpstan_v1_apstats.neon` ruleset used to generate https://cti.dolibarr.org/) reports:

```
htdocs/core/lib/bank.lib.php:465: Variable $s might not be defined.
```

## Cause

In `checkBanForAccount()`, `$s` was initialized inside the `for()` init expression:

```php
for ($i = 0, $s = 0; $i < 3; $i++) {
```

The apstats ruleset sets `polluteScopeWithLoopInitialAssignments: false`, so the assignment is not considered defined after the loop, where `$s` is used to compute the RIB key (`$cle_rib = 97 - ($s % 97);`).

## Fix

Move the `$s = 0` initialization to its own statement just before the loop. No behaviour change.
