### PR TITLE
Qual: Fix PHPStan warning (undefined variable $filter) in cron/list.php

### DIFF
--- a/htdocs/cron/list.php
+++ b/htdocs/cron/list.php
@@ -59,6 +59,7 @@ $search_module_name = GETPOST("search_module_name", 'alpha');
 $search_lastresult = GETPOST("search_lastresult", "alphawithlgt");
 $search_processing = GETPOST("search_processing", 'int');
 $securitykey = GETPOST('securitykey', 'alpha');
+$filter = array();	// Search filter built later, initialized here so it is always defined (e.g. when a hook intercepts the Actions section)
 
 $id = GETPOSTINT('id');
 
@@ -360,7 +361,7 @@ if (GETPOSTISSET('search_processing')) {
 	$sql .= " AND t.processing = ".((int) $search_processing);
 }
 // Manage filter
-if (is_array($filter) && count($filter) > 0) {
+if (count($filter) > 0) {
 	foreach ($filter as $key => $value) {
 		$sql .= " AND ".$db->sanitize($key)." LIKE '%".$db->escape($value)."%'";
 	}


### PR DESCRIPTION
## Context

PHPStan level 9 (the `dev/tools/phpstan/phpstan_v1_apstats.neon` ruleset used to generate https://cti.dolibarr.org/) reports:

```
htdocs/cron/list.php:363: Variable $filter might not be defined.
```

## Cause

`$filter` was only initialized inside the `if (empty($reshook))` Actions block:

```php
$filter = array();
if (!empty($search_label)) {
    $filter['t.label'] = $search_label;
}
```

But it is used unconditionally further down to build the SQL `WHERE` clause:

```php
if (is_array($filter) && count($filter) > 0) {
```

When a hook intercepts the Actions section (`$reshook` not empty), the block is skipped and `$filter` stays undefined.

## Fix

- Initialize `$filter = array();` together with the other search criteria so it is always defined.
- Since `$filter` is now always an array, the `is_array($filter)` guard is redundant (it would otherwise raise a level 10 `Call to function is_array() ... will always evaluate to true` warning), so the condition is simplified to `count($filter) > 0`.

No behaviour change.
