### PR TITLE
Qual: Fix PHPStan warning (undefined variable $maxlength) in recruitmentcandidature_list.php

### DIFF
--- a/htdocs/recruitment/recruitmentcandidature_list.php
+++ b/htdocs/recruitment/recruitmentcandidature_list.php
@@ -441,7 +441,7 @@ if ($jobposition->id > 0 && (empty($action) || ($action != 'edit' && $action != 
 				$morehtmlref .= '<form method="post" action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'">';
 				$morehtmlref .= '<input type="hidden" name="action" value="classin">';
 				$morehtmlref .= '<input type="hidden" name="token" value="'.newToken().'">';
-				$morehtmlref .= $formproject->select_projects(0, (string) $object->fk_project, 'projectid', $maxlength, 0, 1, 0, 1, 0, 0, '', 1);
+				$morehtmlref .= $formproject->select_projects(0, (string) $object->fk_project, 'projectid', 0, 0, 1, 0, 1, 0, 0, '', 1);
 				$morehtmlref .= '<input type="submit" class="button valignmiddle" value="'.$langs->trans("Modify").'">';
 				$morehtmlref .= '</form>';
 			} else {


### PR DESCRIPTION
## Context

PHPStan level 9 (the `dev/tools/phpstan/phpstan_v1_apstats.neon` ruleset used to generate https://cti.dolibarr.org/) reports:

```
htdocs/recruitment/recruitmentcandidature_list.php:444: Variable $maxlength might not be defined.
```

## Cause

`$maxlength` is never defined in this file but is passed as the 4th argument (maximum label length) of `FormProjets::select_projects()`:

```php
$morehtmlref .= $formproject->select_projects(0, (string) $object->fk_project, 'projectid', $maxlength, 0, 1, 0, 1, 0, 0, '', 1);
```

An undefined variable evaluates to `null`. Inside the combo building, the label is truncated with `dol_trunc($title, $maxlength)`, and `dol_trunc()` returns the string unchanged when its size argument is empty (`if (empty($size)) return $string;`). So `null` behaves exactly like `0` (no truncation).

## Fix

Pass `0` explicitly instead of the undefined `$maxlength`. This keeps the exact same behaviour and removes the undefined-variable warning.
