### PR TITLE
Qual: Fix PHPStan warning (undefined variable $backtopageforcancel) in product/inventory/card.php

### DIFF
--- a/htdocs/product/inventory/card.php
+++ b/htdocs/product/inventory/card.php
@@ -50,6 +50,7 @@ $confirm    = GETPOST('confirm', 'alpha');
 $cancel     = GETPOST('cancel');
 $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'inventorycard'; // To manage different context of search
 $backtopage = GETPOST('backtopage', 'alpha');
+$backtopageforcancel = GETPOST('backtopageforcancel', 'alpha');
 $include_sub_warehouse = !empty(GETPOST('include_sub_warehouse')) ? GETPOST('include_sub_warehouse') : 0;
 
 $hookmanager->initHooks(array('inventorycard', 'globalcard')); // Note that conf->hooks_modules contains array


### PR DESCRIPTION
## Context

PHPStan level 9 (the `dev/tools/phpstan/phpstan_v1_apstats.neon` ruleset used to generate https://cti.dolibarr.org/) reports:

```
htdocs/product/inventory/card.php:244: Variable $backtopageforcancel might not be defined.
```

## Cause

The page reads `$backtopage` from the request and prints **both** a `backtopage` and a `backtopageforcancel` hidden field:

```php
if ($backtopageforcancel) {
    print '<input type="hidden" name="backtopageforcancel" value="'.$backtopageforcancel.'">';
}
```

But `$backtopageforcancel` was never read from the request, so it was always undefined (and the hidden field was never emitted).

## Fix

Add the standard `$backtopageforcancel = GETPOST('backtopageforcancel', 'alpha');` line right after `$backtopage`, matching the canonical pattern already used in `htdocs/product/card.php` and `htdocs/societe/card.php`.
