### PR TITLE
Qual: Fix static analysis warnings in salaries/list.php

### DIFF
--- a/htdocs/salaries/list.php
+++ b/htdocs/salaries/list.php
@@ -805,8 +805,8 @@ while ($i < $imaxinloop) {
 	$userstatic->login = $obj->login;
 	$userstatic->email = $obj->email;
 	$userstatic->socid = $obj->fk_soc;
-	$userstatic->statut = $obj->status;		// deprecated
-	$userstatic->status = $obj->status;
+	$userstatic->statut = (int) $obj->status;		// deprecated
+	$userstatic->status = (int) $obj->status;
 	$userstatic->photo = $obj->photo;
 
 	$salstatic->id = $obj->rowid;
@@ -827,6 +827,7 @@ while ($i < $imaxinloop) {
 			print '<div class="box-flex-container kanban">';
 		}
 		// Output Kanban
+		$selected = 0;
 		if ($massactionbutton || $massaction) { // If we are in select mode (massactionbutton defined) or if we have already selected and sent an action ($massaction) defined
 			$selected = 0;
 			if (in_array($object->id, $arrayofselected)) {


### PR DESCRIPTION
Fixes the static-analysis warnings reported on https://cti.dolibarr.org/ for `htdocs/salaries/list.php`.

## PHPStan (level 9) — undefined variable

```
htdocs/salaries/list.php:836: Variable $selected might not be defined.
```

In the Kanban output `$selected` is only assigned inside the select-mode block, but it is always passed to `getKanbanView()`:

```php
// Output Kanban
if ($massactionbutton || $massaction) {
    $selected = 0;
    if (in_array($object->id, $arrayofselected)) {
        $selected = 1;
    }
}
print $salstatic->getKanbanView('', array('user' => $userstatic, 'selected' => $selected));
```

Initialize `$selected = 0;` before the block. `0` is exactly the value `getKanbanView()` falls back to when `selected` is empty/absent (`$selected = empty($arraydata['selected']) ? 0 : $arraydata['selected'];`), so behaviour is strictly unchanged.

## Phan — type mismatch

```
htdocs/salaries/list.php:808/809: Assigning $obj->status of type string to property but User->statut/status is int
```

`$obj->status` comes from the SQL alias `u.statut as status` — an `int` column returned as a `string` by the DB layer — and is assigned to the `int`-typed `User::$status` / `User::$statut` properties. Cast it to `(int)`.
