### PR TITLE
Fix #34684 avoid double sign-flip on supplier orders driven by PROJECT_ELEMENTS_FOR_MINUS_MARGIN

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1071,8 +1071,11 @@ foreach ($listofreferent as $key => $value) {
 					}
 				}
 
-				// Change sign of $total_ht_by_line and $total_ttc_by_line for supplier proposal and supplier order
-				if ($tablename == 'commande_fournisseur' || $tablename == 'supplier_proposal') {
+				// Change sign of $total_ht_by_line and $total_ttc_by_line for supplier proposal and supplier order.
+				// Skip when the element already participates to the margin computation via margin='minus'
+				// (line 1095 below will revert sign too, and double-negation would silently flip the value
+				// back to positive - see PROJECT_ELEMENTS_FOR_MINUS_MARGIN=order_supplier in #34684).
+				if (($tablename == 'commande_fournisseur' || $tablename == 'supplier_proposal') && $margin !== 'minus') {
 					$total_ht_by_line = -$total_ht_by_line;
 					$total_ttc_by_line = -$total_ttc_by_line;
 				}


### PR DESCRIPTION
Closes #34684.

htdocs/projet/element.php:1075 unconditionally negates `total_ht` / `total_ttc` for `commande_fournisseur` and `supplier_proposal` rows. A few lines below at 1095, the margin block also negates when `$margin === 'minus'`.

The default `order_supplier` entry in `$listofreferent` ships without a margin key, so users opt it into the profit calculation via `PROJECT_ELEMENTS_FOR_MINUS_MARGIN=order_supplier`. The loop at line 819 then sets `$margin='minus'` for that key, and both negations fire on the same value - the supplier total flows into `balance_ht` as a positive amount instead of being subtracted, which matches the symptom in the screenshot.

Skip the line-level negation when the margin block will take care of it. Behavior for elements that are NOT opted into the margin system (the original use case for the unconditional flip) is unchanged.