### PR TITLE
Fix #34774 accept YYYYMMDDHHMMSS datep param sent by /societe/agenda.php

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -101,7 +101,9 @@ $reg = [];
 if (GETPOST('datep')) {
 	if (GETPOST('datep') == 'now') {
 		$datep = dol_now();
-	} elseif (preg_match('/^([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])$/', GETPOST("datep"), $reg)) {		// Try to not use this. Use instead '&datep=now'
+	} elseif (preg_match('/^([0-9]{4})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})([0-9]{2})$/', GETPOST("datep"), $reg)) {		// YYYYMMDDHHMMSS (dayhourlog) - e.g. from /societe/agenda.php "Add event" button
+		$datep = dol_mktime((int) $reg[4], (int) $reg[5], (int) $reg[6], (int) $reg[2], (int) $reg[3], (int) $reg[1], 'tzuserrel');
+	} elseif (preg_match('/^([0-9][0-9][0-9][0-9])([0-9][0-9])([0-9][0-9])$/', GETPOST("datep"), $reg)) {		// YYYYMMDD - try to not use this. Use instead '&datep=now'
 		$datep = dol_mktime(0, 0, 0, (int) $reg[2], (int) $reg[3], (int) $reg[1], 'tzuserrel');
 	}
 }

--- a/htdocs/societe/agenda.php
+++ b/htdocs/societe/agenda.php
@@ -246,7 +246,7 @@ if (isModEnabled('agenda') && ($user->hasRight('agenda', 'myactions', 'read') ||
 		$param .= '&search_complete='.urlencode($search_complete);
 	}
 	if ($search_filtert != '') {
-		$param .= '&search_filtert='.urlencode($search_filtert);
+		$param .= '&search_filtert='.urlencode((string) $search_filtert);
 	}
 	if ($search_dateevent_start != '') {
 		$param .= '&dateevent_startyear='.GETPOSTINT('dateevent_startyear');

--- a/htdocs/societe/agenda.php
+++ b/htdocs/societe/agenda.php
@@ -192,7 +192,12 @@ if ((!empty($objthirdparty->id) || !empty($objcon->id)) && $permok) {
 		$out .= '&originid='.$objthirdparty->id.($objthirdparty->id > 0 ? '&socid='.$objthirdparty->id : '').'&backtopage='.urlencode($_SERVER['PHP_SELF'].($objthirdparty->id > 0 ? '?socid='.$objthirdparty->id : ''));
 	}
 	$out .= (!empty($objcon->id) ? '&contactid='.$objcon->id : '');
-	$out .= '&datep='.dol_print_date(dol_now(), 'dayhourlog', 'tzuserrel');
+	// Use the documented &datep=now form (see comm/action/card.php:104) instead of
+	// a 14-digit YYYYMMDDHHMMSS which the consumer regex did not accept, leaving
+	// the date un-prefilled on the AddAction form (#34774). The consumer-side
+	// 14-digit fallback in the same PR keeps any other caller still emitting the
+	// old format working.
+	$out .= '&datep=now';
 }
 
 $morehtmlright = '';


### PR DESCRIPTION
Closes #34774.

htdocs/societe/agenda.php:195 builds the AddAction button URL with `&datep=` from `dol_print_date(dol_now(), 'dayhourlog')`, which expands to 14 digits (YYYYMMDDHHMMSS) - see htdocs/core/lib/functions.lib.php:3961 where dayhourlog = '%Y%m%d%H%M%S'.

htdocs/comm/action/card.php:104 only accepts the 8-digit YYYYMMDD variant, so the regex misses, `$datep` stays null and the date/time pre-fill on the form fails. The thirdparty preselection works because the `&socid=` parameter is consumed by a separate code path.

Add a leading regex branch that decodes the dayhourlog form. The legacy 8-digit handler stays as a fallback for older callers.