### PR TITLE
Fix #38781 allow editing dictionary entries with rowid = 0 (ST_NEVER)

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -2399,7 +2399,10 @@ if ($id > 0) {
 					print '</td>';
 				}
 
-				if ($action == 'edit' && ($rowid == (!empty($obj->rowid) ? $obj->rowid : $obj->code))) {
+				// Use isset() rather than !empty() so a dictionary row with rowid = 0
+				// (for example ST_NEVER in llx_c_stcomm) is treated as a real rowid and
+				// not fallen back to the code, which would make it un-editable (#38781).
+				if ($action == 'edit' && ($rowid == (isset($obj->rowid) ? $obj->rowid : $obj->code))) {
 					$tmpaction = 'edit';
 					$parameters = array('fieldlist' => $fieldlist, 'tabname' => $tabname[$id]);
 					$reshook = $hookmanager->executeHooks('editDictionaryFieldlist', $parameters, $obj, $tmpaction); // Note that $action and $object may have been modified by some hooks
@@ -2412,7 +2415,7 @@ if ($id > 0) {
 					}
 
 					print '<td colspan="3" class="center">';
-					print '<div name="'.(!empty($obj->rowid) ? $obj->rowid : $obj->code).'"></div>';
+					print '<div name="'.(isset($obj->rowid) ? $obj->rowid : $obj->code).'"></div>';
 					print '<input type="hidden" name="page" value="'.dol_escape_htmltag((string) $page).'">';
 					print '<input type="hidden" name="rowid" value="'.dol_escape_htmltag($rowid).'">';
 					if (!is_null($withentity)) {


### PR DESCRIPTION
Closes #38781.

htdocs/admin/dict.php:2402 guards the edit-form rendering with `$rowid == (!empty($obj->rowid) ? $obj->rowid : $obj->code)`. PHP `empty(0)` returns true, so the ternary falls back to `$obj->code` for any row whose rowid is 0. The comparison becomes `'0' == 'ST_NEVER'` and the form never renders. `ST_NEVER` in `llx_c_stcomm` is inserted with id = 0 by the install fixture, so its label / picto are stuck non-editable.

Switch the guard to `isset()` so rowid = 0 is treated as a real rowid. The same fallback exists at line 2415 for the name attribute of a hidden div; same change for consistency. Any other dictionary row inserted with id = 0 gets unblocked too.

Reporter pinpointed both the line and the fix.