### PR TITLE
Fix #38786 datapolicy: restrict isObjectUsed() guard to deletion, not anonymization

### DIFF
--- a/htdocs/datapolicy/class/datapolicycron.class.php
+++ b/htdocs/datapolicy/class/datapolicycron.class.php
@@ -375,7 +375,11 @@ class DataPolicyCron
 			$object = clone $object;
 			$object->fetch($obj->rowid);
 
-			if (!empty($object->childtables) && method_exists($object, 'isObjectUsed') && $object->isObjectUsed() != 0) {
+			// isObjectUsed() is a referential-integrity guard for deletion (cannot drop a
+			// thirdparty that still has quotes/orders/contracts pointing at it). Anonymization
+			// must still be allowed: personal data has to be erasable even when commercial
+			// documents from the retention period are kept (#38786).
+			if ($action === 'delete' && !empty($object->childtables) && method_exists($object, 'isObjectUsed') && $object->isObjectUsed() != 0) {
 				continue; // Not an error, just skipping.
 			}
 


### PR DESCRIPTION
Closes #38786.

htdocs/datapolicy/class/datapolicycron.class.php:378 skipped the row as soon as `isObjectUsed()` returned non-zero, regardless of whether the cron loop was running the delete or anonymize action. `isObjectUsed()` on Societe is true as soon as a quote, order, contract, intervention, shipment, etc. points at the record - all things that are legitimately kept under accounting / commercial retention while the personal data on the thirdparty itself must still be erasable under GDPR.

Apply the guard only for `action === 'delete'` (where referential integrity is at stake). Anonymization runs to completion regardless of attached commercial documents. Reporter pinpointed the line and the fix.