### PR TITLE
Fix #38783 enforce supplier qty_min on PRODUCT_USE_SUPPLIER_PACKAGING rounding

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2159,6 +2159,21 @@ class CommandeFournisseur extends CommonOrder
 							setEventMessages($langs->trans('QtyRecalculatedWithPackaging'), null, 'mesgs');
 						}
 					}
+
+					// Enforce the supplier minimum purchase quantity on top of packaging
+					// rounding. The packaging block above only ensures qty is a packaging
+					// multiple, not that it satisfies pfp.quantity (=qty_min). If the line
+					// is below the supplier minimum, round qty_min itself up to the next
+					// packaging multiple so we end up with the smallest valid order qty (#38783).
+					if (!empty($prod->fourn_qty) && abs((float) $qty) < (float) $prod->fourn_qty) {
+						if (!empty($prod->packaging) && (float) price2num(fmod((float) $prod->fourn_qty, (float) $prod->packaging), 'MS')) {
+							$coeff = intval((float) $prod->fourn_qty / (float) $prod->packaging) + 1;
+							$qty = (float) price2num((float) $prod->packaging * $coeff, 'MS');
+						} else {
+							$qty = (float) $prod->fourn_qty;
+						}
+						setEventMessages($langs->trans('QtyRecalculatedWithPackaging'), null, 'mesgs');
+					}
 				}
 			}
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -2644,6 +2644,11 @@ class Product extends CommonObject
 				if (getDolGlobalString('PRODUCT_USE_SUPPLIER_PACKAGING')) {
 					$this->packaging = (float) $obj->packaging;
 				}
+				// Expose the supplier minimum purchase quantity so callers can enforce qty_min
+				// on top of packaging-multiple rounding (#38783). pfp.quantity is the lowest
+				// qty for which this price line is valid; for "below-min" callers this is the
+				// floor they must round up to.
+				$this->fourn_qty = $obj->quantity;
 				$result = $obj->fk_product;
 				return $result;
 			} else { // If not found
@@ -2709,6 +2714,9 @@ class Product extends CommonObject
 						if (getDolGlobalString('PRODUCT_USE_SUPPLIER_PACKAGING')) {
 							$this->packaging = (float) $obj->packaging;
 						}
+						// Expose pfp.quantity so callers can enforce qty_min on top of packaging
+						// rounding (#38783).
+						$this->fourn_qty = $obj->quantity;
 						$result = $obj->fk_product;
 						return $result;
 					} else {


### PR DESCRIPTION
Closes #38783.

`CommandeFournisseur::addline` rounds the line quantity to the next packaging multiple but never enforces `pfp.quantity` (the supplier minimum purchase quantity). A line with packaging=3 and qty_min=15 can therefore be saved at qty=6 (multiple of packaging only) - the user-facing scenario in the issue.

Two small changes:

1. `htdocs/product/class/product.class.php` `get_buyprice()` already maintains `$prod_supplier->fourn_qty` on the dynamic-price code path (lines 2622, 2691) but never propagates the value to `$this->fourn_qty` (the public property documented as MOQ at line 738). Assign in both branches so callers can read it after the call.

2. `htdocs/fourn/class/fournisseur.commande.class.php` `addline` applies a second rounding pass against `$prod->fourn_qty` after the packaging-multiple step. If qty is still below qty_min, qty_min itself is rounded up to the next packaging multiple - the smallest qty that satisfies both constraints simultaneously.

Reporter pinpointed both the symptom and the missing check. `updateline` is left for a follow-up; it currently reads `$this->line->packaging` without calling `get_buyprice`, so propagating qty_min there needs an extra fetch and a maintainer call on which fetch path to use.