### PR TITLE
Fix #38782 harmonize packaging-rounding logic between supplier and customer order paths

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3286,7 +3286,7 @@ class Commande extends CommonOrder
 			}
 
 			if (getDolGlobalString('PRODUCT_USE_CUSTOMER_PACKAGING')) {
-				if ($qty < $this->line->packaging) {
+				if (abs((float) $qty) < $this->line->packaging) {
 					$qty = $this->line->packaging;
 					setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'warnings');
 				} else {
@@ -3294,8 +3294,10 @@ class Commande extends CommonOrder
 						&& is_numeric($this->line->packaging)
 						&& (float) $this->line->packaging > 0
 						&& (float) price2num(fmod((float) $qty, (float) $this->line->packaging), 'MS')) {
-						$coeff = intval($qty / $this->line->packaging) + 1;
-						$qty = $this->line->packaging * $coeff;
+						// Use abs() to keep the rounding consistent for negative qty,
+						// matching what addline() at line 1725 already does (#38782 bug 5).
+						$coeff = intval(abs((float) $qty) / $this->line->packaging) + 1;
+						$qty = price2num((float) $this->line->packaging * $coeff, 'MS');
 						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'warnings');
 					}
 				}

--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2150,13 +2150,16 @@ class CommandeFournisseur extends CommonOrder
 					$prod = new Product($this->db);
 					$prod->get_buyprice($fk_prod_fourn_price, (float) $qty, $fk_product, 'none', (empty($this->fk_soc) ? $this->socid : $this->fk_soc));
 
+					// Align messaging, type and float-safety with the customer-order path at commande.class.php:1720
+					// (#38782 bugs 1, 2, 6).
 					if (abs((float) $qty) < $prod->packaging) {
 						$qty = (float) $prod->packaging;
+						setEventMessages($langs->trans('QtyRecalculatedWithPackaging'), null, 'warnings');
 					} else {
 						if (!empty($prod->packaging) && (float) price2num(fmod((float) $qty, (float) $prod->packaging), 'MS')) {
 							$coeff = intval(abs((float) $qty) / $prod->packaging) + 1;
-							$qty = (float) $prod->packaging * $coeff;
-							setEventMessages($langs->trans('QtyRecalculatedWithPackaging'), null, 'mesgs');
+							$qty = price2num((float) $prod->packaging * $coeff, 'MS');
+							setEventMessages($langs->trans('QtyRecalculatedWithPackaging'), null, 'warnings');
 						}
 					}
 				}
@@ -3204,14 +3207,19 @@ class CommandeFournisseur extends CommonOrder
 			$this->line->desc = $desc;
 
 			// redefine quantity according to packaging
+			// Mirror commande.class.php::updateline at line 3289: surface the auto-correction
+			// to the user with a warning, float-safe the fmod / coeff arithmetic and use
+			// abs() so negative qty is handled too (#38782 bugs 3, 4, 5, 6).
 			if (getDolGlobalString('PRODUCT_USE_SUPPLIER_PACKAGING')) {
-				if ($qty < $this->line->packaging) {
+				if (abs((float) $qty) < $this->line->packaging) {
 					$qty = $this->line->packaging;
+					setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'warnings');
 				} else {
-					if (!empty($this->line->packaging) && is_numeric($this->line->packaging) && (float) $this->line->packaging > 0 && (fmod((float) $qty, (float) $this->line->packaging) > 0)) {
-						$coeff = intval($qty / $this->line->packaging) + 1;
-						$qty = $this->line->packaging * $coeff;
-						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'mesgs');
+					if (!empty($this->line->packaging) && is_numeric($this->line->packaging) && (float) $this->line->packaging > 0
+						&& (float) price2num(fmod((float) $qty, (float) $this->line->packaging), 'MS')) {
+						$coeff = intval(abs((float) $qty) / $this->line->packaging) + 1;
+						$qty = price2num((float) $this->line->packaging * $coeff, 'MS');
+						setEventMessage($langs->trans('QtyRecalculatedWithPackaging'), 'warnings');
 					}
 				}
 			}


### PR DESCRIPTION
Closes #38782.

When PRODUCT_USE_CUSTOMER_PACKAGING / PRODUCT_USE_SUPPLIER_PACKAGING are enabled, the four order-line methods (`Commande::addline`, `Commande::updateline`, `CommandeFournisseur::addline`, `CommandeFournisseur::updateline`) recompute the quantity to the next packaging multiple. Reporter audited the four code paths and listed six divergences; the customer addline at htdocs/commande/class/commande.class.php:1720 is the reference and the rest are re-aligned on it:

- **Bug 1**: supplier `addline` did not call `setEventMessages()` when `qty < packaging`. The user was silently corrected (htdocs/fourn/class/fournisseur.commande.class.php:2153).
- **Bug 2**: supplier `addline` used raw float multiplication; switched to `price2num('MS')`.
- **Bug 3**: supplier `updateline` used `fmod() > 0` which is vulnerable to float noise (`fmod(3.0, 1.5)` can yield `4.44e-16`); switched to `price2num((float) ..., 'MS')`.
- **Bug 4**: supplier `updateline` missed the `qty < packaging` notification.
- **Bug 5**: both `updateline` paths missed `abs()` in `coeff = intval(qty / packaging) + 1`, which broke rounding for negative qty. The `addline` paths already do `abs()`.
- **Bug 6**: supplier path used `setEventMessages('mesgs')` (green/info); the user feedback is a corrected input - semantically a warning. Switched to `'warnings'` to match the customer path.

No behavior change for callers passing positive, valid quantities; the diff only affects edge cases (negative qty, qty just under packaging, float-fmod noise) and the message channel.