### PR TITLE
Fix #37773 align inventory pmp-perentity write condition with Product::fetch read

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -261,7 +261,12 @@ if (empty($reshook)) {
 							setEventMessages($db->lasterror(), null, 'errors');
 							break;
 						}
-						if (getDolGlobalString('MAIN_PRODUCT_PERENTITY_SHARED')) {
+						// Mirror Product::fetch (product.class.php:2995-2997) which reads pmp from
+						// llx_product_perentity only when MULTICOMPANY_PRODUCT_SHARING_ENABLED and
+						// MULTICOMPANY_PMP_PER_ENTITY_ENABLED are both set. MAIN_PRODUCT_PERENTITY_SHARED
+						// is the accountancy-codes flag; using it to gate the pmp write here means we
+						// silently write into a row that fetch never looks at (#37773).
+						if (getDolGlobalString('MULTICOMPANY_PRODUCT_SHARING_ENABLED') && getDolGlobalString('MULTICOMPANY_PMP_PER_ENTITY_ENABLED')) {
 							$sqlpmp = 'UPDATE '.MAIN_DB_PREFIX.'product_perentity SET pmp = '.((float) $line->pmp_real).' WHERE fk_product = '.((int) $line->fk_product).' AND entity='.$conf->entity;
 							$resqlpmp = $db->query($sqlpmp);
 							if (! $resqlpmp) {


### PR DESCRIPTION
Closes #37773.

htdocs/product/inventory/inventory.php:264 wrote into `llx_product_perentity` under `MAIN_PRODUCT_PERENTITY_SHARED`, but `Product::fetch` at htdocs/product/class/product.class.php:2995-2997 only reads pmp from that table when both `MULTICOMPANY_PRODUCT_SHARING_ENABLED` and `MULTICOMPANY_PMP_PER_ENTITY_ENABLED` are set. `MAIN_PRODUCT_PERENTITY_SHARED` is the accountancy-codes flag; using it to gate the pmp write meant inventory wrote a value that fetch would silently ignore.

Align the inventory write with the fetch read so the two stay in sync. Reporter pinpointed both files and the mismatch.