### PR TITLE
Fix #34602 modulebuilder: preserve case of composite property types

### DIFF
--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -1853,10 +1853,17 @@ if ($dirins && $action == 'addproperty' && empty($cancel) && !empty($module) && 
 
 
 		if (!$error && !GETPOST('regenerateclasssql') && !GETPOST('regeneratemissing')) {
+			// Preserve case for composite types such as 'integer:Societe:societe/class/societe.class.php:1:(...__SHARED_ENTITIES__...)'
+			// because the colon-separated parts include PHP class names (case-sensitive) and __XXX__ substitution
+			// tokens that are uppercase by convention. Only lowercase simple atomic types (#34602).
+			$proptype = GETPOST('proptype', 'alpha');
+			if (strpos($proptype, ':') === false && strpos($proptype, '_') === false) {
+				$proptype = strtolower($proptype);
+			}
 			$addfieldentry = array(
 				'name' => GETPOST('propname', 'aZ09'),
 				'label' => GETPOST('proplabel', 'alpha'),
-				'type' => strtolower(GETPOST('proptype', 'alpha')),
+				'type' => $proptype,
 				'arrayofkeyval' => GETPOST('proparrayofkeyval', 'nohtml'), 	// Example json string '{"0":"Draft","1":"Active","-1":"Cancel"}'
 				'visible' => GETPOST('propvisible', 'alphanohtml'),
 				'enabled' => GETPOST('propenabled', 'alphanohtml'),


### PR DESCRIPTION
Closes #34602.

htdocs/modulebuilder/index.php:1859 ran `strtolower()` on the raw `$proptype` form value, lower-casing composite types such as `integer:Societe:societe/class/societe.class.php:1:((status:=:1) and (entity:in:__SHARED_ENTITIES__))` into `integer:societe:...:(...__shared_entities__...)`. Two breakages from a single transform:

- PHP class names are case-sensitive on case-sensitive filesystems; `societe` then fails to instantiate where `Societe` worked.
- Substitution tokens such as `__SHARED_ENTITIES__` are matched verbatim by the entity filter; once lower-cased they no longer match.

Only lowercase atomic types (`Integer` -> `integer`, `TEXT` -> `text`). For any value containing `:` (composite spec) or `_` (substitution token), keep the user-typed casing.