### PR TITLE
Fix #38804 restore row-highlight on checkbox toggle in list views

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -11496,12 +11496,11 @@ class Form
 			$out .= 'if (typeof initCheckForSelect == \'function\') { initCheckForSelect(0, "' . $massactionname . '", "' . $cssclass . '"); } else { console.log("No function initCheckForSelect found. Call won\'t be done."); }';
 		}
 		$out .= '         });
-/*
         	        $(".' . $cssclass . '").change(function() {
 						console.log("We check and change the tr class highlight after a change on .'.$cssclass.'");
 						var $row = $(this).closest("tr");
 						if ($row.length) {
-	    					var anyChecked = $row.find(\'input[type="checkbox"].checkforselect:checked\').length > 0;
+	    					var anyChecked = $row.find(\'input[type="checkbox"].' . $cssclass . ':checked\').length > 0;
 							console.log("anychecked="+anyChecked);
 							if (!anyChecked) {
 								$row.removeClass("highlight");
@@ -11510,7 +11509,6 @@ class Form
 							}
 						}
 					});
-*/
 		 	});
     	</script>';
 


### PR DESCRIPTION
Closes #38804.

`Form::showCheckAddButtons()` emitted the JS handler that toggles the `highlight` class on the parent `<tr>` when a row checkbox flips, but the block was wrapped in `/* ... */` at htdocs/core/class/html.form.class.php:11499. Mass-action checkboxes were therefore checked but the row never received the visual highlight, regressing the v22 behaviour.

The block was probably commented because the inner `.find(...)` was hardcoded to `.checkforselect` while the surrounding handler attaches to `.$cssclass` (default `checkforaction`). With the two selectors mismatched, the row count was always zero.

Re-enable the block and reuse `$cssclass` in the inner find so the parent row sees its own checkbox states. Reporter pinpointed the function and the commented block.