### PR TITLE
Fix #37438 show full PU TTC on situation invoice lines with progress < 100

### DIFF
--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -268,8 +268,15 @@ $coldisplay++;
 	if (!empty($inputalsopricewithtax) && !getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH_TAX')) {
 		$coldisplay++;
 		$upinctax = isset($line->pu_ttc) ? $line->pu_ttc : null;
-		if (getDolGlobalInt('MAIN_UNIT_PRICE_WITH_TAX_IS_FOR_ALL_TAXES')) {
+		// On a situation invoice line whose progress is not 100%, total_ttc is the
+		// situation total, not the full PU TTC. Fall back to subprice * (1+vat) so
+		// the unit price displayed is the contract unit price, not the partial one.
+		$lineprogress = isset($line->situation_percent) ? (float) $line->situation_percent : 100;
+		if (getDolGlobalInt('MAIN_UNIT_PRICE_WITH_TAX_IS_FOR_ALL_TAXES') && $lineprogress >= 100) {
 			$upinctax = price2num($line->total_ttc / (float) $line->qty, 'MU');
+		}
+		if (!$upinctax && $lineprogress < 100 && $line->subprice) {
+			$upinctax = price2num($line->subprice * (1 + ($line->tva_tx / 100)), 'MU');
 		}
 		print '<td class="right"><input type="text" class="flat right width75" id="price_ttc" name="price_ttc" value="'.(GETPOSTISSET('price_ttc') ? GETPOST('price_ttc') : (isset($upinctax) ? price($upinctax, 0, '', 0) : '')).'"';
 		if ($situationinvoicelinewithparent) {

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -418,8 +418,17 @@ print $tooltiponpriceend;
 if (!empty($inputalsopricewithtax) && !getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH_TAX')) { ?>
 	<td class="linecoluttc nowraponall right"><?php $coldisplay++; ?><?php
 	$upinctax = isset($line->subprice_ttc) ? $line->subprice_ttc : null;
-	if (!$upinctax && $line->total_ttc && $line->qty) {
+	// On a situation invoice line whose progress is not 100%, total_ttc is the
+	// situation total, not the full PU TTC. Fall back to subprice * (1+vat) so
+	// the unit price displayed is the contract unit price, not the partial one.
+	$lineprogress = isset($line->situation_percent) ? (float) $line->situation_percent : 100;
+	if (!$upinctax && $line->total_ttc && $line->qty && $lineprogress >= 100) {
 		$upinctax = price2num($line->total_ttc / (float) $line->qty, 'MU');
+	}
+	if (!$upinctax && $lineprogress < 100 && $line->subprice) {
+		// On a situation invoice line whose progress < 100, total_ttc is partial.
+		// Recompute from subprice so the customer sees the full unit price (#37438).
+		$upinctax = price2num($line->subprice * (1 + ($line->tva_tx / 100)), 'MU');
 	}
 	if (!$upinctax) {
 		$multicurrency_upinctax = price2num($line->multicurrency_subprice * (1 + ($line->tva_tx / 100)), 'MU'); // one tax
@@ -432,7 +441,8 @@ if (!empty($inputalsopricewithtax) && !getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH
 if (isModEnabled("multicurrency") && $this->multicurrency_code && $this->multicurrency_code != $conf->currency && !empty($inputalsopricewithtax) && !getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH_TAX')) { ?>
 	<td class="linecoluttc_currency nowraponall right"><?php $coldisplay++; ?><?php
 	$multicurrency_upinctax = isset($line->multicurrency_subprice_ttc) ? $line->multicurrency_subprice_ttc : null;
-	if (!$multicurrency_upinctax && $line->multicurrency_total_ttc && $line->qty) {
+	$lineprogress = isset($line->situation_percent) ? (float) $line->situation_percent : 100;
+	if (!$multicurrency_upinctax && $line->multicurrency_total_ttc && $line->qty && $lineprogress >= 100) {
 		$multicurrency_upinctax = price2num($line->multicurrency_total_ttc / (float) $line->qty, 'MU');
 	}
 	if (!$multicurrency_upinctax) {

--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -417,7 +417,7 @@ print $tooltiponpriceend;
 // Multicurrency HT
 if (!empty($inputalsopricewithtax) && !getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH_TAX')) { ?>
 	<td class="linecoluttc nowraponall right"><?php $coldisplay++; ?><?php
-	$upinctax = isset($line->subprice_ttc) ? $line->subprice_ttc : null;
+	$upinctax = !empty($line->subprice_ttc) ? $line->subprice_ttc : null;
 	// On a situation invoice line whose progress is not 100%, total_ttc is the
 	// situation total, not the full PU TTC. Fall back to subprice * (1+vat) so
 	// the unit price displayed is the contract unit price, not the partial one.
@@ -440,7 +440,7 @@ if (!empty($inputalsopricewithtax) && !getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH
 // Multicurrency TTC
 if (isModEnabled("multicurrency") && $this->multicurrency_code && $this->multicurrency_code != $conf->currency && !empty($inputalsopricewithtax) && !getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH_TAX')) { ?>
 	<td class="linecoluttc_currency nowraponall right"><?php $coldisplay++; ?><?php
-	$multicurrency_upinctax = isset($line->multicurrency_subprice_ttc) ? $line->multicurrency_subprice_ttc : null;
+	$multicurrency_upinctax = !empty($line->multicurrency_subprice_ttc) ? $line->multicurrency_subprice_ttc : null;
 	$lineprogress = isset($line->situation_percent) ? (float) $line->situation_percent : 100;
 	if (!$multicurrency_upinctax && $line->multicurrency_total_ttc && $line->qty && $lineprogress >= 100) {
 		$multicurrency_upinctax = price2num($line->multicurrency_total_ttc / (float) $line->qty, 'MU');


### PR DESCRIPTION
Closes #37438.

On INVOICE_USE_SITUATION=2, htdocs/compta/facture/class/facture.class.php:4268 forces situation_percent=0 on every new line, so total_ttc is zero and total_ttc/qty (objectline_view.tpl.php:421-422, objectline_edit.tpl.php:272) returns 0 - that is the empty PU TTC the reporter sees. With a partial progress like 50, the same expression returns half the real PU TTC.

Detect situation_percent < 100 and fall back to subprice * (1 + vat/100) so the customer sees the full contract unit price while the totals still follow the progress.