### PR TITLE
Fix #38219 takepos: keep empty draft invoice when a non-default customer is selected

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -995,14 +995,22 @@ if (empty($reshook)) {
 		}
 
 		if (count($invoice->lines) == 0) {
-			$invoice->delete($user);
+			// Keep an empty draft invoice alive when a non-default customer was
+			// already attached so deleting the last line does not silently lose
+			// the customer that was just selected (#38219). Only drop the invoice
+			// when it is still on the default cashdesk thirdparty (or none).
+			$defaultsocid = (int) getDolGlobalString('CASHDESK_ID_THIRDPARTY'.$_SESSION["takeposterminal"]);
+			$invoicesocid = (int) $invoice->socid;
+			if ($invoicesocid === 0 || $invoicesocid === $defaultsocid) {
+				$invoice->delete($user);
 
-			if (defined('INCLUDE_PHONEPAGE_FROM_PUBLIC_PAGE')) {
-				header("Location: ".DOL_URL_ROOT."/takepos/public/auto_order.php");
-			} else {
-				header("Location: ".DOL_URL_ROOT."/takepos/invoice.php");
+				if (defined('INCLUDE_PHONEPAGE_FROM_PUBLIC_PAGE')) {
+					header("Location: ".DOL_URL_ROOT."/takepos/public/auto_order.php");
+				} else {
+					header("Location: ".DOL_URL_ROOT."/takepos/invoice.php");
+				}
+				exit;
 			}
-			exit;
 		}
 	}
 


### PR DESCRIPTION
Closes #38219.

htdocs/takepos/invoice.php:997 deleted the draft invoice and redirected to a fresh page whenever the last line was removed. With a non-default customer already attached, the redirect re-created a PROV invoice owned by the default cashdesk thirdparty, so the cashier's selection was silently lost.

The guard now keeps the empty draft when invoice->socid differs from CASHDESK_ID_THIRDPARTY<terminal>. The auto-drop still fires on the default thirdparty (or when none is configured and none was selected) so the previous clean-slate behavior is unchanged in that case.