### PR TITLE
Fix #38378 cast cost_price to (double) before empty() in BOM/MO cost calculation

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1421,7 +1421,10 @@ class BOM extends CommonObject
 				$tmpproduct->pmp = 0;
 				$result = $tmpproduct->fetch($line->fk_product, '', '', '', 0, 1, 1);	// We discard selling price and language loading
 
-				$unit_cost = (float) (is_null($tmpproduct->cost_price) ? $tmpproduct->pmp : $tmpproduct->cost_price);
+				// Treat the DECIMAL DDL default "0.00000000" the same as NULL when
+				// deciding whether to fall back to pmp - empty((double)"0.00000000")
+				// is true, while empty("0.00000000") is false (#38378).
+				$unit_cost = (float) (empty((double) $tmpproduct->cost_price) ? $tmpproduct->pmp : $tmpproduct->cost_price);
 				if (empty($unit_cost)) {	// @phpstan-ignore-line phpstan thinks this is always false. No,if unit_cost is 0, it is not.
 					if ($productFournisseur->find_min_price_product_fournisseur($line->fk_product) > 0) {
 						if ($productFournisseur->fourn_remise_percent != "0") {

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1424,7 +1424,7 @@ class BOM extends CommonObject
 				// Treat the DECIMAL DDL default "0.00000000" the same as NULL when
 				// deciding whether to fall back to pmp - empty((double)"0.00000000")
 				// is true, while empty("0.00000000") is false (#38378).
-				$unit_cost = (float) (empty((double) $tmpproduct->cost_price) ? $tmpproduct->pmp : $tmpproduct->cost_price);
+				$unit_cost = (float) (empty((double) $tmpproduct->cost_price) ? $tmpproduct->pmp : $tmpproduct->cost_price);	// @phpstan-ignore-line phpstan tracks cost_price as the 0 default set above, missing that fetch() mutates it.
 				if (empty($unit_cost)) {	// @phpstan-ignore-line phpstan thinks this is always false. No,if unit_cost is 0, it is not.
 					if ($productFournisseur->find_min_price_product_fournisseur($line->fk_product) > 0) {
 						if ($productFournisseur->fourn_remise_percent != "0") {

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1083,7 +1083,10 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 					if ($object->qty > 0) {
 						// add free consume line cost to $bomcostupdated
-						$costprice = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+						// Cast to (double) before empty() so DECIMAL string "0.00000000" is
+						// recognized as zero - empty("0.00000000") is false in PHP, which
+						// previously made cost_price=0 silently win over a real pmp (#38378).
+						$costprice = price2num((!empty((double) $tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
 						if (empty($costprice)) {
 							require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 							$productFournisseur = new ProductFournisseur($db);


### PR DESCRIPTION
Closes #38378.

DECIMAL columns come back from mysqlnd as strings; llx_product.cost_price defaults to 0 so any product whose cost was never set returns the string '0.00000000'. empty('0.00000000') is false in PHP, which silently made cost_price=0 win over a real pmp at two sites:

- htdocs/mrp/mo_production.php:1086 - the free consume cost ternary picked '0.00000000' instead of pmp, so the manufactured product's PMP was averaged against itself.
- htdocs/bom/class/bom.class.php:1424 - the is_null() guard catches NULL but not '0.00000000', so the code slipped through to the supplier-price fallback instead of using pmp.

Both sites now cast to (double) inside the empty() check, matching the reporter's recommendation. The cascade defensive sites at lines 1792 and 1945 are left alone because they are still rescued by price2num('0.00000000','MU') returning '0' - kept the patch atomic.