### PR TITLE
Fix #37775 do not overwrite POSTed extrafields when creating an invoice from a template

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -612,7 +612,13 @@ class Facture extends CommonInvoice
 			$this->note_private = trim($this->note_private);
 			$this->note_private = dol_concatdesc($this->note_private, $langs->trans("GeneratedFromRecurringInvoice", $_facrec->ref));
 
-			$this->array_options = $_facrec->array_options;
+			// Keep POSTed extrafields if the caller already populated array_options
+			// (htdocs/compta/facture/card.php:1235 calls setOptionalsFromPost before
+			// create()). Falling back to the template values when nothing was POSTed
+			// preserves cron behavior for auto-generated recurring invoices (#37775).
+			if (empty($this->array_options)) {
+				$this->array_options = $_facrec->array_options;
+			}
 
 			if (!$this->mode_reglement_id) {
 				$this->mode_reglement_id = 0;


### PR DESCRIPTION
Closes #37775.

htdocs/compta/facture/card.php:1235 calls setOptionalsFromPost() to fill $object->array_options from the create form, but Facture::create() at line 615 then unconditionally overwrites the array with the recurring template values. The user-entered extrafields are silently lost.

Only adopt the template's array_options when the caller did not provide any, so cron-driven recurring invoices keep template values and manual 'generate now' submissions keep what the operator typed in the form.