### PR TITLE
Fix #37357 emailcollector: pick exact source folder before falling back to first match

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1654,7 +1654,17 @@ class EmailCollector extends CommonObject
 
 				$f = $client->getFolders(false, $tmpsourcedir);	// Note the search of directory do a search on sourcedir*
 				if ($f) {
+					// getFolders does a sourcedir* match so INBOX also returns INBOX.Traites
+					// etc. Pick the folder whose full_name matches the requested source
+					// before falling back to the first result, otherwise polling can land
+					// on an empty subfolder instead of INBOX (#37357).
 					$folder = $f[0];
+					foreach ($f as $candidate) {
+						if ($candidate instanceof Webklex\PHPIMAP\Folder && $candidate->full_name === $tmpsourcedir) {
+							$folder = $candidate;
+							break;
+						}
+					}
 					if ($folder instanceof Webklex\PHPIMAP\Folder) {
 						$Query = $folder->messages()->where($criteria); // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
 					} else {


### PR DESCRIPTION
Closes #37357.

Webklex/PHPIMAP getFolders() in pattern mode treats the second argument as a sourcedir* glob, so INBOX returns INBOX plus every INBOX.* subfolder. htdocs/emailcollector/class/emailcollector.class.php:1655 then took $f[0], which is whichever folder the IMAP server returned first - often an empty INBOX.Traites archive - so the collector silently scanned the wrong mailbox and reported no new mail while messages piled up in INBOX.

Walk the returned list and prefer the folder whose full_name matches $tmpsourcedir exactly. Fallback to $f[0] preserves the previous behavior when no exact match exists (server-side capitalization quirks).