### PR TITLE
Fix #37663 guard SUBTOTALS_SPECIAL_CODE before use in printOriginLine

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -5869,7 +5869,11 @@ abstract class CommonObject
 		$this->tpl['strike'] = 0;
 		if ($restrictlist == 'services' && $line->product_type != Product::TYPE_SERVICE) {
 			$this->tpl['strike'] = 1;
-		} elseif ($line->special_code == SUBTOTALS_SPECIAL_CODE) {
+		} elseif (defined('SUBTOTALS_SPECIAL_CODE') && $line->special_code == SUBTOTALS_SPECIAL_CODE) {
+			// SUBTOTALS_SPECIAL_CODE is only defined when the subtotals module
+			// is loaded (htdocs/subtotals/class/commonsubtotal.class.php:24).
+			// Without the guard, printing origin lines from a PO into a vendor
+			// invoice fatals (#37663). Other tpl files already follow this pattern.
 			$this->tpl['strike'] = 1;
 		}
 


### PR DESCRIPTION
Closes #37663.

SUBTOTALS_SPECIAL_CODE is only defined by the subtotals module (htdocs/subtotals/class/commonsubtotal.class.php:24). When a PO line is printed into a vendor invoice create screen and the subtotals module is not loaded for the current request, htdocs/core/class/commonobject.class.php:5872 fatals with 'Undefined constant SUBTOTALS_SPECIAL_CODE', hiding every origin line.

Wrap the comparison with defined() to match the existing pattern used in objectline_view.tpl.php:81, objectline_edit.tpl.php:71 and originproductline.tpl.php:50.