### PR TITLE
Fix #37282 dispatch API classes whose name ends with the 'Api' suffix

### DIFF
--- a/htdocs/api/index.php
+++ b/htdocs/api/index.php
@@ -419,7 +419,13 @@ if (!empty($reg[1]) && ($reg[1] != 'explorer' || ($reg[2] != '/swagger.json' && 
 		exit(0);
 	}
 
-	if (class_exists($classname)) {
+	// Match the discovery loop above which accepts both "Foo" and "FooApi" class
+	// names (see line ~308). Without the Api suffix branch, a module file named
+	// api_mymodule.class.php exposing class MyModuleApi cannot be dispatched
+	// even though the api explorer lists it (#37282).
+	if (class_exists($classname.'Api')) {
+		$api->r->addAPIClass($classname.'Api');
+	} elseif (class_exists($classname)) {
 		$api->r->addAPIClass($classname);
 	}
 }


### PR DESCRIPTION
Closes #37282 (re-opens the unresolved part of #32491).

The API discovery loop in htdocs/api/index.php (around line 308) accepts both Foo and FooApi class names when scanning module directories. The dispatch loop on the request-handling side (line 422) only checked class_exists($classname), so a module exposing class MyModuleApi from api_mymodule.class.php would appear in the API Explorer yet 501 with 'API not found' when the endpoint was actually called.

Probe class_exists($classname.'Api') first to mirror the discovery behavior. Falls back to the plain class name so existing modules keep working.