### PR TITLE
Fix #30400 inherit default VAT from parent for variant products on order line

### DIFF
--- a/htdocs/product/ajax/products.php
+++ b/htdocs/product/ajax/products.php
@@ -246,6 +246,27 @@ if ($action == 'fetch' && !empty($id)) {
 			$outtva_tx_formated = price($object->tva_tx);
 			$outtva_tx = price2num($object->tva_tx);
 			$outdefault_vat_code = $object->default_vat_code;
+
+			// Variant rows are kept in llx_product without their own price/vat
+			// information - the parent product holds them. If this product is a
+			// variant child and its vat fields are empty, inherit them from the
+			// parent so the sales/order line gets the default tax preselected
+			// like the non-variant flow does (#30400).
+			if (empty($outtva_tx) && empty($outdefault_vat_code)) {
+				require_once DOL_DOCUMENT_ROOT.'/variants/class/ProductCombination.class.php';
+				$combination = new ProductCombination($db);
+				if ($combination->fetchByFkProductChild($object->id, 1) > 0) {
+					$parent = new Product($db);
+					if ($parent->fetch($combination->fk_product_parent) > 0) {
+						$outtva_tx_formated = price($parent->tva_tx);
+						$outtva_tx = price2num($parent->tva_tx);
+						$outdefault_vat_code = $parent->default_vat_code;
+						$product_outtva_tx_formated = $outtva_tx_formated;
+						$product_outtva_tx = $outtva_tx;
+						$product_outdefault_vat_code = $outdefault_vat_code;
+					}
+				}
+			}
 		}
 
 		// VAT to use and default VAT for product are set to same value by default


### PR DESCRIPTION
Closes #30400.

Sales / order line creation uses htdocs/product/ajax/products.php to prefill the VAT field after the product is picked. Variant children are kept in llx_product with their own row but typically without their own tva_tx/default_vat_code, so the fallback at line 242 returns 0 and the tax dropdown stays empty - unlike a non-variant product where the parent's tva_tx populates it.

When the loaded product has no tva_tx and no default_vat_code, look up the ProductCombination row by fk_product_child and re-read the parent's vat fields. The change is gated on both fields being empty, so an explicitly overridden variant VAT keeps winning.