### PR TITLE
Fix #31464 align ref filter on onlineSign with the producer ('alpha')

### DIFF
--- a/htdocs/core/ajax/onlineSign.php
+++ b/htdocs/core/ajax/onlineSign.php
@@ -66,7 +66,11 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 $action = GETPOST('action', 'aZ09');
 
 $signature = GETPOST('signaturebase64');
-$ref = GETPOST('ref', 'aZ09');
+// Match the filter the producer uses in newonlinesign.php:97 ('alpha').
+// Refs such as PR2601-0003 contain a dash, which aZ09 strips. After stripping
+// the dash, dol_verifyHash fails because the security key was built from the
+// full reference, so onlineSign answered 403 even on valid submissions (#31464).
+$ref = GETPOST('ref', 'alpha');
 $mode = GETPOST('mode', 'aZ09');    // 'proposal', ...
 $SECUREKEY = GETPOST("securekey"); // Secure key
 $online_sign_name = GETPOST("onlinesignname");


### PR DESCRIPTION
Closes #31464.

htdocs/public/onlinesign/newonlinesign.php:97 reads the ref with GETPOST('ref','alpha') and embeds it in the secure key sent in the client form. htdocs/core/ajax/onlineSign.php:69 was reading it with the stricter GETPOST('ref','aZ09'), which drops the dash in refs such as PR2601-0003. After stripping the dash, dol_verifyHash compared the client-side secure key (built from the full ref) against a server-side hash built from a truncated ref, so the receiver answered 403 even on valid submissions and the signature page reported 'Bad value for securitykey ... for ref='.