### PR TITLE
Fix #37365 add per-record transaction mode for mass validate

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1058,10 +1058,22 @@ if (!$error && $massaction == 'validate' && $permissiontoadd) {
 		}
 	}
 	if (!$error) {
-		$db->begin();
+		// MAIN_MASSVALIDATE_<OBJECTCLASS>_NO_GLOBAL_TRANSACTION = 1 wraps each
+		// record in its own transaction instead of all-or-nothing. Modules
+		// dealing with external systems (e.g. VeriFactu / AEAT for invoices)
+		// can enable it on the list pages they need so a mid-loop failure does
+		// not roll back the records already committed-and-pushed outside the
+		// database. The default remains the secured all-or-nothing mode (#37365).
+		$perrecordtransaction = (int) getDolGlobalInt('MAIN_MASSVALIDATE_'.strtoupper($objectclass).'_NO_GLOBAL_TRANSACTION');
+		if (!$perrecordtransaction) {
+			$db->begin();
+		}
 
 		$nbok = 0;
 		foreach ($toselect as $toselectid) {
+			if ($perrecordtransaction) {
+				$db->begin();
+			}
 			$result = $objecttmp->fetch($toselectid);
 			if ($result > 0) {
 				if (method_exists($objecttmp, 'validate')) {
@@ -1076,10 +1088,16 @@ if (!$error && $massaction == 'validate' && $permissiontoadd) {
 					$langs->load("errors");
 					setEventMessages($langs->trans("ErrorObjectMustHaveStatusDraftToBeValidated", $objecttmp->ref), null, 'errors');
 					$error++;
+					if ($perrecordtransaction) {
+						$db->rollback();
+					}
 					break;
 				} elseif ($result < 0) {
 					setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
 					$error++;
+					if ($perrecordtransaction) {
+						$db->rollback();
+					}
 					break;
 				} else {
 					// validate() rename pdf but do not regenerate
@@ -1118,10 +1136,16 @@ if (!$error && $massaction == 'validate' && $permissiontoadd) {
 						}
 					}
 					$nbok++;
+					if ($perrecordtransaction) {
+						$db->commit();
+					}
 				}
 			} else {
 				setEventMessages($objecttmp->error, $objecttmp->errors, 'errors');
 				$error++;
+				if ($perrecordtransaction) {
+					$db->rollback();
+				}
 				break;
 			}
 		}
@@ -1132,8 +1156,10 @@ if (!$error && $massaction == 'validate' && $permissiontoadd) {
 			} else {
 				setEventMessages($langs->trans("RecordModifiedSuccessfully"), null, 'mesgs');
 			}
-			$db->commit();
-		} else {
+			if (!$perrecordtransaction) {
+				$db->commit();
+			}
+		} elseif (!$perrecordtransaction) {
 			$db->rollback();
 		}
 	}


### PR DESCRIPTION
Closes #37365.

Implements the hidden option @eldy recommended on the issue.

htdocs/core/actions_massactions.inc.php:1060-1140 wrapped all selected records in a single begin/commit, so a mid-loop failure rolled back records that had already validated. For modules that side-effect on validate (VeriFactu / AEAT push, e-invoice gateways), the external side effect cannot be reverted alongside the local rollback.

This PR adds the constant MAIN_MASSVALIDATE_\<OBJECTCLASS\>_NO_GLOBAL_TRANSACTION. When set to 1 for the relevant objectclass (e.g. MAIN_MASSVALIDATE_FACTURE_NO_GLOBAL_TRANSACTION on the customer invoice list), the begin/commit pair moves inside the loop so each record is its own atomic unit. Failure on record N stops the loop but records 1..N-1 stay validated. The constant is per-objectclass so it can be enabled on the page that needs it without affecting other mass-validate pages.

Default behavior is unchanged: with no constant set, the original all-or-nothing transaction stays in place.