### PR TITLE
do not index Mistral Vibe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ phpstan_custom.neon
 # ignore .htaccess files
 .htaccess
 /.run-phpstan
+
+# Mistral Vibe
+.vibe


### PR DESCRIPTION
This PR is to exclude Mistral Vibe directory per project (./.vibe) folder from source code management.