### PR TITLE
New adding database tables for a budget module, heavily inspired from expense reports

### DIFF
--- a/htdocs/install/mysql/llx_budgetsheet-budgetsheet.key.sql
+++ b/htdocs/install/mysql/llx_budgetsheet-budgetsheet.key.sql
@@ -1,0 +1,30 @@
+-- ===================================================================
+-- Copyright (C) 2026		Jon Bendtsen          		<jon.bendtsen.github@jonb.dk>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+ALTER TABLE llx_budgetsheet ADD UNIQUE INDEX uk_budgetsheet_ref (ref, entity);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_fk_project (fk_project);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_fk_task (fk_task);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_fk_status (fk_status);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_date_create (date_create);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_date_valid (date_valid);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_date_start (date_start);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_date_end (date_end);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_fk_user_author (fk_user_author);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_fk_user_valid (fk_user_valid);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_fk_user_approve (fk_user_approve);
+ALTER TABLE llx_budgetsheet ADD INDEX idx_budgetsheet_fk_user_cancel (fk_user_cancel);

--- a/htdocs/install/mysql/llx_budgetsheet-budgetsheet.sql
+++ b/htdocs/install/mysql/llx_budgetsheet-budgetsheet.sql
@@ -1,0 +1,58 @@
+-- ===================================================================
+-- Copyright (C) 2026		Jon Bendtsen          		<jon.bendtsen.github@jonb.dk>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+CREATE TABLE llx_budgetsheet (
+  rowid              integer AUTO_INCREMENT PRIMARY KEY,
+  ref                varchar(128) NOT NULL,
+  entity             integer DEFAULT 1 NOT NULL,
+
+  label              varchar(255) NOT NULL,
+
+  fk_project         integer DEFAULT NULL,
+  fk_task            integer DEFAULT NULL, 
+
+  fk_status          integer DEFAULT 0,
+
+  date_start         date,
+  date_end           date,
+
+  total_ht           double(24,8) DEFAULT 0,
+  total_tva          double(24,8) DEFAULT 0,
+  localtax1          double(24,8) DEFAULT 0,
+  localtax2          double(24,8) DEFAULT 0,
+  total_ttc          double(24,8) DEFAULT 0,
+
+  note_public        text,
+  note_private       text,
+
+  date_create        datetime NOT NULL,
+  date_valid         datetime,
+  date_approve       datetime,
+  date_cancel        datetime,
+  tms                timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+  fk_user_author     integer NOT NULL,
+  fk_user_creat      integer DEFAULT NULL,
+  fk_user_modif      integer DEFAULT NULL,
+  fk_user_valid      integer DEFAULT NULL,
+  fk_user_approve    integer DEFAULT NULL,
+  fk_user_cancel     integer DEFAULT NULL,
+
+  import_key         varchar(14),
+  extraparams        varchar(255)
+) ENGINE=innodb;

--- a/htdocs/install/mysql/llx_budgetsheet_lines-budgetsheet.key.sql
+++ b/htdocs/install/mysql/llx_budgetsheet_lines-budgetsheet.key.sql
@@ -1,0 +1,23 @@
+-- ===================================================================
+-- Copyright (C) 2026		Jon Bendtsen          		<jon.bendtsen.github@jonb.dk>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+ALTER TABLE llx_budgetsheet_lines ADD INDEX idx_budgetsheet_lines_fk_budgetsheet (fk_budgetsheet);
+ALTER TABLE llx_budgetsheet_lines ADD INDEX idx_budgetsheet_lines_fk_c_type_of_operation (fk_c_type_of_operation);
+ALTER TABLE llx_budgetsheet_lines ADD INDEX idx_budgetsheet_lines_date_start (date_start);
+ALTER TABLE llx_budgetsheet_lines ADD INDEX idx_budgetsheet_lines_date_end (date_end);
+ALTER TABLE llx_budgetsheet_lines ADD INDEX idx_budgetsheet_lines_date_payment_expected (date_payment_expected);

--- a/htdocs/install/mysql/llx_budgetsheet_lines-budgetsheet.sql
+++ b/htdocs/install/mysql/llx_budgetsheet_lines-budgetsheet.sql
@@ -47,8 +47,8 @@ CREATE TABLE llx_budgetsheet_lines (
    total_ttc            double(24,8) DEFAULT 0 NOT NULL,
 
    date_start           date NOT NULL,
-   date_end             date,
-   date_payment_expected date NOT NULL,
+   date_end             date DEFAULT NULL,
+   date_payment_expected date DEFAULT NULL,
 
    docnumber            varchar(128),
    info_bits            integer DEFAULT 0,

--- a/htdocs/install/mysql/llx_budgetsheet_lines-budgetsheet.sql
+++ b/htdocs/install/mysql/llx_budgetsheet_lines-budgetsheet.sql
@@ -1,0 +1,74 @@
+-- ===================================================================
+-- Copyright (C) 2026		Jon Bendtsen          		<jon.bendtsen.github@jonb.dk>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+-- Table: llx_budgetsheet_lines
+-- Description: Detailed line items with liquidity tracking.
+-- Features: Supports prorating (date_range) and cash-flow timing.
+-- ===================================================================
+
+CREATE TABLE llx_budgetsheet_lines (
+   rowid integer AUTO_INCREMENT PRIMARY KEY,
+   fk_budgetsheet       integer NOT NULL,
+
+   label                varchar(255) NOT NULL,
+   fk_c_type_of_operation integer,
+
+   qty                  double(24,8) DEFAULT 1,
+   unit_price_ht        double(24,8) DEFAULT 0,
+   subprice_ttc         double(24,8) DEFAULT 0,
+   value_unit           double(24,8) DEFAULT 0,
+   remise_percent       double(24,8) DEFAULT 0,
+
+   vat_src_code         varchar(10) DEFAULT '',
+   tva_tx               double(7,4),
+   localtax1_tx         double(7,4) DEFAULT 0,
+   localtax1_type       varchar(10),
+   localtax2_tx         double(7,4) DEFAULT 0,
+   localtax2_type       varchar(10),
+
+   total_ht             double(24,8) DEFAULT 0 NOT NULL,
+   total_tva            double(24,8) DEFAULT 0 NOT NULL,
+   total_localtax1      double(24,8) DEFAULT 0,
+   total_localtax2      double(24,8) DEFAULT 0,
+   total_ttc            double(24,8) DEFAULT 0 NOT NULL,
+
+   date_start           date NOT NULL,
+   date_end             date,
+   date_payment_expected date NOT NULL,
+
+   docnumber            varchar(128),
+   info_bits            integer DEFAULT 0,
+   special_code         integer DEFAULT 0,
+   product_type         integer DEFAULT -1,
+   comments             text,
+   rule_warning_message text,
+   rang                 integer DEFAULT 0,
+
+   fk_multicurrency     integer,
+   multicurrency_code   varchar(3),
+   multicurrency_subprice double(24,8) DEFAULT 0,
+   multicurrency_subprice_ttc double(24,8) DEFAULT 0,
+   multicurrency_total_ht double(24,8) DEFAULT 0,
+   multicurrency_total_tva double(24,8) DEFAULT 0,
+   multicurrency_total_ttc double(24,8) DEFAULT 0,
+
+   datec                datetime NOT NULL,
+   tms                  timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+   fk_user_creat        integer DEFAULT NULL,
+   fk_user_modif        integer DEFAULT NULL,
+   import_key           varchar(14)
+) ENGINE=innodb;


### PR DESCRIPTION
# New adding database tables for a budget module, heavily inspired from expense reports
Applying the PR will add 2 new database tables for storing budget and budget lines.

Currently the Project module only supports a single number for the budget, the goal with this (and some upcoming PR's) is to be able to create both simple and detailed budgets for Company, Project and Task in a Project. This should support many use cases in many different companies. The user can make a few lines, or many lines for a much more detailed budget.

The table design is heavily inspired from Expense Reports.

- Overall Budget approval
- Budget lines can be in different currencies

The goal is to have liquidity mangement by budget lines have 3 date fields. This could be a single date for when money is received or should be paid. It can be a range date where the income/expense is then spread over the date range - for now there is no field for specifying how the spread should happen: Linear, S-curve, ...

The final date is for when the money is available or should be paid if an expense. The goal is to be able to do liquidity management.

## Future work

- a 2. PR with the class definitions for budget and budget lines
- a 3. PR with the UIUX for budgets
- a 4. PR with the API for budgets