### PR TITLE
FIX: very old llx_adherent migration bug from 3.6-3.7

### DIFF
--- a/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
+++ b/htdocs/install/mysql/migration/17.0.0-18.0.0.sql
@@ -721,3 +721,6 @@ ALTER TABLE llx_user CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP O
 ALTER TABLE llx_salary_extrafields CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 -- 15.0 -> 16.0 rename llx_advtargetemailing to llx_mailing_advtarget
 ALTER TABLE llx_mailing_advtarget CHANGE COLUMN tms tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- 3.6 -> 3.7 typo on llx_adherents ('end with s') and varchar is 128
+ALTER TABLE llx_adherent MODIFY COLUMN societe VARCHAR(128);


### PR DESCRIPTION
As i have to do an upgrade from 3.6 very old installation i found some sql migration errors, here is the first one.

1. typo on llx_adherents
2. error on varchar size

@eldy question is : for people who already done upgrades i have to push that fix on all migration files up to develop ?