### PR TITLE
Fix #31531 let MySQL ON UPDATE CURRENT_TIMESTAMP refresh facture_fourn.tms

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1277,6 +1277,15 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " fk_soc=".(isset($this->socid) ? ((int) $this->socid) : "null").",";
 		$sql .= " datec=".(dol_strlen((string) $this->datec) != 0 ? "'".$this->db->idate($this->datec)."'" : 'null').",";
 		$sql .= " datef=".(dol_strlen((string) $this->date) != 0 ? "'".$this->db->idate($this->date)."'" : 'null').",";
+		// Only write tms explicitly when the caller wants to import a specific
+		// modification date. Falling back to $this->tms (the value that was
+		// previously fetched into memory) would defeat the ON UPDATE
+		// CURRENT_TIMESTAMP defined on llx_facture_fourn.tms and freeze the
+		// modification date at the loaded value, so a UI edit that does not
+		// touch date_modification would never refresh tms (#31531).
+		if (dol_strlen((string) $this->date_modification) != 0) {
+			$sql .= " tms='".$this->db->idate($this->date_modification)."',";
+		}
 		$sql .= " libelle=".(isset($this->label) ? "'".$this->db->escape($this->label)."'" : "null").",";
 		$sql .= " paye=".(isset($this->paid) ? ((int) $this->paid) : "0").",";
 		$sql .= " close_code=".(isset($this->close_code) ? "'".$this->db->escape($this->close_code)."'" : "null").",";

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1277,15 +1277,6 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " fk_soc=".(isset($this->socid) ? ((int) $this->socid) : "null").",";
 		$sql .= " datec=".(dol_strlen((string) $this->datec) != 0 ? "'".$this->db->idate($this->datec)."'" : 'null').",";
 		$sql .= " datef=".(dol_strlen((string) $this->date) != 0 ? "'".$this->db->idate($this->date)."'" : 'null').",";
-		// Only write tms explicitly when the caller wants to import a specific
-		// modification date. Falling back to $this->tms (the value that was
-		// previously fetched into memory) would defeat the ON UPDATE
-		// CURRENT_TIMESTAMP defined on llx_facture_fourn.tms and freeze the
-		// modification date at the loaded value, so a UI edit that does not
-		// touch date_modification would never refresh tms (#31531).
-		if (dol_strlen((string) $this->date_modification) != 0) {
-			$sql .= " tms='".$this->db->idate($this->date_modification)."',";
-		}
 		$sql .= " libelle=".(isset($this->label) ? "'".$this->db->escape($this->label)."'" : "null").",";
 		$sql .= " paye=".(isset($this->paid) ? ((int) $this->paid) : "0").",";
 		$sql .= " close_code=".(isset($this->close_code) ? "'".$this->db->escape($this->close_code)."'" : "null").",";

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1277,14 +1277,10 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " fk_soc=".(isset($this->socid) ? ((int) $this->socid) : "null").",";
 		$sql .= " datec=".(dol_strlen((string) $this->datec) != 0 ? "'".$this->db->idate($this->datec)."'" : 'null').",";
 		$sql .= " datef=".(dol_strlen((string) $this->date) != 0 ? "'".$this->db->idate($this->date)."'" : 'null').",";
-		// Only write tms explicitly when the caller wants to import a specific
-		// modification date. Falling back to $this->tms (the value that was
-		// previously fetched into memory) would defeat the ON UPDATE
-		// CURRENT_TIMESTAMP defined on llx_facture_fourn.tms and freeze the
-		// modification date at the loaded value, so a UI edit that does not
-		// touch date_modification would never refresh tms (#31531).
 		if (dol_strlen((string) $this->date_modification) != 0) {
-			$sql .= " tms='".$this->db->idate($this->date_modification)."',";
+			$sql .= " tms=".(dol_strlen((string) $this->date_modification) != 0 ? "'".$this->db->idate($this->date_modification)."'" : 'null').",";
+		} elseif (dol_strlen((string) $this->tms) != 0) {	// For backward compatibility
+			$sql .= " tms=".(dol_strlen((string) $this->tms) != 0 ? "'".$this->db->idate($this->tms)."'" : 'null').",";
 		}
 		$sql .= " libelle=".(isset($this->label) ? "'".$this->db->escape($this->label)."'" : "null").",";
 		$sql .= " paye=".(isset($this->paid) ? ((int) $this->paid) : "0").",";

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1277,10 +1277,14 @@ class FactureFournisseur extends CommonInvoice
 		$sql .= " fk_soc=".(isset($this->socid) ? ((int) $this->socid) : "null").",";
 		$sql .= " datec=".(dol_strlen((string) $this->datec) != 0 ? "'".$this->db->idate($this->datec)."'" : 'null').",";
 		$sql .= " datef=".(dol_strlen((string) $this->date) != 0 ? "'".$this->db->idate($this->date)."'" : 'null').",";
+		// Only write tms explicitly when the caller wants to import a specific
+		// modification date. Falling back to $this->tms (the value that was
+		// previously fetched into memory) would defeat the ON UPDATE
+		// CURRENT_TIMESTAMP defined on llx_facture_fourn.tms and freeze the
+		// modification date at the loaded value, so a UI edit that does not
+		// touch date_modification would never refresh tms (#31531).
 		if (dol_strlen((string) $this->date_modification) != 0) {
-			$sql .= " tms=".(dol_strlen((string) $this->date_modification) != 0 ? "'".$this->db->idate($this->date_modification)."'" : 'null').",";
-		} elseif (dol_strlen((string) $this->tms) != 0) {	// For backward compatibility
-			$sql .= " tms=".(dol_strlen((string) $this->tms) != 0 ? "'".$this->db->idate($this->tms)."'" : 'null').",";
+			$sql .= " tms='".$this->db->idate($this->date_modification)."',";
 		}
 		$sql .= " libelle=".(isset($this->label) ? "'".$this->db->escape($this->label)."'" : "null").",";
 		$sql .= " paye=".(isset($this->paid) ? ((int) $this->paid) : "0").",";

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1266,6 +1266,10 @@ class FactureFournisseur extends CommonInvoice
 		// Check parameters
 		// Put here code to add control on parameters values
 
+		if (dol_strlen((string) $this->date_modification) == 0) {
+			$this->tms = dol_now();
+		}
+
 		// Update request
 		$sql = "UPDATE ".MAIN_DB_PREFIX."facture_fourn SET";
 		$sql .= " ref=".(isset($this->ref) ? "'".$this->db->escape($this->ref)."'" : "null").",";


### PR DESCRIPTION
Closes #31531.

FactureFournisseur::update() at htdocs/fourn/class/fournisseur.facture.class.php:1280-1284 wrote tms back with $this->tms when no $this->date_modification was provided, defeating the ON UPDATE CURRENT_TIMESTAMP on the column (see install/mysql/tables/llx_facture_fourn.sql:40). Any UI edit that did not touch date_modification re-wrote the previous tms and the modification date never moved.

Drop the elseif backward-compat branch so the UPDATE omits tms by default and MySQL bumps it. The customer Facture::update() already follows this pattern.