### PR TITLE
Fix #38320 treat null/empty rang as auto in addline (Propal, Commande, Facture)

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -783,7 +783,7 @@ class Propal extends CommonObject
 
 			// Rang to use
 			$ranktouse = $rang;
-			if ($ranktouse == -1) {
+			if (empty($ranktouse) || $ranktouse == -1) {
 				$rangmax = $this->line_max($fk_parent_line);
 				$ranktouse = $rangmax + 1;
 			}

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1763,7 +1763,7 @@ class Commande extends CommonOrder
 			// Rang to use
 			$ranktouse = $rang;
 
-			if ($ranktouse == -1) {
+			if (empty($ranktouse) || $ranktouse == -1) {
 				$rangmax = $this->line_max($fk_parent_line);
 				$ranktouse = $rangmax + 1;
 			}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4397,7 +4397,7 @@ class Facture extends CommonInvoice
 
 			// Rank to use
 			$ranktouse = $rang;
-			if ($ranktouse == -1) {
+			if (empty($ranktouse) || $ranktouse == -1) {
 				$rangmax = $this->line_max($fk_parent_line);
 				$ranktouse = $rangmax + 1;
 			}


### PR DESCRIPTION
Closes #38320.

API callers like api_proposals.php postLine forward $request_data->rang unset, so null reaches addline. The '== -1' check does not match null and $ranktouse stays null, persisted as 0 - every line then carries rang=0 and the order is propagated through createFromProposal / createFromOrder.

Accept null and 0 alongside -1 so the auto-rank branch fires at htdocs/comm/propal/class/propal.class.php:786, htdocs/commande/class/commande.class.php:1766, htdocs/compta/facture/class/facture.class.php:4400. Confirmed by @JonBendtsen on the issue with a propal built via API.