### PR TITLE
FIX : fix duplicate contact names in messaging timeline

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13510,12 +13510,12 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = '', $n
 			if (isset($histo[$key]['socpeopleassigned']) && is_array($histo[$key]['socpeopleassigned']) && count($histo[$key]['socpeopleassigned']) > 0) {
 				$contactList = '';
 				foreach ($histo[$key]['socpeopleassigned'] as $cid => $Tab) {
-					if (empty($conf->cache['contact'][$histo[$key]['contact_id']])) {
+					if (empty($conf->cache['contact'][$cid])) {
 						$contact = new Contact($db);
 						$contact->fetch($cid);
-						$conf->cache['contact'][$histo[$key]['contact_id']] = $contact;
+						$conf->cache['contact'][$cid] = $contact;
 					} else {
-						$contact = $conf->cache['contact'][$histo[$key]['contact_id']];
+						$contact = $conf->cache['contact'][$cid];
 					}
 
 					if ($contact) {


### PR DESCRIPTION
# FIX Fix duplicate contact names displayed in messaging timeline

In `show_actions_messaging()` (`htdocs/core/lib/functions.lib.php`), when an
event has multiple contacts assigned via `llx_actioncomm_resources`, all
contacts after the first are displayed with the same name as the first one.

**Root cause:** the contact cache array was keyed on
`$histo[$key]["contact_id"]` (the legacy `fk_contact` field, always pointing
to the first contact) instead of `$cid` (the id of the contact currently
iterated). After the first iteration populates the cache, every subsequent
contact hits the same cache entry and returns the first contact's data.

**Fix:** use `$cid` as the cache key inside the `socpeopleassigned` foreach
loop (3 occurrences).