### PR TITLE
FIX supplier proposal line extrafields not loaded

### DIFF
--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -1367,6 +1367,7 @@ class SupplierProposal extends CommonObject
 
 						$line->rowid = $objp->rowid; // deprecated
 						$line->id = $objp->rowid;
+						$line->fetch_optionals();
 						$line->fk_supplier_proposal = $objp->fk_supplier_proposal;
 						$line->fk_parent_line = $objp->fk_parent_line;
 						$line->product_type     = $objp->product_type;
@@ -2701,6 +2702,7 @@ class SupplierProposal extends CommonObject
 				$this->lines[$i] = new SupplierProposalLine($this->db);
 				$this->lines[$i]->id = $obj->rowid; // for backward compatibility
 				$this->lines[$i]->rowid				= $obj->rowid;
+				$this->lines[$i]->fetch_optionals();
 				$this->lines[$i]->label 			= $obj->custom_label;
 				$this->lines[$i]->description = $obj->description;
 				$this->lines[$i]->fk_product = $obj->fk_product;


### PR DESCRIPTION
Closes #38869

Supplier proposal / vendor quote line extrafields were saved correctly in llx_supplier_proposaldet_extrafields, but were not loaded/displayed on the supplier proposal page or generated PDFs.

This adds fetch_optionals() in two supplier proposal line-loading sections so line extrafields are available after lines are loaded.

Tested locally on Dolibarr 22.0.4:
- line extrafield value displayed on supplier proposal page
- line extrafield value displayed in generated supplier proposal PDF