### PR TITLE
Fix #38857 keep html links and block tags in ticket mail intro/signature

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1866,14 +1866,15 @@ class FormTicket
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO') || getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE')) {
 				$texttooltip .= '<br><br>'.$langs->trans("ForEmailMessageWillBeCompletedWith").'...';
 			}
+			$allowedmailtags = array('a', 'div', 'strong', 'em', 'i', 'u', 'p', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img');
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO')) {
 				$mail_intro = make_substitutions(getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO'), $this->substit);
-				print '<input type="hidden" name="mail_intro" value="'.dolPrintHTMLForAttribute($mail_intro).'">';
+				print '<input type="hidden" name="mail_intro" value="'.dolPrintHTMLForAttribute($mail_intro, 0, $allowedmailtags).'">';
 				$texttooltip .= '<br><u>'.$langs->trans("TicketMessageMailIntro").'</u><br>'.$mail_intro;
 			}
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE')) {
 				$mail_signature = make_substitutions(getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE'), $this->substit);
-				print '<input type="hidden" name="mail_signature" value="'.dolPrintHTMLForAttribute($mail_signature).'">';
+				print '<input type="hidden" name="mail_signature" value="'.dolPrintHTMLForAttribute($mail_signature, 0, $allowedmailtags).'">';
 				$texttooltip .= '<br><br><u>'.$langs->trans("TicketMessageMailFooter").'</u><br>'.$mail_signature;
 			}
 			print $form->textwithpicto('', $texttooltip, 1, 'help');


### PR DESCRIPTION
Fixes #38857.

The reply form in `html.formticket.class.php` serializes TICKET_MESSAGE_MAIL_INTRO and TICKET_MESSAGE_MAIL_SIGNATURE through `dolPrintHTMLForAttribute()` whose default whitelist is only `br/b/font/hr/span`, so admin formatted footers lose `<a>`, `<div>`, `<strong>`, etc. before the email is built.

This passes an extended whitelist (a, div, strong, em, i, u, p, ul/ol/li, h1-h6, img) for these two hidden transport inputs only. The values are then re-read by `GETPOST('mail_intro', 'restricthtml')` which strips `<script>`, event handlers and `javascript:` URIs, so XSS is not opened.

E2E checked in Docker: `<div><strong><a href=...>` round-trips correctly; `<script>alert</script>` and `onmouseover` payloads are still purged on receipt.