### PR TITLE
Fix #36800 do not crash syslog admin page on stale handler files

### DIFF
--- a/htdocs/admin/syslog.php
+++ b/htdocs/admin/syslog.php
@@ -69,10 +69,19 @@ foreach ($dirsyslogs as $reldir) {
 				if (substr($file, 0, 11) == 'mod_syslog_' && substr($file, dol_strlen($file) - 3, 3) == 'php') {
 					$file = substr($file, 0, dol_strlen($file) - 4);
 
-					require_once $newdir.$file.'.php';
+					try {
+						require_once $newdir.$file.'.php';
 
-					$module = new $file();
-					'@phan-var-force LogHandler $module';
+						if (!class_exists($file)) {
+							dol_syslog('admin/syslog.php skipping stale handler '.$file.' (class not declared)', LOG_WARNING);
+							continue;
+						}
+						$module = new $file();
+						'@phan-var-force LogHandler $module';
+					} catch (Throwable $e) {
+						dol_syslog('admin/syslog.php skipping stale handler '.$file.': '.$e->getMessage(), LOG_WARNING);
+						continue;
+					}
 
 					// Show modules according to features level
 					if ($module->getVersion() == 'development' && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {


### PR DESCRIPTION
Fixes #36800.

Leftover mod_syslog_chromephp.php / mod_syslog_firephp.php / logHandlerInterface.php files from a pre-v10 install break /admin/syslog.php silently because the dynamic scan in syslog.php require_onces them and instantiates whatever class it expects. The scan now wraps require_once + new and guards with class_exists, so stale handlers are skipped with a LOG_WARNING and the rest of the page renders.