### PR TITLE
Fix #36312 refuse to set a category as its own parent

### DIFF
--- a/htdocs/categories/class/categorie.class.php
+++ b/htdocs/categories/class/categorie.class.php
@@ -677,6 +677,13 @@ class Categorie extends CommonObject
 		$this->fk_parent = ($this->fk_parent != "" ? intval($this->fk_parent) : 0);
 		$this->visible = ($this->visible != "" ? intval($this->visible) : 0);
 
+		if ($this->fk_parent > 0 && $this->fk_parent == $this->id) {
+			$langs->load('categories');
+			$this->error = $langs->trans("ErrorCategoryCannotBeItsOwnParent");
+			dol_syslog($this->error, LOG_WARNING);
+			return -1;
+		}
+
 		if ($this->already_exists()) {
 			$this->error = $langs->trans("ImpossibleUpdateCat");
 			$this->error .= " : ".$langs->trans("CategoryExistsAtSameLevel");

--- a/htdocs/langs/en_US/categories.lang
+++ b/htdocs/langs/en_US/categories.lang
@@ -21,6 +21,7 @@ NoSubCat=No subcategory.
 SubCatOf=Subcategory
 FoundCats=Found tags/categories
 ImpossibleAddCat=Impossible to add the tag/category %s
+ErrorCategoryCannotBeItsOwnParent=A tag/category cannot be its own parent.
 WasAddedSuccessfully=<b>%s</b> was added successfully.
 ObjectAlreadyLinkedToCategory=Element is already linked to this tag/category.
 ProductIsInCategories=Product/service is linked to following tags/categories


### PR DESCRIPTION
Fixes #36312.

llx_categorie.fk_parent had no application-level guard against fk_parent = rowid, so the recursive tree walk in get_full_arbo / get_filles can loop on a self-parented category. The check is added at the top of Categorie::update() with a translated ErrorCategoryCannotBeItsOwnParent string and a LOG_WARNING; the database constraint is left to a separate schema PR if maintainers want one.