### PR TITLE
Fix #35649 allow credit note with positive HT when TTC is zero or negative

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -411,7 +411,9 @@ if (empty($reshook)) {
 		// We check invoice sign
 		if ($object->type == Facture::TYPE_CREDIT_NOTE) {
 			// If a credit note, the sign must be negative
-			if ($object->total_ht > 0) {
+			// Note: total_ht can be positive when total_ttc is 0 or negative (mirror of the
+			// invoice case below), e.g. a refund of a 0 VAT gift card line cancelling a VAT line.
+			if ($object->total_ttc > 0) {
 				setEventMessages($langs->trans("ErrorInvoiceAvoirMustBeNegative"), null, 'errors');
 				$action = '';
 			}


### PR DESCRIPTION
Fixes #35649.

Validation in htdocs/compta/facture/card.php refused a credit note as soon as total_ht was strictly positive, blocking legitimate refunds where a 0% VAT gift-card line cancels a VAT line (HT=+10, VAT=-10, TTC=0). The check now runs on total_ttc, mirroring the symmetric guard a few lines below (total_ttc<0 forbidden on non credit-note invoices).