### PR TITLE
Fix #34927 allow returning to floor 0 in TakePOS Bar/Restaurant

### DIFF
--- a/htdocs/takepos/floors.php
+++ b/htdocs/takepos/floors.php
@@ -238,13 +238,13 @@ $( document ).ready(function() {
 <div style="position: absolute; left: 25%; bottom: 8%; width:50%; height:3%;">
 	<center>
 	<h1>
-	<?php if ($floor > 1) { ?>
-	<img class="valignmiddle" src="./img/arrow-prev.png" width="5%" onclick="location.href='floors.php?floor=<?php if ($floor > 1) {
+	<?php if ($floor > 0) { ?>
+	<img class="valignmiddle" src="./img/arrow-prev.png" width="5%" onclick="location.href='floors.php?floor=<?php if ($floor > 0) {
 		$floor--;
 		echo $floor;
 		$floor++;
 																											 } else {
-																												 echo "1";
+																												 echo "0";
 																											 } ?>';">
 	<?php } ?>
 	<span class="valignmiddle"><?php echo $langs->trans("Floor")." ".$floor; ?></span>


### PR DESCRIPTION
Fixes #34927.

The previous-floor arrow on takepos/floors.php was rendered only when floor>1, and its click handler bottomed out at 1 instead of decrementing past it, so users navigating from floor 0 to a higher floor could never get back. Lowering both thresholds to floor>0 makes the arrow visible at floor 1 and lets it decrement to 0.