### PR TITLE
Fix #35086 do not show TicketMarkedAsClosed when close() failed

### DIFF
--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -461,7 +461,7 @@ if (empty($reshook)) {
 			$object->context['contact_id'] = GETPOSTINT('contactid');
 		}
 
-		if ($object->close($user, ($action == "confirm_abandon" ? 1 : 0))) {	// Test on pemrission already done
+		if ($object->close($user, ($action == "confirm_abandon" ? 1 : 0)) > 0) {	// Test on pemrission already done
 			setEventMessages($langs->trans('TicketMarkedAsClosed'), null, 'mesgs');
 
 			$url = 'card.php?track_id=' . GETPOST('track_id', 'alpha');
@@ -478,13 +478,15 @@ if (empty($reshook)) {
 		if ($_SESSION['email_customer'] == $object->origin_email || $_SESSION['email_customer'] == $object->thirdparty->email) {
 			$object->context['contact_id'] = GETPOSTINT('contactid');
 
-			$object->close($user);
+			if ($object->close($user) > 0) {
+				setEventMessages('<div class="confirm">' . $langs->trans('TicketMarkedAsClosed') . '</div>', null, 'mesgs');
 
-			setEventMessages('<div class="confirm">' . $langs->trans('TicketMarkedAsClosed') . '</div>', null, 'mesgs');
-
-			$url = 'card.php?track_id=' . GETPOST('track_id', 'alpha');
-			header("Location: " . $url);
-			exit;
+				$url = 'card.php?track_id=' . GETPOST('track_id', 'alpha');
+				header("Location: " . $url);
+				exit;
+			}
+			setEventMessages($object->error, $object->errors, 'errors');
+			$action = '';
 		} else {
 			setEventMessages($object->error, $object->errors, 'errors');
 			$action = '';


### PR DESCRIPTION
Fixes #35086.

Ticket::close() returns >0 on success, 0 on no-op, <0 on error (including when a custom TICKET_CLOSE trigger blocks the close). Two action handlers in ticket/card.php (confirm_close/confirm_abandon, confirm_public_close) relied on PHP truthiness, so a returned -1 was treated as success and the green TicketMarkedAsClosed message was printed together with the trigger's error. Both call sites now check >0 explicitly.