### PR TITLE
Fix #34592 fall back to pmp when product cost_price is zero in MO

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1083,7 +1083,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 					if ($object->qty > 0) {
 						// add free consume line cost to $bomcostupdated
-						$costprice = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+						$costprice = price2num(((float) $tmpproduct->cost_price > 0) ? $tmpproduct->cost_price : $tmpproduct->pmp);
 						if (empty($costprice)) {
 							require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 							$productFournisseur = new ProductFournisseur($db);


### PR DESCRIPTION
Fixes #34592.

calculateCosts() in mo_production.php used `!empty($tmpproduct->cost_price)` to decide whether to use cost_price or fall back to pmp. The string '0.00000' stored in llx_product.cost_price is truthy under empty(), so the MO consumed cost ended up at 0 instead of falling back to pmp. Compare the casted float to 0 explicitly, mirroring the BOM-side check.