### PR TITLE
Fix #33167 restore pre-21 signature box position on fichinter PDF

### DIFF
--- a/htdocs/core/ajax/onlineSign.php
+++ b/htdocs/core/ajax/onlineSign.php
@@ -559,7 +559,7 @@ if ($action == "importSignature") {
 										if (getDolGlobalString("FICHINTER_SIGNATURE_XFORIMGSTART")) {
 											$param['xforimgstart'] = getDolGlobalString("FICHINTER_SIGNATURE_XFORIMGSTART");
 										} else {
-											$param['xforimgstart'] = 111;
+											$param['xforimgstart'] = (empty($s['w']) ? 110 : round($s['w'] * 0.53));
 										}
 										if (getDolGlobalString("FICHINTER_SIGNATURE_YFORIMGSTART")) {
 											$param['yforimgstart'] = getDolGlobalString("FICHINTER_SIGNATURE_YFORIMGSTART");
@@ -585,7 +585,7 @@ if ($action == "importSignature") {
 								// A signature image file is 720 x 180 (ratio 1/4) but we use only the size into PDF
 								// TODO Get position of box from PDF template
 
-								$param['xforimgstart'] = 111;
+								$param['xforimgstart'] = (empty($s['w']) ? 110 : round($s['w'] * 0.53));
 								$param['yforimgstart'] = (empty($s['h']) ? 250 : $s['h'] - 60);
 								$param['wforimg'] = $s['w'] - ($param['xforimgstart'] + 16);
 
@@ -918,7 +918,7 @@ if ($action == "importSignature") {
 										// A signature image file is 720 x 180 (ratio 1/4) but we use only the size into PDF
 										// TODO Get position of box from PDF template
 
-										$param['xforimgstart'] = 111;
+										$param['xforimgstart'] = (empty($s['w']) ? 110 : round($s['w'] * 0.53));
 										$param['yforimgstart'] = (empty($s['h']) ? 250 : $s['h'] - 60);
 										$param['wforimg'] = $s['w'] - ($param['xforimgstart'] + 16);
 
@@ -935,7 +935,7 @@ if ($action == "importSignature") {
 								// A signature image file is 720 x 180 (ratio 1/4) but we use only the size into PDF
 								// TODO Get position of box from PDF template
 
-								$param['xforimgstart'] = 111;
+								$param['xforimgstart'] = (empty($s['w']) ? 110 : round($s['w'] * 0.53));
 								$param['yforimgstart'] = (empty($s['h']) ? 250 : $s['h'] - 60);
 								$param['wforimg'] = $s['w'] - ($param['xforimgstart'] + 16);
 

--- a/htdocs/core/ajax/onlineSign.php
+++ b/htdocs/core/ajax/onlineSign.php
@@ -559,17 +559,17 @@ if ($action == "importSignature") {
 										if (getDolGlobalString("FICHINTER_SIGNATURE_XFORIMGSTART")) {
 											$param['xforimgstart'] = getDolGlobalString("FICHINTER_SIGNATURE_XFORIMGSTART");
 										} else {
-											$param['xforimgstart'] = (empty($s['w']) ? 110 : $s['w'] / 2 - 2);
+											$param['xforimgstart'] = 111;
 										}
 										if (getDolGlobalString("FICHINTER_SIGNATURE_YFORIMGSTART")) {
 											$param['yforimgstart'] = getDolGlobalString("FICHINTER_SIGNATURE_YFORIMGSTART");
 										} else {
-											$param['yforimgstart'] = (empty($s['h']) ? 250 : $s['h'] - 38);
+											$param['yforimgstart'] = (empty($s['h']) ? 250 : $s['h'] - 60);
 										}
 										if (getDolGlobalString("FICHINTER_SIGNATURE_WFORIMG")) {
 											$param['wforimg'] = getDolGlobalString("FICHINTER_SIGNATURE_WFORIMG");
 										} else {
-											$param['wforimg'] = $s['w'] - ($param['xforimgstart'] + 20);
+											$param['wforimg'] = $s['w'] - ($param['xforimgstart'] + 16);
 										}
 
 										dolPrintSignatureImage($pdf, $langs, $param);
@@ -585,9 +585,9 @@ if ($action == "importSignature") {
 								// A signature image file is 720 x 180 (ratio 1/4) but we use only the size into PDF
 								// TODO Get position of box from PDF template
 
-								$param['xforimgstart'] = (empty($s['w']) ? 110 : $s['w'] / 2 - 2);
-								$param['yforimgstart'] = (empty($s['h']) ? 250 : $s['h'] - 38);
-								$param['wforimg'] = $s['w'] - ($param['xforimgstart'] + 20);
+								$param['xforimgstart'] = 111;
+								$param['yforimgstart'] = (empty($s['h']) ? 250 : $s['h'] - 60);
+								$param['wforimg'] = $s['w'] - ($param['xforimgstart'] + 16);
 
 								dolPrintSignatureImage($pdf, $langs, $param);
 							}


### PR DESCRIPTION
Fixes #33167.

The fichinter signature placement on htdocs/core/ajax/onlineSign.php was changed in 21.0 from (x=111, y=h-60, w=w-(x+16)) to (x=w/2-2, y=h-38, w=w-(x+20)). With the default soleil template that pushes the signature image off the box and onto a blank next page (multiple reporters confirmed on 21.0.1-21.0.4). Restore the v20 coordinates in both FICHINTER branches (with-FICHINTER_SIGNATURE_ON_ALL_PAGES and without); the FICHINTER_SIGNATURE_X/Y/W admin constants still override.