### PR TITLE
Fix #37661 require price_base_type on product CSV import

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -514,7 +514,7 @@ class modProduct extends DolibarrModules
 			'p.price_min' => "MinPrice",
 			'p.price_ttc' => "SellingPriceTTC", //with tax
 			'p.price_min_ttc' => "SellingMinPriceTTC",
-			'p.price_base_type' => "PriceBaseType", //price base: with-tax (TTC) or without (HT) tax. Displays accordingly in Product card
+			'p.price_base_type' => "PriceBaseType*", //price base: with-tax (TTC) or without (HT) tax. Displays accordingly in Product card
 			'p.tva_tx' => 'VATRate',
 			'p.datec' => 'DateCreation',
 			'p.cost_price' => "CostPrice"


### PR DESCRIPTION
Fixes #37661.

The CSV importer (htdocs/core/modules/import/import_csv.modules.php:682) skips the regex validation when the value is empty, so an empty 'price_base_type' column slipped through into llx_product as ''/NULL even though the schema enforces HT or TTC. Mark the field mandatory in import_fields_array so the user must map a column and provide HT or TTC at import time.