### PR TITLE
FIX : thirdparty url in draft interventions widget may be incorrect

### DIFF
--- a/htdocs/comm/index.php
+++ b/htdocs/comm/index.php
@@ -624,7 +624,7 @@ if (isModEnabled('intervention') && is_object($fichinterstatic)) {
 				print $fichinterstatic->getNomUrl(1);
 				print "</td>";
 				print '<td class="tdoverflowmax250 minwidth100">';
-				print $companystatic->getNomUrl(1, 'customer');
+				print $companystatic->getNomUrl(1');
 				print '</td>';
 				print '<td class="nowraponall tdoverflowmax100 right">';
 				print convertSecondToTime($obj->duration);


### PR DESCRIPTION
How to reproduce the bug : 
- create an intervention with a supplier

- Draft intervention widget : click on the thirdparty link
<img width="878" height="229" alt="image" src="https://github.com/user-attachments/assets/3a886984-8e05-4bd5-aeb5-5261d375914c" />

<img width="524" height="173" alt="image" src="https://github.com/user-attachments/assets/0b66e957-62c3-4979-a5b6-697d15d5bd40" />
