### PR TITLE
Fix #36432 block leave request when balance would become negative

### DIFF
--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -728,9 +728,9 @@ class Holiday extends CommonObject
 
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
-			$nbopenedday = num_open_day($this->date_debut_gmt, $this->date_fin_gmt, 0, 1, $this->halfday);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
 
-			if (($balance - $nbopenedday) < 0) {
+			if (($balance - $daysAsked) < 0 && getDolGlobalString("HOLIDAY_DISALLOW_NEGATIVE_BALANCE")) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -852,9 +852,9 @@ class Holiday extends CommonObject
 		if ($checkBalance > 0) {
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
-			$nbopenedday = num_open_day($this->date_debut_gmt, $this->date_fin_gmt, 0, 1, $this->halfday);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
 
-			if (($balance - $nbopenedday) < 0) {
+			if (($balance - $daysAsked) < 0 && getDolGlobalString("HOLIDAY_DISALLOW_NEGATIVE_BALANCE")) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -983,9 +983,9 @@ class Holiday extends CommonObject
 		if ($checkBalance > 0 && $this->statut != self::STATUS_DRAFT) {
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
-			$nbopenedday = num_open_day($this->date_debut_gmt, $this->date_fin_gmt, 0, 1, $this->halfday);
+			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1);
 
-			if (($balance - $nbopenedday) < 0) {
+			if (($balance - $daysAsked) < 0 && getDolGlobalString("HOLIDAY_DISALLOW_NEGATIVE_BALANCE")) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}

--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -721,14 +721,16 @@ class Holiday extends CommonObject
 	{
 		global $conf, $langs;
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+		require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 		$error = 0;
 
 		$checkBalance = getDictionaryValue('c_holiday_types', 'block_if_negative', $this->fk_type);
 
 		if ($checkBalance > 0) {
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
+			$nbopenedday = num_open_day($this->date_debut_gmt, $this->date_fin_gmt, 0, 1, $this->halfday);
 
-			if ($balance < 0) {
+			if (($balance - $nbopenedday) < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -848,9 +850,11 @@ class Holiday extends CommonObject
 		$checkBalance = getDictionaryValue('c_holiday_types', 'block_if_negative', $this->fk_type);
 
 		if ($checkBalance > 0) {
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
+			$nbopenedday = num_open_day($this->date_debut_gmt, $this->date_fin_gmt, 0, 1, $this->halfday);
 
-			if ($balance < 0) {
+			if (($balance - $nbopenedday) < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -977,9 +981,11 @@ class Holiday extends CommonObject
 		$checkBalance = getDictionaryValue('c_holiday_types', 'block_if_negative', $this->fk_type);
 
 		if ($checkBalance > 0 && $this->statut != self::STATUS_DRAFT) {
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
+			$nbopenedday = num_open_day($this->date_debut_gmt, $this->date_fin_gmt, 0, 1, $this->halfday);
 
-			if ($balance < 0) {
+			if (($balance - $nbopenedday) < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}


### PR DESCRIPTION
Fixes #36432.

The c_holiday_types.block_if_negative flag only refused a leave when the balance was already negative, so a user with one day left could still submit 200 days. The three call sites (validate, update, approve) now subtract num_open_day(date_debut_gmt, date_fin_gmt, halfday) from the balance before testing the sign, so the request is blocked when the resulting balance would be negative.