### PR TITLE
Fix #36238 keep supplier filter when sorting product list

### DIFF
--- a/htdocs/fourn/product/list.php
+++ b/htdocs/fourn/product/list.php
@@ -315,13 +315,13 @@ if ($resql) {
 
 	// Line for title
 	print '<tr class="liste_titre">';
-	print_liste_field_titre("Ref", $_SERVER["PHP_SELF"], "p.ref", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("RefSupplierShort", $_SERVER["PHP_SELF"], "ppf.ref_fourn", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("Label", $_SERVER["PHP_SELF"], "p.label", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("Supplier", $_SERVER["PHP_SELF"], "ppf.fk_soc", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("BuyingPrice", $_SERVER["PHP_SELF"], "ppf.price", $param, "", '', $sortfield, $sortorder, 'right ');
-	print_liste_field_titre("QtyMin", $_SERVER["PHP_SELF"], "ppf.quantity", $param, "", '', $sortfield, $sortorder, 'right ');
-	print_liste_field_titre("UnitPrice", $_SERVER["PHP_SELF"], "ppf.unitprice", $param, "", '', $sortfield, $sortorder, 'right ');
+	print_liste_field_titre("Ref", $_SERVER["PHP_SELF"], "p.ref", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("RefSupplierShort", $_SERVER["PHP_SELF"], "ppf.ref_fourn", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("Label", $_SERVER["PHP_SELF"], "p.label", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("Supplier", $_SERVER["PHP_SELF"], "ppf.fk_soc", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("BuyingPrice", $_SERVER["PHP_SELF"], "ppf.price", "", $param, '', $sortfield, $sortorder, 'right ');
+	print_liste_field_titre("QtyMin", $_SERVER["PHP_SELF"], "ppf.quantity", "", $param, '', $sortfield, $sortorder, 'right ');
+	print_liste_field_titre("UnitPrice", $_SERVER["PHP_SELF"], "ppf.unitprice", "", $param, '', $sortfield, $sortorder, 'right ');
 	// add header cells from hooks
 	$parameters = array();
 	$reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters, $object, $action);


### PR DESCRIPTION
Fixes #36238.

print_liste_field_titre signature is (name, file, field, begin, moreparam, ...) but the seven calls in fourn/product/list.php passed `$param` at position 4 (begin) instead of 5 (moreparam). The URL builder then dropped the fourn_id filter on click so the list reset to all products. Move $param to the moreparam slot, matching the same fix already in 22.0+.