### PR TITLE
Fix #38378 fall back to pmp when product cost_price is zero (LTS 18.0)

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1426,7 +1426,7 @@ class BOM extends CommonObject
 							$this->error = $tmpproduct->error;
 							return -1;
 						}
-						$line->unit_cost = price2num(((float) $tmpproduct->cost_price > 0) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+						$line->unit_cost = price2num(is_null($tmpproduct->cost_price) ? $tmpproduct->pmp : $tmpproduct->cost_price);
 						if (empty($line->unit_cost)) {
 							if ($productFournisseur->find_min_price_product_fournisseur($line->fk_product) > 0) {
 								if ($productFournisseur->fourn_remise_percent != "0") {

--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1426,7 +1426,7 @@ class BOM extends CommonObject
 							$this->error = $tmpproduct->error;
 							return -1;
 						}
-						$line->unit_cost = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+						$line->unit_cost = price2num(((float) $tmpproduct->cost_price > 0) ? $tmpproduct->cost_price : $tmpproduct->pmp);
 						if (empty($line->unit_cost)) {
 							if ($productFournisseur->find_min_price_product_fournisseur($line->fk_product) > 0) {
 								if ($productFournisseur->fourn_remise_percent != "0") {

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -859,7 +859,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 					if ($object->qty > 0) {
 						// add free consume line cost to $bomcostupdated
-						$costprice = price2num((!empty($tmpproduct->cost_price)) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+						$costprice = price2num(((float) $tmpproduct->cost_price > 0) ? $tmpproduct->cost_price : $tmpproduct->pmp);
 						if (empty($costprice)) {
 							require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 							$productFournisseur = new ProductFournisseur($db);

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -859,7 +859,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 					if ($object->qty > 0) {
 						// add free consume line cost to $bomcostupdated
-						$costprice = price2num(((float) $tmpproduct->cost_price > 0) ? $tmpproduct->cost_price : $tmpproduct->pmp);
+						$costprice = price2num(is_null($tmpproduct->cost_price) ? $tmpproduct->pmp : $tmpproduct->cost_price);
 						if (empty($costprice)) {
 							require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
 							$productFournisseur = new ProductFournisseur($db);


### PR DESCRIPTION
Fixes #38378.

The loader-level normalization landed earlier does not cover the two sites that still read `$tmpproduct->cost_price` directly through an `empty()` ternary, so for a product with cost_price stored as '0.00000000' (truthy under empty), the MO/BOM cost calc reuses the manufactured product's own old PMP as the new production cost. Apply the `(float) cost_price > 0` check at htdocs/mrp/mo_production.php:862 and htdocs/bom/class/bom.class.php:1429 so the pmp fallback kicks in. Companion to #38898 for 23.0.