### PR TITLE
Fix #36480 timesheet date comparison accepts string and timestamp

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1315,7 +1315,7 @@ class Task extends CommonObjectLine
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 			$restrictBefore = dol_time_plus_duree(dol_now(), - $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS, 'm');
 
-			if ($this->timespent_date < $restrictBefore) {
+			if ((is_numeric($this->timespent_date) ? (int) $this->timespent_date : (int) strtotime((string) $this->timespent_date)) < $restrictBefore) {
 				$this->error = $langs->trans('TimeRecordingRestrictedToNMonthsBack', $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS);
 				$this->errors[] = $this->error;
 				return -1;
@@ -1763,7 +1763,7 @@ class Task extends CommonObjectLine
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 			$restrictBefore = dol_time_plus_duree(dol_now(), - $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS, 'm');
 
-			if ($this->timespent_date < $restrictBefore) {
+			if ((is_numeric($this->timespent_date) ? (int) $this->timespent_date : (int) strtotime((string) $this->timespent_date)) < $restrictBefore) {
 				$this->error = $langs->trans('TimeRecordingRestrictedToNMonthsBack', $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS);
 				$this->errors[] = $this->error;
 				return -1;
@@ -1864,7 +1864,7 @@ class Task extends CommonObjectLine
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
 			$restrictBefore = dol_time_plus_duree(dol_now(), - $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS, 'm');
 
-			if ($this->timespent_date < $restrictBefore) {
+			if ((is_numeric($this->timespent_date) ? (int) $this->timespent_date : (int) strtotime((string) $this->timespent_date)) < $restrictBefore) {
 				$this->error = $langs->trans('TimeRecordingRestrictedToNMonthsBack', $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS);
 				$this->errors[] = $this->error;
 				return -1;


### PR DESCRIPTION
Fixes #36480.

addTimeSpent, updateTimeSpent and delTimeSpent compare `$this->timespent_date` (which is an int timestamp in the common path but can be a 'YYYY-MM-DD' string when set by some callers) directly with the integer timestamp returned by dol_time_plus_duree, so the PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS guard silently allowed past entries it should refuse. Normalize the left-hand side with is_numeric / strtotime at the three comparison sites.