### PR TITLE
Fix #31471 translate CostPrice and PriceBaseType on import field list

### DIFF
--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -34,7 +34,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/images.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/import.lib.php';
 
 // Load translation files required by the page
-$langs->loadLangs(array('exports', 'compta', 'errors'));
+$langs->loadLangs(array('exports', 'compta', 'errors', 'products', 'margins'));
 
 // Security check
 $result = restrictedArea($user, 'import');


### PR DESCRIPTION
Fixes #31471.

htdocs/imports/import.php only loaded exports/compta/errors so labels coming from modProduct and modService import_fields_array that resolve to keys in products.lang (PriceBaseType) and margins.lang (CostPrice) stayed in English on a French install. Add 'products' and 'margins' to the loadLangs call so the import field picker shows the translated label that the rest of the product card already uses.