### PR TITLE
Fix #32407 translate prospection status libelle in dictionaries

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -2234,6 +2234,10 @@ if ($id > 0) {
 								$valuetoshow = $langs->trans($valuetoshow ? $valuetoshow : $tmpid);
 							} elseif ($tabname[$id] == 'c_exp_tax_cat') {
 								$valuetoshow = $langs->trans($valuetoshow);
+							} elseif ($value == 'libelle' && ($tabname[$id] == 'c_stcomm' || $tabname[$id] == 'c_stcommcontact')) {
+								$key = 'StatusProspect'.$obj->rowid;
+								$trans = $langs->trans($key);
+								$valuetoshow = ($trans != $key ? $trans : $obj->{$value});
 							} elseif ($value == 'label' && $tabname[$id] == 'c_units') {
 								$langs->load('other');
 								$key = $langs->trans($obj->label);


### PR DESCRIPTION
Fixes #32407.

dict.php translated label for some tables (c_units, c_product_nature, c_productbatch_qcstatus) but left the libelle column of c_stcomm and c_stcommcontact as raw seed English text, so the prospection status dictionary stayed in English on a French install even though StatusProspect{N} translations exist in companies.lang. Add an elseif branch that maps the row id to the StatusProspect{id} key and falls back to the stored libelle when no translation is found.