### PR TITLE
Fix tms from extrafield

### DIFF
--- a/htdocs/modulebuilder/template/class/myobject.class.php
+++ b/htdocs/modulebuilder/template/class/myobject.class.php
@@ -1040,7 +1040,7 @@ class MyObject extends CommonObject
 	{
 		$sql = "SELECT t.rowid, t.date_creation as datec";
 		if (!empty($this->isextrafieldmanaged) && $this->isextrafieldmanaged == 1) {
-			$sql .= ", GREATEST(t.tms, te.tms) as datem";
+			$sql .= ", GREATEST(t.tms, COALESCE(te.tms, t.tms)) as datem";
 		} else {
 			$sql .= ", t.tms as datem";
 		}


### PR DESCRIPTION
If the object created with modulebuilder manages extrafields, as long as the end-user doesn't create a first extrafield, the extrafield table is empty, so tms is null, so greatest of a real tms and null = null, so no last modification date is displayed