### PR TITLE
FIX: French amount in words (cent/vingt agreement, et, hyphens, mille/million, centimes)

### DIFF
--- a/htdocs/core/lib/functionsnumtoword.lib.php
+++ b/htdocs/core/lib/functionsnumtoword.lib.php
@@ -42,9 +42,15 @@ function dol_convertToWord($num, $langs, $currency = '', $centimes = false)
 		return false;
 	}
 
-	if ($centimes && strlen((string) $num) == 1) {
-		$num *= 10;
+	// Dedicated converter for French. The generic algorithm below is built on the English
+	// number structure and cannot express French spelling rules (et, hyphens, agreement of
+	// cent/vingt, elision of "un" before cent/mille). See dolConvertToWordFrench().
+	$langcode = $langs->getDefaultLang(0);
+	if (preg_match('/^fr/i', (string) $langcode)) {
+		return dolConvertToWordFrench($num, $langs, $currency, $centimes);
 	}
+
+	$numbackup = $num;
 
 	if (isModEnabled('numberwords')) {
 		$concatWords = $langs->getLabelFromNumber((string) $num, $currency);
@@ -147,21 +153,216 @@ function dol_convertToWord($num, $langs, $currency = '', $centimes = false)
 			$concatWords .= ' '.$currency;
 		}
 
-		// If we need to write cents call again this function for cents
-		$decimalpart = empty($TNum[1]) ? '' : preg_replace('/0+$/', '', $TNum[1]);
+		// If we need to write cents, spell the 2-digit cents value (e.g. 0.07 => 7 cents, not 70)
+		$tmptab = explode('.', number_format((float) abs($numbackup), 2, '.', ''));
+		$cents = isset($tmptab[1]) ? (int) $tmptab[1] : 0;
 
-		if ($decimalpart) {
+		if ($cents > 0) {
 			if (!empty($currency)) {
 				$concatWords .= ' '.$langs->transnoentities('and');
 			}
 
-			$concatWords .= ' '.dol_convertToWord((float) $decimalpart, $langs, '', true);
+			$concatWords .= ' '.dol_convertToWord((float) $cents, $langs, '', false);
 			if (!empty($currency)) {
 				$concatWords .= ' '.$langs->transnoentities('centimes');
 			}
 		}
 		return $concatWords;
 	}
+}
+
+
+/**
+ * Convert a non-negative integer into French words (standard French: soixante-dix,
+ * quatre-vingts, quatre-vingt-dix). Handles "et", hyphens and the agreement of
+ * "cent" and "quatre-vingt(s)".
+ *
+ * @param	int		$n			Integer to convert (sign is ignored)
+ * @param	bool	$reform		false = traditional spelling (hyphen only between tens and units),
+ * 								true = 1990 rectified spelling (hyphens everywhere)
+ * @return	string				Number written in French words
+ */
+function dolConvertIntToFrenchWords($n, $reform = false)
+{
+	$n = (int) $n;
+	if ($n < 0) {
+		$n = -$n;
+	}
+	if ($n === 0) {
+		return 'zéro';
+	}
+
+	$sep = $reform ? '-' : ' ';
+	$etjoin = $reform ? '-et-' : ' et ';
+
+	$units = array(
+		'zéro', 'un', 'deux', 'trois', 'quatre', 'cinq', 'six', 'sept', 'huit', 'neuf',
+		'dix', 'onze', 'douze', 'treize', 'quatorze', 'quinze', 'seize',
+		'dix-sept', 'dix-huit', 'dix-neuf'
+	);
+	$tensmap = array(2 => 'vingt', 3 => 'trente', 4 => 'quarante', 5 => 'cinquante', 6 => 'soixante');
+	$scales = array('', 'mille', 'million', 'milliard', 'billion', 'billiard', 'trillion');
+
+	// Spell a number from 1 to 99
+	$below100 = function (int $m) use ($units, $tensmap, $etjoin): string {
+		if ($m < 20) {
+			return $units[$m] ?? '';
+		}
+		$t = intdiv($m, 10);
+		$u = $m % 10;
+		if ($t == 7 || $t == 9) {
+			// 70-79 = soixante + (10..19), 90-99 = quatre-vingt + (10..19)
+			$base = ($t == 7) ? 'soixante' : 'quatre-vingt';
+			if ($t == 7 && $u == 1) {
+				return $base.$etjoin.$units[10 + $u]; // soixante et onze (but quatre-vingt-onze takes no "et")
+			}
+			return $base.'-'.$units[10 + $u];
+		}
+		if ($t == 8) {
+			// 80 = quatre-vingts, 81..89 = quatre-vingt-x (no "s", no "et")
+			return ($u == 0) ? 'quatre-vingts' : 'quatre-vingt-'.$units[$u];
+		}
+		// 20..69
+		$w = $tensmap[$t] ?? '';
+		if ($u == 0) {
+			return $w;
+		}
+		if ($u == 1) {
+			return $w.$etjoin.$units[1]; // vingt et un .. soixante et un
+		}
+		return $w.'-'.$units[$u];
+	};
+
+	// Split into groups of 3 digits, lowest group first (index 0 = units, 1 = thousands, 2 = millions...)
+	$groups = array();
+	$tmp = $n;
+	while ($tmp > 0) {
+		$groups[] = $tmp % 1000;
+		$tmp = intdiv($tmp, 1000);
+	}
+	$ng = count($groups);
+
+	$pieces = array(); // each entry: array('text' => string, 'noun' => bool) ; noun = million/milliard scale
+	for ($g = $ng - 1; $g >= 0; $g--) {
+		$val = $groups[$g];
+		if ($val == 0) {
+			continue;
+		}
+		$h = intdiv($val, 100);
+		$r = $val % 100;
+
+		// "cent" agrees (becomes "cents") only when multiplied and not followed by another numeral:
+		// plural when terminal (units group) or directly before a noun scale (million+),
+		// but invariable before "mille".
+		$centplural = ($h >= 2 && $r == 0 && ($g === 0 || $g >= 2));
+
+		$text = '';
+		if ($h >= 1) {
+			$text = ($h == 1) ? 'cent' : $units[$h].$sep.'cent';
+			if ($centplural) {
+				$text .= 's';
+			}
+		}
+		if ($r > 0) {
+			$rtext = $below100($r);
+			// "quatre-vingts" keeps its "s" only when terminal or before a noun scale, not before "mille".
+			if ($r == 80 && $g === 1) {
+				$rtext = 'quatre-vingt';
+			}
+			$text = ($text === '') ? $rtext : $text.$sep.$rtext;
+		}
+
+		if ($g == 1) {
+			// thousands: "mille" is invariable and takes no leading "un"
+			$text = ($val == 1) ? 'mille' : $text.$sep.'mille';
+			$pieces[] = array('text' => $text, 'noun' => false);
+		} elseif ($g >= 2) {
+			$scaleword = isset($scales[$g]) ? $scales[$g] : '';
+			if ($scaleword !== '') {
+				if ($val >= 2) {
+					$scaleword .= 's'; // millions, milliards...
+				}
+				$text .= ' '.$scaleword; // a noun scale is always separated by a space
+			}
+			$pieces[] = array('text' => $text, 'noun' => true);
+		} else {
+			$pieces[] = array('text' => $text, 'noun' => false);
+		}
+	}
+
+	$result = '';
+	foreach ($pieces as $i => $piece) {
+		if ($i === 0) {
+			$result = $piece['text'];
+		} else {
+			// after a noun scale (million+) keep a space, otherwise use the chosen separator
+			$result .= ($pieces[$i - 1]['noun'] ? ' ' : $sep).$piece['text'];
+		}
+	}
+
+	return $result;
+}
+
+
+/**
+ * Convert a number into French words. Used by dol_convertToWord() for French languages.
+ *
+ * @param	float		$num		Number to convert
+ * @param	Translate	$langs		Language object (used for the "and"/"centime"/"centimes" labels)
+ * @param	string		$currency	'' = no currency word, otherwise a currency string appended after the integer part
+ * @param	bool		$centimes	true = render the decimal part as "et X centime(s)"
+ * @return	string					Number written in French words
+ */
+function dolConvertToWordFrench($num, $langs, $currency = '', $centimes = false)
+{
+	// Spelling convention, set with constant CONVERT_TO_WORD_FR (Home - Setup - Other setup):
+	// - default/'PRE1990' = traditional spelling (hyphen only between tens and units)
+	// - 'REFORME1990'      = 1990 rectified spelling (hyphens between all the numeral words)
+	$reform = (getDolGlobalString('CONVERT_TO_WORD_FR') === 'REFORME1990');
+
+	$numstr = number_format((float) $num, 2, '.', '');
+	$negative = false;
+	if (strpos($numstr, '-') === 0) {
+		$negative = true;
+		$numstr = substr($numstr, 1);
+	}
+	$tmptab = explode('.', $numstr);
+	$intpart = (int) $tmptab[0];
+	$cents = isset($tmptab[1]) ? (int) $tmptab[1] : 0;
+
+	$result = ($intpart === 0) ? '' : dolConvertIntToFrenchWords($intpart, $reform);
+
+	if (!empty($currency)) {
+		if ($result === '') {
+			$result = 'zéro';
+		}
+		$result .= ' '.$currency;
+	}
+
+	if ($cents > 0) {
+		if ($centimes) {
+			$label = $langs->transnoentitiesnoconv($cents === 1 ? 'centime' : 'centimes');
+			$and = $langs->transnoentitiesnoconv('and');
+			$centtext = dolConvertIntToFrenchWords($cents, $reform).' '.$label;
+			if ($result === '') {
+				$result = $centtext;
+			} else {
+				$result .= ' '.$and.' '.$centtext;
+			}
+		} else {
+			// Not an amount: spell the decimal part after "virgule"
+			$result = ($result === '' ? 'zéro' : $result).' virgule '.dolConvertIntToFrenchWords($cents, $reform);
+		}
+	}
+
+	if ($result === '') {
+		$result = 'zéro';
+	}
+	if ($negative) {
+		$result = 'moins '.$result;
+	}
+
+	return $result;
 }
 
 

--- a/htdocs/langs/en_US/main.lang
+++ b/htdocs/langs/en_US/main.lang
@@ -1096,6 +1096,7 @@ million=million
 billion=billion
 trillion=trillion
 quadrillion=quadrillion
+centime=cent
 centimes=cents
 SelectMailModel=Select an email template
 SetRef=Set ref

--- a/htdocs/langs/fr_FR/main.lang
+++ b/htdocs/langs/fr_FR/main.lang
@@ -1088,6 +1088,7 @@ million=million
 billion=milliard
 trillion=mille milliards
 quadrillion=million de milliards
+centime=centime
 centimes=centimes
 SelectMailModel=Sélectionner un modèle d'e-mail
 SetRef=Définir réf.

--- a/test/phpunit/FunctionsNumToWordTest.php
+++ b/test/phpunit/FunctionsNumToWordTest.php
@@ -1,0 +1,241 @@
+<?php
+/* Copyright (C) 2026 Dolibarr contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/FunctionsNumToWordTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the number-to-words conversion (functionsnumtoword.lib.php)
+ *      \remarks    To run this script as CLI:  phpunit FunctionsNumToWordTest.php
+ */
+
+global $conf,$user,$langs,$db;
+//define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
+
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/functionsnumtoword.lib.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->loadRights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class to test the number-to-words conversion functions, focused on the French rules
+ * (et, hyphens, agreement of cent/vingt, elision of "un" before cent/mille, centimes).
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class FunctionsNumToWordTest extends CommonClassTest
+{
+	/**
+	 * Set up the French language before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$langs->setDefaultLang('fr_FR');
+		$langs->load('main');
+
+		// Traditional spelling (pre-1990) is the default
+		unset($conf->global->CONVERT_TO_WORD_FR);
+	}
+
+	/**
+	 * Data provider: integer => expected French words (traditional, pre-1990 spelling).
+	 *
+	 * @return array<int, array{0:int, 1:string}>
+	 */
+	public function providerFrenchIntegersTraditional()
+	{
+		$map = array(
+			0 => 'zéro', 1 => 'un', 2 => 'deux', 3 => 'trois', 4 => 'quatre', 5 => 'cinq',
+			6 => 'six', 7 => 'sept', 8 => 'huit', 9 => 'neuf', 10 => 'dix', 11 => 'onze',
+			12 => 'douze', 13 => 'treize', 14 => 'quatorze', 15 => 'quinze', 16 => 'seize',
+			17 => 'dix-sept', 18 => 'dix-huit', 19 => 'dix-neuf', 20 => 'vingt',
+			21 => 'vingt et un', 22 => 'vingt-deux', 23 => 'vingt-trois', 30 => 'trente',
+			31 => 'trente et un', 32 => 'trente-deux', 40 => 'quarante', 41 => 'quarante et un',
+			50 => 'cinquante', 51 => 'cinquante et un', 60 => 'soixante', 61 => 'soixante et un',
+			62 => 'soixante-deux', 69 => 'soixante-neuf', 70 => 'soixante-dix',
+			71 => 'soixante et onze', 72 => 'soixante-douze', 73 => 'soixante-treize',
+			74 => 'soixante-quatorze', 75 => 'soixante-quinze', 76 => 'soixante-seize',
+			77 => 'soixante-dix-sept', 78 => 'soixante-dix-huit', 79 => 'soixante-dix-neuf',
+			80 => 'quatre-vingts', 81 => 'quatre-vingt-un', 82 => 'quatre-vingt-deux',
+			89 => 'quatre-vingt-neuf', 90 => 'quatre-vingt-dix', 91 => 'quatre-vingt-onze',
+			92 => 'quatre-vingt-douze', 95 => 'quatre-vingt-quinze', 97 => 'quatre-vingt-dix-sept',
+			99 => 'quatre-vingt-dix-neuf', 100 => 'cent', 101 => 'cent un', 102 => 'cent deux',
+			110 => 'cent dix', 111 => 'cent onze', 120 => 'cent vingt', 121 => 'cent vingt et un',
+			180 => 'cent quatre-vingts', 181 => 'cent quatre-vingt-un', 199 => 'cent quatre-vingt-dix-neuf',
+			200 => 'deux cents', 201 => 'deux cent un', 202 => 'deux cent deux',
+			280 => 'deux cent quatre-vingts', 300 => 'trois cents', 360 => 'trois cent soixante',
+			500 => 'cinq cents', 555 => 'cinq cent cinquante-cinq', 999 => 'neuf cent quatre-vingt-dix-neuf',
+			1000 => 'mille', 1001 => 'mille un', 1100 => 'mille cent',
+			1199 => 'mille cent quatre-vingt-dix-neuf', 1200 => 'mille deux cents', 1234 => 'mille deux cent trente-quatre',
+			1500 => 'mille cinq cents', 1980 => 'mille neuf cent quatre-vingts', 1990 => 'mille neuf cent quatre-vingt-dix',
+			2000 => 'deux mille', 2001 => 'deux mille un', 2020 => 'deux mille vingt',
+			10000 => 'dix mille', 21000 => 'vingt et un mille', 80000 => 'quatre-vingt mille',
+			100000 => 'cent mille', 200000 => 'deux cent mille', 300000 => 'trois cent mille',
+			143360 => 'cent quarante-trois mille trois cent soixante',
+			1000000 => 'un million', 1000001 => 'un million un', 2000000 => 'deux millions',
+			1234567 => 'un million deux cent trente-quatre mille cinq cent soixante-sept',
+			71000000 => 'soixante et onze millions', 80000000 => 'quatre-vingts millions',
+			100000000 => 'cent millions', 200000000 => 'deux cents millions',
+			123456789 => 'cent vingt-trois millions quatre cent cinquante-six mille sept cent quatre-vingt-neuf',
+			999999999 => 'neuf cent quatre-vingt-dix-neuf millions neuf cent quatre-vingt-dix-neuf mille neuf cent quatre-vingt-dix-neuf',
+			1000000000 => 'un milliard', 2000000000 => 'deux milliards',
+			1000000000000 => 'un billion',
+		);
+		$data = array();
+		foreach ($map as $n => $expected) {
+			$data[(string) $n] = array($n, $expected);
+		}
+		return $data;
+	}
+
+	/**
+	 * Test dolConvertIntToFrenchWords() with the traditional (pre-1990) spelling.
+	 *
+	 * @param	int		$number		Integer to convert
+	 * @param	string	$expected	Expected French words
+	 * @return	void
+	 * @dataProvider providerFrenchIntegersTraditional
+	 */
+	public function testDolConvertIntToFrenchWordsTraditional($number, $expected)
+	{
+		$this->assertSame($expected, dolConvertIntToFrenchWords($number, false), "Conversion failed for $number");
+	}
+
+	/**
+	 * Test dolConvertIntToFrenchWords() with the 1990 rectified spelling (hyphens everywhere).
+	 *
+	 * @return	void
+	 */
+	public function testDolConvertIntToFrenchWordsReform()
+	{
+		$map = array(
+			21 => 'vingt-et-un',
+			71 => 'soixante-et-onze',
+			80 => 'quatre-vingts',
+			81 => 'quatre-vingt-un',
+			91 => 'quatre-vingt-onze',
+			143360 => 'cent-quarante-trois-mille-trois-cent-soixante',
+			200000000 => 'deux-cents millions',
+			1234567 => 'un million deux-cent-trente-quatre-mille-cinq-cent-soixante-sept',
+		);
+		foreach ($map as $n => $expected) {
+			$this->assertSame($expected, dolConvertIntToFrenchWords($n, true), "Reform conversion failed for $n");
+		}
+	}
+
+	/**
+	 * Test dol_convertToWord() for French amounts (currency empty, with centimes).
+	 *
+	 * @return	void
+	 */
+	public function testDolConvertToWordFrenchAmounts()
+	{
+		global $langs;
+
+		$map = array(
+			'0.70' => 'soixante-dix centimes',
+			'0.07' => 'sept centimes',
+			'0.05' => 'cinq centimes',
+			'0.01' => 'un centime',
+			'1.5' => 'un et cinquante centimes',
+			'2.01' => 'deux et un centime',
+			'100.99' => 'cent et quatre-vingt-dix-neuf centimes',
+			'143360' => 'cent quarante-trois mille trois cent soixante',
+			'143360.70' => 'cent quarante-trois mille trois cent soixante et soixante-dix centimes',
+		);
+		foreach ($map as $num => $expected) {
+			$this->assertSame($expected, dol_convertToWord((float) $num, $langs, '', true), "Amount conversion failed for $num");
+		}
+	}
+
+	/**
+	 * Test dol_convertToWord() for French amounts with a currency word and negative values.
+	 *
+	 * @return	void
+	 */
+	public function testDolConvertToWordFrenchCurrencyAndNegative()
+	{
+		global $langs;
+
+		$this->assertSame(
+			'cent quarante-trois mille trois cent soixante dirhams et soixante-dix centimes',
+			dol_convertToWord(143360.70, $langs, 'dirhams', true)
+		);
+		$this->assertSame('deux millions dirhams', dol_convertToWord(2000000, $langs, 'dirhams', true));
+		$this->assertSame('moins cinq', dol_convertToWord(-5, $langs, '', true));
+		$this->assertSame(
+			'moins mille deux cent trente-quatre et cinquante-six centimes',
+			dol_convertToWord(-1234.56, $langs, '', true)
+		);
+	}
+
+	/**
+	 * Test the 1990 rectified spelling on full amounts (driven by CONVERT_TO_WORD_FR).
+	 *
+	 * @return	void
+	 */
+	public function testDolConvertToWordFrenchReformConstant()
+	{
+		global $conf, $langs;
+
+		$conf->global->CONVERT_TO_WORD_FR = 'REFORME1990';
+		$this->assertSame(
+			'cent-quarante-trois-mille-trois-cent-soixante et soixante-dix centimes',
+			dol_convertToWord(143360.70, $langs, '', true)
+		);
+		unset($conf->global->CONVERT_TO_WORD_FR);
+	}
+
+	/**
+	 * Non-regression test for the cents extraction bug (e.g. 0.07 must be 7 cents, not 70),
+	 * checked on the generic (non-French) path in English.
+	 *
+	 * @return	void
+	 */
+	public function testDolConvertToWordCentsExtractionEnglish()
+	{
+		global $conf;
+
+		// Use a fresh Translate object: the shared $langs caches translations, so reusing it
+		// after the French tests would keep French values (seven => sept) on the English path.
+		$langsen = new Translate('', $conf);
+		$langsen->setDefaultLang('en_US');
+		$langsen->load('main');
+
+		// 0.07 used to wrongly yield "seventy"; it must be "seven"
+		$this->assertSame('seven', trim(dol_convertToWord(0.07, $langsen, '', true)));
+		$this->assertSame('five', trim(dol_convertToWord(0.05, $langsen, '', true)));
+		$this->assertSame('seventy', trim(dol_convertToWord(0.70, $langsen, '', true)));
+	}
+}


### PR DESCRIPTION
## Problem

The "amount in words" conversion (`dol_convertToWord()` in `htdocs/core/lib/functionsnumtoword.lib.php`) is built on the **English** number structure with words merely translated, so it cannot express French spelling rules. For example an invoice total of `143360.70` rendered as:

> un cent quarante trois mille trois cents soixante soixante-dix

instead of the correct:

> cent quarante-trois mille trois cent soixante **et soixante-dix centimes**

## Fix

A dedicated French converter (`dolConvertToWordFrench()` + `dolConvertIntToFrenchWords()`) is used for `fr_*` languages; the English/other path is unchanged. It handles:

- elision of "un" before cent/mille (`cent`, `mille`, not "un cent"/"un mille")
- agreement of cent/quatre-vingt (`deux cents`, `trois cent soixante`, `quatre-vingts`, `quatre-vingt mille`)
- the conjunction "et" for 21/31/41/51/61/71 (`vingt et un`, `soixante et onze`)
- hyphenation, **configurable** via constant `CONVERT_TO_WORD_FR` = `PRE1990` (default, traditional) / `REFORME1990` (1990 rectified spelling, hyphens everywhere)
- plural of million/milliard

It also fixes, for **all languages**, the cents extraction bug where `0.07` produced "seventy" instead of "seven", and renders the decimal part as "… et X centime(s)".

## Tests

New PHPUnit test `test/phpunit/FunctionsNumToWordTest.php` with 100+ French values (traditional + 1990 spelling, amounts, currency, negatives). Validated against a real configured instance (111 tests / 131 assertions, OK).

## Notes

- This is the forward-port to `develop` of #38945 (which targets `23.0`).
- Known out-of-scope items left untouched: English "two hundreds" in the generic path, Belgian/Swiss variants (septante/nonante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
