### PR TITLE
fix: translate company creation event labels

### DIFF
--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -972,6 +972,12 @@ class ActionComm extends CommonObject
 				$this->transparency			= $obj->transparency;
 
 				$this->socid = $obj->fk_soc; // To have fetch_thirdparty method working
+				if (!empty($obj->socname)) {
+					require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
+					$this->thirdparty = new Societe($this->db);
+					$this->thirdparty->id = $obj->fk_soc;
+					$this->thirdparty->name = $obj->socname;
+				}
 				$this->contact_id = $obj->fk_contact; // To have fetch_contact method working
 				$this->fk_project = $obj->fk_project; // To have fetch_projet method working
 
@@ -1721,8 +1727,9 @@ class ActionComm extends CommonObject
 		if (!empty($this->ref)) {
 			$datas['ref'] = '<br><b>'.$langs->trans('Ref').':</b> '.dol_escape_htmltag($this->ref);
 		}
-		if (!empty($this->label)) {
-			$datas['title'] = '<br><b>'.$langs->trans('Title').':</b> '.dol_escape_htmltag($this->label);
+		$translatedlabel = $this->getTranslatedLabel();
+		if (!empty($translatedlabel)) {
+			$datas['title'] = '<br><b>'.$langs->trans('Title').':</b> '.dol_escape_htmltag($translatedlabel);
 		}
 		if (!empty($labeltype)) {
 			$datas['labeltype'] = '<br><b>'.$langs->trans('Type').':</b> '.dol_escape_htmltag($labeltype);
@@ -1832,7 +1839,7 @@ class ActionComm extends CommonObject
 			$option = 'nolink';
 		}
 
-		$label = $this->label;
+		$label = $this->getTranslatedLabel();
 
 		$result = '';
 
@@ -1908,13 +1915,13 @@ class ActionComm extends CommonObject
 				if (empty($this->label)) {
 					$label = $labeltype;
 				} else {
-					$label = $this->label;
+					$label = $this->getTranslatedLabel();
 				}
 			}
 			if ($maxlength < 0) {
 				$labelshort = $this->ref;
 			} else {
-				$labelshort = dol_trunc(empty($this->label) ? $labeltype : $this->label, $maxlength);
+				$labelshort = dol_trunc(empty($label) ? $labeltype : $label, $maxlength);
 			}
 		}
 
@@ -1944,6 +1951,35 @@ class ActionComm extends CommonObject
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Return the label translated with current user language when the event was created from a known automatic trigger.
+	 *
+	 * @return string
+	 */
+	public function getTranslatedLabel()
+	{
+		global $conf, $langs;
+
+		if ($this->code == 'AC_COMPANY_CREATE' && !empty($this->thirdparty->name)) {
+			$langs->loadLangs(array('agenda', 'companies'));
+			$translatedlabel = $langs->transnoentitiesnoconv('NewCompanyToDolibarr', $this->thirdparty->name);
+			$defaultlabels = array($translatedlabel, 'Third party '.$this->thirdparty->name.' created');
+
+			foreach (array('en_US', 'fr_FR') as $langcode) {
+				$outputlangs = new Translate('', $conf);
+				$outputlangs->setDefaultLang($langcode);
+				$outputlangs->loadLangs(array('agenda', 'companies'));
+				$defaultlabels[] = $outputlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $this->thirdparty->name);
+			}
+
+			if (in_array($this->label, array_unique($defaultlabels), true)) {
+				return $translatedlabel;
+			}
+		}
+
+		return $this->label;
 	}
 
 	/**

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1960,39 +1960,10 @@ class ActionComm extends CommonObject
 	 */
 	public function getTranslatedLabel()
 	{
-		global $conf, $langs;
+		global $langs;
 
 		if ($this->code == 'AC_COMPANY_CREATE' && !empty($this->thirdparty->name)) {
-			static $defaultlabeltemplates = null;
-
-			$langs->loadLangs(array('agenda', 'companies'));
-			$translatedlabel = $langs->transnoentitiesnoconv('NewCompanyToDolibarr', $this->thirdparty->name);
-			$defaultlabels = array($translatedlabel);
-			$thirdpartynameplaceholder = '__THIRDPARTY_NAME__';
-
-			if ($defaultlabeltemplates === null) {
-				$defaultlabeltemplates = array('Third party '.$thirdpartynameplaceholder.' created');
-
-				foreach (array_keys($langs->get_available_languages(DOL_DOCUMENT_ROOT, 0, 2)) as $langcode) {
-					$outputlangs = new Translate('', $conf);
-					$outputlangs->setDefaultLang($langcode);
-					$outputlangs->loadLangs(array('agenda', 'companies'));
-					$defaultlabel = $outputlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $thirdpartynameplaceholder);
-					if ($defaultlabel != 'NewCompanyToDolibarr') {
-						$defaultlabeltemplates[] = $defaultlabel;
-					}
-				}
-
-				$defaultlabeltemplates = array_unique($defaultlabeltemplates);
-			}
-
-			foreach ($defaultlabeltemplates as $defaultlabeltemplate) {
-				$defaultlabels[] = str_replace($thirdpartynameplaceholder, $this->thirdparty->name, $defaultlabeltemplate);
-			}
-
-			if (in_array($this->label, array_unique($defaultlabels), true)) {
-				return $translatedlabel;
-			}
+			return $langs->transnoentitiesnoconv('NewCompanyToDolibarr', $this->thirdparty->name);
 		}
 
 		return $this->label;

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1963,15 +1963,31 @@ class ActionComm extends CommonObject
 		global $conf, $langs;
 
 		if ($this->code == 'AC_COMPANY_CREATE' && !empty($this->thirdparty->name)) {
+			static $defaultlabeltemplates = null;
+
 			$langs->loadLangs(array('agenda', 'companies'));
 			$translatedlabel = $langs->transnoentitiesnoconv('NewCompanyToDolibarr', $this->thirdparty->name);
-			$defaultlabels = array($translatedlabel, 'Third party '.$this->thirdparty->name.' created');
+			$defaultlabels = array($translatedlabel);
+			$thirdpartynameplaceholder = '__THIRDPARTY_NAME__';
 
-			foreach (array('en_US', 'fr_FR') as $langcode) {
-				$outputlangs = new Translate('', $conf);
-				$outputlangs->setDefaultLang($langcode);
-				$outputlangs->loadLangs(array('agenda', 'companies'));
-				$defaultlabels[] = $outputlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $this->thirdparty->name);
+			if ($defaultlabeltemplates === null) {
+				$defaultlabeltemplates = array('Third party '.$thirdpartynameplaceholder.' created');
+
+				foreach (array_keys($langs->get_available_languages(DOL_DOCUMENT_ROOT, 0, 2)) as $langcode) {
+					$outputlangs = new Translate('', $conf);
+					$outputlangs->setDefaultLang($langcode);
+					$outputlangs->loadLangs(array('agenda', 'companies'));
+					$defaultlabel = $outputlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $thirdpartynameplaceholder);
+					if ($defaultlabel != 'NewCompanyToDolibarr') {
+						$defaultlabeltemplates[] = $defaultlabel;
+					}
+				}
+
+				$defaultlabeltemplates = array_unique($defaultlabeltemplates);
+			}
+
+			foreach ($defaultlabeltemplates as $defaultlabeltemplate) {
+				$defaultlabels[] = str_replace($thirdpartynameplaceholder, $this->thirdparty->name, $defaultlabeltemplate);
 			}
 
 			if (in_array($this->label, array_unique($defaultlabels), true)) {

--- a/test/phpunit/ActionCommTest.php
+++ b/test/phpunit/ActionCommTest.php
@@ -30,6 +30,7 @@ global $conf,$user,$langs,$db;
 //require_once 'PHPUnit/Autoload.php';
 require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
 require_once dirname(__FILE__).'/../../htdocs/comm/action/class/actioncomm.class.php';
+require_once dirname(__FILE__).'/../../htdocs/societe/class/societe.class.php';
 require_once dirname(__FILE__).'/CommonClassTest.class.php';
 
 if (empty($user->id)) {
@@ -46,6 +47,10 @@ $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
  * @backupGlobals disabled
  * @backupStaticAttributes enabled
  * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ * @phan-file-suppress PhanUndeclaredClass
+ * @phan-file-suppress PhanUndeclaredExtendedClass
+ * @phan-file-suppress PhanUndeclaredMethod
+ * @phan-file-suppress PhanUndeclaredProperty
  */
 class ActionCommTest extends CommonClassTest
 {
@@ -140,6 +145,52 @@ class ActionCommTest extends CommonClassTest
 		$this->assertLessThan($result, 0);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		return $localobject;
+	}
+
+	/**
+	 * testActionCommGetTranslatedCompanyCreateLabel
+	 *
+	 * @return void
+	 */
+	public function testActionCommGetTranslatedCompanyCreateLabel()
+	{
+		global $conf,$langs,$db;
+		$conf = $this->savconf;
+		$db = $this->savdb;
+
+		$thirdpartyname = 'Test company';
+
+		$englishlangs = new Translate('', $conf);
+		$englishlangs->setDefaultLang('en_US');
+		$englishlangs->loadLangs(array('agenda', 'companies'));
+		$englishlabel = $englishlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $thirdpartyname);
+
+		$frenchlangs = new Translate('', $conf);
+		$frenchlangs->setDefaultLang('fr_FR');
+		$frenchlangs->loadLangs(array('agenda', 'companies'));
+		$frenchlabel = $frenchlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $thirdpartyname);
+
+		$localobject = new ActionComm($db);
+		$localobject->code = 'AC_COMPANY_CREATE';
+		$localobject->thirdparty = new Societe($db);
+		$localobject->thirdparty->name = $thirdpartyname;
+
+		try {
+			$langs = new Translate('', $conf);
+			$langs->setDefaultLang('fr_FR');
+			$localobject->label = $englishlabel;
+			$this->assertSame($frenchlabel, $localobject->getTranslatedLabel());
+
+			$langs = new Translate('', $conf);
+			$langs->setDefaultLang('en_US');
+			$localobject->label = $frenchlabel;
+			$this->assertSame($englishlabel, $localobject->getTranslatedLabel());
+
+			$localobject->label = 'Manual agenda label';
+			$this->assertSame('Manual agenda label', $localobject->getTranslatedLabel());
+		} finally {
+			$langs = $this->savlangs;
+		}
 	}
 
 	/**

--- a/test/phpunit/ActionCommTest.php
+++ b/test/phpunit/ActionCommTest.php
@@ -162,12 +162,12 @@ class ActionCommTest extends CommonClassTest
 
 		$englishlangs = new Translate('', $conf);
 		$englishlangs->setDefaultLang('en_US');
-		$englishlangs->loadLangs(array('agenda', 'companies'));
+		$englishlangs->load('agenda');
 		$englishlabel = $englishlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $thirdpartyname);
 
 		$frenchlangs = new Translate('', $conf);
 		$frenchlangs->setDefaultLang('fr_FR');
-		$frenchlangs->loadLangs(array('agenda', 'companies'));
+		$frenchlangs->load('agenda');
 		$frenchlabel = $frenchlangs->transnoentitiesnoconv('NewCompanyToDolibarr', $thirdpartyname);
 
 		$localobject = new ActionComm($db);
@@ -178,14 +178,17 @@ class ActionCommTest extends CommonClassTest
 		try {
 			$langs = new Translate('', $conf);
 			$langs->setDefaultLang('fr_FR');
+			$langs->load('agenda');
 			$localobject->label = $englishlabel;
 			$this->assertSame($frenchlabel, $localobject->getTranslatedLabel());
 
 			$langs = new Translate('', $conf);
 			$langs->setDefaultLang('en_US');
+			$langs->load('agenda');
 			$localobject->label = $frenchlabel;
 			$this->assertSame($englishlabel, $localobject->getTranslatedLabel());
 
+			$localobject->code = 'AC_OTH_AUTO';
 			$localobject->label = 'Manual agenda label';
 			$this->assertSame('Manual agenda label', $localobject->getTranslatedLabel());
 		} finally {


### PR DESCRIPTION
## Summary
- keep the third-party name available on agenda events through the existing `$this->thirdparty` object
- resolve company-creation event labels from the stable `AC_COMPANY_CREATE` code with the page-loaded `agenda` translation
- remove render-time language discovery, `Translate` construction, and translation-file loading

Fixes #32397

## Checks
- `php -l htdocs/comm/action/class/actioncomm.class.php`
- `php -l test/phpunit/ActionCommTest.php`
- `git diff --check`

Note: local PHPUnit is not available in this checkout (`vendor/bin/phpunit` and global `phpunit` are missing); CI remains the source for full project checks.