### PR TITLE
fix: preserve supplier deposit discount currency

### DIFF
--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -314,6 +314,8 @@ class PaiementFourn extends Paiement
 											$discount->fk_soc = $invoice->socid;
 											$discount->socid = $invoice->socid;
 											$discount->fk_invoice_supplier_source = $invoice->id;
+											$discount->multicurrency_code = $invoice->multicurrency_code;
+											$discount->multicurrency_tx = $invoice->multicurrency_tx;
 
 											// Loop on each vat rate
 											$i = 0;


### PR DESCRIPTION
## What Problem This Solves
Supplier deposit invoices in a foreign currency can auto-create a `(DEPOSIT)` supplier discount when fully paid, but that discount was missing `multicurrency_code` and `multicurrency_tx`.

## Why This Change Was Made
`DiscountAbsolute::create()` already persists the multicurrency code and rate when they are set. The automatic supplier deposit conversion path populated multicurrency amounts from the source invoice lines, but did not copy the source invoice currency code/rate onto the discount.

## User Impact
Discounts generated from fully paid foreign-currency supplier deposit invoices keep the invoice currency metadata, so later multicurrency balance calculations can use the correct currency/rate.

## Evidence
- `php -l htdocs/fourn/class/paiementfourn.class.php`
- `git diff --check`

Note: local PHPUnit is not available in this checkout (`vendor/bin/phpunit` and global `phpunit` are missing); CI remains the source for full project checks.

Fixes #38959