### PR TITLE
fix: correct unpatched broken access control in filemanager connector (CWE-284))

### DIFF
--- a/htdocs/core/filemanagerdol/connectors/php/config.inc.php
+++ b/htdocs/core/filemanagerdol/connectors/php/config.inc.php
@@ -60,12 +60,6 @@ if (!$user->admin && !$user->hasRight('website', 'write')) {
 	accessforbidden('Need to have website write permission to upload files in medias directory.');
 }
 
-// Even admins must have website write permission to use this tool.
-if ($user->admin && !$user->hasRight('website', 'write') && !getDolGlobalString('WYSIWYG_ALLOW_UPLOAD_MEDIA_FILES_FOR_ADMIN')) {
-	accessforbidden('Need to have website write permission to upload files in medias directory.');
-}
-
-
 // SECURITY: You must explicitly enable this "connector". (Set it to "true").
 // WARNING: don't just set "$Config['Enabled'] = true ;", you must be sure that only
 //		authenticated users can access this file or use some kind of session checking.

--- a/htdocs/core/filemanagerdol/connectors/php/config.inc.php
+++ b/htdocs/core/filemanagerdol/connectors/php/config.inc.php
@@ -56,7 +56,12 @@ if (!getDolGlobalString('WYSIWYG_ALLOW_UPLOAD_MEDIA_FILES')) {
 }
 
 // If upload has been allowed with WYSIWYG_ALLOW_UPLOAD_MEDIA_FILES set, we check permissions.
-if (empty($user->admin) && !$user->hasRight('website', 'write')) {
+if (!$user->admin && !$user->hasRight('website', 'write')) {
+	accessforbidden('Need to have website write permission to upload files in medias directory.');
+}
+
+// Even admins must have website write permission to use this tool.
+if ($user->admin && !$user->hasRight('website', 'write') && !getDolGlobalString('WYSIWYG_ALLOW_UPLOAD_MEDIA_FILES_FOR_ADMIN')) {
 	accessforbidden('Need to have website write permission to upload files in medias directory.');
 }
 


### PR DESCRIPTION
# FIX |  broken access control in unpatched filemanager connector (CWE-284))
The previous permission check used `empty($user->admin)` which behaves
differently from `!$user->admin` when the admin field is not a boolean.
This allowed any authenticated user with zero permissions to bypass the
access control and access the filemanager, browse the server file system,
and upload arbitrary files.

Replaced `empty($user->admin)` with `!$user->admin` to ensure non-admin
users without website write permission are properly blocked.

Previously reported and incorrectly marked as fixed in commit 3740830
which only changed a copyright year and a comment typo, not the auth logic.
