### PR TITLE
NEW add product/batch extrafields on principal product warehouse list

### DIFF
--- a/htdocs/langs/en_US/productbatch.lang
+++ b/htdocs/langs/en_US/productbatch.lang
@@ -53,3 +53,6 @@ IlligalQtyForSerialNumbers= Stock correction required because unique serial numb
 ErrorBatchesNeedStockManagement=Error. A product with batch/lot management must also be managed in stock.
 ForceBatchesNeedStockManagement=A product with batch/lot management must be managed in stock (stock management force to yes)
 BatchInformationNotfound=Batch information not found
+DisableDisplaySellBy=Disable display SellBy on lists
+DisableDisplayEatBy=Disable display EatBy on lists
+ShowProductLotExtrafields=Show Batch/lot Extrafields on lists

--- a/htdocs/product/admin/product_lot.php
+++ b/htdocs/product/admin/product_lot.php
@@ -1,7 +1,8 @@
 <?php
-/* Copyright (C) 2021		Christophe Battarel  <christophe.battarel@altairis.fr>
+/* Copyright (C) 2021		Christophe Battarel 	<christophe.battarel@altairis.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		Charlene Benke          <charlene@patas-monkey.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -533,15 +534,38 @@ if (!empty($def)) {
 	print '</div>';
 }
 
+print '<form action="'.$_SERVER["PHP_SELF"].'" method="post">';
+print '<input type="hidden" name="token" value="'.newToken().'">';
+print '<input type="hidden" name="action" value="setoptions">';
 
-if (empty($def) && getDolGlobalInt('MAIN_FEATURES_LEVEL') < 2) {
-	// The feature to define the numbering module of lot or serial is no enabled because it is not used anywhere in Dolibarr code: You can set it
-	// but the numbering module is not used.
-	// TODO Use it on lot creation page, when you create a lot and when the lot number is kept empty to define the lot according
-	// to the selected product.
-	print $langs->trans("NothingToSetup");
-}
+print load_fiche_titre($langs->trans("OtherOptions"), '', '');
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>'.$langs->trans("Parameter").'</td>';
+print '<td class="center" width="60"></td>';
+print "</tr>\n";
 
+print '<tr class="oddeven"><td>';
+print $langs->trans('DisableDisplaySellBy');
+print '</td><td class="right">';
+print ajax_constantonoff('PRODUCT_DISABLE_SELLBY');
+
+print '<tr class="oddeven"><td>';
+print $langs->trans('DisableDisplayEatBy');
+print '</td><td class="right">';
+print ajax_constantonoff('PRODUCT_DISABLE_EATBY');
+print '</td></tr>';
+
+print '<tr class="oddeven"><td>';
+print $langs->trans('ShowProductLotExtrafields');
+print '</td><td class="right">';
+print ajax_constantonoff('PRODUCT_LOT_SHOW_EXTRAFIELDS');
+print '</td></tr>';
+
+print '</table>';
+
+print '</form>';
+print dol_get_fiche_end();
 
 // End of page
 llxFooter();

--- a/htdocs/product/reassortlot.php
+++ b/htdocs/product/reassortlot.php
@@ -9,6 +9,8 @@
  * Copyright (C) 2021       Noé Cendrier			<noe.cendrier@altairis.fr>
  * Copyright (C) 2024-2025  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Charlene Benke			<charlene@patas-monkey.com>
+
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -277,7 +279,7 @@ $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_stock as ps on p.rowid = ps.fk_pro
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot as e on ps.fk_entrepot = e.rowid'; // Link on unique key
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_batch as pb on pb.fk_product_stock = ps.rowid'; // Detail for each lot on each warehouse
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot as pl on pl.fk_product = p.rowid AND pl.batch = pb.batch'; // Link on unique key
-$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot_extrafields as ef on pl.rowid = ef.fk_object'; 
+$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot_extrafields as ef on pl.rowid = ef.fk_object';
 
 // Add table from hooks
 $parameters = array();
@@ -866,7 +868,7 @@ while ($i < $imaxinloop) {
 			$totalarray['nbfield']++;
 		}
 	}
-	
+
 	if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
 		// Extra fields
 		$obj = $objp; // trick for not change more thing

--- a/htdocs/product/reassortlot.php
+++ b/htdocs/product/reassortlot.php
@@ -97,10 +97,12 @@ if (GETPOSTISSET('catid')) {
 $search_warehouse_categ = GETPOSTINT('search_warehouse_categ');
 
 // Fetch optionals attributes and labels
-$extrafields->fetch_name_optionals_label($object->table_element);
+$extrafieldsobjectkey = "product_lot";
+
+$extrafields->fetch_name_optionals_label($extrafieldsobjectkey);
 //$extrafields->fetch_name_optionals_label($object->table_element_line);
 
-$search_array_options = $extrafields->getOptionalsFromPost($object->table_element, '', 'search_');
+$search_array_options = $extrafields->getOptionalsFromPost($extrafieldsobjectkey, '', 'search_');
 
 // Default sort order (if not yet defined by previous GETPOST)
 if (!$sortfield) {
@@ -154,6 +156,8 @@ $arrayfields = array(
 	array('type' => 'int', 'label' => 'StatusSell', 'checked' => 1, 'enabled' => 1, 'position' => 1),
 	array('type' => 'int', 'label' => 'StatusBuy', 'checked' => 1, 'enabled' => 1, 'position' => 1),
 );
+// Extra fields
+include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
 
 //$arrayfields['anotherfield'] = array('type'=>'integer', 'label'=>'AnotherField', 'checked'=>1, 'enabled'=>1, 'position'=>90, 'csslist'=>'right');
 $arrayfields = dol_sort_array($arrayfields, 'position');
@@ -256,7 +260,14 @@ $sql .= ' ps.fk_entrepot, ps.reel,';
 $sql .= ' e.ref as warehouse_ref, e.lieu as warehouse_lieu, e.fk_parent as warehouse_parent,';
 $sql .= ' pb.batch, pb.eatby as oldeatby, pb.sellby as oldsellby,';
 $sql .= ' pl.rowid as lotid, pl.eatby, pl.sellby,';
-$sql .= ' SUM(pb.qty) as stock_physique, COUNT(pb.rowid) as nbinbatchtable';
+// Add fields from extrafields
+if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
+	foreach ($extrafields->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
+		$sql .= ($extrafields->attributes[$extrafieldsobjectkey]['type'][$key] != 'separate' ? ", ef.".$key." as options_".$key : '');
+	}
+}
+
+$sql .= ', SUM(pb.qty) as stock_physique, COUNT(pb.rowid) as nbinbatchtable';
 // Add fields from hooks
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters, $object); // Note that $action and $object may have been modified by hook
@@ -266,6 +277,8 @@ $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_stock as ps on p.rowid = ps.fk_pro
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'entrepot as e on ps.fk_entrepot = e.rowid'; // Link on unique key
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_batch as pb on pb.fk_product_stock = ps.rowid'; // Detail for each lot on each warehouse
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot as pl on pl.fk_product = p.rowid AND pl.batch = pb.batch'; // Link on unique key
+$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_lot_extrafields as ef on pl.rowid = ef.fk_object'; 
+
 // Add table from hooks
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object); // Note that $action and $object may have been modified by hook
@@ -386,6 +399,12 @@ $sql .= " ps.fk_entrepot, ps.reel,";
 $sql .= " e.ref, e.lieu, e.fk_parent,";
 $sql .= " pb.batch, pb.eatby, pb.sellby,";
 $sql .= " pl.rowid, pl.eatby, pl.sellby";
+if (!empty($extrafields->attributes[$extrafieldsobjectkey]['label'])) {
+	foreach ($extrafields->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
+		$sql .= ($extrafields->attributes[$extrafieldsobjectkey]['type'][$key] != 'separate' ? ", ef.".$key : '');
+	}
+}
+
 // Add GROUP BY from hooks
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListGroupBy', $parameters, $object); // Note that $action and $object may have been modified by hook
@@ -540,6 +559,9 @@ if (!empty($search_warehouse_categ) && $search_warehouse_categ != '-1') {
 if ($search_stock_physique) {
 	$param .= '&search_stock_physique=' . urlencode($search_stock_physique);
 }
+// Add $param from extra fields
+include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_param.tpl.php';
+
 /*if ($eatby)		$param.="&eatby=".$eatby;
 if ($sellby)	$param.="&sellby=".$sellby;*/
 
@@ -646,6 +668,11 @@ if (!getDolGlobalString('PRODUCT_DISABLE_EATBY')) {
 	print '</div>';
 	print '</td>';
 }
+if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+	// Extra fields
+	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_input.tpl.php';
+}
+
 // Physical stock
 print '<td class="liste_titre right">';
 print '<input class="flat" type="text" size="5" name="search_stock_physique" value="'.dol_escape_htmltag($search_stock_physique).'">';
@@ -688,6 +715,10 @@ if (!getDolGlobalString('PRODUCT_DISABLE_SELLBY')) {
 }
 if (!getDolGlobalString('PRODUCT_DISABLE_EATBY')) {
 	print_liste_field_titre("EatByDate", $_SERVER["PHP_SELF"], "pl.eatby", '', $param, "", $sortfield, $sortorder, 'center ');
+}
+if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+	// Extra fields
+	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_title.tpl.php';
 }
 print_liste_field_titre("PhysicalStock", $_SERVER["PHP_SELF"], "stock_physique", '', $param, "", $sortfield, $sortorder, 'right ');
 // TODO Add info of running suppliers/customers orders
@@ -834,6 +865,12 @@ while ($i < $imaxinloop) {
 		if (!$i) {
 			$totalarray['nbfield']++;
 		}
+	}
+	
+	if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+		// Extra fields
+		$obj = $objp; // trick for not change more thing
+		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_print_fields.tpl.php';
 	}
 
 	print '<td class="right">';

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1046,8 +1046,31 @@ if ($showstockdetails) {
 	print '<div class="div-table-responsive">';
 	print '<table class="noborder centpercent">';
 
+	// Batch fields display management
+	$colspan = 4;
+	if ((isModEnabled('productbatch')) && $object->hasbatch()) {
+		if (getDolGlobalString('PRODUCT_DISABLE_SELLBY')) 
+			$colspan--;
+		if (getDolGlobalString('PRODUCT_DISABLE_EATBY')) 
+			$colspan--;
+		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+			$extrafieldsobjectkey = "product_lot";
+			$extrafieldsProductLot = new Extrafields($db);
+			$extrafieldsProductLot->fetch_name_optionals_label($extrafieldsobjectkey);
+			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+				&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
+				foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
+					if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key] == 'separate') {
+						continue;
+					}
+					$colspan++;
+				}
+			}
+		}
+	}
 	print '<tr class="liste_titre">';
-	print '<td colspan="4">'.$langs->trans("Warehouse").'</td>';
+	print '<td colspan="'.$colspan.'">'.$langs->trans("Warehouse").'</td>';
 	print '<td class="right">'.$langs->trans("NumberOfUnit").'</td>';
 	print '<td class="right">'.$form->textwithpicto($langs->trans("AverageUnitPricePMPShort"), $langs->trans("AverageUnitPricePMPDesc")).'</td>';
 	print '<td class="right">'.$langs->trans("EstimatedStockValueShort").'</td>';
@@ -1058,7 +1081,6 @@ if ($showstockdetails) {
 	print '</tr>';
 
 	if ((isModEnabled('productbatch')) && $object->hasbatch()) {
-		$colspan = 3;
 		print '<tr class="liste_titre"><td class="minwidth200">';
 		if (!empty($conf->use_javascript_ajax)) {
 			print '<a id="show_all" href="#" class="hideobject">'.img_picto('', 'folder-open', 'class="paddingright"').$langs->trans("ShowAllLots").'</a>';
@@ -1069,14 +1091,26 @@ if ($showstockdetails) {
 		print '</td>';
 		print '<td class="right">'.$langs->trans("batch_number").'</td>';
 		if (!getDolGlobalString('PRODUCT_DISABLE_SELLBY')) {
-			$colspan--;
 			print '<td class="center width100">'.$langs->trans("SellByDate").'</td>';
 		}
 		if (!getDolGlobalString('PRODUCT_DISABLE_EATBY')) {
-			$colspan--;
 			print '<td class="center width100">'.$langs->trans("EatByDate").'</td>';
 		}
-		print '<td colspan="'.$colspan.'"></td>';
+		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+			// fetch optionals attributes and labels
+			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+				&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
+				foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
+					if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key] == 'separate') {
+						continue;
+					}
+					print "<td>".$extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'][$key]."</td>";
+				}
+			}
+		}
+		
+		print '<td colspan="'.($colspan+5).'"></td>';
 		print '<td></td>';
 		print '<td></td>';
 		print '<td></td>';
@@ -1233,6 +1267,20 @@ if ($showstockdetails) {
 							print $form->selectDate($pdluo->eatby, 'eatby', 0, 0, 1, '', 1, 0);
 							print '</td>';
 						}
+						if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+							// fetch optionals attributes and labels
+							if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+								&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+								&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
+								foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
+									if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key] == 'separate') {
+										continue;
+									}
+									print "<td></td>";
+								}
+							}
+						}
+
 						print '<td class="right" colspan="3">'.$pdluo->qty.($pdluo->qty < 0 ? ' '.img_warning() : '').'</td>';
 						print '<td colspan="4"><input type="submit" class="button button-save" id="savelinebutton marginbottomonly" name="save" value="'.$langs->trans("Save").'">';
 						print '<input type="submit" class="button button-cancel" id="cancellinebutton" name="Cancel" value="'.$langs->trans("Cancel").'"></td></tr>';
@@ -1252,15 +1300,56 @@ if ($showstockdetails) {
 							print $product_lot_static->getNomUrl(1, 'nolink');
 						}
 						print '</td>';
-						$colspan = 3;
 						if (!getDolGlobalString('PRODUCT_DISABLE_SELLBY')) {
-							$colspan--;
 							print '<td class="center">'.dol_print_date($pdluo->sellby, 'day').'</td>';
 						}
 						if (!getDolGlobalString('PRODUCT_DISABLE_EATBY')) {
-							$colspan--;
 							print '<td class="center">'.dol_print_date($pdluo->eatby, 'day').'</td>';
 						}
+												if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+							// fetch optionals attributes and labels
+							if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+								&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+								&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
+								$product_lot_static->fetch($pdluo->lotid);
+								foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
+									if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key] == 'separate') {
+										continue;
+									}
+
+									$cssclasstd = $extrafieldsProductLot->getCSSClass($key, $extrafieldsobjectkey, 'csslist');
+									$cssclassview = $extrafieldsProductLot->getCSSClass($key, $extrafieldsobjectkey, 'cssview');
+
+									$tmpkey = 'options_'.$key;
+
+									if (in_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key], array('int'))) {
+										$value = (isset($product_lot_static->array_options[$tmpkey]) ? $product_lot_static->array_options[$tmpkey] : null) ;
+									} else {
+										// The key may be in $obj->array_options if not in $obj
+										$value =(isset($product_lot_static->array_options[$tmpkey]) ? $product_lot_static->array_options[$tmpkey] : '');
+									}
+									// If field is a computed field, we make computation to get value
+									if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['computed'][$key]) {
+										$objectoffield = $object; // For compatibility with the computed formula. $objectoffield is exported by dol_eval().
+										$value = dol_eval((string) $extrafieldsProductLot->attributes[$extrafieldsobjectkey]['computed'][$key], 1, 1, '2');
+									}
+
+									$valuetoshow = $extrafieldsProductLot->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object ?? null, 'list');
+
+									$title = dol_string_nohtmltag($valuetoshow);
+
+									print '<td'.($cssclasstd ? ' class="'.$cssclasstd.'"' : '');
+									print ' data-key="'.$extrafieldsobjectkey.'.'.$key.'"';
+									print ($title && !in_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key], array('stars')) ? ' title="'.dol_escape_htmltag($title).'"' : '');
+									print '>';
+									print $cssclassview ? '<span class="'.$cssclassview.'">' : '';
+									print $valuetoshow;
+									print $cssclassview ? '</span>' : '';
+									print '</td>';
+									}
+							}
+						}
+
 						print '<td class="right" colspan="'.$colspan.'">'.$pdluo->qty.($pdluo->qty < 0 ? ' '.img_warning() : (($pdluo->qty > 1 && $object->status_batch == 2) ? ' '.img_warning($langs->trans('IlligalQtyForSerialNumbers')) : '')).'</td>';
 						print '<td colspan="4"></td>';
 						print '<td class="center tdoverflowmax125" title="'.dol_escape_htmltag($langs->trans("TransferStock")).'">';
@@ -1298,7 +1387,7 @@ if ($showstockdetails) {
 	}
 
 	// Total line
-	print '<tr class="liste_total"><td class="right liste_total" colspan="4">'.$langs->trans("Total").':</td>';
+	print '<tr class="liste_total"><td class="right liste_total" colspan="'.$colspan.'">'.$langs->trans("Total").':</td>';
 	print '<td class="liste_total right">'.price2num($total, 'MS').'</td>';
 	print '<td class="liste_total right">';
 	if ($usercancreadsupplierprice) {

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1334,7 +1334,7 @@ if ($showstockdetails) {
 										$value = dol_eval((string) $extrafieldsProductLot->attributes[$extrafieldsobjectkey]['computed'][$key], 1, 1, '2');
 									}
 
-									$valuetoshow = $extrafieldsProductLot->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object ?? null, 'list');
+									$valuetoshow = $extrafieldsProductLot->showOutputField($key, $value, '', $extrafieldsobjectkey, null, $object, 'list');
 
 									$title = dol_string_nohtmltag($valuetoshow);
 

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1308,8 +1308,8 @@ if ($showstockdetails) {
 						}
 						if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
 							// fetch optionals attributes and labels
-							if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
-								&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+							if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
+								&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
 								&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
 								$product_lot_static->fetch($pdluo->lotid);
 								foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
@@ -1346,7 +1346,7 @@ if ($showstockdetails) {
 									print $valuetoshow;
 									print $cssclassview ? '</span>' : '';
 									print '</td>';
-									}
+								}
 							}
 						}
 

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1049,16 +1049,16 @@ if ($showstockdetails) {
 	// Batch fields display management
 	$colspan = 4;
 	if ((isModEnabled('productbatch')) && $object->hasbatch()) {
-		if (getDolGlobalString('PRODUCT_DISABLE_SELLBY')) 
+		if (getDolGlobalString('PRODUCT_DISABLE_SELLBY'))
 			$colspan--;
-		if (getDolGlobalString('PRODUCT_DISABLE_EATBY')) 
+		if (getDolGlobalString('PRODUCT_DISABLE_EATBY'))
 			$colspan--;
 		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
 			$extrafieldsobjectkey = "product_lot";
 			$extrafieldsProductLot = new Extrafields($db);
 			$extrafieldsProductLot->fetch_name_optionals_label($extrafieldsobjectkey);
-			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
-				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
+				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
 				&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
 				foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
 					if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key] == 'separate') {
@@ -1098,8 +1098,8 @@ if ($showstockdetails) {
 		}
 		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
 			// fetch optionals attributes and labels
-			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
-				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
+				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
 				&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
 				foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
 					if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key] == 'separate') {
@@ -1109,7 +1109,7 @@ if ($showstockdetails) {
 				}
 			}
 		}
-		
+
 		print '<td colspan="'.($colspan+5).'"></td>';
 		print '<td></td>';
 		print '<td></td>';
@@ -1269,8 +1269,8 @@ if ($showstockdetails) {
 						}
 						if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
 							// fetch optionals attributes and labels
-							if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
-								&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
+							if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
+								&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
 								&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {
 								foreach ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'] as $key => $val) {
 									if ($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['type'][$key] == 'separate') {
@@ -1306,7 +1306,7 @@ if ($showstockdetails) {
 						if (!getDolGlobalString('PRODUCT_DISABLE_EATBY')) {
 							print '<td class="center">'.dol_print_date($pdluo->eatby, 'day').'</td>';
 						}
-												if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
+						if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
 							// fetch optionals attributes and labels
 							if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 
 								&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label']) 

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -112,6 +112,8 @@ if ($user->socid) {
 $object = new Product($db);
 $extrafields = new ExtraFields($db);
 $extrafieldsobjectkey = "product_lot";
+$extrafieldsProductLot = new ExtraFields($db);
+$extrafieldsProductLot->fetch_name_optionals_label($extrafieldsobjectkey);
 
 // fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
@@ -1055,8 +1057,6 @@ if ($showstockdetails) {
 		if (getDolGlobalString('PRODUCT_DISABLE_EATBY'))
 			$colspan--;
 		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
-			$extrafieldsProductLot = new ExtraFields($db);
-			$extrafieldsProductLot->fetch_name_optionals_label($extrafieldsobjectkey);
 			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
 				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
 				&& count($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])) {

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -111,6 +111,7 @@ if ($user->socid) {
 
 $object = new Product($db);
 $extrafields = new ExtraFields($db);
+$extrafieldsobjectkey = "product_lot";
 
 // fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
@@ -1054,7 +1055,7 @@ if ($showstockdetails) {
 		if (getDolGlobalString('PRODUCT_DISABLE_EATBY'))
 			$colspan--;
 		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
-			$extrafieldsobjectkey = "product_lot";
+
 			$extrafieldsProductLot = new ExtraFields($db);
 			$extrafieldsProductLot->fetch_name_optionals_label($extrafieldsobjectkey);
 			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1055,7 +1055,6 @@ if ($showstockdetails) {
 		if (getDolGlobalString('PRODUCT_DISABLE_EATBY'))
 			$colspan--;
 		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
-
 			$extrafieldsProductLot = new ExtraFields($db);
 			$extrafieldsProductLot->fetch_name_optionals_label($extrafieldsobjectkey);
 			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])

--- a/htdocs/product/stock/product.php
+++ b/htdocs/product/stock/product.php
@@ -1055,7 +1055,7 @@ if ($showstockdetails) {
 			$colspan--;
 		if (getDolGlobalString('PRODUCT_LOT_SHOW_EXTRAFIELDS')) {
 			$extrafieldsobjectkey = "product_lot";
-			$extrafieldsProductLot = new Extrafields($db);
+			$extrafieldsProductLot = new ExtraFields($db);
 			$extrafieldsProductLot->fetch_name_optionals_label($extrafieldsobjectkey);
 			if (!empty($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])
 				&& is_array($extrafieldsProductLot->attributes[$extrafieldsobjectkey]['label'])


### PR DESCRIPTION
Add setting to show extrafields and disable eatby & sellby fields
Add extrafields product/stock/product and product/reassortlot

I should point out that this is a request from one of my clients; I didn't want to change the entire page structure by implementing dynamic column management—as used in the other lists—but rather just improve the existing setup by adding the extra fields.