### PR TITLE
FIX JS SyntaxError on agenda event creation card in reminder section   

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -2042,7 +2042,7 @@ if ($action == 'create') {
 							$("#select_offsetunittype_duration").select2("destroy");
 							$("#select_offsetunittype_duration").select2();
 							selectremindertype();
-	            		 });
+	            		 }
 
 						toggle_reminder_part();
 						$("#addreminder").click(toggle_reminder_part);


### PR DESCRIPTION
   # Fix JS SyntaxError on agenda event creation card in reminder section                           
                                                                                                    
   On `comm/action/card.php` (agenda event creation), a JavaScript error is                         
   thrown in the browser when the reminder section is rendered:                                     
                                                                                                    
 ```                                                                                                
                                                                                                    
 Uncaught SyntaxError: expected expression, got ')'                                                 
                                                                                                    
 ```                                                                                                
                                                                                                    
   **Root cause**                                                                                   
                                                                                                    
   The bug was introduced by #36857, which refactored the inline `addreminder`                      
   click handler into a named function `toggle_reminder_part(evt)`.                                 
                                                                                                    
   Before the refactor, the handler was:                                                            
   ```javascript                                                                                    
   $(document).ready(function () {                                                                  
       ...                                                                                          
       $("#addreminder").click(function(){                                                          
           ...                                                                                      
       });   // ← correct: closes click(function(){...})                                            
       ...                                                                                          
      })                                                                                            
 ```                                                                                                
                                                                                                    
 The refactor turned it into a function declaration but kept the same });                           
 closing:                                                                                           
                                                                                                    
 ```javascript                                                                                      
   $(document).ready(function () {                                                                  
       function toggle_reminder_part(evt) {                                                         
           ...                                                                                      
       });   // ← BUG: } closes the function body, but ) then closes                                
              //        $(document).ready( prematurely                                              
       ...                                                                                          
      })     // ← orphaned: ) has no matching ( → SyntaxError                                       
 ```                                                                                                
                                                                                                    
 The stray ) closes the outer $(document).ready(function () { call too                              
 early. Everything that follows (toggle_reminder_part(),                                            
 $("#addreminder").click(...), selectremindertype declaration) runs                                 
 outside of document.ready. The final }) is then left with an unmatched                             
 ), which is the SyntaxError browsers report.                                                       
                                                                                                    
 **Fix**                                                                                                
                                                                                                    
 Replace  }); with } to close only the toggle_reminder_part function                                
 body, leaving the outer $(document).ready() to be properly closed by the                           
 existing }) at the end of the block.                                                               
                                                                                                    
 ```                                                                                                
                                                                                                    
   ---                                                                                              
                                                                                                    
   A few notes:                                                                                     
   - No screenshot is needed here since this is a pure JS fix with no visible UI change (the        
 SyntaxError itself is the symptom).                                                                
   - Target branch: **22.0** (oldest branch containing the bug; 21.0 is not affected).              
   - The change is one character on one line, which matches Dolibarr's guideline of keeping         
 maintenance-branch fixes as small as possible.                                                     
 ```  
