### PR TITLE
fix: remove invalid invoice type check from supplier order stats

### DIFF
--- a/htdocs/product/stock/stats/commande_fournisseur.php
+++ b/htdocs/product/stock/stats/commande_fournisseur.php
@@ -328,10 +328,6 @@ if ($id > 0 || !empty($ref)) {
 					while ($i < min($num, $limit)) {
 						$objp = $db->fetch_object($result);
 
-						if ($objp->type == Facture::TYPE_CREDIT_NOTE) {
-							$objp->qty = -($objp->qty);
-						}
-
 						//                      $total_ht_pondere += $objp->total_ht_pondere;
 						$total_qty += $objp->qty;
 


### PR DESCRIPTION
## Summary
- remove an invalid invoice credit-note check from the supplier order batch statistics page
- avoid referencing `Facture::TYPE_CREDIT_NOTE` from a page that does not load invoice classes and whose query does not select an invoice `type`

Fix #37968

## Verification
- `php -l htdocs/product/stock/stats/commande_fournisseur.php`
- `git diff --check`
- confirmed `commande_fournisseur.php` no longer references `Facture::TYPE_CREDIT_NOTE` or `$objp->type`