### PR TITLE
FIX User can edit own GUI setup without self write permission

### DIFF
--- a/htdocs/user/param_ihm.php
+++ b/htdocs/user/param_ihm.php
@@ -65,12 +65,14 @@ $socid = 0;
 if ($user->socid > 0) {
 	$socid = $user->socid;
 }
-$feature2 = (($socid && $user->hasRight("user", "self", "write")) ? '' : 'user');
-
 // Initialize a technical object to manage hooks of page. Note that conf->hooks_modules contains an array of hook context
 $hookmanager->initHooks(array('usercard', 'userihm', 'globalcard'));
-
-$result = restrictedArea($user, 'user', $id, 'user&user', $feature2);
+if ($user->id == $id) {
+	$result = 1; // A user can always edit its own GUI setup
+} else {
+	$feature2 = 'user';
+	$result = restrictedArea($user, 'user', $id, 'user&user', $feature2);
+}
 if ($user->id != $id && !$canreaduser) {
 	accessforbidden();
 }

--- a/htdocs/user/param_ihm.php
+++ b/htdocs/user/param_ihm.php
@@ -56,7 +56,7 @@ if (!isset($id) || empty($id)) {
 '@phan-var-force int<1,max> $id';
 
 // $user is the user doing the edit, $id is the id of the user being edited
-$caneditfield = ((($user->id == $id) && $user->hasRight("user", "self", "write"))
+$caneditfield = (($user->id == $id)
 || (($user->id != $id) && $user->hasRight("user", "user", "write")));
 
 


### PR DESCRIPTION
# FIX Allow a user to edit its own GUI setup
The GUI setup page currently requires the self write permission,
including when a user edits only its own interface preferences.
This patch updates `htdocs/user/param_ihm.php` to allow a user to
edit its own GUI setup without requiring the self write permission.
The change removes the self write requirement from caneditfield and
skips the restrictedArea() write check when a user edits its own
GUI setup page.
The existing write permission check is kept unchanged for the case
where one user edits the GUI setup of another user.