### PR TITLE
FIX reset fk_code_ventilation on cloned customer invoice lines

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1354,6 +1354,7 @@ class Facture extends CommonInvoice
 			}
 
 			$object->lines[$i]->ref_ext = ''; // Do not clone ref_ext
+			$object->lines[$i]->fk_code_ventilation = 0; // Do not clone accounting binding
 		}
 
 		// Create clone


### PR DESCRIPTION
# FIX Reset `fk_code_ventilation` on cloned customer invoice lines

When cloning a customer invoice (`createFromClone()`), the accounting binding (`fk_code_ventilation`) was not reset on the new invoice lines.
                                                                                                                                                                                                                                                
This caused the cloned draft invoice to inherit the accounting account already bound on the source invoice, bypassing the manual binding step in `Accountancy > Customers invoices to bind`.
                                                                                                                                                                                                                                              
The bug was latent before PR #36792, which corrected the field name used in `fetch()` (from `fk_accounting_account` to `fk_code_ventilation`). Before that fix, `$line->fk_code_ventilation` was always `0` in memory even when the database held a non-zero value, so the bug was invisible. After #36792, the real DB value is correctly loaded and passed through to `addline()`, making the bug visible.
                                                                                                                                                                                                                                                
**Fix:** add `$object->lines[$i]->fk_code_ventilation = 0;` in the `foreach` loop of `createFromClone()` in `htdocs/compta/facture/class/facture.class.php`, alongside the existing `ref_ext` reset.