### PR TITLE
Fix #38949 enforce takepos editlines permission on all line actions

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -486,6 +486,11 @@ if (empty($reshook)) {
 		$invoice->fetch($placeid);
 	}
 
+	if (($action == "addline" || $action == "freezone" || $action == "addnote" || $action == "deleteline" || $action == "updateqty" || $action == "updateprice" || $action == "updatereduction" || $action == 'update_reduction_global') && empty($user->rights->takepos->editlines)) {
+		dol_htmloutput_errors($langs->trans("NotEnoughPermissions", "TakePos"), null, 1);
+		$action = '';
+	}
+
 	// If we add a line and no invoice yet, we create the invoice
 	if (($action == "addline" || $action == "freezone") && $placeid == 0) {
 		$invoice->socid = getDolGlobalString($constforcompanyid);

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -180,7 +180,10 @@ $parameters=array();
 $reshook=$hookmanager->executeHooks('doActions', $parameters, $invoice, $action);    // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 
-if (in_array($action, array('addline', 'freezone', 'addnote', 'deleteline', 'updateqty', 'updateprice', 'updatereduction', 'update_reduction_global')) && !$user->hasRight('takepos', 'editlines')) {
+// Enforce the "edit lines" permission on every action that modifies an existing line
+// (delete, quantity, price, discount). Adding a line, a free zone or a note is gated by
+// the "run" permission elsewhere and must stay available to a plain cashier (#38949).
+if (in_array($action, array('deleteline', 'updateqty', 'updateprice', 'updatereduction', 'update_reduction_global')) && !$user->hasRight('takepos', 'editlines')) {
 	dol_htmloutput_errors($langs->trans("NotEnoughPermissions", "TakePos"), null, 1);
 	$action = '';
 }

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -180,6 +180,11 @@ $parameters=array();
 $reshook=$hookmanager->executeHooks('doActions', $parameters, $invoice, $action);    // Note that $action and $object may have been modified by some hooks
 if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 
+if (in_array($action, array('addline', 'freezone', 'addnote', 'deleteline', 'updateqty', 'updateprice', 'updatereduction', 'update_reduction_global')) && !$user->hasRight('takepos', 'editlines')) {
+	dol_htmloutput_errors($langs->trans("NotEnoughPermissions", "TakePos"), null, 1);
+	$action = '';
+}
+
 if (empty($reshook)) {
 	// Action to record a payment on a TakePOS invoice
 	if ($action == 'valid' && $user->hasRight('facture', 'creer')) {
@@ -484,11 +489,6 @@ if (empty($reshook)) {
 		}
 		$invoice = new Facture($db);
 		$invoice->fetch($placeid);
-	}
-
-	if (($action == "addline" || $action == "freezone" || $action == "addnote" || $action == "deleteline" || $action == "updateqty" || $action == "updateprice" || $action == "updatereduction" || $action == 'update_reduction_global') && empty($user->rights->takepos->editlines)) {
-		dol_htmloutput_errors($langs->trans("NotEnoughPermissions", "TakePos"), null, 1);
-		$action = '';
 	}
 
 	// If we add a line and no invoice yet, we create the invoice


### PR DESCRIPTION
Fixes #38949 (companion of #38889 which already landed the deleteline guard on 23.0).

addline, freezone, addnote, deleteline, updateqty, updateprice, updatereduction and update_reduction_global all mutated the invoice content, but only updateqty / updateprice / updatereduction had a server-side editlines check. A user with only takepos.run could therefore add free-text lines, change prices, delete lines and apply discounts before payment - exactly the operations the editlines permission was supposed to gate. Refuse the request at the top of the action dispatcher when editlines is missing. The editlines right is enabled by default at module activation so existing TakePOS setups are unaffected; the editorderedlines per-line check on special_code = 4 inside updateqty/updateprice/updatereduction still applies after this gate. Credit @Abderrahmane Aksoum per the issue request.