### PR TITLE
Fix #39005 keep UTF-8 body extraction values

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1004,26 +1004,15 @@ class EmailCollector extends CommonObject
 
 						if (preg_match('/'.$regexstring.'/'.$regexoptions, $sourcestring, $regforval)) {
 							// Overwrite param $tmpproperty
-							$valueextracted = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : null;
-							if (strtolower($sourcefield) == 'header') {		// extract from HEADER
-								if (preg_match('/^options_/', $tmpproperty)) {
-									$object->array_options[preg_replace('/^options_/', '', $tmpproperty)] = $this->decodeSMTPSubject($valueextracted);
+							$valueextracted = isset($regforval[count($regforval) - 1]) ? trim($regforval[count($regforval) - 1]) : '';
+							$valuetoset = (strtolower($sourcefield) == 'body') ? $valueextracted : $this->decodeSMTPSubject($valueextracted);
+							if (preg_match('/^options_/', $tmpproperty)) {
+								$object->array_options[preg_replace('/^options_/', '', $tmpproperty)] = $valuetoset;
+							} else {
+								if (property_exists($object, $tmpproperty)) {
+									$object->$tmpproperty = $valuetoset;
 								} else {
-									if (property_exists($object, $tmpproperty)) {
-										$object->$tmpproperty = $this->decodeSMTPSubject($valueextracted);
-									} else {
-										$tmp[$tmpproperty] = $this->decodeSMTPSubject($valueextracted);
-									}
-								}
-							} else {	// extract from BODY
-								if (preg_match('/^options_/', $tmpproperty)) {
-									$object->array_options[preg_replace('/^options_/', '', $tmpproperty)] = $this->decodeSMTPSubject($valueextracted);
-								} else {
-									if (property_exists($object, $tmpproperty)) {
-										$object->$tmpproperty = $this->decodeSMTPSubject($valueextracted);
-									} else {
-										$tmp[$tmpproperty] = $this->decodeSMTPSubject($valueextracted);
-									}
+									$tmp[$tmpproperty] = $valuetoset;
 								}
 							}
 
@@ -4304,7 +4293,7 @@ class EmailCollector extends CommonObject
 	/**
 	 * Decode a subject string according to RFC2047
 	 * Example: '=?Windows-1252?Q?RE=A0:_ABC?=' => 'RE : ABC...'
-	 * Example: '=?UTF-8?Q?A=C3=A9B?=' => 'AéB'
+	 * Example: '=?UTF-8?Q?A=C3=A9B?=' => 'A[e acute]B'
 	 * Example: '=?UTF-8?B?2KLYstmF2KfbjNi0?=' =>
 	 * Example: '=?utf-8?B?UkU6IG1vZHVsZSBkb2xpYmFyciBnZXN0aW9ubmFpcmUgZGUgZmljaGllcnMg?= =?utf-8?B?UsOpZsOpcmVuY2UgZGUgbGEgY29tbWFuZGUgVFVHRURJSklSIOKAkyBwYXNz?= =?utf-8?B?w6llIGxlIDIyLzA0LzIwMjA=?='
 	 *

--- a/test/phpunit/EmailCollectorTest.php
+++ b/test/phpunit/EmailCollectorTest.php
@@ -48,6 +48,15 @@ $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
  * @backupGlobals disabled
  * @backupStaticAttributes enabled
  * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ * @phan-file-suppress PhanDeprecatedFunctionInternal
+ * @phan-file-suppress PhanPluginUnknownObjectMethodCall
+ * @phan-file-suppress PhanTypeMismatchReturn
+ * @phan-file-suppress PhanTypeMismatchReturnProbablyReal
+ * @phan-file-suppress PhanUndeclaredClass
+ * @phan-file-suppress PhanUndeclaredExtendedClass
+ * @phan-file-suppress PhanUndeclaredMethod
+ * @phan-file-suppress PhanUndeclaredProperty
+ * @phan-file-suppress PhanUndeclaredStaticMethod
  */
 class EmailCollectorTest extends CommonClassTest
 {
@@ -129,6 +138,34 @@ class EmailCollectorTest extends CommonClassTest
 		$this->assertEquals('{localhost:993/service=imap/ssl/novalidate-cert}', $result, 'Error in getConnectStringIMAP '.$localobject->error);
 
 		return $localobject->id;
+	}
+
+	/**
+	 * testEmailCollectorExtractBodyKeepsUtf8
+	 *
+	 * @return  void
+	 */
+	public function testEmailCollectorExtractBodyKeepsUtf8()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$localobject = new EmailCollector($db);
+		$object = new stdClass();
+		$object->element = 'societe';
+		$object->name = '';
+		$object->array_options = array();
+
+		$messagetext = "ThirdpartyName: Günni GmbH\nContactName: Günni Pfannenstiel\n";
+		$operationslog = '';
+		$args = array(&$object, 'name=EXTRACT:BODY:^ThirdpartyName:\s*([^\r\n]+)', $messagetext, '', '', &$operationslog);
+		$result = self::callMethod($localobject, 'overwritePropertiesOfObject', $args);
+
+		$this->assertSame(0, $result);
+		$this->assertSame('Günni GmbH', $object->name);
 	}
 
 	/**


### PR DESCRIPTION
Fix #39005

When an Email Collector action extracts a value from `BODY`, the extracted text is already normal body content and should not be decoded as an RFC2047 SMTP header. Running `decodeSMTPSubject()` on these values can strip non-ASCII characters such as German umlauts.

This keeps `EXTRACT:BODY` values unchanged while still decoding values extracted from `HEADER` or `SUBJECT`, and adds a regression test for `ThirdpartyName: Günni GmbH`.

Tests run locally:
- `php -l htdocs/emailcollector/class/emailcollector.class.php`
- `php -l test/phpunit/EmailCollectorTest.php`
- `git diff --check`

Not run locally: `phpunit` / `pre-commit` because they are not installed in this workspace PATH.