### PR TITLE
 Fix: mass createbills success message showed draft PROV ref instead …

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -693,6 +693,7 @@ if (empty($reshook)) {
 				}
 
 				$id = $objecttmp->id; // For builddoc action
+			    $lastref = $objecttmp->ref; // Refresh ref after validation (was the draft PROVxxxx ref set at creation)
 
 				// Builddoc
 				$donotredirect = 1;

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -693,7 +693,7 @@ if (empty($reshook)) {
 				}
 
 				$id = $objecttmp->id; // For builddoc action
-			    $lastref = $objecttmp->ref; // Refresh ref after validation (was the draft PROVxxxx ref set at creation)
+				$lastref = $objecttmp->ref; // Refresh ref after validation (was the draft PROVxxxx ref set at creation)
 
 				// Builddoc
 				$donotredirect = 1;


### PR DESCRIPTION
When creating an invoice from several orders at once via the order listmass action ("Create invoice for this customer"), with the "Validate generated invoices" option set to "yes", the success message and its link displayed the temporary draft reference (PROVxxxx) instead of the final validated invoice reference.

  Root cause:
  In htdocs/commande/list.php, during the confirm_createbills action, $lastref
  is captured right after $objecttmp->create($user), at which point the invoice
  is still a draft (PROVxxxx). When the "validate invoices" option is enabled,
  each invoice is then validated through $objecttmp->validate($user), which
  assigns the definitive reference to the object. However $lastref was never
  refreshed afterwards, so the "BillXCreated" message (single-invoice case) kept
  showing the draft ref.

  Fix:
  Refresh $lastref from the object inside the validation loop, after a successful
  validate(), so the success message links to and displays the final reference.

  Only the single-invoice success message exposes a reference, so this is the only
  case affected; the multi-invoice message only shows a counter.

  Steps to reproduce:
  1. Go to the orders list.
  2. Select several orders (or one), and choose the "Create invoice for this
     customer" mass action.
  3. Set "Validate generated invoices" to "Yes".
  4. Confirm.
  => Before: the success message links to the draft ref PROVxxxx.
  => After: the success message links to the final validated invoice ref.