### PR TITLE
 Fix: mass createbills could invoice canceled or already-billed orders

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -434,7 +434,7 @@ if (empty($reshook)) {
 			if ($cmd->fetch($id_order) <= 0) {
 				continue;
 			}
-			
+
 			// Skip orders that cannot be billed, to mirror the "CreateBill" button availability on the order card
 			// (card.php only shows it when status > STATUS_DRAFT and the order is not already billed): this excludes
 			// draft and canceled orders, as well as orders already classified as billed.

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -434,6 +434,15 @@ if (empty($reshook)) {
 			if ($cmd->fetch($id_order) <= 0) {
 				continue;
 			}
+			
+			// Skip orders that cannot be billed, to mirror the "CreateBill" button availability on the order card
+			// (card.php only shows it when status > STATUS_DRAFT and the order is not already billed): this excludes
+			// draft and canceled orders, as well as orders already classified as billed.
+			if ($cmd->status <= Commande::STATUS_DRAFT || !empty($cmd->billed)) {
+				setEventMessages($langs->trans('WarningOrderNotEligibleForInvoicing', $cmd->ref), null, 'warnings');
+				continue;
+			}
+
 			$cmd->fetch_thirdparty();
 
 			$objecttmp = new Facture($db);

--- a/htdocs/langs/en_US/orders.lang
+++ b/htdocs/langs/en_US/orders.lang
@@ -166,6 +166,7 @@ PDFEdisonDescription=A simple order model
 PDFProformaDescription=A complete Proforma invoice template
 CreateInvoiceForThisCustomer=Bill orders
 CreateInvoiceForThisSupplier=Bill orders
+WarningOrderNotEligibleForInvoicing=Order %s has been skipped: its status does not allow creating an invoice
 CreateInvoiceForThisReceptions=Bill receptions
 NoOrdersToInvoice=No orders billable
 CloseProcessedOrdersAutomatically=Classify "Processed" all selected orders.


### PR DESCRIPTION
 On the order list, the "Bill orders" mass action (confirm_createbills) created
  an invoice for every selected order without checking its status or whether it
  was already billed. As a result, canceled orders, draft orders and orders
  already classified as billed could all be invoiced from the list, while the
  order card hides the "Create invoice" button for those orders.

  The card only enables the CreateBill button when the order status is greater
  than STATUS_DRAFT and the order is not already billed (see htdocs/commande/
  card.php), so draft (0), canceled (-1) and already-billed orders are not
  billable there.

  Fix:
  In htdocs/commande/list.php, skip selected orders that are not eligible during
  the mass createbills loop, mirroring the card button availability: orders with
  status <= STATUS_DRAFT (draft and canceled) or already flagged as billed are
  skipped. Each skipped order produces a non-blocking warning (so the rest of the
  batch is still billed and the transaction is not rolled back), using the new
  translation key WarningOrderNotEligibleForInvoicing (en_US).

  Steps to reproduce:
  1. Have a canceled (or draft, or already-billed) customer order.
  2. Go to the orders list, tick that order, and run the "Bill orders" mass
     action, then confirm.
  => Before: an invoice was created for the ineligible order.
  => After: the order is skipped with a warning, no invoice is created for it.
