### PR TITLE
Qual: Generate phan specific changed php files list

### DIFF
--- a/.github/scripts/get_changed_php.sh
+++ b/.github/scripts/get_changed_php.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Copyright (C) 2025		MDW	<mdeweerd@users.noreply.github.com>
+# Copyright (C) 2025-2026	MDW	<mdeweerd@users.noreply.github.com>
+
+# shellcheck disable=2129,2128,2034,2016
 
 set -euo pipefail
 
@@ -41,22 +43,33 @@ repo="${GITHUB_REPOSITORY##*/}"   # Extract text after the last '/'
 page=1
 per_page=100
 changed_php_files=()
+changed_phan_files=()
 changed_lang_files=()
+
+# Get phan path configuration
+phan_directory_list=$(php -r '$config = require("dev/tools/phan/config.php"); echo "^".implode("|",$config["directory_list"]);')
+phan_exclude_directory=$(php -r '$config = require("dev/tools/phan/config.php"); echo "^".implode("|",$config["exclude_analysis_directory_list"]);')
+
+phan_exclude_file_regex=$(php -r '$config = require("dev/tools/phan/config.php"); echo $config["exclude_file_regex"];')
+phan_exclude_file_regex=${phan_exclude_file_regex#@}
+phan_exclude_file_regex=${phan_exclude_file_regex%@}
 
 # Loop through all pages to gather changed files
 while true; do
 	response=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
 		"https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/files?per_page=${per_page}&page=${page}")
 
-        phan_exclude_file_regex=$(php -r '$config = require("dev/tools/phan/config.php"); echo $config["exclude_file_regex"];')
 
 
 	# Filter for files ending with .php and add them to the list
-	mapfile -t files < <(echo "$response" | jq -r '.[] | select((.filename | test("\\.php$")) and (.filename | test("^dev/") | not)) | .filename' | grep -vP "$phan_exclude_file_regex")
+	mapfile -t files < <(echo "$response" | jq -r '.[] | select((.filename | test("\\.php$")) and (.filename | test("^dev/") | not)) | .filename')
 	changed_php_files+=("${files[@]}")
 
+	mapfile -t files < <(echo "$response" | jq -r '.[] | select((.filename | test("\\.php$")) and (.filename | test("'"$phan_directory_list"'"))) | .filename' | grep -vP "$phan_exclude_file_regex")
+	changed_phan_files+=("${files[@]}")
+
 	mapfile -t files < <(echo "$response" | jq -r '.[] | select(.filename | test("\\.lang$")) | .filename')
-    changed_lang_files+=("${files[@]}")
+	changed_lang_files+=("${files[@]}")
 
 	# Check if we have reached the last page (less than per_page results)
 	count=$(echo "$response" | jq 'length')
@@ -69,10 +82,12 @@ done
 
 # Build a space-separated string of changed PHP and lang files
 # This does not cope with files that have spaces.
+
 # But such files do not exist in the project (at least not for the
 # files we are filtering).
 all_changed_files=$(IFS=" " ; echo "${changed_php_files[*]}")
 all_changed_lang=$(IFS=" " ; echo "${changed_lang_files[*]}")
+phan_changed_files=$(IFS=" " ; echo "${changed_phan_files[*]}")
 
 
 forbidden_files=""
@@ -85,21 +100,31 @@ forbidden_files=""
 #fi
 
 
-# Determine changed files flag
-if [ -z "$all_changed_files" ]; then
+# Determine changed files flags
+if [ -z "${all_changed_files}" ]; then
     any_changed="false"
 else
     any_changed="true"
 fi
 
+if [ -z "${phan_changed_files}" ]; then
+    phan_changed="false"
+else
+    phan_changed="true"
+fi
+
 # Set outputs for GitHub Actions if GITHUB_OUTPUT is available
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
 	echo "any_changed=${any_changed}" >> "$GITHUB_OUTPUT"
+	echo "phan_changed=${phan_changed}" >> "$GITHUB_OUTPUT"
 	echo "all_changed_files=${all_changed_files}" >> "$GITHUB_OUTPUT"
+	echo "phan_changed_files=${phan_changed_files[*]}" >> "$GITHUB_OUTPUT"
 	echo "forbidden_files=${forbidden_files}" >> "$GITHUB_OUTPUT"
 else
 	# Otherwise, print the outputs
 	echo "any_changed=${any_changed}"
+	echo "phan_changed=${phan_changed}"
+	echo "phan_changed_files=${phan_changed_files[*]}"
 	echo "all_changed_files=${all_changed_files}"
 	echo "forbidden_files=${forbidden_files}"
 fi

--- a/.github/workflows/phan.yml
+++ b/.github/workflows/phan.yml
@@ -61,9 +61,10 @@ jobs:
         #   - the merge from branch contains 'phan_full', or,
         #   - there are changes in PHP files.
         # Note: --output-mode=github does not provide file:line, so using checkstyle and cs2pr
-        if: ${{ ! cancelled() && (github.ref_name == 'develop' || github.ref_name == 'refs/heads/develop' || endsWith(github.ref_name, '.0') || contains(github.head_ref, 'phan_full') || steps.changed-php.outputs.any_changed == 'true') }}
+        if: ${{ ! cancelled() && (github.ref_name == 'develop' || github.ref_name == 'refs/heads/develop' || endsWith(github.ref_name, '.0') || contains(github.head_ref, 'phan_full') || steps.changed-php.outputs.phan_changed == 'true') }}
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-php.outputs.all_changed_files }}
+          PHAN_CHANGED_FILES: ${{ steps.changed-php.outputs.phan_changed_files }}
         # shellcheck disable=2086
           FILE_CHANGED_LIST: /tmp/phan-changed.lst
         run: |
@@ -73,7 +74,7 @@ jobs:
             phan $PHAN_QUICK -k "$PHAN_CONFIG" -B "$PHAN_BASELINE" --analyze-twice --minimum-target-php-version "$PHAN_MIN_PHP" --output-mode=checkstyle -o _phan.xml
           else
             echo -n "" > "$FILE_CHANGED_LIST"
-            for f in $ALL_CHANGED_FILES; do echo "$f" >> "$FILE_CHANGED_LIST"; done
+            for f in $PHAN_CHANGED_FILES; do echo "$f" >> "$FILE_CHANGED_LIST"; done
             # Must exclude same files as in phan configuration
             grep -v -E '^htdocs/(custom/|.*/canvas/.*/tpl/.*.tpl.php|admin/tools/ui/|includes/(nusoap/|restler/|stripe/)|conf/conf.php)$' "$FILE_CHANGED_LIST"> "$FILE_CHANGED_LIST".tmp || true
             mv "$FILE_CHANGED_LIST".tmp "$FILE_CHANGED_LIST"


### PR DESCRIPTION
# Qual: Generate phan specific changed php files list

Uses multiple parts of the Phan configuration to select and exclude files for phan analysis.

This correct the grep filter and uses the directory_list and directory exclusions from phan.
Tested through #39026 .