### PR TITLE
NEW Add formBuilddocLineAction hook inside document action cell

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1071,6 +1071,11 @@ class FormFile
 							$morepicto = preg_replace('/__FILENAMEURLENCODED__/', urlencode($relativepath), $morepicto);
 							$out .= $morepicto;
 						}
+						if (is_object($hookmanager)) {
+								$parameters = array('modulepart' => $modulepart, 'relativepath' => $relativepath, 'socid' => (isset($GLOBALS['socid']) ? $GLOBALS[ ? $GLOBALS['id'] : ''));
+								$hookmanager->executeHooks('formBuilddocLineAction', $parameters, $file);
+								$out .= $hookmanager->resPrint;
+						}
 						$out .= '</td>';
 					}
 


### PR DESCRIPTION
 # NEW Add formBuilddocLineAction hook inside document action cell

  Add a new hook `formBuilddocLineAction` that fires inside the existing
  action cell (`<td>`) of each document row rendered by `FormFile::showdocuments()`.

  Unlike the existing `formBuilddocLineOptions` hook which appends new `<td>`
  elements after the row (causing uneven table columns when only some rows
  trigger the hook), this hook allows custom modules to inject action buttons
  directly into the existing action cell alongside the delete and print buttons,
  without any JavaScript workarounds needed.

  The hook receives `modulepart`, `relativepath`, `socid` and `id` as parameters.