### PR TITLE
FIX #32909 Restrict salary/HR field edit to authorized users

### DIFF
--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -161,6 +161,8 @@ if ($id > 0) {
 	$permissiontoeditpasswordandsend = ((($user->id == $id) && $user->hasRight("user", "self", "password")) || (($user->id != $id) && $user->hasRight("user", "user", "password")))&& (empty($user->socid) || $user->socid == $object->socid);
 }
 
+// Salary and other HR fields must only be editable by users allowed to see them (same rights as the display, see issue #32909)
+$permissiontoeditsalary = (!empty($user->admin) || (isModEnabled('salaries') && $user->hasRight('salaries', 'readall')) || (isModEnabled('hrm') && $user->hasRight('hrm', 'employee', 'read')));
 $passwordismodified = false;
 $ldap = null;
 
@@ -333,14 +335,17 @@ if (empty($reshook)) {
 			$object->fk_user_holiday_validator = GETPOSTINT("fk_user_holiday_validator") > 0 ? GETPOSTINT("fk_user_holiday_validator") : 0;
 			$object->employee = GETPOSTINT('employee');
 
-			$object->thm = GETPOST("thm", 'alphanohtml') != '' ? GETPOST("thm", 'alphanohtml') : '';
-			$object->thm = price2num($object->thm);
-			$object->tjm = GETPOST("tjm", 'alphanohtml') != '' ? GETPOST("tjm", 'alphanohtml') : '';
-			$object->tjm = price2num($object->tjm);
-			$object->salary = GETPOST("salary", 'alphanohtml') != '' ? GETPOST("salary", 'alphanohtml') : '';
-			$object->salary = price2num($object->salary);
-			$object->salaryextra = GETPOST("salaryextra", 'alphanohtml') != '' ? GETPOST("salaryextra", 'alphanohtml') : '';
-			$object->weeklyhours = GETPOST("weeklyhours", 'alphanohtml') != '' ? GETPOST("weeklyhours", 'alphanohtml') : '';
+			// Only users allowed to see salary/HR fields can modify them (issue #32909)
+			if ($permissiontoeditsalary) {
+				$object->thm = GETPOST("thm", 'alphanohtml') != '' ? GETPOST("thm", 'alphanohtml') : '';
+				$object->thm = price2num($object->thm);
+				$object->tjm = GETPOST("tjm", 'alphanohtml') != '' ? GETPOST("tjm", 'alphanohtml') : '';
+				$object->tjm = price2num($object->tjm);
+				$object->salary = GETPOST("salary", 'alphanohtml') != '' ? GETPOST("salary", 'alphanohtml') : '';
+				$object->salary = price2num($object->salary);
+				$object->salaryextra = GETPOST("salaryextra", 'alphanohtml') != '' ? GETPOST("salaryextra", 'alphanohtml') : '';
+				$object->weeklyhours = GETPOST("weeklyhours", 'alphanohtml') != '' ? GETPOST("weeklyhours", 'alphanohtml') : '';
+		}
 
 			$object->color = GETPOST("color", 'alphanohtml') != '' ? GETPOST("color", 'alphanohtml') : '';
 
@@ -524,16 +529,19 @@ if (empty($reshook)) {
 				$object->fk_user_holiday_validator = GETPOSTINT("fk_user_holiday_validator") > 0 ? GETPOSTINT("fk_user_holiday_validator") : 0;
 				$object->employee = GETPOSTINT('employee');
 
-				$object->thm = GETPOST("thm", 'alphanohtml') != '' ? GETPOST("thm", 'alphanohtml') : '';
-				$object->thm = price2num($object->thm);
-				$object->tjm = GETPOST("tjm", 'alphanohtml') != '' ? GETPOST("tjm", 'alphanohtml') : '';
-				$object->tjm = price2num($object->tjm);
-				$object->salary = GETPOST("salary", 'alphanohtml') != '' ? GETPOST("salary", 'alphanohtml') : '';
-				$object->salary = price2num($object->salary);
-				$object->salaryextra = GETPOST("salaryextra", 'alphanohtml') != '' ? GETPOST("salaryextra", 'alphanohtml') : '';
-				$object->salaryextra = price2num($object->salaryextra);
-				$object->weeklyhours = GETPOST("weeklyhours", 'alphanohtml') != '' ? GETPOST("weeklyhours", 'alphanohtml') : '';
-				$object->weeklyhours = price2num($object->weeklyhours);
+			// Only users allowed to see salary/HR fields can modify them (issue #32909)
+			if ($permissiontoeditsalary) {
+					$object->thm = GETPOST("thm", 'alphanohtml') != '' ? GETPOST("thm", 'alphanohtml') : '';
+					$object->thm = price2num($object->thm);
+					$object->tjm = GETPOST("tjm", 'alphanohtml') != '' ? GETPOST("tjm", 'alphanohtml') : '';
+					$object->tjm = price2num($object->tjm);
+					$object->salary = GETPOST("salary", 'alphanohtml') != '' ? GETPOST("salary", 'alphanohtml') : '';
+					$object->salary = price2num($object->salary);
+					$object->salaryextra = GETPOST("salaryextra", 'alphanohtml') != '' ? GETPOST("salaryextra", 'alphanohtml') : '';
+					$object->salaryextra = price2num($object->salaryextra);
+					$object->weeklyhours = GETPOST("weeklyhours", 'alphanohtml') != '' ? GETPOST("weeklyhours", 'alphanohtml') : '';
+					$object->weeklyhours = price2num($object->weeklyhours);
+			}
 
 				$object->color = GETPOST("color", 'alphanohtml') != '' ? GETPOST("color", 'alphanohtml') : '';
 				$object->dateemployment = $dateemployment;

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -345,7 +345,7 @@ if (empty($reshook)) {
 				$object->salary = price2num($object->salary);
 				$object->salaryextra = GETPOST("salaryextra", 'alphanohtml') != '' ? GETPOST("salaryextra", 'alphanohtml') : '';
 				$object->weeklyhours = GETPOST("weeklyhours", 'alphanohtml') != '' ? GETPOST("weeklyhours", 'alphanohtml') : '';
-		}
+			}
 
 			$object->color = GETPOST("color", 'alphanohtml') != '' ? GETPOST("color", 'alphanohtml') : '';
 
@@ -529,8 +529,8 @@ if (empty($reshook)) {
 				$object->fk_user_holiday_validator = GETPOSTINT("fk_user_holiday_validator") > 0 ? GETPOSTINT("fk_user_holiday_validator") : 0;
 				$object->employee = GETPOSTINT('employee');
 
-			// Only users allowed to see salary/HR fields can modify them (issue #32909)
-			if ($permissiontoeditsalary) {
+				// Only users allowed to see salary/HR fields can modify them (issue #32909)
+				if ($permissiontoeditsalary) {
 					$object->thm = GETPOST("thm", 'alphanohtml') != '' ? GETPOST("thm", 'alphanohtml') : '';
 					$object->thm = price2num($object->thm);
 					$object->tjm = GETPOST("tjm", 'alphanohtml') != '' ? GETPOST("tjm", 'alphanohtml') : '';
@@ -541,7 +541,7 @@ if (empty($reshook)) {
 					$object->salaryextra = price2num($object->salaryextra);
 					$object->weeklyhours = GETPOST("weeklyhours", 'alphanohtml') != '' ? GETPOST("weeklyhours", 'alphanohtml') : '';
 					$object->weeklyhours = price2num($object->weeklyhours);
-			}
+				}
 
 				$object->color = GETPOST("color", 'alphanohtml') != '' ? GETPOST("color", 'alphanohtml') : '';
 				$object->dateemployment = $dateemployment;

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -162,7 +162,8 @@ if ($id > 0) {
 }
 
 // Salary and other HR fields must only be editable by users allowed to see them (same rights as the display, see issue #32909)
-$permissiontoeditsalary = (!empty($user->admin) || (isModEnabled('salaries') && $user->hasRight('salaries', 'readall')) || (isModEnabled('hrm') && $user->hasRight('hrm', 'employee', 'read')));
+$permissiontoeditsalary = ((isModEnabled('salaries') && $user->hasRight("salaries", "read") && in_array($id, $childids)) || (isModEnabled('salaries') && $user->hasRight("salaries", "readall")) || (isModEnabled('hrm') && $user->hasRight("hrm", "employee", "read")));
+
 $passwordismodified = false;
 $ldap = null;
 


### PR DESCRIPTION
## Summary

On the user card (htdocs/user/card.php), a user who only has the "Modify own information" permission (user->self->write) is able to change their own compensation fields - thm, tjm, salary, salaryextra and weeklyhours - by submitting the create/edit form.

This is inconsistent with the display logic: those same fields are only shown to users who have salaries->readall or hrm->employee->read. So a self-service user cannot see these fields, yet can still overwrite them via a crafted (or pre-filled) POST.

Fixes #32909.

## Cause

In the add and update actions, the salary/HR fields are assigned from GETPOST(...) guarded only by $permissiontoedit, which is true for a self-write user. The display, however, is guarded by salaries->readall / hrm->employee->read.

## Change

Introduce $permissiontoeditsalary, set with the same rights already used to display these fields (admin, or salaries->readall, or hrm->employee->read), and use it to guard the write of thm, tjm, salary, salaryextra and weeklyhours in both the create and edit actions.

In the edit action, $object is fetched before the field assignments, so when the guard is false the existing values are simply left untouched and persisted unchanged. Non-salary fields (color, employment dates, validity dates, birth date) are intentionally left as-is.

Only one file is changed. No database change, no new permission, no language change, no dependency change.

## Steps to reproduce (before the fix)

- Step 1: Create a user B and grant them only "Users & Groups > Modify own information" (user->self->write). Do not grant salaries->readall or hrm->employee->read.
- - Step 2: Log in as user B and open their own user card (user/card.php), then click Modify.
- - Step 3: Note the salary/rate fields (Salary, THM, TJM, Weekly hours) are not displayed, as expected.
- - Step 4: Submit the edit form with an added POST parameter, e.g. salary=9999 (for example by adding a hidden input via the browser dev tools, or by replaying the form).
- - Step 5: Before the fix, the value is saved - user B has changed their own salary despite not being allowed to see the field.
## Expected result (after the fix)

At step 5 the salary/rate fields are ignored for a user without salaries->readall / hrm->employee->read; the stored values remain unchanged.

## Testing done

Verified manually with the reproduction steps above: a self-write user can no longer persist salary/thm/tjm/salaryextra/weeklyhours, while an admin / salaries-readall user still can. No automated test is included: this controller path reads $_POST and requires a full DB + session context, and there is no existing unit coverage for it. Happy to add a functional test if the maintainers prefer.

## Target branch

Targeting 21.0 as the oldest supported branch where the issue is present; can be forward-ported to develop if desired.