### PR TITLE
fix: to calculate dateLastMovement in export stock some other field are required

### DIFF
--- a/htdocs/core/modules/modStock.class.php
+++ b/htdocs/core/modules/modStock.class.php
@@ -349,7 +349,7 @@ class modStock extends DolibarrModules
 			}
 			$this->export_aggregate_array[$r] = array('ps.reel' => 'SUM'); // TODO Not used yet
 			// We must keep this until the aggregate_array is used. To add unique key if we ask a field of a child to avoid the DISTINCT to discard them.
-			$this->export_dependencies_array[$r] = array('stockbatch' => array('pb.rowid'), 'batch' => array('pb.rowid'), ('movement') => array('e.rowid','p.rowid','pb.batch'));
+			$this->export_dependencies_array[$r] = array('stockbatch' => array('pb.rowid'), 'batch' => array('pb.rowid'), 'movement' => array('e.rowid','p.rowid','pb.batch'));
 			$keyforselect = 'product_lot';
 			$keyforelement = 'batch';
 			$keyforaliasextra = 'extra';

--- a/htdocs/core/modules/modStock.class.php
+++ b/htdocs/core/modules/modStock.class.php
@@ -348,7 +348,8 @@ class modStock extends DolibarrModules
 				$this->export_entities_array[$r] = array_merge($this->export_entities_array[$r], array('p.barcode' => 'product'));
 			}
 			$this->export_aggregate_array[$r] = array('ps.reel' => 'SUM'); // TODO Not used yet
-			$this->export_dependencies_array[$r] = array('stockbatch' => array('pb.rowid'), 'batch' => array('pb.rowid')); // We must keep this until the aggregate_array is used. To add unique key if we ask a field of a child to avoid the DISTINCT to discard them.
+			// We must keep this until the aggregate_array is used. To add unique key if we ask a field of a child to avoid the DISTINCT to discard them.
+			$this->export_dependencies_array[$r] = array('stockbatch' => array('pb.rowid'), 'batch' => array('pb.rowid'), ('movement') => array('e.rowid','p.rowid','pb.batch'));
 			$keyforselect = 'product_lot';
 			$keyforelement = 'batch';
 			$keyforaliasextra = 'extra';


### PR DESCRIPTION
In https://github.com/Dolibarr/dolibarr/blob/850f53b11bec9eda79da459eeb332021a4f5fcd1/htdocs/core/modules/modStock.class.php#L345
the field to export `none.dateLastMovement` use` 'rule'=>'compute'` and required `'method_params'=>['e_rowid', 'p_rowid', 'pb_batch']`

these fields "e.rowid,p.rowid,pb.batch" should be added automatically when exported field "Last mvt" is added to the export at Step 2