### PR TITLE
fix: missing create table on fresh intall when module catagory is activated

### DIFF
--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -944,6 +944,15 @@ class modCategorie extends DolibarrModules
 		if (isModEnabled("order")) {
 			$this->_load_tables('/install/mysql/', 'commande');
 		}
+		if (isModEnabled("propal")) {
+			$this->_load_tables('/install/mysql/', 'propal');
+		}
+		if (isModEnabled("project")) {
+			$this->_load_tables('/install/mysql/', 'project');
+		}
+		if (isModEnabled("knowledgemanagement")) {
+			$this->_load_tables('/install/mysql/', 'knowledgemanagement');
+		}
 
 		// Permissions
 		$this->remove($options);

--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -947,12 +947,6 @@ class modCategorie extends DolibarrModules
 		if (isModEnabled("propal")) {
 			$this->_load_tables('/install/mysql/', 'propal');
 		}
-		if (isModEnabled("project")) {
-			$this->_load_tables('/install/mysql/', 'project');
-		}
-		if (isModEnabled("knowledgemanagement")) {
-			$this->_load_tables('/install/mysql/', 'knowledgemanagement');
-		}
 
 		// Permissions
 		$this->remove($options);

--- a/htdocs/core/modules/modPropale.class.php
+++ b/htdocs/core/modules/modPropale.class.php
@@ -505,6 +505,8 @@ class modPropale extends DolibarrModules
 	{
 		global $conf, $langs;
 
+		$this->_load_tables('/install/mysql/', 'propal');
+
 		// Remove permissions and default values
 		$this->remove($options);
 


### PR DESCRIPTION
For propal module when module is activated the table llx_categorie_propal is not created
 even if the module category is desactivated and reactivated