### PR TITLE
FIX: Prevent total discount rounding error on standard lines

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2916,6 +2916,9 @@ function pdfGetLineTotalDiscountAmount($object, $i, $outputlangs, $hidedetails =
 		}
 
 		if (empty($hidedetails) || $hidedetails > 1) {
+			if (empty($object->lines[$i]->remise_percent)) {
+				return 0;
+			}
 			if (empty($multicurrency)) {
 				return (float) price2num($sign * (($object->lines[$i]->subprice * (float) $object->lines[$i]->qty) - $object->lines[$i]->total_ht), 'MT', 1);
 			} else {

--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2916,13 +2916,12 @@ function pdfGetLineTotalDiscountAmount($object, $i, $outputlangs, $hidedetails =
 		}
 
 		if (empty($hidedetails) || $hidedetails > 1) {
-			if (empty($object->lines[$i]->remise_percent)) {
-				return 0;
-			}
 			if (empty($multicurrency)) {
-				return (float) price2num($sign * (($object->lines[$i]->subprice * (float) $object->lines[$i]->qty) - $object->lines[$i]->total_ht), 'MT', 1);
+				$diff = (float) price2num($sign * $object->lines[$i]->subprice * (float) $object->lines[$i]->qty, 'MT', 1) - $object->lines[$i]->total_ht;
+				return (float) price2num($diff, 'MT', 1);
 			} else {
-				return (float) price2num($sign * (($object->lines[$i]->multicurrency_subprice * (float) $object->lines[$i]->qty) - $object->lines[$i]->multicurrency_total_ht), 'MT', 1);
+				$diff = (float) price2num($sign * $object->lines[$i]->multicurrency_subprice * (float) $object->lines[$i]->qty, 'MT', 1) - $object->lines[$i]->multicurrency_total_ht;
+				return (float) price2num($diff, 'MT', 1);
 			}
 		}
 	}


### PR DESCRIPTION
# FIX| Prevent total discount rounding error on standard lines
Added a missing check in pdfGetLineTotalDiscountAmount() to skip the discount math entirely on lines without a discount. This prevents subprice rounding discrepancies on standard items from incorrectly altering the document's total discount.

**Bug Description**

When generating a PDF quote or invoice in Dolibarr, a discrepancy can appear where a negative line intended as an explicit discount (e.g., -0.69) results in a slightly different Remise totale printed at the bottom of the page (e.g., 0.68).

This happens because the system loops through every single document line to calculate the total discount by executing pdfGetLineTotalDiscountAmount().

The core calculation performed is:

``
price2num( $sign * ( ($subprice * $qty) - $total_ht ), 'MT', 1 );
``

For standard item lines with NO discount, ($subprice * $qty) and $total_ht should theoretically be identical. However, due to database rounding (e.g., rounding a 3-decimal internal price to a 2-decimal total), a tiny discrepancy can occur.

Step-by-Step Example of the Failure:

A standard item is priced at 5.55 TTC per unit with 20% VAT. The strict internal P.U. HT (subprice) is 4.625.
Quantity is 3. The theoretical total is 4.625 * 3 = 13.875.
The actual line total stored in the database is rounded to 13.88.
The system subtracts the actual total from the theoretical total: 13.875 - 13.88 = -0.005.
The price2num() function rounds -0.005 to -0.01.
Because the function blindly calculated a -0.01 difference on a regular line, it treated it as a "negative discount" (a surcharge of 1 cent).

When a true discount line (e.g., -0.69) is evaluated by the fallback rule and added to the pool, the system sums everything up (-0.01 + 0.69 = 0.68), resulting in an incorrect Remise totale printed on the document.

The Fix: The pdfGetLineTotalDiscountAmount() function was missing a check to verify if the line actually had a discount applied before running the math.

I added a short-circuit condition that aborts the calculation and returns 0 early if the line has no discount percentage (remise_percent):

``
if (empty($object->lines[$i]->remise_percent)) {
    return 0;
}
``

This ensures the math is exclusively executed on lines that actually have a discount, entirely preventing rounding discrepancies on standard items from bleeding into the total discount pool.*]


