### PR TITLE
FIX #37800 Keep line breaks in plain text descriptions containing '&'

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8828,6 +8828,12 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 						//$out = '<html><head><meta charset="utf-8"></head><body><div class="tricktoremove">'.$out.'</div></body></html>';
 					} else {
 						//$out = '<?xml encoding="UTF-8"><html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">'.dol_nl2br($out).'</div></body></html>';
+						// Protect the raw '&' of the plain text before the DOMDocument round trip (same trick as in
+						// dol_htmlentitiesbr()), otherwise saveHTML() encodes it into '&amp;' and the text becomes
+						// entity-bearing content that dol_textishtml() will detect as HTML at output time, so line breaks
+						// would no longer be converted at rendering. A pre-existing entity, for example a literal '&amp;'
+						// inside a URL, becomes '__PROTECTand__amp;' and is so restored unchanged.
+						$out = str_replace('&', '__PROTECTand__', $out);
 						$out = '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head><body><div class="tricktoremove">'.dol_nl2br($out).'</div></body></html>';
 						//$out = '<html><head><meta charset="utf-8"></head><body><div class="tricktoremove">'.dol_nl2br($out).'</div></body></html>';
 					}
@@ -8848,10 +8854,7 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 
 					if (!$outishtml) {		// If $out was not HTML content we made before a dol_nl2br so we must do the opposite operation now
 						$out = str_replace('<br>', '', $out);
-						// DOMDocument::saveHTML() has also encoded the raw '&' of the plain text into '&amp;'. Restore it,
-						// otherwise the text becomes entity-bearing content that dol_textishtml() will detect as HTML at
-						// output time, and line breaks would no longer be converted by dol_htmlentitiesbr().
-						$out = str_replace('&amp;', '&', $out);
+						$out = str_replace('__PROTECTand__', '&', $out);
 					}
 				} catch (Exception $e) {
 					// If error, invalid HTML string with no way to clean it

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8848,6 +8848,10 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 
 					if (!$outishtml) {		// If $out was not HTML content we made before a dol_nl2br so we must do the opposite operation now
 						$out = str_replace('<br>', '', $out);
+						// DOMDocument::saveHTML() has also encoded the raw '&' of the plain text into '&amp;'. Restore it,
+						// otherwise the text becomes entity-bearing content that dol_textishtml() will detect as HTML at
+						// output time, and line breaks would no longer be converted by dol_htmlentitiesbr().
+						$out = str_replace('&amp;', '&', $out);
 					}
 				} catch (Exception $e) {
 					// If error, invalid HTML string with no way to clean it


### PR DESCRIPTION
# FIX #37800 Keep line breaks in plain text descriptions containing '&'

When MAIN_RESTRICTHTML_ONLY_VALID_HTML is enabled (now the default), fields checked with 'restricthtml' go through a DOMDocument round trip in dol_htmlwithnojs(). DOMDocument::saveHTML() encodes a raw '&' into '&amp;'.

For plain text input, the non-HTML branch already performs the reverse operation for the <br> added by dol_nl2br() before the round trip ("we must do the opposite operation now"), but the '&' mutation is not compensated. The stored text then contains a complete HTML entity, so at output time dol_textishtml() classifies it as HTML and dol_htmlentitiesbr() no longer converts the newlines to <br>: line breaks are lost on generated documents (proposal, invoice, intervention PDFs).

Reproduction on 22.0.3 (PHP CLI, option forced on):

```
input:  "Tarifs: R&D + maintenance\nLigne 2 apres saut"      dol_textishtml() = false
stored: sanitizeVal(input, 'restricthtml')
        = "Tarifs: R&amp;D + maintenance\nLigne 2 apres saut" dol_textishtml() = true
render: dol_htmlentitiesbr(stored) contains no <br>, line breaks lost in PDF
```

Fix: protect the raw '&' before the DOMDocument round trip and restore it in the existing "opposite operation" block, using the same __PROTECTand__ trick already used by dol_htmlentitiesbr(). A raw '&' never reaches DOMDocument, so no entity can be introduced. A pre-existing entity, for example a literal '&amp;' inside a URL (which reaches this branch because dol_textishtml() strips URLs before its entity detection, as raised by the Codex review), becomes '__PROTECTand__amp;' and is restored byte identical.

Verified end to end through the patched function on 22.0.3:

```
"Tarifs: R&D + maintenance\nLigne 2..."     stored byte identical, rendered with <br>
"voir https://host/?a=1&amp;b=2\nnext"      stored byte identical, rendered with <br>
"R&D budget\nurl https://x/?p=1&amp;q=2"    stored byte identical, rendered with <br>
```

Safety analysis:

- No blanket decoding: the replacement only restores the exact markers created from raw '&' in the same call, so pre-existing entities are never rewritten.
- '<' and '>' are not touched, so no tag can be created. XSS probes ('<script>', 'onmouseover=', 'javascript:') produce the same output as before the change.
- The do-while loop still converges and the sanitization is idempotent: sanitizeVal() applied to a stored value returns it unchanged.
- This restores the same stored content as when MAIN_RESTRICTHTML_ONLY_VALID_HTML is disabled: a raw '&' in plain text was stored as is before the option became the default.
- The marker trick has the same pre-existing limitation as in dol_htmlentitiesbr(): a literal '__PROTECTand__' typed by a user is turned into '&'.

The 21.0 branch does not have the <br> removal block, so the issue starts with 22.0. The sibling problem with bare '<' and '>' is tracked in #38919 and addressed by PR #38920, so it is kept out of scope here.
