### PR TITLE
FIX #38981 product/stats/facture.php fatal error when the invoice module is disabled

### DIFF
--- a/htdocs/product/stats/facture.php
+++ b/htdocs/product/stats/facture.php
@@ -137,13 +137,17 @@ $result = restrictedArea($user, 'produit|service', $fieldvalue, 'product&product
 $toselect = GETPOST('toselect', 'array:int');
 $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'invoicelist';
 $massaction = GETPOST('massaction', 'alpha');
-$diroutputmassaction = $conf->invoice->dir_output.'/temp/massgeneration/'.$user->id;
+$diroutputmassaction = isModEnabled('invoice') ? $conf->invoice->dir_output.'/temp/massgeneration/'.$user->id : '';
 
 if (GETPOST('cancel', 'alpha')) {
 	$action = 'list';
 	$massaction = '';
 }
 if (!GETPOST('confirmmassaction', 'alpha') && $massaction != 'presend' && $massaction != 'confirm_presend') {
+	$massaction = '';
+}
+if (!isModEnabled('invoice')) {
+	// The mass actions of this page rely on the invoice module (objects, permissions, upload directory)
 	$massaction = '';
 }
 $arrayfields = array(
@@ -164,9 +168,10 @@ $formother = new FormOther($db);
 
 
 
-$arrayofmassactions = array(
-	'presend' => img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
-);
+$arrayofmassactions = array();
+if (isModEnabled('invoice')) {
+	$arrayofmassactions['presend'] = img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail");
+}
 $massactionbutton = $form->selectMassAction('', $arrayofmassactions);
 $arrayofselected = is_array($toselect) ? $toselect : array();
 $selectedfields = (count($arrayofmassactions) ? $form->showCheckAddButtons('checkforselect', 1) : '');
@@ -180,7 +185,7 @@ $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 }
-if (empty($reshook)) {
+if (empty($reshook) && isModEnabled('invoice')) {
 	$objectclass = 'Facture';
 	$objectlabel = 'Invoices';
 	$permissiontoread = $user->hasRight("facture", "lire");


### PR DESCRIPTION
# FIX #38981 product/stats/facture.php fatal error when the invoice module is disabled

## Root cause

The massaction sendEmail feature added to this page for v24 by 8f0b7e3f (#37937) does the following on every page load, including a plain GET:

- reads `$conf->invoice->dir_output` to build `$diroutputmassaction`
- sets `$uploaddir = $conf->invoice->dir_output` and includes `core/actions_massactions.inc.php`

When the invoice module is disabled, `$conf->invoice->dir_output` is empty, so the include hits its protection at core/actions_massactions.inc.php line 100 and exits:

```
include of actions_massactions.inc.php is done but var $objectclass or $uploaddir was not defined
```

This is exactly the error reported in #38981, and it explains why it could not be reproduced in triage: the crash only happens when the invoice module is disabled, and the reporter's module list contains no invoice module (user, export, agenda, bom, service, workstation, stock, mrp, expedition, commande, fournisseur, societe, product, ...).

The impact is not limited to a direct URL: `product_prepare_head()` (core/lib/product.lib.php) links the product referers tab to `product/stats/facture.php?showmessage=1&id=...` unconditionally, which matches the URL in the report. So on a v24 install without the invoice module, clicking the referers tab of any product produces the fatal error. In 23.0 this page had no mass action code and rendered fine without the module.

## Fix

Make the massaction machinery conditional on `isModEnabled('invoice')`, restoring the 23.0 behavior when the module is off and changing nothing when it is on:

- `$diroutputmassaction` is only built from `$conf->invoice->dir_output` when the module is enabled (also avoids a property read on a possibly unset conf object)
- `$massaction` is forced empty when the module is off, so no massaction code path (including the presend template in the view) can trigger
- `$arrayofmassactions` stays empty when the module is off: `selectMassAction()` returns null for an empty array, so the mass action select and the row checkboxes are not displayed, as in 23.0
- the doActions block that sets `$objectclass`/`$uploaddir` and includes `actions_massactions.inc.php` is skipped when the module is off

## Verification

- Code path analysis against the protection in actions_massactions.inc.php: with the module off, the include is no longer reached; with the module on, all four changes are no-ops.
- `php -l` clean.
- `isModEnabled('invoice')` is the mapped name of the facture module (MODULE_MAPPING) and is already used elsewhere in the product pages.

An alternative would be `accessforbidden()` when the module is disabled, but since the referers tab links to this page unconditionally and the 23.0 page rendered without the module, this fix keeps the previous behavior instead of introducing a blocking page.
