### PR TITLE
FIX #39046 Cash control period saved as wrong day

### DIFF
--- a/htdocs/compta/cashcontrol/cashcontrol_card.php
+++ b/htdocs/compta/cashcontrol/cashcontrol_card.php
@@ -129,14 +129,14 @@ $ssec = 0;
 if ($object->id > 0) {
 	// When object is know, we must define first the end date (stored in database with different components) and deduct the start date
 	if (empty($object->day_close) && !empty($object->month_close)) {
-		$dateend = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, $object->month_close, $object->day_close, $object->year_close, 'gmt');
+		$dateend = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, $object->month_close, $object->day_close, $object->year_close, 'tzuserrel');
 		$datestart = dol_time_plus_duree($dateend, -1, 'y', 0);
 	} elseif (empty($object->day_close) && empty($object->month_close)) {
-		$dateend = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, 12, 31, $object->year_close, 'gmt');
-		$datestart = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, 12, 1, $object->year_close, 'gmt');
+		$dateend = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, 12, 31, $object->year_close, 'tzuserrel');
+		$datestart = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, 12, 1, $object->year_close, 'tzuserrel');
 		$datestart = dol_time_plus_duree($datestart, -1, 'm', 0);
 	} else {
-		$dateend = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, $object->month_close, $object->day_close, $object->year_close, 'gmt');
+		$dateend = dol_mktime((int) $object->hour_close, (int) $object->min_close, (int) $object->sec_close, $object->month_close, $object->day_close, $object->year_close, 'tzuserrel');
 		$datestart = dol_time_plus_duree($dateend, -1, 'd', 0);
 	}
 	$datestart += 1;	// Add 1 second
@@ -247,9 +247,9 @@ if ($action == "start" && $permissiontoadd) {
 
 	if (!$error) {
 		if (GETPOSTINT('closeday')) {
-			$dateclosegmt = dol_mktime(GETPOSTISSET('closehour') ? GETPOSTINT('closehour') : 23, GETPOSTISSET('closemin') ? GETPOSTINT('closemin') : 59, GETPOSTISSET('closesec') ? GETPOSTINT('closesec') : 59, GETPOSTINT('closemonth') ? GETPOSTINT('closemonth') : 12, GETPOSTINT('closeday'), GETPOSTINT('closeyear'), 'tzuserrel');
+			$dateclosegmt = dol_mktime(GETPOSTISSET('closehour') ? GETPOSTINT('closehour') : 23, GETPOSTISSET('closemin') ? GETPOSTINT('closemin') : 59, GETPOSTISSET('closesec') ? GETPOSTINT('closesec') : 59, GETPOSTINT('closemonth') ? GETPOSTINT('closemonth') : 12, GETPOSTINT('closeday'), GETPOSTINT('closeyear'), 'gmt');
 		} else {
-			$dateclosegmt = dol_mktime(GETPOSTISSET('closehour') ? GETPOSTINT('closehour') : 23, GETPOSTISSET('closemin') ? GETPOSTINT('closemin') : 59, GETPOSTISSET('closesec') ? GETPOSTINT('closesec') : 59, GETPOSTINT('closemonth') ? GETPOSTINT('closemonth') : 12, 15, GETPOSTINT('closeyear'), 'tzuserrel');
+			$dateclosegmt = dol_mktime(GETPOSTISSET('closehour') ? GETPOSTINT('closehour') : 23, GETPOSTISSET('closemin') ? GETPOSTINT('closemin') : 59, GETPOSTISSET('closesec') ? GETPOSTINT('closesec') : 59, GETPOSTINT('closemonth') ? GETPOSTINT('closemonth') : 12, 15, GETPOSTINT('closeyear'), 'gmt');
 		}
 		dol_syslog('The closing date will be '.dol_print_date($dateclosegmt, 'standard', 'gmt').' UTC');
 


### PR DESCRIPTION
FIX #39046

## Bug

In the add action of `htdocs/compta/cashcontrol/cashcontrol_card.php`, the closing timestamp is built in the user timezone then decomposed in GMT before being stored:

```php
$dateclosegmt = dol_mktime(..., GETPOSTINT('closeday'), GETPOSTINT('closeyear'), 'tzuserrel');
...
$tmparray = dol_getdate($dateclosegmt, false, 'gmt');
$object->day_close = GETPOSTINT('closeday') ? $tmparray['mday'] : null;
```

The two timezones do not match, so `day_close/month_close/year_close/hour_close/min_close/sec_close` receive the UTC decomposition of the local instant instead of the calendar values the user entered:

- user in a UTC-negative timezone (reported case, America/La_Paz UTC-4): closing day 2026-06-11 stores `day_close = 12`
- user in a UTC-positive timezone (Europe/Paris UTC+2): closing at 00:30 stores the previous day

Reproduction on 24.0.0-beta (same code as 23.0 for these lines), simulating the two timezones:

```
User enters closing period: 2026-6-11 23:59:59 (user tz America/La_Paz, UTC-4)
CURRENT: mktime('tzuserrel') -> getdate('gmt') => stored day_close=12  *** shifted to next day
FIXED  : mktime('gmt')       -> getdate('gmt') => stored day_close=11  OK, matches entered day
CURRENT Paris (UTC+2), 00:30 input: stored day_close=10  *** shifted to previous day
```

## Why the stored values must be the entered calendar values

Every reader of these columns treats them as a plain local calendar label:

- the cash control list prints them raw (`cashcontrol_list.php`)
- the card and the valid/close steps reuse them directly as `$syear/$smonth/$sday`
- the TakePOS closed period check (`takepos/invoice.php`) compares them against `dol_getdate(dol_now())`, the server local today; with a shifted `day_close` the fence blocks the wrong day
- version 22.0 stored the raw entered values (`$object->day_close = GETPOSTINT('closeday')`)

## Fix (6 lines, timezone arguments only, no logic change)

1. Build `$dateclosegmt` with `'gmt'` (2 lines): the `dol_mktime`/`dol_getdate` roundtrip becomes an identity on the entered values (it still normalizes overflow values), so the stored fields are exactly what the user chose, as in 22.0.
2. When rebuilding `$datestart/$dateend` on an existing record (4 lines), interpret the stored values with `'tzuserrel'` instead of `'gmt'`: this matches the preview branch used before the record exists (which already uses `'tzuserrel'`), so the theoretical cash period after saving equals the one previewed at creation:

```
Theoretical-cash window end (must equal creation preview 2026-06-12 03:59:59 UTC):
  rebuild with 'gmt' (unchanged)    : 2026-06-11 23:59:59 UTC (4h off)
  rebuild with 'tzuserrel' (patched): 2026-06-12 03:59:59 UTC (consistent)
```

Base 23.0: the decomposition roundtrip does not exist on 22.0 (direct storage of the entered values), so 23.0 is the oldest affected maintained branch.

## Note on existing data

Cash control is new in 23.0. Rows created before this patch by a user in a non-UTC timezone stored the UTC decomposition of the local close instant (this is the reported bug: the displayed day is off). Because the creating user's timezone is not persisted on the row, those legacy values cannot be migrated deterministically. After this change such a legacy row is interpreted like a normal local calendar label, so its rebuilt valid/close window shifts by the user's UTC offset. Rows created in UTC are unaffected, and all new rows are fully consistent (stored values = entered values, period = user-local day = creation preview).
