### PR TITLE
FIX #39038 Double quote in product label truncates the combo dropdown

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -3620,11 +3620,11 @@ class Form
 		}
 
 		if ($stocktag == 1) {
-			$opt .= ' class="product_line_stock_ok" data-html="'.$labeltoshowhtml.$outvalUnits.$labeltoshowhtmlprice.dolPrintHTMLForAttribute($labeltoshowhtmlstock).'"';
+			$opt .= ' class="product_line_stock_ok" data-html="'.dolPrintHTMLForAttribute($labeltoshowhtml, 0, array('strong')).dolPrintHTMLForAttribute($outvalUnits).$labeltoshowhtmlprice.dolPrintHTMLForAttribute($labeltoshowhtmlstock).'"';
 			//$opt .= ' class="product_line_stock_ok"';
 		}
 		if ($stocktag == -1) {
-			$opt .= ' class="product_line_stock_too_low" data-html="'.$labeltoshowhtml.$outvalUnits.$labeltoshowhtmlprice.dolPrintHTMLForAttribute($labeltoshowhtmlstock).'"';
+			$opt .= ' class="product_line_stock_too_low" data-html="'.dolPrintHTMLForAttribute($labeltoshowhtml, 0, array('strong')).dolPrintHTMLForAttribute($outvalUnits).$labeltoshowhtmlprice.dolPrintHTMLForAttribute($labeltoshowhtmlstock).'"';
 			//$opt .= ' class="product_line_stock_too_low"';
 		}
 


### PR DESCRIPTION
FIX #39038

## Bug

When the predefined product/service combo is rendered as the rich dropdown (ajaxcombo / select2) and stock is shown, a product whose label, unit or reference contains a double quote `"` is displayed truncated exactly at the quote. A common case is an inch mark in hardware retail, e.g. `PVC Pipe 1/2" Standard`.

## Root cause

In `Form::select_produits_list()` (`htdocs/core/class/html.form.class.php`), the option `data-html` attribute is built by concatenating `$labeltoshowhtml`, `$outvalUnits` and `$labeltoshowhtmlprice` as raw strings. A `"` in the user text closes the `data-html="..."` attribute early and the rest of the name is lost in the dropdown.

The variables that carry user text are `$labeltoshowhtml` (ref, customer ref, barcode and product label, the case of the issue) and `$outvalUnits` (unit short label coming from the measuring units dictionary). `$labeltoshowhtmlprice` only carries outputs of `price()` and `$langs->transnoentities()` and cannot contain a double quote.

## Fix

As requested in review, sanitize the user variables with `dolPrintHTMLForAttribute()`, as the stock part of the same attribute already does:

```php
$opt .= ' class="product_line_stock_ok" data-html="'.dolPrintHTMLForAttribute($labeltoshowhtml, 0, array('strong')).dolPrintHTMLForAttribute($outvalUnits).$labeltoshowhtmlprice.dolPrintHTMLForAttribute($labeltoshowhtmlstock).'"';
```

The tag `strong` is passed in the `allowothertags` parameter for the label so the highlight added around the typed search key is kept in the rich label (without it the helper strips the highlight).

## Verification (helpers identical on 21.0 and develop, run on 24.0.0-beta)

`data-html` value built with the patched expression for a stock tagged product:

- label `PVC Pipe 1/2" Standard` with `<strong>` highlight: no raw double quote left in the attribute value, quote displayed in the dropdown, highlight still bold
- unit short label `12"pack`: quote escaped, full name kept
- stock part unchanged (already sanitized)
- label with a bare less-than sign and no highlight (`Cable <5m`): kept and displayed as text
- label with a bare less-than sign inside a highlighted label: filtered by the helper tag filtering, same behavior as the other `dolPrintHTMLForAttribute()` call sites; before this fix that case was already truncated at render time by the browser parser

## Scope / target branch

Base 21.0: the `data-html` attribute on the product option was introduced in 21.0; on 20.0 the option carried only a class and select2 used the plain option text where a quote is harmless. In develop the code was reworked by #39057 which now escapes the whole value with `dol_escape_htmltag()`, so develop is already covered and this fix is for the maintained branches.
