### PR TITLE
FIX #39035 Timeline read more hides a message wrapped in a block tag

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8555,6 +8555,48 @@ function dolGetFirstLineOfText($text, $nboflines = 1, $charset = 'UTF-8')
 
 
 /**
+ * Close the HTML tags left open in a string (for example after a truncation of HTML content),
+ * so the returned string is well formed HTML. Void elements and self closed tags are ignored,
+ * remaining open tags are closed in last in first out order. A non HTML string is returned as is.
+ *
+ * @param	string	$stringtoclean		String to close the still open tags of
+ * @return	string						String with the open tags closed
+ * @see	dolGetFirstLineOfText()
+ */
+function dolCloseUnclosedTags($stringtoclean)
+{
+	if (empty($stringtoclean) || !dol_textishtml($stringtoclean)) {
+		return $stringtoclean;
+	}
+	$voidtags = array('br', 'img', 'hr', 'input', 'meta', 'link', 'area', 'base', 'col', 'embed', 'param', 'source', 'track', 'wbr');
+	preg_match_all('/<(\/?)([a-zA-Z][a-zA-Z0-9]*)\b[^>]*?(\/?)>/', $stringtoclean, $tagsfound, PREG_SET_ORDER);
+	$opentags = array();
+	foreach ($tagsfound as $tagfound) {
+		$tagname = strtolower($tagfound[2]);
+		if (in_array($tagname, $voidtags, true) || !empty($tagfound[3])) {
+			continue;	// void element or self closed tag, nothing to close
+		}
+		if (!empty($tagfound[1])) {	// closing tag, unstack the matching opening tag
+			for ($j = count($opentags) - 1; $j >= 0; $j--) {
+				// $opentags is non-empty here (for-loop guard), phan wrongly infers the initial empty shape.  @phan-suppress-next-line PhanTypeInvalidDimOffset
+				if ($opentags[$j] === $tagname) {
+					array_splice($opentags, $j);
+					break;
+				}
+			}
+		} else {	// opening tag
+			$opentags[] = $tagname;
+		}
+	}
+	// Close still open tags in last in first out order
+	for ($j = count($opentags) - 1; $j >= 0; $j--) {
+		$stringtoclean .= '</' . $opentags[$j] . '>';
+	}
+	return $stringtoclean;
+}
+
+
+/**
  * Replace CRLF in string with a HTML BR tag.
  * WARNING: The content after operation contains some HTML tags (the <br>) so be sure to also have
  *          encoded the special chars of stringtoencode into HTML before with dol_htmlentitiesbr().
@@ -15057,7 +15099,7 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = null, 
 				if ($truncateLines > 0 && strlen($histo[$key]['message']) > strlen($truncatedText)) {
 					$out .= '<div class="readmore-block --closed" >';
 					$out .= '	<div class="readmore-block__excerpt">';
-					$out .= 	dolPrintHTML($truncatedText);
+					$out .= 	dolPrintHTML(dolCloseUnclosedTags($truncatedText));
 					$out .= ' 	<br><a class="read-more-link" data-read-more-action="open" href="'.DOL_MAIN_URL_ROOT.'/comm/action/card.php?id='.$actionstatic->id.'&backtopage='.urlencode($_SERVER["PHP_SELF"].'?'.$param).'" >'.$langs->trans("ReadMore").' <span class="fa fa-chevron-right" aria-hidden="true"></span></a>';
 					$out .= '	</div>';
 					$out .= '	<div class="readmore-block__full-text" >';


### PR DESCRIPTION
FIX #39035

## Bug

In the Agenda/Ticket event timeline, a long message is shown as a truncated excerpt with a "Read more" link that expands to the full text via a CSS class toggle. When the message content is wrapped in a block-level tag (typically a `<div>` from the WYSIWYG editor), clicking "Read more" makes the **whole message disappear** instead of expanding it.

## Root cause

`show_actions_messaging()` builds the excerpt with `dolGetFirstLineOfText($newmess, $truncateLines)`, which truncates after N lines by splitting on `<br>` **without regard for tag balance**. For `<div>line1<br>line2<br>line3<br>line4</div>` the opening `<div>` is kept but the `</div>` on line4 is dropped, so the excerpt is `<div>line1<br>line2<br>line3...` (unclosed `<div>`). It is printed in `.readmore-block__excerpt`, so the browser nests the "Read more" link and the `.readmore-block__full-text` sibling **inside** the excerpt, and the `--closed`/`--open` toggle then hides them.

(The DOM sanitizer of `dol_htmlwithnojs()` would balance the tag, but it only runs when `MAIN_RESTRICTHTML_ONLY_VALID_HTML` is enabled, off by default.)

## Fix

Add a small helper `dolCloseUnclosedTags()` (void elements and self closed tags ignored, remaining open tags closed in last in first out order, non HTML returned unchanged) and apply it **only to the excerpt that is displayed**, so it is well formed HTML.

The truncation detection `strlen($newmess) > strlen($truncatedText)` keeps using the raw `dolGetFirstLineOfText()` output, so it is byte-identical to upstream and the read-more trigger is unchanged (this is the point raised in the review of the first revision).

## Verification (dolibarr-test 24.0.0-beta; PhpStan level 10 + Phan 5.5.2)

Number of tags left unclosed in the displayed excerpt (0 = well formed), and gate input length:

| input | excerpt before | excerpt after | gate input length |
|---|---|---|---|
| `<div>l1<br>l2<br>l3<br>l4</div>` | 1 unclosed | 0 | unchanged |
| realistic 4-line `<div>` note | 1 unclosed | 0 | unchanged |
| `<b>hi</b>` / plain text | 0 | 0 | unchanged |

The new helper adds **0 issues under PhpStan level 10 and 0 under Phan 5.5.2** (verified locally with the repo config + baseline: pristine file and patched file report the same count, delta 0).

## Scope / target branch

Base 21.0: the readmore-block excerpt mechanism is present on 21.0/22.0/23.0/develop; 21.0 is the oldest maintained affected branch.
