### PR TITLE
Fix product combo search for long quoted labels

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4042,10 +4042,11 @@ class Form
 
 		$maxlengtharticle = getDolGlobalInt('PRODUCT_MAX_LENGTH_COMBO', 48);
 
-		$label = $objp->label;
+		$productlabel = $objp->label;
 		if (!empty($objp->label_translated)) {
-			$label = $objp->label_translated;
+			$productlabel = $objp->label_translated;
 		}
+		$label = $productlabel;
 		if (!empty($filterkey) && $filterkey != '') {
 			$label = preg_replace('/(' . preg_quote($filterkey, '/') . ')/i', '<strong>$1</strong>', $label, 1);
 		}
@@ -4121,18 +4122,19 @@ class Form
 			}
 		}
 
-		// Set $labeltoshow
-		$labeltoshow = '';
-		$labeltoshow .= $objp->ref;
+		// Set full plain label for the native <option> text. Select2 uses this text
+		// as its search corpus, while data-html below keeps the visible label short.
+		$labeltosearch = '';
+		$labeltosearch .= $objp->ref;
 		if (!empty($objp->custref)) {
-			$labeltoshow .= ' (' . $objp->custref . ')';
+			$labeltosearch .= ' (' . $objp->custref . ')';
 		}
 		if ($outbarcode) {
-			$labeltoshow .= ' (' . $outbarcode . ')';
+			$labeltosearch .= ' (' . $outbarcode . ')';
 		}
-		$labeltoshow .= ' - ' . dol_trunc($label, $maxlengtharticle);
+		$labeltosearch .= ' - ' . $productlabel;
 		if ($outorigin && getDolGlobalString('PRODUCT_SHOW_ORIGIN_IN_COMBO')) {
-			$labeltoshow .= ' (' . getCountry($outorigin, '1') . ')';
+			$labeltosearch .= ' (' . getCountry($outorigin, '1') . ')';
 		}
 
 		// Set $labltoshowhtml
@@ -4304,6 +4306,10 @@ class Form
 			$outdefault_vat_code = $objp->default_vat_code;
 		}
 
+		$optiontext = $labeltosearch.$outvalUnits.$labeltoshowprice.$labeltoshowstock;
+		$optionhtml = $labeltoshowhtml.$outvalUnits.$labeltoshowhtmlprice.$labeltoshowhtmlstock;
+		$optionhtmlforattribute = dol_escape_htmltag($optionhtml, 0, 0, '', 0, 1);
+
 		// Build options
 		$opt = '<option value="' . $objp->rowid . '"';
 		$opt .= ($objp->rowid == $selected) ? ' selected' : '';
@@ -4311,35 +4317,33 @@ class Form
 			$opt .= ' pbq="' . $objp->price_by_qty_rowid . '" data-pbq="' . $objp->price_by_qty_rowid . '" data-pbqup="' . $objp->price_by_qty_unitprice . '" data-pbqbase="' . $objp->price_by_qty_price_base_type . '" data-pbqqty="' . $objp->price_by_qty_quantity . '" data-pbqpercent="' . $objp->price_by_qty_remise_percent . '"';
 		}
 		if (getDolGlobalString('PRODUIT_TEXTS_IN_THIRDPARTY_LANGUAGE')) {
-			$opt .= ' data-labeltrans="' . $outlabel_translated . '"';
+			$opt .= ' data-labeltrans="' . dol_escape_htmltag($outlabel_translated, 0, 0, '', 0, 1) . '"';
 			$opt .= ' data-desctrans="' . dol_escape_htmltag($outdesc_translated) . '"';
 		}
 
 		if ($stocktag == 1) {
-			$opt .= ' class="product_line_stock_ok" data-html="'.$labeltoshowhtml.$outvalUnits.$labeltoshowhtmlprice.dolPrintHTMLForAttribute($labeltoshowhtmlstock).'"';
+			$opt .= ' class="product_line_stock_ok"';
 			//$opt .= ' class="product_line_stock_ok"';
 		}
 		if ($stocktag == -1) {
-			$opt .= ' class="product_line_stock_too_low" data-html="'.$labeltoshowhtml.$outvalUnits.$labeltoshowhtmlprice.dolPrintHTMLForAttribute($labeltoshowhtmlstock).'"';
+			$opt .= ' class="product_line_stock_too_low"';
 			//$opt .= ' class="product_line_stock_too_low"';
 		}
+		$opt .= ' data-html="'.$optionhtmlforattribute.'" data-select-html="'.$optionhtmlforattribute.'"';
 
 		$opt .= '>';
 
 		// Ref, barcode, country
-		$opt .= $labeltoshow;
+		$opt .= dol_escape_htmltag($optiontext, 0, 0, '', 0, 1);
 		$outval .= $labeltoshowhtml;
 
 		// Units
-		$opt .= $outvalUnits;
 		$outval .= $outvalUnits;
 
 		// Price
-		$opt .= $labeltoshowprice;
 		$outval .= $labeltoshowhtmlprice;
 
 		// Stock
-		$opt .= $labeltoshowstock;
 		$outval .= $labeltoshowhtmlstock;
 
 

--- a/test/phpunit/FormTest.php
+++ b/test/phpunit/FormTest.php
@@ -30,6 +30,7 @@ global $conf,$user,$langs,$db;
 //require_once 'PHPUnit/Autoload.php';
 require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
 require_once dirname(__FILE__).'/../../htdocs/core/class/html.form.class.php';
+require_once dirname(__FILE__).'/../../htdocs/product/class/product.class.php';
 require_once dirname(__FILE__).'/CommonClassTest.class.php';
 
 if (empty($user->id)) {
@@ -38,6 +39,28 @@ if (empty($user->id)) {
 	$user->loadRights();
 }
 $conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+/**
+ * Helper class for testing product option generation.
+ */
+class FormProductOptionTest extends Form
+{
+	/**
+	 * Build a product option by exposing the protected helper for unit tests.
+	 *
+	 * @param stdClass $product Product row object
+	 * @return array{0:string,1:array<string,mixed>}
+	 */
+	public function buildProductOption($product)
+	{
+		$option = '';
+		$optionJson = array();
+
+		$this->constructProductListOption($product, $option, $optionJson, 0, 0, 1, '', 1);
+
+		return array($option, $optionJson);
+	}
+}
 
 
 /**
@@ -76,5 +99,54 @@ class FormTest extends CommonClassTest
 		print __METHOD__." count result=".count($result)."\n";
 
 		return $result;
+	}
+
+	/**
+	 * testProductOptionUsesFullEscapedTextForSearch
+	 *
+	 * @return void
+	 */
+	public function testProductOptionUsesFullEscapedTextForSearch()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$conf->global->PRODUCT_MAX_LENGTH_COMBO = 48;
+		$conf->global->PRODUCT_SHOW_ORIGIN_IN_COMBO = 0;
+		$conf->global->PRODUCT_SHOW_DIMENSIONS_IN_COMBO = 0;
+		$conf->global->PRODUCT_USE_UNITS = 0;
+
+		$form = new FormProductOptionTest($db);
+		$product = (object) array(
+			'rowid' => 123,
+			'ref' => 'P00489',
+			'label' => 'PVC Pipe 1/2" Standard Quality Professional Grade Heavy Duty Construction Tool for Industrial Use - KEYWORD',
+			'label_translated' => '',
+			'description' => '',
+			'description_translated' => '',
+			'barcode' => '',
+			'fk_country' => 0,
+			'fk_product_type' => Product::TYPE_PRODUCT,
+			'duration' => '',
+			'price_by_qty_rowid' => '',
+		);
+
+		list($option) = $form->buildProductOption($product);
+
+		$htmlMatches = array();
+		$textMatches = array();
+		$this->assertSame(1, preg_match('/ data-html="([^"]+)"/', $option, $htmlMatches));
+		$this->assertSame(1, preg_match('/>(.*)<\/option>/s', $option, $textMatches));
+
+		$visibleText = html_entity_decode($htmlMatches[1], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+		$searchText = html_entity_decode($textMatches[1], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+		$this->assertStringContainsString('PVC Pipe 1/2" Standard Quality', $visibleText);
+		$this->assertStringNotContainsString('KEYWORD', $visibleText);
+		$this->assertStringContainsString('PVC Pipe 1/2" Standard Quality', $searchText);
+		$this->assertStringContainsString('KEYWORD', $searchText);
 	}
 }


### PR DESCRIPTION
## Summary
- keep product combo display labels truncated through `data-html` / `data-select-html`
- keep the native `<option>` text full and escaped so Select2 can search beyond the visible truncation
- escape generated product option HTML attributes so quotes in labels do not break dropdown markup

Fixes #39038

## Tests
- `php -l htdocs/core/class/html.form.class.php`
- `php -l test/phpunit/FormTest.php`
- `git diff --check`
- manual PHP check for a product option with a quoted label and a trailing keyword after the visual truncation point