### PR TITLE
Qual: Fix database typo (DoliDb -> DoliDB)

### DIFF
--- a/htdocs/accountancy/class/bookkeepingtemplate.class.php
+++ b/htdocs/accountancy/class/bookkeepingtemplate.class.php
@@ -163,7 +163,7 @@ class BookkeepingTemplate extends CommonObject
 	/**
 	 * Constructor
 	 *
-	 * @param DoliDb $db Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct(DoliDB $db)
 	{

--- a/htdocs/accountancy/class/bookkeepingtemplateline.class.php
+++ b/htdocs/accountancy/class/bookkeepingtemplateline.class.php
@@ -182,7 +182,7 @@ class BookkeepingTemplateLine extends CommonObject
 	/**
 	 * Constructor
 	 *
-	 * @param DoliDb $db Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct(DoliDB $db)
 	{


### PR DESCRIPTION
# Qual: Fix database typo (DoliDb -> DoliDB)
The database handler type was updated from `DoliDb` to `DoliDB` in both `bookkeepingtemplate.class.php` and `bookkeepingtemplateline.class.php`.