### PR TITLE
FIX migration of const inversion STOCK_ALLOW_NEGATIVE_TRANSFER

### DIFF
--- a/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
+++ b/htdocs/install/mysql/migration/21.0.0-22.0.0.sql
@@ -243,7 +243,8 @@ UPDATE llx_accounting_account as acc SET acc.centralized = 1 WHERE acc.account_n
 -- invert constant STOCK_ALLOW_NEGATIVE_TRANSFER because it was automatically set to 1, deleting the user config.
 INSERT INTO llx_const (name, entity, value, type, visible, note) SELECT DISTINCT 'STOCK_DISALLOW_NEGATIVE_TRANSFER', entity, '1', 'chaine', 0, '' FROM llx_const as c1 WHERE NOT EXISTS (SELECT rowid FROM llx_const as c2 WHERE c2.name = 'STOCK_ALLOW_NEGATIVE_TRANSFER' AND c2.value = '1' AND c2.entity = c1.entity);
 UPDATE llx_const SET name = 'STOCK_DISALLOW_NEGATIVE_TRANSFER', value = '1' WHERE name = 'STOCK_ALLOW_NEGATIVE_TRANSFER' AND value = '0';
-DELETE FROM llx_const WHERE name = 'STOCK_ALLOW_NEGATIVE_TRANSFER' AND value = '1';
+-- Do not delete this const, otherwise the 'INSERT INTO...' will be triggered on next update
+-- DELETE FROM llx_const WHERE name = 'STOCK_ALLOW_NEGATIVE_TRANSFER' AND value = '1';
 
 ALTER TABLE llx_links ADD COLUMN  share varchar(128) NULL AFTER objectid;
 ALTER TABLE llx_links ADD COLUMN  share_pass varchar(32) NULL AFTER share;


### PR DESCRIPTION
# FIX const inversion STOCK_DISALLOW_NEGATIVE_TRANSFER

**problem :** 

on updates in the same major (ex. 22.0.4 -> 22.0.5), the constant STOCK_DISALLOW_NEGATIVE_TRANSFER is set to 1 while it should stay disabled.

**reason :** 

Context : on 21.0.x -> 22.0.0, the constant `STOCK_ALLOW_NEGATIVE_TRANSFER` was inverted to `STOCK_DISALLOW_NEGATIVE_TRANSFER`. The migration script ensures that STOCK_DISALLOW_NEGATIVE_TRANSFER is set, or not, relatively to the previous config.

Then it deletes STOCK_ALLOW_NEGATIVE_TRANSFER. This is where the bug arises. On next migration, the SQL script will not find STOCK_ALLOW_NEGATIVE_TRANSFER so it will set STOCK_DISALLOW_NEGATIVE_TRANSFER to 1.