### PR TITLE
fix: correct naming of file upladed on supplier invoice by drag and drop on main Supplier Invoice tab header

### DIFF
--- a/htdocs/core/class/fileupload.class.php
+++ b/htdocs/core/class/fileupload.class.php
@@ -73,6 +73,7 @@ class FileUpload
 		$pathname = str_replace('/class', '', $element_prop['classpath']);
 		$filename = dol_sanitizeFileName($element_prop['classfile']);
 		$dir_output = dol_sanitizePathName($element_prop['dir_output']);
+		$savingDocMask = '';
 
 		//print 'fileupload.class.php: element='.$element.' pathname='.$pathname.' filename='.$filename.' dir_output='.$dir_output."\n";
 
@@ -88,6 +89,11 @@ class FileUpload
 			$object = fetchObjectByElement($fk_element, $element);
 
 			$object_ref = dol_sanitizeFileName($object->ref);
+
+			// add object reference as file name prefix if const MAIN_DISABLE_SUGGEST_REF_AS_PREFIX is not enabled
+			if (!getDolGlobalInt('MAIN_DISABLE_SUGGEST_REF_AS_PREFIX')) {
+				$savingDocMask = $object_ref.'-__file__';
+			}
 
 			// Special cases to forge $object_ref used to forge $upload_dir
 			if ($element == 'invoice_supplier') {
@@ -114,6 +120,7 @@ class FileUpload
 			'script_url' => $_SERVER['PHP_SELF'],
 			'upload_dir' => $dir_output.'/'.$object_ref.'/',
 			'upload_url' => DOL_URL_ROOT.'/document.php?modulepart='.$element.'&attachment=1&file=/'.$object_ref.'/',
+			'saving_doc_mask' => $savingDocMask,
 			'param_name' => 'files',
 			// Set the following option to 'POST', if your server does not support
 			// DELETE requests. This is a parameter sent to the client:
@@ -439,6 +446,14 @@ class FileUpload
 
 		if ($validate) {
 			if (dol_mkdir($this->options['upload_dir']) >= 0) {
+				// add object reference as file name prefix if const MAIN_DISABLE_SUGGEST_REF_AS_PREFIX is not enabled
+				$fileNameWithoutExt = preg_replace('/\.[^\.]+$/', '', $file->name);
+				$savingDocMask = $this->options['saving_doc_mask'];
+				if ($savingDocMask && strpos($savingDocMask, $fileNameWithoutExt) !== 0) {
+					$fileNameWithPrefix = preg_replace('/__file__/', $file->name, $savingDocMask);
+					$file->name = $fileNameWithPrefix;
+				}
+
 				$file_path = dol_sanitizePathName($this->options['upload_dir']).dol_sanitizeFileName($file->name);
 				$append_file = !$this->options['discard_aborted_uploads'] && dol_is_file($file_path) && $file->size > dol_filesize($file_path);
 


### PR DESCRIPTION

When user drag and drop a file on supplier invoice tab
<img width="1786" height="623" alt="image" src="https://github.com/user-attachments/assets/719f5af1-bb58-444d-a3cc-fc40497c34b7" />
the uploaded file was correctly name with "(__REF__)-filename"


this feature exist in 18.0, 19.0, 20.0 since this commit
[f7bd03fb751d611aee6e8483e29c1b8eaaa779e2](https://github.com/Dolibarr/dolibarr/commit/f7bd03fb751d611aee6e8483e29c1b8eaaa779e2)

but 21.0 this feature is not here anymore.

May be something like merge 20.0 into 21.0 was not done anymore, and this code was introduced in 20.0 after the last merge of 20.0 into 21.0

So I would like to reintroduce this feature in 23.0 and future version


