### PR TITLE
FIX: propagate extrafields from objectsrc in extrafields_add.tpl.php

### DIFF
--- a/htdocs/core/tpl/extrafields_add.tpl.php
+++ b/htdocs/core/tpl/extrafields_add.tpl.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2014	    Maxime Kohlhaas		    <support@atm-consulting.fr>
  * Copyright (C) 2014	    Juanjo Menent		    <jmenent@2byte.es>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026       Palisandro David Gamez  <pali@eisbcn.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,6 +86,21 @@ if (empty($reshook)) {
 		$tpExtrafieldLabels = $tpExtrafields->fetch_name_optionals_label($thirdpartytopropagateextrafieldsfrom->table_element);
 		if ($thirdpartytopropagateextrafieldsfrom->fetch_optionals() > 0) {
 			$object->array_options = array_merge($object->array_options, $thirdpartytopropagateextrafieldsfrom->array_options);
+		}
+	}
+
+	// Propagate extrafields from an origin object (e.g. commande -> expedition) when the
+	// calling card.php passes its source object via $parameters['objectsrc']. This was
+	// inline logic in each card.php up to v21.x and was lost during the refactor to this
+	// shared template in v22.x. Only extrafields defined on the target elementtype are
+	// effectively displayed (showOptionals filters by target), so there are no side
+	// effects if origin and target have disjoint extrafield sets.
+	if (!empty($parameters['objectsrc']) && is_object($parameters['objectsrc'])
+		&& method_exists($parameters['objectsrc'], 'fetch_optionals')) {
+		$tmpobjectsrc = $parameters['objectsrc'];
+		'@phan-var-force CommonObject $tmpobjectsrc';
+		if ($tmpobjectsrc->fetch_optionals() > 0 && !empty($tmpobjectsrc->array_options)) {
+			$object->array_options = array_merge($object->array_options, $tmpobjectsrc->array_options);
 		}
 	}
 


### PR DESCRIPTION
Backport of #37942 to the 22.0 maintenance branch (targeting the oldest version in which the bug occurs, per the contributing guidelines).

Restore propagation of extrafields from an origin object to the new object being created at the form level. This behavior was inline in each card.php up to v21.x and was lost during the refactor to the shared extrafields_add.tpl.php template in v22.x. The template only propagated from thirdparty, silently dropping the propagation from objectsrc.

Reproduction:
1. Define an extrafield with the same name on both 'commande' and 'expedition'.
2. Create a sales order and fill the extrafield.
3. From the order, click "Create shipment".
4. Expected: the shipment form pre-fills the extrafield (v21.x behavior).
5. Actual (22.x): the field is empty.

This also affects adherents, asset, contact, holiday, intracommreport, societe, user, variants — any card.php that uses this template with an objectsrc passed via $parameters. showOptionals filters by target elementtype, so only matching extrafields are shown (no side effects with disjoint sets).

Same change already merged to develop in #37942.