### PR TITLE
FIX #39047 Supplier invoice template multicurrency price

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1166,7 +1166,7 @@ class FactureFournisseurRec extends CommonInvoice
 	 * @param int 			$info_bits 			Bits of type of lines
 	 * @param int 			$special_code 		Special code
 	 * @param int 			$rang 				Position of line
-	 * @param string 		$fk_unit 			Unit
+	 * @param ?int 			$fk_unit 			Unit
 	 * @param float			$pu_ht_devise 		Unit price in currency
 	 * @param float			$pu_ttc             Unit price TTC (> 0 even for credit note)
 	 * @return int  			                Return integer <0 if KO, Id of line if OK
@@ -1273,7 +1273,7 @@ class FactureFournisseurRec extends CommonInvoice
 		$sql .= ', info_bits = ' . (int) $info_bits;
 		$sql .= ', special_code = ' . (int) $special_code;
 		$sql .= ', rang = ' . (int) $rang;
-		$sql .= ', fk_unit = ' . ($fk_unit ? "'" . $this->db->escape($fk_unit) . "'" : 'null');
+		$sql .= ', fk_unit = ' . ($fk_unit ? (int) $fk_unit : 'null');
 		$sql .= ', fk_user_modif = ' . (int) $user->id;
 		$sql .= ', multicurrency_subprice = '.price2num($pu_ht_devise);
 		$sql .= ', multicurrency_total_ht = '.price2num($multicurrency_total_ht);

--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -698,7 +698,7 @@ if (empty($reshook)) {
 				setEventMessages($mesg, null, 'errors');
 			} else {
 				// Insert line
-				$result = $object->addline($idprod, (string) $ref_fournisseur, $label, $desc, $pu_ht, $pu_ttc, (float) $qty, $remise_percent, (string) $tva_tx, $localtax1_tx, $localtax2_tx, $price_base_type, $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1, $fk_unit);
+				$result = $object->addline($idprod, (string) $ref_fournisseur, $label, $desc, $pu_ht, $pu_ttc, (float) $qty, $remise_percent, (string) $tva_tx, $localtax1_tx, $localtax2_tx, $price_base_type, $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1, $fk_unit, (float) $price_ht_devise);
 
 				if ($result > 0) {
 					$object->fetch($object->id); // Reload lines
@@ -845,7 +845,7 @@ if (empty($reshook)) {
 
 		// Update line
 		if (! $error) {
-			$result = $object->updateline(GETPOSTINT('lineid'), GETPOSTINT('productid'), $ref_fourn, $label, $description, (float) $pu_ht, (float) $qty, (float) $remise_percent, $vat_rate, $localtax1_rate, $localtax1_rate, 'HT', $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1);
+			$result = $object->updateline(GETPOSTINT('lineid'), GETPOSTINT('productid'), $ref_fourn, $label, $description, (float) $pu_ht, (float) $qty, (float) $remise_percent, $vat_rate, $localtax1_rate, $localtax2_rate, 'HT', $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1, $objectline->fk_unit, (float) $pu_ht_devise);
 			if ($result >= 0) {
 				$object->fetch($object->id); // Reload lines
 


### PR DESCRIPTION
## Summary
- pass the posted multicurrency unit price to recurring supplier invoice template addline()
- pass multicurrency_subprice to updateline() so edited template lines keep foreign unit prices
- fix the duplicated local tax argument on recurring supplier invoice line update
- add ChangeLog entry for #39047

Fix #39047

## Tests
- php -l htdocs/fourn/facture/card-rec.php
- git diff --check origin/develop...HEAD