### PR TITLE
FIX XLSX import failing silently on large files

### DIFF
--- a/htdocs/core/modules/import/import_xlsx.modules.php
+++ b/htdocs/core/modules/import/import_xlsx.modules.php
@@ -104,6 +104,11 @@ class ImportXlsx extends ModeleImports
 	 */
 	public $headers;
 
+	/**
+	 * @var int
+	 */
+	public $countcolumns = 0; // cached column count to avoid re-parsing the file on each row
+
 
 	/**
 	 *	Constructor
@@ -339,9 +344,13 @@ class ImportXlsx extends ModeleImports
 		}
 		$array = array();
 
-		$xlsx = new Xlsx();
-		$info = $xlsx->listWorksheetinfo($this->file);
-		$countcolumns = $info[0]['totalColumns'];
+		if (empty($this->countcolumns)) {
+			$xlsx = new Xlsx();
+			$info = $xlsx->listWorksheetinfo($this->file);
+			$this->countcolumns = $info[0]['totalColumns'];
+			unset($xlsx);
+		}
+		$countcolumns = $this->countcolumns;
 
 		for ($col = 1; $col <= $countcolumns; $col++) {
 			$tmpcell = $this->workbook->getActiveSheet()->getCellByColumnAndRow($col, $this->record);
@@ -358,8 +367,6 @@ class ImportXlsx extends ModeleImports
 			$array[$col]['type'] = (dol_strlen($val) ? 1 : -1); // If empty we consider it null
 		}
 		$this->record++;
-
-		unset($xlsx);
 
 		return $array;
 	}


### PR DESCRIPTION
# FIX Fix XLSX import failing silently on large files

`ImportXlsx::import_read_record()` was calling `new Xlsx()` and `listWorksheetinfo()` on every single row read, re-parsing the entire XLSX file each iteration.

                                                                                                                                                                                                                                                
For a file with N rows, this resulted in N full file parses, causing a `Fatal error: Maximum execution time of 300 seconds exceeded` in `PhpSpreadsheet/Reader/Xlsx.php` when importing files with more than ~2000 rows.                                                                                                                                                               

The symptom was: the import simulation would hang, then stop with no error message and no import button, making the issue hard to diagnose.

Fix: cache the column count in `$this->countcolumns` on the first call to `import_read_record()` so `listWorksheetinfo()` is only called once per file.