### PR TITLE
Fix #39063 enforce user write right on other users notes

### DIFF
--- a/htdocs/user/note.php
+++ b/htdocs/user/note.php
@@ -50,7 +50,9 @@ if (($object->id != $user->id) && (!$user->hasRight("user", "user", "read"))) {
 }
 
 // Permissions
-$permissionnote = $user->hasRight("user", "self", "write"); // Used by the include of actions_setnotes.inc.php
+// Writing notes on own record needs the "self" write right, writing on another user's record needs the "user" write right.
+// Without this distinction a user holding only "self" write could edit the notes of any user, including admins.
+$permissionnote = ((($object->id == $user->id) && $user->hasRight("user", "self", "write")) || (($object->id != $user->id) && $user->hasRight("user", "user", "write"))); // Used by the include of actions_setnotes.inc.php
 
 // Security check
 $socid = 0;


### PR DESCRIPTION
Fixes #39063. In htdocs/user/note.php the note editor set $permissionnote from user->self->write alone, so a user holding user->user->read plus user->self->write (but not user->user->write) could edit the public/private notes of any user, admins included.

The setnote_public / setnote_private actions are not in restrictedArea's write-check list, so restrictedArea only validated read access here and $permissionnote was the only remaining guard on the write path in core/actions_setnotes.inc.php.

The guard now requires user->user->write to edit another user's notes and keeps user->self->write for one's own record, matching caneditfield in user/card.php. Editing own notes and admin/HR editing others are unchanged.

Reported by Abderrahmane Aksoum.