### PR TITLE
fix php warnings

### DIFF
--- a/htdocs/core/modules/ticket/mod_ticket_universal.php
+++ b/htdocs/core/modules/ticket/mod_ticket_universal.php
@@ -151,7 +151,7 @@ class mod_ticket_universal extends ModeleNumRefTicket
 		$entity = getEntity('ticketnumber', 1, $ticket);
 
 		$date = empty($ticket->datec) ? dol_now() : $ticket->datec;
-		$numFinal = get_next_value($db, $mask, 'ticket', 'ref', '', $objsoc->code_client, $date, 'next', false, null, $entity);
+		$numFinal = get_next_value($db, $mask, 'ticket', 'ref', '', (is_object($objsoc) ? $objsoc->code_client : ''), $date, 'next', false, null, $entity);
 
 		return $numFinal;
 	}


### PR DESCRIPTION
`getNextValue($objsoc, $ticket)` is called from `Ticket::getDefaultRef($thirdparty = null)` (htdocs/ticket/class/ticket.class.php:2499), where `$thirdparty` defaults to null—a ticket can legitimately not be linked to a third party. Line 154 directly accessed `$objsoc->code_client` without checking if the object existed, causing `Attempt to read property "code_client"` to be null. I reused the exact same fix already applied by Dolibarr core in the analogous numbering model `mod_task_universal.php:148` (`is_object($objsoc) ? $objsoc->code_client : ''`), to maintain consistency with the existing convention.

