### PR TITLE
FIX Mass action "Reverse movement" bypasses the MAIN_LIMIT_FOR_MASS_ACTIONS limit

### DIFF
--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -621,6 +621,7 @@ if ($action == "transfert_stock" && $permissiontoadd && !$cancel) {
 // reverse movement of stock
 if (!$error && $action == 'confirm_reverse' && $confirm == "yes" && $permissiontoadd) {
 	$toselect = array_map('intval', $toselect);
+	$error = 0;
 
 	$db->begin();
 
@@ -632,7 +633,6 @@ if (!$error && $action == 'confirm_reverse' && $confirm == "yes" && $permissiont
 	if ($resql) {
 		$num = $db->num_rows($resql);
 		$i = 0;
-		$error =0;
 		while ($i < $num) {
 			$obj = $db->fetch_object($resql);
 

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -250,7 +250,7 @@ if (empty($reshook)) {
 	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x', 'alpha') || GETPOST('button_removefilter', 'alpha')
 		|| GETPOST('button_search_x', 'alpha') || GETPOST('button_search.x', 'alpha') || GETPOST('button_search', 'alpha')) {
 		$massaction = ''; // Protection to avoid mass action if we force a new search during a mass action confirmation
-		if ($action == 'confirm_reverse') {
+		if ($action == 'confirm_reverse') {	// Test on permission not required here, we only cancel a pending action
 			$action = 'list'; // Protection to avoid the reverse if we force a new search during the reverse confirmation
 		}
 	}

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -250,6 +250,9 @@ if (empty($reshook)) {
 	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x', 'alpha') || GETPOST('button_removefilter', 'alpha')
 		|| GETPOST('button_search_x', 'alpha') || GETPOST('button_search.x', 'alpha') || GETPOST('button_search', 'alpha')) {
 		$massaction = ''; // Protection to avoid mass action if we force a new search during a mass action confirmation
+		if ($action == 'confirm_reverse') {
+			$action = 'list'; // Protection to avoid the reverse if we force a new search during the reverse confirmation
+		}
 	}
 
 	// Mass actions
@@ -616,7 +619,7 @@ if ($action == "transfert_stock" && $permissiontoadd && !$cancel) {
 }
 
 // reverse movement of stock
-if ($action == 'confirm_reverse' && $confirm == "yes" && $permissiontoadd) {
+if (!$error && $action == 'confirm_reverse' && $confirm == "yes" && $permissiontoadd) {
 	$toselect = array_map('intval', $toselect);
 
 	$db->begin();
@@ -1146,7 +1149,7 @@ $modelmail = "movementstock";
 $objecttmp = new MouvementStock($db);
 $trackid = 'mov'.$warehouse->id;
 include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
-if ($massaction == 'prereverse') {
+if ($massaction == 'prereverse' && count($toselect) <= getDolGlobalInt('MAIN_LIMIT_FOR_MASS_ACTIONS', 1000)) {
 	print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans("ConfirmMassReverse"), $langs->trans("ConfirmMassReverseQuestion", count($toselect)), "confirm_reverse", null, '', 0, 200, 500, 1, 'Yes');
 }
 


### PR DESCRIPTION
On the stock movements list, the mass action "Reverse" (added in 19.0 by #26623) is not protected by the mass action limit `MAIN_LIMIT_FOR_MASS_ACTIONS` (default 1000): the `TooManyRecordForMassAction` error is displayed, but the confirmation form is still rendered and confirming it executes the reverse on all selected records anyway. The generic limit control in `actions_massactions.inc.php` only raises `$error`, which the `confirm_reverse` handler never checks. Relaunching a search while the confirmation is open also triggers the reverse: the existing protection only resets `$massaction`, while the reverse is keyed on `$action`, posted as a hidden field embedded in the list form.

Fix, all in `product/stock/movement_list.php`:
- skip the `confirm_reverse` handler when `$error` was raised, like the generic mass action handlers;
- reset `$action` when a search button is submitted while a reverse confirmation is pending;
- do not render the confirmation form when the selection exceeds the limit.

Affected: 19.0 up to develop (not present in 18.0). Tested on 23.0.2: over-limit reverse and search-relaunch are blocked, legit reverse below the limit still works.

Same fix forward-ported to 23.0: #39092