### PR TITLE
NEW Multiselect and "Not defined" search filters for payment terms, payment modes and sellist extrafields on lists

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -153,9 +153,9 @@ $search_project_ref = GETPOST('search_project_ref', 'alpha');
 $search_project = GETPOST('search_project', 'alpha');
 $search_shippable = GETPOST('search_shippable', 'aZ09');
 
-$search_fk_cond_reglement = GETPOST('search_fk_cond_reglement', 'intcomma');
+$search_fk_cond_reglement = GETPOST('search_fk_cond_reglement', 'array:intcomma');	// Array from the multiselect combo. A scalar value (old links, saved filters) is exploded into an array by GETPOST.
 $search_fk_shipping_method = GETPOST('search_fk_shipping_method', 'intcomma');
-$search_fk_mode_reglement = GETPOST('search_fk_mode_reglement', 'intcomma');
+$search_fk_mode_reglement = GETPOST('search_fk_mode_reglement', 'array:intcomma');	// Array from the multiselect combo. A scalar value (old links, saved filters) is exploded into an array by GETPOST.
 $search_fk_input_reason = GETPOST('search_fk_input_reason', 'intcomma');
 
 $search_option = GETPOST('search_option', 'alpha');
@@ -385,9 +385,9 @@ if (empty($reshook)) {
 		$search_billed = '';
 		$search_datecloture_start = '';
 		$search_datecloture_end = '';
-		$search_fk_cond_reglement = '';
+		$search_fk_cond_reglement = [];
 		$search_fk_shipping_method = '';
-		$search_fk_mode_reglement = '';
+		$search_fk_mode_reglement = [];
 		$search_fk_input_reason = '';
 		$search_option = '';
 		$search_import_key = '';
@@ -1169,15 +1169,11 @@ if ($search_project_ref != '') {
 if ($search_project != '') {
 	$sql .= natural_search("p.title", $search_project);
 }
-if ($search_fk_cond_reglement > 0) {
-	$sql .= " AND c.fk_cond_reglement = ".((int) $search_fk_cond_reglement);
-}
+$sql .= natural_search_multiselect("c.fk_cond_reglement", $search_fk_cond_reglement);
 if ($search_fk_shipping_method > 0) {
 	$sql .= " AND c.fk_shipping_method = ".((int) $search_fk_shipping_method);
 }
-if ($search_fk_mode_reglement > 0) {
-	$sql .= " AND c.fk_mode_reglement = ".((int) $search_fk_mode_reglement);
-}
+$sql .= natural_search_multiselect("c.fk_mode_reglement", $search_fk_mode_reglement);
 if ($search_fk_input_reason > 0) {
 	$sql .= " AND c.fk_input_reason = ".((int) $search_fk_input_reason);
 }
@@ -1562,14 +1558,18 @@ if (($search_categ_cus > 0) || ($search_categ_cus == -2)) {
 if ($search_billed != '') {
 	$param .= '&search_billed='.urlencode($search_billed);
 }
-if ($search_fk_cond_reglement > 0) {
-	$param .= '&search_fk_cond_reglement='.urlencode((string) ($search_fk_cond_reglement));
+if (count($search_fk_cond_reglement) > 0) {
+	foreach ($search_fk_cond_reglement as $val) {
+		$param .= '&search_fk_cond_reglement[]='.urlencode((string) $val);
+	}
 }
 if ($search_fk_shipping_method > 0) {
 	$param .= '&search_fk_shipping_method='.urlencode((string) ($search_fk_shipping_method));
 }
-if ($search_fk_mode_reglement > 0) {
-	$param .= '&search_fk_mode_reglement='.urlencode((string) ($search_fk_mode_reglement));
+if (count($search_fk_mode_reglement) > 0) {
+	foreach ($search_fk_mode_reglement as $val) {
+		$param .= '&search_fk_mode_reglement[]='.urlencode((string) $val);
+	}
 }
 if ($search_fk_input_reason > 0) {
 	$param .= '&search_fk_input_reason='.urlencode((string) ($search_fk_input_reason));
@@ -1925,13 +1925,13 @@ if (!empty($arrayfields['c.fk_shipping_method']['checked'])) {
 // Payment term
 if (!empty($arrayfields['c.fk_cond_reglement']['checked'])) {
 	print '<td class="liste_titre">';
-	print $form->getSelectConditionsPaiements((int) $search_fk_cond_reglement, 'search_fk_cond_reglement', 1, 1, 1);
+	print $form->multiSelectConditionsPaiements($search_fk_cond_reglement, 'search_fk_cond_reglement', 1, 1, 'minwidth100 maxwidth100');
 	print '</td>';
 }
 // Payment mode
 if (!empty($arrayfields['c.fk_mode_reglement']['checked'])) {
 	print '<td class="liste_titre">';
-	print $form->select_types_paiements($search_fk_mode_reglement, 'search_fk_mode_reglement', '', 0, 1, 1, 0, -1, '', 1);
+	print $form->multiSelectTypesPaiements($search_fk_mode_reglement, 'search_fk_mode_reglement', '', 1, 'minwidth100 maxwidth100', -1);
 	print '</td>';
 }
 // Channel

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -133,8 +133,8 @@ $search_status = GETPOST('search_status', 'array:intcomma');
 // } elseif (is_array($search_status) && count($search_status) == 0) {
 // 	$search_status = '';
 // }
-$search_paymentmode = GETPOST('search_paymentmode', 'intcomma');
-$search_paymentterms = GETPOST('search_paymentterms', 'intcomma');
+$search_paymentmode = GETPOST('search_paymentmode', 'array:intcomma');	// Array from the multiselect combo. A scalar value (old links, saved filters) is exploded into an array by GETPOST.
+$search_paymentterms = GETPOST('search_paymentterms', 'array:intcomma');	// Array from the multiselect combo. A scalar value (old links, saved filters) is exploded into an array by GETPOST.
 $search_bankaccount = GETPOST('search_bankaccount', 'intcomma');
 $search_fk_input_reason = GETPOSTINT('search_fk_input_reason');
 $search_module_source = GETPOST('search_module_source', 'alpha');
@@ -445,8 +445,8 @@ if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter', 
 	$search_multicurrency_montant_ttc = '';
 	$search_dispute_status = '';
 	$search_status = [];
-	$search_paymentmode = '';
-	$search_paymentterms = '';
+	$search_paymentmode = [];
+	$search_paymentterms = [];
 	$search_bankaccount = '';
 	$search_fk_input_reason = '';
 	$search_module_source = '';
@@ -980,12 +980,8 @@ if (is_array($search_status) && count($search_status) > 0) {
 	$sql .= " AND f.fk_statut IN (" . $db->sanitize(implode(',', array_map('intval', $search_statusArray))) . ")";
 }
 
-if ($search_paymentmode > 0) {
-	$sql .= " AND f.fk_mode_reglement = ".((int) $search_paymentmode);
-}
-if ($search_paymentterms > 0) {
-	$sql .= " AND f.fk_cond_reglement = ".((int) $search_paymentterms);
-}
+$sql .= natural_search_multiselect("f.fk_mode_reglement", $search_paymentmode);
+$sql .= natural_search_multiselect("f.fk_cond_reglement", $search_paymentterms);
 if ($search_bankaccount > 0) {
 	$sql .= " AND ba.rowid = ".((int) $search_bankaccount);
 }
@@ -1428,11 +1424,15 @@ if (count($search_status) > 0) {
 		$param .= '&search_status[]='.urlencode($val);
 	}
 }
-if ($search_paymentmode > 0) {
-	$param .= '&search_paymentmode='.urlencode((string) ($search_paymentmode));
+if (count($search_paymentmode) > 0) {
+	foreach ($search_paymentmode as $val) {
+		$param .= '&search_paymentmode[]='.urlencode((string) $val);
+	}
 }
-if ($search_paymentterms > 0) {
-	$param .= '&search_paymentterms='.urlencode((string) ($search_paymentterms));
+if (count($search_paymentterms) > 0) {
+	foreach ($search_paymentterms as $val) {
+		$param .= '&search_paymentterms[]='.urlencode((string) $val);
+	}
 }
 if ($search_bankaccount > 0) {
 	$param .= '&search_bankaccount='.urlencode((string) ($search_bankaccount));
@@ -1548,13 +1548,15 @@ $trackid = 'inv'.$object->id;
 include DOL_DOCUMENT_ROOT.'/core/tpl/massactions_pre.tpl.php';
 
 if ($massaction == 'makepayment') {
+	// Preselect the payment mode of the confirm dialog from the list filter, only when a single payment mode is selected in the multiselect
+	$paiementidpreselected = (count($search_paymentmode) == 1 && (int) reset($search_paymentmode) > 0) ? (string) reset($search_paymentmode) : '';
 	$formconfirm = '';
 	$formquestion = array(
 		// 'text' => $langs->trans("ConfirmClone"),
 		// array('type' => 'checkbox', 'name' => 'clone_content', 'label' => $langs->trans("CloneMainAttributes"), 'value' => 1),
 		// array('type' => 'checkbox', 'name' => 'update_prices', 'label' => $langs->trans("PuttingPricesUpToDate"), 'value' => 1),
 		array('type' => 'date', 'name' => 'datepaiment', 'label' => $langs->trans("Date"), 'datenow' => 1),
-		array('type' => 'other', 'name' => 'paiementid', 'label' => $langs->trans("PaymentMode"), 'value' => $form->select_types_paiements(GETPOST('search_paymentmode'), 'paiementid', '', 0, 0, 1, 0, 1, '', 1)),
+		array('type' => 'other', 'name' => 'paiementid', 'label' => $langs->trans("PaymentMode"), 'value' => $form->select_types_paiements($paiementidpreselected, 'paiementid', '', 0, 0, 1, 0, 1, '', 1)),
 		array('type' => 'other', 'name' => 'bankid', 'label' => $langs->trans("BankAccount"), 'value' => $form->select_comptes('', 'bankid', 0, '', 0, '', 0, '', 1)),
 		array('type' => 'other', 'name' => 'note_private', 'label' => $langs->trans("Comments"), 'value' => '<textarea name="note_private" id="note_private" class="minwidth200" rows="3"></textarea>'),
 		//array('type' => 'other', 'name' => 'invoicesid', 'label' => '', 'value'=>'<input type="hidden" id="invoicesid" name="invoicesid" value="'.implode('#',GETPOST('toselect','array')).'">'),
@@ -1777,13 +1779,13 @@ if (!empty($arrayfields['typent.code']['checked'])) {
 // Payment mode
 if (!empty($arrayfields['f.fk_mode_reglement']['checked'])) {
 	print '<td class="liste_titre">';
-	print $form->select_types_paiements($search_paymentmode, 'search_paymentmode', '', 0, 1, 1, 0, 1, 'minwidth100 maxwidth100', 1);
+	print $form->multiSelectTypesPaiements($search_paymentmode, 'search_paymentmode', '', 1, 'minwidth100 maxwidth100');
 	print '</td>';
 }
 // Payment terms
 if (!empty($arrayfields['f.fk_cond_reglement']['checked'])) {
 	print '<td class="liste_titre left">';
-	print $form->getSelectConditionsPaiements((int) $search_paymentterms, 'search_paymentterms', -1, 1, 1, 'minwidth100 maxwidth100');
+	print $form->multiSelectConditionsPaiements($search_paymentterms, 'search_paymentterms', -1, 1, 'minwidth100 maxwidth100');
 	print '</td>';
 }
 // Bank account

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1485,6 +1485,15 @@ class ExtraFields
 			}
 		} elseif ($type == 'sellist') {		// List of values selected from a table (1 choice)
 			$out = '';
+			// Into search filters of list pages, render the combo as a multiselect to allow searching on several values
+			// at once, with an extra "Not defined" entry (special value -2). SQL criteria is forged into
+			// extrafields_list_search_sql.tpl.php. Restricted to the 'search_' prefix so other $mode == 1 callers
+			// (like advtargetemailing.php) that expect a scalar value keep the single select, and excluded when the
+			// ajax select2 mode is on (rendering not compatible).
+			$multiselectdata = null;
+			if ($mode == 1 && strpos($keyprefix, 'search_') === 0 && getDolGlobalString('MAIN_EXTRAFIELDS_USE_MULTISELECT_IN_FILTERS') && !getDolGlobalString('MAIN_EXTRAFIELDS_ENABLE_NEW_SELECT2')) {
+				$multiselectdata = array(-2 => '- '.$langs->trans("NotDefined").' -');
+			}
 			if (!empty($conf->use_javascript_ajax)) {
 				if (getDolGlobalString('MAIN_EXTRAFIELDS_ENABLE_NEW_SELECT2')) {
 					// generate an ajax select2 infinite list
@@ -1515,14 +1524,16 @@ class ExtraFields
 					$out .= '<select class="flat '.$morecss.' maxwidthonsmartphone" name="'.$keyprefix.$key.$keysuffix.'" id="'.$keyprefix.$key.$keysuffix.'" '.($moreparam ? $moreparam : '').'>';
 					$out .= '	<option value="'.$value.'" selected>'.$this->showOutputField($key, $value, $moreparam, $extrafieldsobjectkey).'</option>';
 					$out .= '</select>';
-				} elseif (!getDolGlobalString('MAIN_EXTRAFIELDS_DISABLE_SELECT2')) {
+				} elseif ($multiselectdata === null && !getDolGlobalString('MAIN_EXTRAFIELDS_DISABLE_SELECT2')) {
 					include_once DOL_DOCUMENT_ROOT.'/core/lib/ajax.lib.php';
 					$out .= ajax_combobox($keyprefix.$key.$keysuffix, array(), 0);
 				}
 			}
 			if (!getDolGlobalString('MAIN_EXTRAFIELDS_ENABLE_NEW_SELECT2')) {
 				//$out .= '<!-- type = sellist -->';
-				$out .= '<select class="flat '.$morecss.' maxwidthonsmartphone" name="'.$keyprefix.$key.$keysuffix.'" id="'.$keyprefix.$key.$keysuffix.'" '.($moreparam ? $moreparam : '').'>';
+				if ($multiselectdata === null) {
+					$out .= '<select class="flat '.$morecss.' maxwidthonsmartphone" name="'.$keyprefix.$key.$keysuffix.'" id="'.$keyprefix.$key.$keysuffix.'" '.($moreparam ? $moreparam : '').'>';
+				}
 				if (is_array($param['options'])) {
 					// WARNING!! @FIXME This code is duplicated into core/class/extrafields.class.php
 
@@ -1707,7 +1718,9 @@ class ExtraFields
 						dol_syslog(get_class($this).'::showInputField type=sellist', LOG_DEBUG);
 						$resql = $this->db->query($sql);
 						if ($resql) {
-							$out .= '<option value="0">&nbsp;</option>';
+							if ($multiselectdata === null) {
+								$out .= '<option value="0">&nbsp;</option>';
+							}
 							$num = $this->db->num_rows($resql);
 							$i = 0;
 							while ($i < $num) {
@@ -1733,7 +1746,7 @@ class ExtraFields
 									$labeltoshow = $obj->$nameFields;
 								}
 
-								if ($value == $obj->rowid) {
+								if ($multiselectdata === null && $value == $obj->rowid) {
 									if (!$notrans) {
 										foreach ($fields_label as $field_toshow) {
 											$translabel = $langs->trans($obj->$field_toshow);
@@ -1756,10 +1769,14 @@ class ExtraFields
 										$parent = $parentName.':'.$obj->{$parentField};
 									}
 
-									$out .= '<option value="'.$obj->rowid.'"';
-									$out .= ($value == $obj->rowid ? ' selected' : '');
-									$out .= (!empty($parent) ? ' parent="'.$parent.'"' : '');
-									$out .= '>'.$labeltoshow.'</option>';
+									if ($multiselectdata !== null) {
+										$multiselectdata[$obj->rowid] = $labeltoshow;
+									} else {
+										$out .= '<option value="'.$obj->rowid.'"';
+										$out .= ($value == $obj->rowid ? ' selected' : '');
+										$out .= (!empty($parent) ? ' parent="'.$parent.'"' : '');
+										$out .= '>'.$labeltoshow.'</option>';
+									}
 								}
 
 								$i++;
@@ -1778,17 +1795,28 @@ class ExtraFields
 						}
 
 						$data = $form->select_all_categories($categcode, '', 'parent', 64, $InfoFieldList[6], 1, 1);
-						$out .= '<option value="0">&nbsp;</option>';
+						if ($multiselectdata === null) {
+							$out .= '<option value="0">&nbsp;</option>';
+						}
 						if (is_array($data)) {
 							foreach ($data as $data_key => $data_value) {
-								$out .= '<option value="'.$data_key.'"';
-								$out .= ($value == $data_key ? ' selected' : '');
-								$out .= '>'.$data_value.'</option>';
+								if ($multiselectdata !== null) {
+									$multiselectdata[$data_key] = $data_value;
+								} else {
+									$out .= '<option value="'.$data_key.'"';
+									$out .= ($value == $data_key ? ' selected' : '');
+									$out .= '>'.$data_value.'</option>';
+								}
 							}
 						}
 					}
 				}
-				$out .= '</select>';
+				if ($multiselectdata !== null) {
+					$value_arr = is_array($value) ? $value : ((string) $value !== '' ? explode(',', (string) $value) : array());
+					$out = $form->multiselectarray($keyprefix.$key.$keysuffix, $multiselectdata, $value_arr, 0, 0, '', 0, '100%');
+				} else {
+					$out .= '</select>';
+				}
 			}
 		} elseif ($type == 'checkbox') {
 			$value_arr = $value;
@@ -2031,6 +2059,7 @@ class ExtraFields
 
 						$sql .= $sqlwhere;
 						$sql .= ' ORDER BY '.implode(', ', $fields_label);
+						$sql .= ' LIMIT '.getDolGlobalInt('MAIN_EXTRAFIELDS_LIMIT_SELLIST_SQL', 1000);
 
 						dol_syslog(get_class($this).'::showInputField type=chkbxlst', LOG_DEBUG);
 
@@ -2097,6 +2126,10 @@ class ExtraFields
 							}
 							$this->db->free($resql);
 
+							if ($mode == 1 && strpos($keyprefix, 'search_') === 0 && getDolGlobalString('MAIN_EXTRAFIELDS_USE_MULTISELECT_IN_FILTERS')) {
+								// Add a "Not defined" entry (special value -2) to allow the search of records with no value set
+								$data = array(-2 => '- '.$langs->trans("NotDefined").' -') + $data;
+							}
 							$out = $form->multiselectarray($keyprefix.$key.$keysuffix, $data, $value_arr, 0, 0, '', 0, '100%');
 						} else {
 							print 'Error in request '.$sql.' '.$this->db->lasterror().'. Check setup of extra parameters.<br>';
@@ -2111,6 +2144,10 @@ class ExtraFields
 						}
 
 						$data = $form->select_all_categories($categcode, '', 'parent', 64, $InfoFieldList[6], 1, 1);
+						if ($mode == 1 && strpos($keyprefix, 'search_') === 0 && getDolGlobalString('MAIN_EXTRAFIELDS_USE_MULTISELECT_IN_FILTERS')) {
+							// Add a "Not defined" entry (special value -2) to allow the search of records with no value set
+							$data = array(-2 => '- '.$langs->trans("NotDefined").' -') + $data;
+						}
 						$out = $form->multiselectarray($keyprefix.$key.$keysuffix, $data, $value_arr, 0, 0, '', 0, '100%');
 					}
 				}
@@ -3167,12 +3204,20 @@ class ExtraFields
 					} else {
 						continue; // Value was not provided, we should not set it.
 					}
-				} elseif ($key_type == 'select') {
-					// to detect if we are in search context
+				} elseif ($key_type == 'select' || ($key_type == 'sellist' && GETPOSTISARRAY($keyprefix."options_".$key.$keysuffix))) {
+					// sellist is an array when used into a search filter rendered as a multiselect (option MAIN_EXTRAFIELDS_USE_MULTISELECT_IN_FILTERS),
+					// otherwise it is a scalar and is handled by the default case below
 					if (GETPOSTISARRAY($keyprefix."options_".$key.$keysuffix)) {
 						$value_arr = GETPOST($keyprefix."options_".$key.$keysuffix, 'array:aZ09');
 						// Make sure we get an array even if there's only one selected
 						$value_arr = (array) $value_arr;
+						// Remove non-scalar entries (forged requests) and values emptied by the sanitizer
+						// so the imploded criteria has no empty part (would forge a broken SQL filter)
+						foreach ($value_arr as $value_arr_key => $value_arr_val) {
+							if (!is_scalar($value_arr_val) || (string) $value_arr_val === '') {
+								unset($value_arr[$value_arr_key]);
+							}
+						}
 						$value_key = implode(',', $value_arr);
 					} else {
 						$value_key = GETPOST($keyprefix."options_".$key.$keysuffix);

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5484,6 +5484,44 @@ class Form
 		return $out;
 	}
 
+	/**
+	 * Return a multiselect combo of payment terms, to use into search filters of list pages.
+	 * With $addnotdefined, an entry with the special value -2 is added to allow the search of records with no payment term defined.
+	 * The SQL criteria can then be forged with natural_search_multiselect().
+	 *
+	 * @param 	int[]|string[]	$selected 		Array of ids of payment terms preselected (-2 for "not defined")
+	 * @param 	string 			$htmlname 		Name of the multiselect zone
+	 * @param 	int 			$filtertype 	If > 0, include payment terms with deposit percentage (for objects other than invoices and invoice templates)
+	 * @param 	int<0,1> 		$addnotdefined 	1=Add an entry "Not defined" with the special value -2 (to search records with no value set)
+	 * @param 	string 			$morecss 		Add more CSS on select tag
+	 * @return	string							String for the HTML multiselect component
+	 * @see getSelectConditionsPaiements(), multiselectarray(), natural_search_multiselect()
+	 */
+	public function multiSelectConditionsPaiements($selected = array(), $htmlname = 'search_paymentterms', $filtertype = -1, $addnotdefined = 0, $morecss = '')
+	{
+		global $langs;
+
+		$this->load_cache_conditions_paiements();
+
+		$arrayofpaymentterms = array();
+		if ($addnotdefined) {
+			$arrayofpaymentterms[-2] = '- '.$langs->trans("NotDefined").' -';
+		}
+		foreach ($this->cache_conditions_paiements as $id => $arrayconditions) {
+			if ($filtertype <= 0 && !empty($arrayconditions['deposit_percent'])) {
+				continue;
+			}
+
+			$label = $arrayconditions['label'];
+			if (!empty($arrayconditions['deposit_percent'])) {
+				$label = str_replace('__DEPOSIT_PERCENT__', (string) $arrayconditions['deposit_percent'], $label);
+			}
+			$arrayofpaymentterms[$id] = $label;
+		}
+
+		return $this->multiselectarray($htmlname, $arrayofpaymentterms, $selected, 0, 0, $morecss);
+	}
+
 
 	/**
 	 * Returns select with rule for lines dates
@@ -5633,6 +5671,61 @@ class Form
 		} else {
 			return $out;
 		}
+	}
+
+	/**
+	 * Return a multiselect combo of payment modes, to use into search filters of list pages.
+	 * With $addnotdefined, an entry with the special value -2 is added to allow the search of records with no payment mode defined.
+	 * The SQL criteria can then be forged with natural_search_multiselect().
+	 *
+	 * @param 	int[]|string[]	$selected 		Array of ids of payment modes preselected (-2 for "not defined")
+	 * @param 	string 			$htmlname 		Name of the multiselect zone
+	 * @param 	string 			$filtertype 	To filter on field type in llx_c_paiement ('CRDT' or 'DBIT' or a list of ids 'id1,id2,...')
+	 * @param 	int<0,1> 		$addnotdefined 	1=Add an entry "Not defined" with the special value -2 (to search records with no value set)
+	 * @param 	string 			$morecss 		Add more CSS on select tag
+	 * @param 	int 			$active 		Keep only active (1) or inactive (0) payment modes, -1 = all
+	 * @return	string							String for the HTML multiselect component
+	 * @see select_types_paiements(), multiselectarray(), natural_search_multiselect()
+	 */
+	public function multiSelectTypesPaiements($selected = array(), $htmlname = 'search_paymentmode', $filtertype = '', $addnotdefined = 0, $morecss = '', $active = 1)
+	{
+		global $langs;
+
+		$filterarray = array();
+		if ($filtertype == 'CRDT') {
+			$filterarray = array(0, 2, 3);
+		} elseif ($filtertype == 'DBIT') {
+			$filterarray = array(1, 2, 3);
+		} elseif ($filtertype != '' && $filtertype != '-1') {
+			$filterarray = explode(',', $filtertype);
+		}
+
+		$this->load_cache_types_paiements();
+
+		$arrayofpaymentmodes = array();
+		if ($addnotdefined) {
+			$arrayofpaymentmodes[-2] = '- '.$langs->trans("NotDefined").' -';
+		}
+		foreach ($this->cache_types_paiements as $id => $arraytypes) {
+			// If not good status
+			if ($active >= 0 && $arraytypes['active'] != $active) {
+				continue;
+			}
+
+			// We skip of the user requested to filter on specific payment modes
+			if (count($filterarray) && !in_array($arraytypes['type'], $filterarray)) {
+				continue;
+			}
+
+			// We discard empty lines
+			if (empty($arraytypes['code'])) {
+				continue;
+			}
+
+			$arrayofpaymentmodes[$id] = $arraytypes['label'];
+		}
+
+		return $this->multiselectarray($htmlname, $arrayofpaymentmodes, $selected, 0, 0, $morecss);
 	}
 
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13435,6 +13435,50 @@ function dol_getmypid()
 }
 
 /**
+ * Generate a SQL search string for a criteria coming from a multiselect search filter (array of ids selected into a Form::multiselectarray combo).
+ * The special value -2 means "not defined" and searches records where the field is NULL or 0.
+ * Other accepted values are int ids > 0. Other values ('', '0', '-1', ...) are ignored, so an empty array or an array
+ * with only ignored values returns '' (no filter).
+ *
+ * @param	string				$field		Name of the SQL field to filter on, including SQL alias. Example: "f.fk_mode_reglement"
+ * @param	int[]|string[]		$values		Array of values selected into the search filter (int ids > 0 and/or -2 for "not defined")
+ * @return	string							The statement to append to the SQL query (starting with " AND ("), or '' if there is nothing to filter on
+ * @see natural_search(), Form::multiselectarray()
+ */
+function natural_search_multiselect($field, $values)
+{
+	global $db;
+
+	if (!is_array($values) || !count($values)) {
+		return '';
+	}
+
+	$ids = array();
+	$searchnotdefined = false;
+	foreach ($values as $value) {
+		if ((int) $value == -2) {	// -2 is the special value to search records with the field not defined
+			$searchnotdefined = true;
+		} elseif ((int) $value > 0) {
+			$ids[] = (int) $value;
+		}
+	}
+
+	$sqlfilters = array();
+	if (count($ids)) {
+		$sqlfilters[] = natural_search($field, implode(',', $ids), 2, 1);	// Returns "(field IN (id1,id2,...))"
+	}
+	if ($searchnotdefined) {
+		$sqlfilters[] = "(".$field." IS NULL OR ".$field." = 0)";
+	}
+
+	if (!count($sqlfilters)) {
+		return '';
+	}
+
+	return " AND (".implode(" OR ", $sqlfilters).")";
+}
+
+/**
  * Generate natural SQL search string for a criteria (this criteria can be tested on one or several fields)
  *
  * @param   string|string[]	$fields 	String or array of strings, filled with the name of all fields in the SQL query we must check (combined with a OR). Example: array("p.field1","p.field2")

--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -60,6 +60,11 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 		$tmpkey = preg_replace('/'.$search_options_pattern.'/', '', $key);
 		$typ = $extrafields->attributes[$extrafieldsobjectkey]['type'][$tmpkey];
 
+		if (is_array($crit) && in_array($typ, array('sellist', 'chkbxlst'))) {
+			// Multiselect filter criteria can be restored as an array (for example from the search session with restore_lastsearch_values)
+			$crit = implode(',', $crit);
+		}
+
 		if ($crit != '' && in_array($typ, array('date', 'datetime', 'timestamp'))) {
 			if (is_numeric($crit)) {
 				if ($typ == 'date') {
@@ -84,6 +89,27 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 				}
 				$morewhere .= ")";
 			}
+		} elseif ($crit != '' && in_array($typ, array('sellist', 'chkbxlst')) && preg_match('/(^|,)-2(,|$)/', $crit)) {
+			// Criteria coming from a multiselect search filter (option MAIN_EXTRAFIELDS_USE_MULTISELECT_IN_FILTERS) with
+			// the special entry -2 = "not defined" selected. We search records with no value set, plus records matching the other selected keys.
+			// An empty sellist/chkbxlst value can be stored as NULL, '' or '0' depending on how the record was saved.
+			$critkeys = array();
+			foreach (explode(',', $crit) as $critvalue) {
+				if ($critvalue !== '' && $critvalue != '0' && $critvalue != '-1' && $critvalue != '-2') {
+					$critkeys[] = $critvalue;
+				}
+			}
+			$morewhere .= " AND (".$extrafieldsobjectprefix.$tmpkey." IS NULL OR ".$extrafieldsobjectprefix.$tmpkey." = '' OR ".$extrafieldsobjectprefix.$tmpkey." = '0'";
+			if (count($critkeys)) {
+				$modeforsearch = 3; // List of string keys
+				if ($typ == 'chkbxlst') {
+					$modeforsearch = 4; // Search inside a comma separated string
+				} elseif (preg_match('/^\d+(,\d+)*$/', implode(',', $critkeys))) {
+					$modeforsearch = 2; // List of int keys
+				}
+				$morewhere .= " OR ".natural_search($extrafieldsobjectprefix.$tmpkey, implode(',', $critkeys), $modeforsearch, 1);
+			}
+			$morewhere .= ")";
 		} elseif ($crit != ''
 			&& (!in_array($typ, array('select', 'sellist', 'select', 'link')) || $crit != '0')
 			&& (!in_array($typ, array('link')) || ($crit != '0' && $crit != '-1'))) {
@@ -96,6 +122,10 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 			}
 			if (in_array($typ, array('sellist')) && !is_numeric($crit)) {
 				$mode_search = 0;// Search on a foreign key string
+				if (preg_match('/,/', $crit)) {
+					// List of keys coming from a multiselect search filter (not gated on the option so saved criteria keep working if the option is disabled later)
+					$mode_search = preg_match('/^\d+(,\d+)+$/', $crit) ? 2 : 3;
+				}
 			}
 			if (in_array($typ, array('chkbxlst', 'checkbox', 'select'))) {
 				$mode_search = 4; // Search on a multiselect field with sql type = text


### PR DESCRIPTION
# NEW Multiselect and "Not defined" search filters for payment terms, payment modes and sellist extrafields on lists

Allows list search filters to match **several values at once** and/or **records with no value set**, following the pattern of the MO status multiselect merged in #37069. The "- Not defined -" entry uses the special value -2 (same convention as "no sales representative" / "not categorized") and the existing `NotDefined` translation key (no new key). An empty selection still means "no filter".

**Payment terms / payment modes on invoice and order lists:**
- New reusable `Form::multiSelectConditionsPaiements()` / `Form::multiSelectTypesPaiements()` (labels from the existing caches, so same translations as the legacy selects, which are untouched) and `natural_search_multiselect()` helper for the `AND (field IN (...) OR field IS NULL OR field = 0)` criteria.
- `GETPOST('...', 'array:intcomma')` keeps old bookmarked URLs with a scalar value working.
- The "make payment" mass action still preselects the payment mode when exactly one is selected.
- Note for external modules reading these search params on the two converted lists: `GETPOST('search_paymentmode', 'intcomma')` now receives an array when the multiselect posts (same as the existing `search_status`); read it with `'array:intcomma'`.

**Sellist/chkbxlst extrafields filters — only when the new hidden option `MAIN_EXTRAFIELDS_USE_MULTISELECT_IN_FILTERS` is set (off by default):**
- `sellist` search filters are rendered as multiselect, inside the existing sellist block so the options SQL/filter logic ($MODE$, $SEL$ guard, object tags...) is strictly the same as the single select; both types get the "- Not defined -" entry (matches NULL / '' / '0' stored values).
- Strictly limited to search context (`$mode == 1` + `search_` prefix) so pages building their own SQL from `showInputField()` (e.g. advtargetemailing) are unaffected; ignored with `MAIN_EXTRAFIELDS_ENABLE_NEW_SELECT2`.
- The SQL interpretation (multi-values, -2) is driven by the submitted value, not by the option, so saved filters keep working if the option is disabled later. Also fixes array criteria restored from session (previously generated a wrong `LIKE` clause) and adds the missing `MAIN_EXTRAFIELDS_LIMIT_SELLIST_SQL` LIMIT to the chkbxlst options query.

## Screenshots

Payment mode filter on invoice list (several values + "Not defined"):

![invoice payment mode multiselect](https://raw.githubusercontent.com/nikube/dolibarr/assets-multiselect-filters/shot1_invoices_paymentmode.png)

Sellist extrafield filter with `MAIN_EXTRAFIELDS_USE_MULTISELECT_IN_FILTERS` on:

![sellist extrafield multiselect](https://raw.githubusercontent.com/nikube/dolibarr/assets-multiselect-filters/shot2_invoices_extrafield.png)

"Not defined" payment terms on order list:

![orders not defined payment terms](https://raw.githubusercontent.com/nikube/dolibarr/assets-multiselect-filters/shot3_orders_notdefined.png)

