### PR TITLE
FIX #39059 Save member extrafields from subscriptions tab

### DIFF
--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -123,6 +123,11 @@ if ($id > 0 || !empty($ref)) {
 
 // Define variables to determine what the current user can do on the members
 $permissiontoaddmember = $user->hasRight('adherent', 'creer');
+$permissiontoeditextra = $permissiontoaddmember;
+if (GETPOST('attribute', 'aZ09') && isset($extrafields->attributes[$object->table_element]['perms'][GETPOST('attribute', 'aZ09')])) {
+	// For action 'update_extras', is there a specific permission set for the attribute to update
+	$permissiontoeditextra = dol_eval((string) $extrafields->attributes[$object->table_element]['perms'][GETPOST('attribute', 'aZ09')]);
+}
 
 // Security check
 $result = restrictedArea($user, 'adherent', $object->id, '', '', 'socid', 'rowid', 0);
@@ -136,6 +141,28 @@ $parameters = array();
 $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action);
 if ($reshook < 0) {
 	setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+}
+
+if (empty($reshook) && $action == 'update_extras' && $permissiontoeditextra) {
+	$error = 0;
+	$object->oldcopy = dol_clone($object, 2);  // @phan-suppress-current-line PhanTypeMismatchProperty
+	$attribute_name = GETPOST('attribute', 'aZ09');
+
+	// Fill array 'array_options' with data from update form
+	$ret = $extrafields->setOptionalsFromPost(null, $object, $attribute_name);
+	if ($ret < 0) {
+		$error++;
+	}
+	if (!$error) {
+		$result = $object->updateExtraField($attribute_name, 'MEMBER_MODIFY');
+		if ($result < 0) {
+			setEventMessages($object->error, $object->errors, 'errors');
+			$error++;
+		}
+	}
+	if ($error) {
+		$action = 'edit_extras';
+	}
 }
 
 // Create third party from a member


### PR DESCRIPTION
## Summary
- handle `update_extras` from the member subscriptions/contributions page
- reuse the member extrafield permission rule when one is configured for the edited attribute
- keep the inline extrafield editor open if saving fails

FIX #39059

## Tests
- `php -l htdocs/adherents/subscription.php`
- `git diff --check origin/develop..HEAD`