### PR TITLE
FIX import types PHPDoc for Phan

### DIFF
--- a/htdocs/imports/class/import.class.php
+++ b/htdocs/imports/class/import.class.php
@@ -57,7 +57,7 @@ class Import
 	public $array_import_module;
 
 	/**
-	 * @var array<string,string>
+	 * @var array<array<string,string>>
 	 */
 	public $array_import_types;
 


### PR DESCRIPTION
## Summary
- update `Import::$array_import_types` PHPDoc to match the per-dataset array assigned by `load_arrays()`
- fixes the current Phan `PhanTypeMismatchProperty` warning on `develop`

## Tests
- `php -l htdocs/imports/class/import.class.php`
- `git diff --check`