### PR TITLE
FIX #39084 Use service reference label on service creation

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -1,5 +1,6 @@
 # Dolibarr language file - Source file is en_US - products
 ProductRef=Product ref.
+ServiceRef=Service ref.
 ProductLabel=Product label
 ProductLabelTranslated=Translated product label
 ProductDescription=Product description

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -1,5 +1,6 @@
 # Dolibarr language file - Source file is en_US - products
 ProductRef=Réf. produit
+ServiceRef=Réf. service
 ProductLabel=Libellé produit
 ProductLabelTranslated=Libellé produit traduit
 ProductDescription=Description du produit

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -157,6 +157,7 @@ if ($result > 0) {
 
 $object = new Product($db);
 $object->type = $type; // so test later to fill $usercancxxx is correct
+$refLabelKey = ($type == Product::TYPE_SERVICE ? 'ServiceRef' : 'ProductRef');
 
 // fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
@@ -531,7 +532,7 @@ if (empty($reshook)) {
 		}
 		if (empty($ref)) {
 			if (!getDolGlobalString('PRODUCT_GENERATE_REF_AFTER_FORM')) {
-				setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentities('ProductRef')), null, 'errors');
+				setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentities($refLabelKey)), null, 'errors');
 				$action = "create";
 				$error++;
 			}
@@ -1516,7 +1517,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 					/** @var ModeleProductCode $modCodeProduct */
 					$tmpcode = $modCodeProduct->getNextValue($object, $type);
 				}
-				print '<td class="titlefieldcreate fieldrequired">'.$langs->trans("ProductRef").'</td><td><input id="ref" name="ref" class="maxwidth200" maxlength="128" value="'.dol_escape_htmltag(GETPOSTISSET('ref') ? GETPOST('ref', 'alphanohtml') : $tmpcode).'">';
+				print '<td class="titlefieldcreate fieldrequired">'.$langs->trans($refLabelKey).'</td><td><input id="ref" name="ref" class="maxwidth200" maxlength="128" value="'.dol_escape_htmltag(GETPOSTISSET('ref') ? GETPOST('ref', 'alphanohtml') : $tmpcode).'">';
 				if ($refalreadyexists) {
 					print $langs->trans("RefAlreadyExists");
 				}


### PR DESCRIPTION
Fix #39084.

The create-service form was using the product reference translation key for the required reference field, so French displayed the product reference label even when creating a service. This adds a service-specific reference label and uses it for service creation, including the required-field error message.

Tests run:
- php -l htdocs/product/card.php
- git diff --check

CI note:
- pre-commit, fileset lock, phpstan, Travis, and Snyk passed.
- Phan currently fails on the inherited htdocs/imports/class/import.class.php PHPDoc issue already fixed separately in #39096; the Phan changed-file list for this PR is only htdocs/product/card.php.
- phpunit and pre-commit are not available in my local PATH.
