### PR TITLE
Third-party contact form: Add submits with empty required Lastname, generic server error instead of client validation

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -680,7 +680,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 
 			// Name
 			print '<tr><td class="titlefieldcreate fieldrequired"><label for="lastname">'.$langs->trans("Lastname").' / '.$langs->trans("Label").'</label></td>';
-			print '<td colspan="3"><input name="lastname" id="lastname" type="text" class="minwidth200" maxlength="80" value="'.dol_escape_htmltag(GETPOST("lastname", 'alpha') ? GETPOST("lastname", 'alpha') : $object->lastname).'" autofocus="autofocus"></td>';
+			print '<td colspan="3"><input name="lastname" id="lastname" type="text" class="minwidth200" maxlength="80" value="'.dol_escape_htmltag(GETPOST("lastname", 'alpha') ? GETPOST("lastname", 'alpha') : $object->lastname).'" autofocus="autofocus" required="required"></td>';
 			print '</tr>';
 
 			// Firstname
@@ -999,7 +999,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($action)) {
 
 			// Lastname
 			print '<tr><td class="titlefieldcreate fieldrequired"><label for="lastname">'.$langs->trans("Lastname").' / '.$langs->trans("Label").'</label></td>';
-			print '<td colspan="3"><input name="lastname" id="lastname" type="text" class="minwidth200" maxlength="80" value="'.(GETPOSTISSET("lastname") ? GETPOST("lastname") : $object->lastname).'" autofocus="autofocus"></td>';
+			print '<td colspan="3"><input name="lastname" id="lastname" type="text" class="minwidth200" maxlength="80" value="'.(GETPOSTISSET("lastname") ? GETPOST("lastname") : $object->lastname).'" autofocus="autofocus" required="required"></td>';
 			print '</tr>';
 			print '<tr>';
 			// Firstname


### PR DESCRIPTION
Fixes #39099

**Summary:** The "Add" button on the contact/address creation form (reached from a third party's Contacts/addresses tab, and from the standalone contact creation page) could be clicked with the mandatory Lastname field left empty, causing a generic server-side error instead of blocking the submission. The fix adds the standard HTML `required` attribute to the Lastname input so the browser blocks submission and highlights the field with a native "This field is required" message, matching the pattern already used elsewhere in Dolibarr core (e.g. `admin/hrm.php`, `admin/agenda_xcal.php`).
**Files changed:**
- `htdocs/contact/card.php` — added `required="required"` to both Lastname `<input>` elements in the contact/address create form (the third-party "Create contact" flow and the standalone c