### PR TITLE
New project form: Create submits with an empty required Title and shows a generic error instead of validating

### DIFF
--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -722,7 +722,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer')) {
 	print '</td></tr>';
 
 	// Label
-	print '<tr><td><span class="fieldrequired">'.$langs->trans("Label").'</span></td><td><input class="width500 maxwidth150onsmartphone" type="text" name="title" value="'.dol_escape_htmltag(GETPOST("title", 'alphanohtml')).'" autofocus></td></tr>';
+	print '<tr><td><span class="fieldrequired">'.$langs->trans("Label").'</span></td><td><input class="width500 maxwidth150onsmartphone" type="text" name="title" value="'.dol_escape_htmltag(GETPOST("title", 'alphanohtml')).'" autofocus required></td></tr>';
 
 	// Parent
 	if (getDolGlobalInt('PROJECT_ENABLE_SUB_PROJECT')) {


### PR DESCRIPTION
Fixes #39101

**Summary:** The "New project" form allowed clicking Create with the Title/Label field empty, submitting to the server and showing a generic error instead of a clear inline validation message. This adds standard browser-native required-field validation to the Title input, matching the pattern already used on Dolibarr's public project-creation form, so the field is highlighted with a "required" message before the form ever submits.
**Files changed:**
- `htdocs/projet/card.php` — added the `required` HTML attribute to the project Title/Label input on the create form.
- `.sdlc/ui_scenario.json` — QA scenario that submits the create form with an empty title and asserts the browser blocks it (`:invalid` state).

**How to test:** Go to Projects → New project, leave Label empty, click Create — th