### PR TITLE
New Odt generation : create missing temp directory

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -122,6 +122,10 @@ class Odf
 
 		// A working directory is required for some zip proxy like PclZipProxy
 		if (in_array($this->config['ZIP_PROXY'], array('PclZipProxy')) && ! is_dir($this->config['PATH_TO_TMP'])) {
+			$result = mkdir($this->config['PATH_TO_TMP']);
+		}
+		// Check the dir has been created
+		if (in_array($this->config['ZIP_PROXY'], array('PclZipProxy')) && ! is_dir($this->config['PATH_TO_TMP'])) {
 			throw new OdfException('Temporary directory '.$this->config['PATH_TO_TMP'].' must exists');
 		}
 


### PR DESCRIPTION
# Fix : missing directory for ODT generation with PclZipProxy

A working directory is required for some zip proxy like PclZipProxy.

If it does not exist, one should try to create it. This would avoid some errors on a freshly installed Dolibarr.

