### PR TITLE
New warehouse form: Create submits with an empty required Label and shows a generic error instead of validating

### DIFF
--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -333,7 +333,7 @@ if ($action == 'create') {
 	print '<table class="border centpercent">';
 
 	// Ref
-	print '<tr><td class="titlefieldcreate fieldrequired">'.$langs->trans("Ref").'</td><td><input class="width200" name="libelle" value=""></td></tr>';
+	print '<tr><td class="titlefieldcreate fieldrequired">'.$langs->trans("Ref").'</td><td><input class="width200" name="libelle" value="" required></td></tr>';
 
 	print '<tr><td>'.$langs->trans("LocationSummary").'</td><td><input name="lieu" size="40" value="'.(!empty($object->lieu) ? $object->lieu : '').'"></td></tr>';
 
@@ -932,7 +932,7 @@ if ($action == 'create') {
 			print '<table class="border centpercent">';
 
 			// Ref
-			print '<tr><td class="titlefieldcreate fieldrequired">'.$langs->trans("Ref").'</td><td><input name="libelle" size="20" value="'.$object->label.'"></td></tr>';
+			print '<tr><td class="titlefieldcreate fieldrequired">'.$langs->trans("Ref").'</td><td><input name="libelle" size="20" value="'.$object->label.'" required></td></tr>';
 
 			print '<tr><td>'.$langs->trans("LocationSummary").'</td><td><input name="lieu" class="minwidth300" value="'.$object->lieu.'"></td></tr>';
 


### PR DESCRIPTION
Fixes #39107

**Summary:** Creating (or editing) a warehouse previously let users submit the form with an empty Label/Ref field, resulting in a confusing generic server-side error. The Label input now has the standard HTML5 `required` attribute, so the browser blocks submission and highlights the field with a native "This field is required" message before the request ever reaches the server.
**Files changed:**
- `htdocs/product/stock/card.php` — added `required` to the Label (`libelle`) input on both the warehouse create form and the edit form.
- `.sdlc/ui_scenario.json` — QA scenario that loads the create form, clicks Create with an empty Label, and asserts the browser flags the field as invalid.

**How to test:**
1. Go to Stocks > Warehouses > New warehouse.
2. Leave the Label field empty and click Cr