### PR TITLE
Qual: Fix PHPStan always true/false errors breaking develop CI

### DIFF
--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -81,7 +81,7 @@ if ((isset($_GET["modulepart"]) && $_GET["modulepart"] == 'medias')) {
 // be the one of this entity.
 // Do not use GETPOST here, function is not defined and define must be done before including main.inc.php
 $entity = (!empty($_GET['entity']) ? (int) $_GET['entity'] : (!empty($_POST['entity']) ? (int) $_POST['entity'] : 0));
-if (is_numeric($entity) && $entity > 0) {
+if ($entity > 0) {
 	// An entity was forced on param, so we force the constant to allow master.inc.php to use this entity if not already logged.
 	// It has no effect if already logged.
 	define("DOLENTITY", $entity);

--- a/htdocs/salaries/stats/index.php
+++ b/htdocs/salaries/stats/index.php
@@ -104,12 +104,11 @@ $massactionbutton = '';
 $num = -1;
 $nbtotalofrecords = $langs->trans("Statistics");
 $limit = 0;
-$mode = 'statistics';
 
 $newcardbutton  = '';
-$newcardbutton .= dolGetButtonTitle($langs->trans('ViewList'), '', 'fa fa-bars imgforviewmode', DOL_URL_ROOT.'/salaries/list.php?mode=common'.preg_replace('/(&|\?)*mode=[^&]+/', '', $param), '', ($mode == 'common' ? 2 : 1), array('morecss' => 'reposition'));
-$newcardbutton .= dolGetButtonTitle($langs->trans('ViewKanban'), '', 'fa fa-th-list imgforviewmode', DOL_URL_ROOT.'/salaries/list.php?mode=kanban'.preg_replace('/(&|\?)*mode=[^&]+/', '', $param), '', ($mode == 'kanban' ? 2 : 1), array('morecss' => 'reposition'));
-$newcardbutton .= dolGetButtonTitle($langs->trans('Statistics'), '', 'fa fa-chart-bar imgforviewmode', DOL_URL_ROOT.'/salaries/stats/index.php?'.preg_replace('/(&|\?)*(mode|groupby)=[^&]+/', '', $param), '', ($mode == 'statistics' ? 2 : 1), array('morecss' => 'reposition'));
+$newcardbutton .= dolGetButtonTitle($langs->trans('ViewList'), '', 'fa fa-bars imgforviewmode', DOL_URL_ROOT.'/salaries/list.php?mode=common'.preg_replace('/(&|\?)*mode=[^&]+/', '', $param), '', 1, array('morecss' => 'reposition'));
+$newcardbutton .= dolGetButtonTitle($langs->trans('ViewKanban'), '', 'fa fa-th-list imgforviewmode', DOL_URL_ROOT.'/salaries/list.php?mode=kanban'.preg_replace('/(&|\?)*mode=[^&]+/', '', $param), '', 1, array('morecss' => 'reposition'));
+$newcardbutton .= dolGetButtonTitle($langs->trans('Statistics'), '', 'fa fa-chart-bar imgforviewmode', DOL_URL_ROOT.'/salaries/stats/index.php?'.preg_replace('/(&|\?)*(mode|groupby)=[^&]+/', '', $param), '', 2, array('morecss' => 'reposition'));
 $newcardbutton .= dolGetButtonTitleSeparator();
 $newcardbutton .= dolGetButtonTitle($langs->trans('NewSalary'), '', 'fa fa-plus-circle', $url, '', $permissiontoadd);
 

--- a/htdocs/theme/md/style.css.php
+++ b/htdocs/theme/md/style.css.php
@@ -360,7 +360,7 @@ $colortext = implode(',', colorStringToArray($colortext));
 $colortextlink = implode(',', colorStringToArray($colortextlink));
 
 // @phan-suppress-next-line PhanRedefinedClassReference
-$nbtopmenuentries = (is_object($menumanager) && method_exists($menumanager, 'showmenu')) ? $menumanager->showmenu('topnb') : 0;
+$nbtopmenuentries = is_object($menumanager) ? $menumanager->showmenu('topnb') : 0;
 $nbtopmenuentriesreal = $nbtopmenuentries;
 if ($conf->browser->layout == 'phone') {
 	$nbtopmenuentries = max($nbtopmenuentries, 10);


### PR DESCRIPTION
## What / Why

The full PHPStan analysis that runs on push to `develop` (and `*.0` branches) is currently red. The per-PR diff analysis only checks changed files, so these errors slipped through, and the daily baseline refresh has not masked them yet.

Failing run: https://github.com/Dolibarr/dolibarr/actions/runs/29105223719

## Errors fixed (all "always true/false")

- `htdocs/document.php`: `is_numeric($entity)` is always true because `$entity` is int-cast on the line above → removed the redundant check.
- `htdocs/salaries/stats/index.php`: `$mode` is hardcoded to `'statistics'`, so the three view-switch button comparisons are constant → replaced with their literal results (`1`/`1`/`2`) and removed the unused `$mode`.
- `htdocs/theme/md/style.css.php`: `method_exists($menumanager, 'showmenu')` is always true since `$menumanager` is a `MenuManager` → removed the redundant check.

Behaviour is unchanged; the generated HTML / logic is identical.