### PR TITLE
FIX: undefined variables from wrong variable names

### DIFF
--- a/htdocs/loan/payment/card.php
+++ b/htdocs/loan/payment/card.php
@@ -242,7 +242,7 @@ if (empty($action) && $user->hasRight('loan', 'delete')) {
 	if (!$disable_delete) {
 		print dolGetButtonAction($langs->trans("Delete"), '', 'delete', $_SERVER["PHP_SELF"].'?id='.$id.'&action=delete&token='.newToken(), 'delete', 1);
 	} else {
-		print dolGetButtonAction($langs->trans("CantRemovePaymentWithOneInvoicePaid"), $langs->trans("Delete"), 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&token='.newToken(), 'delete', 0);
+		print dolGetButtonAction($langs->trans("CantRemovePaymentWithOneInvoicePaid"), $langs->trans("Delete"), 'delete', $_SERVER["PHP_SELF"].'?id='.$id.'&action=delete&token='.newToken(), 'delete', 0);
 	}
 }
 

--- a/htdocs/opensurvey/card.php
+++ b/htdocs/opensurvey/card.php
@@ -404,7 +404,7 @@ if ($action != 'edit' && $user->hasRight('opensurvey', 'write')) {
 print '</div>';
 
 if ($action == 'delete') {
-	print $form->formconfirm($_SERVER["PHP_SELF"].'?&id='.urlencode($numsondage), $langs->trans("RemovePoll"), $langs->trans("ConfirmRemovalOfPoll", $id), 'delete_confirm', '', '', 1);
+	print $form->formconfirm($_SERVER["PHP_SELF"].'?&id='.urlencode($numsondage), $langs->trans("RemovePoll"), $langs->trans("ConfirmRemovalOfPoll", $numsondage), 'delete_confirm', '', '', 1);
 }
 
 

--- a/htdocs/opensurvey/results.php
+++ b/htdocs/opensurvey/results.php
@@ -528,7 +528,7 @@ print '<table class="border tableforfield centpercent">';
 // Expire date
 print '<tr><td>'.$langs->trans('ExpireDate').'</td><td>';
 if ($action == 'edit') {
-	print $form->selectDate($expiredate ? $expiredate : $object->date_fin, 'expire', 0, 0, 0, '', 1, 0);
+	print $form->selectDate(!empty($expiredate) ? $expiredate : $object->date_fin, 'expire', 0, 0, 0, '', 1, 0);
 } else {
 	print dol_print_date($object->date_fin, 'day');
 	if ($object->date_fin && $object->date_fin < dol_now() && $object->status == Opensurveysondage::STATUS_VALIDATED) {

--- a/htdocs/projet/card.php
+++ b/htdocs/projet/card.php
@@ -1808,7 +1808,7 @@ if ($action == 'create' && $user->hasRight('projet', 'creer')) {
 				print '</td></tr></table>';
 
 				print '<div class="div-table-responsive-no-min">';
-				print '<table class="centpercent noborder'.($morecss ? ' '.$morecss : '').'">';
+				print '<table class="centpercent noborder'.(!empty($morecss) ? ' '.$morecss : '').'">';
 				print '<tr class="liste_titre">';
 				print getTitleFieldOfList('Ref', 0, $_SERVER["PHP_SELF"], '', '', '', '', '', '', '', 1);
 				print getTitleFieldOfList('Title', 0, $_SERVER["PHP_SELF"], '', '', '', '', '', '', '', 1);

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -716,7 +716,7 @@ if (empty($reshook)) {
 			$newlang = GETPOST('lang_id', 'aZ09');
 		}
 		if (getDolGlobalInt('MAIN_MULTILANGS') && empty($newlang)) {
-			$newlang = $reception->thirdparty->default_lang;
+			$newlang = $object->thirdparty->default_lang;
 		}
 		if (!empty($newlang)) {
 			$outputlangs = new Translate("", $conf);


### PR DESCRIPTION
## What

Several pages read a variable that is never defined on that page (a copy/paste
leftover from another page), so PHPStan level 10 reports `Variable $x might not
be defined` and PHP 8 emits an undefined-variable warning (value treated as null):

- `reception/card.php`: `$reception` → `$object` in the `builddoc` block. The 10
  other `builddoc` blocks in the same file already use `$object`; otherwise the
  output PDF language is not resolved.
- `loan/payment/card.php`: `$object->id` → `$id` (the page object is `$payment`;
  this matches the adjacent enabled-button line that already uses `$id`).
- `opensurvey/card.php`: `ConfirmRemovalOfPoll` used `$id` → `$numsondage`
  (otherwise the confirmation message placeholder is empty).
- `opensurvey/results.php`: guard `$expiredate` with `!empty()` (never defined on
  this page; still falls back to `$object->date_fin`).
- `projet/card.php`: guard `$morecss` with `!empty()` (never defined here).

No behaviour change beyond removing the undefined-variable reads.

## Context

These errors are currently hidden in `dev/build/phpstan/phpstan-baseline.neon`
(identifier `variable.undefined`). Fixing the code lets the baseline shrink on
the next refresh.
