### PR TITLE
FIX: undefined $objcanvas/$socid in societe thirdparty canvas templates

### DIFF
--- a/htdocs/societe/canvas/company/tpl/card_view.tpl.php
+++ b/htdocs/societe/canvas/company/tpl/card_view.tpl.php
@@ -34,6 +34,7 @@ if (empty($conf) || !is_object($conf)) {
 
 
 $soc = $GLOBALS['objcanvas']->control->object;
+$socid = $soc->id;
 
 
 print "<!-- BEGIN PHP TEMPLATE CARD_VIEW.TPL.PHP COMPANY -->\n";
@@ -291,7 +292,7 @@ $urlsource = $_SERVER["PHP_SELF"]."?socid=".$socid;
 $genallowed = $user->hasRight('societe', 'lire');
 $delallowed = $user->hasRight('societe', 'creer');
 
-print $formfile->showdocuments('company', $socid, $filedir, $urlsource, $genallowed, $delallowed, '', 0, 0, 0, 28, 0, '', 0, '', $objcanvas->control->object->default_lang);
+print $formfile->showdocuments('company', $socid, $filedir, $urlsource, $genallowed, $delallowed, '', 0, 0, 0, 28, 0, '', 0, '', $soc->default_lang);
 ?>
 
 </td>

--- a/htdocs/societe/canvas/individual/tpl/card_view.tpl.php
+++ b/htdocs/societe/canvas/individual/tpl/card_view.tpl.php
@@ -35,6 +35,7 @@ if (empty($conf) || !is_object($conf)) {
 
 
 $object = $GLOBALS['objcanvas']->control->object;
+$socid = $object->id;
 
 
 print "<!-- BEGIN PHP TEMPLATE CARD_VIEW.TPL.PHP INDIVIDUAL -->\n";
@@ -219,7 +220,7 @@ $urlsource = $_SERVER["PHP_SELF"]."?socid=".$socid;
 $genallowed = $user->hasRight('societe', 'lire');
 $delallowed = $user->hasRight('societe', 'creer');
 
-print $formfile->showdocuments('company', $socid, $filedir, $urlsource, $genallowed, $delallowed, '', 0, 0, 0, 28, 0, '', 0, '', $objcanvas->control->object->default_lang);
+print $formfile->showdocuments('company', $socid, $filedir, $urlsource, $genallowed, $delallowed, '', 0, 0, 0, 28, 0, '', 0, '', $object->default_lang);
 ?>
 
 </td>


### PR DESCRIPTION
## What

`Canvas::display_canvas()` (`htdocs/core/class/canvas.class.php`) includes the
thirdparty canvas card templates from inside a method and imports only
`$db, $conf, $langs, $user, $canvas, $form, $formfile` via `global`. `$objcanvas`
and `$socid` are never brought into that scope, so they were undefined at runtime
(the templates already reconstruct the thirdparty object from `$GLOBALS['objcanvas']`).

- Derive `$socid` from the in-scope thirdparty object (`$soc->id` / `$object->id`),
  fixing the empty socid used for `$filedir`, `$urlsource` and `showdocuments()`.
- Replace the bare `$objcanvas->control->object` with the already-derived `$soc`
  (company) / `$object` (individual).

For the company template, `$socid` was previously masked from PHPStan by a
misleading `@var int $socid` docblock; it is now actually defined.

## Context

Clears `variable.undefined` entries from `dev/build/phpstan/phpstan-baseline.neon`
for these two templates.
