### PR TITLE
FIX: supplier payment document.php runs restrictedArea() on unloaded object

### DIFF
--- a/htdocs/fourn/paiement/document.php
+++ b/htdocs/fourn/paiement/document.php
@@ -63,6 +63,14 @@ $ref = GETPOST('ref', 'alpha');
 $action = GETPOST('action', 'aZ09');
 $confirm = GETPOST('confirm', 'alpha');
 
+// Load object
+$object = new PaiementFourn($db);
+$upload_dir = null;
+if ($object->fetch($id, $ref)) {
+	$object->fetch_thirdparty();
+	$ref = dol_sanitizeFileName($object->ref);
+	$upload_dir = $conf->fournisseur->payment->dir_output.'/'.dol_sanitizeFileName($object->ref);
+}
 
 // Security check
 if ($user->isExternalUser()) {
@@ -86,15 +94,6 @@ if (!$sortorder) {
 }
 if (!$sortfield) {
 	$sortfield = "name";
-}
-
-// Load object
-$object = new PaiementFourn($db);
-$upload_dir = null;
-if ($object->fetch($id, $ref)) {
-	$object->fetch_thirdparty();
-	$ref = dol_sanitizeFileName($object->ref);
-	$upload_dir = $conf->fournisseur->payment->dir_output.'/'.dol_sanitizeFileName($object->ref);
 }
 
 $permissiontoadd = ($user->hasRight("fournisseur", "facture", "creer") || $user->hasRight("supplier_invoice", "creer")); // Used by the include of actions_setnotes.inc.php


### PR DESCRIPTION
## What

`htdocs/fourn/paiement/document.php` called

```php
$result = restrictedArea($user, $object->element, $object->id, 'paiementfourn', '');
```

before `$object` was instantiated — the "Load object" block sat *after* the
security check. So the permission check ran on an undefined `$object`
(null element / null id), and PHPStan level 10 flagged
`Variable $object might not be defined`.

The sibling supplier-payment pages `fourn/paiement/card.php` and
`fourn/paiement/info.php` instantiate the `PaiementFourn` object *before* the
same `restrictedArea()` call. This PR moves the object load ahead of the
security check so the check runs against the real object.

## Context

Clears a `variable.undefined` entry from `dev/build/phpstan/phpstan-baseline.neon`.
