### PR TITLE
FIX: stocktransfer addcontact reports false success without a valid object

### DIFF
--- a/htdocs/product/stock/stocktransfer/stocktransfer_contact.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_contact.php
@@ -106,6 +106,7 @@ if (!$permissiontoread || ($action === 'create' && !$permissiontoadd)) {
  */
 
 if ($action == 'addcontact' && $user->hasRight('stocktransfer', 'stocktransfer', 'write')) {
+	$result = -1;
 	if ($object->id > 0) {
 		$contactid = (GETPOSTINT('userid') ? GETPOSTINT('userid') : GETPOSTINT('contactid'));
 		$result = $object->add_contact($contactid, GETPOST("typecontact") ? GETPOST("typecontact") : GETPOST("type"), GETPOST("source"));


### PR DESCRIPTION
## What

In `htdocs/product/stock/stocktransfer/stocktransfer_contact.php` the
`addcontact` action assigns `$result` only inside `if ($object->id > 0)`, but the
success test `if ($result >= 0)` runs unconditionally. On a POST with no valid
id/ref the object is not fetched (`$object->id == 0`), so `$result` is undefined
and `null >= 0` evaluates to true — redirecting as if the contact had been added.

Initialize `$result = -1;` at the start of the block so the missing-object case
takes the error branch instead of a false-success redirect. PHPStan level 10 also
flagged `Variable $result might not be defined` here.

For reference, the modulebuilder template `myobject_contact.php` calls
`add_contact()` unconditionally (so `$result` is always set); this page had
wrapped it in `if ($object->id > 0)` without initializing `$result`.

## Context

Clears a `variable.undefined` entry from `dev/build/phpstan/phpstan-baseline.neon`.
