### PR TITLE
FIX: #39053 prevent non-admin users deleting admin accounts

### DIFF
--- a/htdocs/langs/en_US/users.lang
+++ b/htdocs/langs/en_US/users.lang
@@ -171,3 +171,4 @@ AtNextLogin=At next connection
 UserDoesNotHaveRightsToChangeHisPassword=This user doesn't have the rights to change his own password
 NotPossible=Not possible
 NoPasswordGenerationRuleConfigured=The engine or rule to generate password has not been set or is set to empty password in the setup page.
+OnlyAdminUsersCanDeleteAdminUsers=Only admin users can delete admin users

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -249,16 +249,22 @@ if (empty($reshook)) {
 
 			$object = new User($db);
 			$object->fetch($id);
-			$object->oldcopy = clone $object; // @phan-suppress-current-line PhanTypeMismatchProperty
-
-			$result = $object->delete($user);
-			if ($result < 0) {
-				$langs->load("errors");
-				setEventMessages($langs->trans("ErrorUserCannotBeDelete"), null, 'errors');
+			if ($object->admin && empty($user->admin)) {
+				// If user to delete is an admin user and if logged user is not admin, we deny the operation.
+				$error++;
+				setEventMessages($langs->trans("OnlyAdminUsersCanDeleteAdminUsers"), null, 'errors');
 			} else {
-				setEventMessages($langs->trans("RecordDeleted"), null);
-				header("Location: ".DOL_URL_ROOT."/user/list.php?restore_lastsearch_values=1");
-				exit;
+				$object->oldcopy = clone $object; // @phan-suppress-current-line PhanTypeMismatchProperty
+
+				$result = $object->delete($user);
+				if ($result < 0) {
+					$langs->load("errors");
+					setEventMessages($langs->trans("ErrorUserCannotBeDelete"), null, 'errors');
+				} else {
+					setEventMessages($langs->trans("RecordDeleted"), null);
+					header("Location: ".DOL_URL_ROOT."/user/list.php?restore_lastsearch_values=1");
+					exit;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# FIX: #39053 prevent non-admin users deleting admin accounts

Fixes #39053.

`confirm_disable` already prevented a non-admin user from disabling an admin account. `confirm_delete` missed the same check and went straight to `User::delete()`.

Add the same admin-target guard before deletion.
