### PR TITLE
FIX: #39063 prevent self-edit users updating other notes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
+FIX: #39063 Prevent self-edit users from updating notes on other user accounts.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,6 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
-FIX: #39063 Prevent self-edit users from updating notes on other user accounts.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/htdocs/user/note.php
+++ b/htdocs/user/note.php
@@ -62,7 +62,7 @@ if (($object->id != $user->id) && (!$user->hasRight("user", "user", "read"))) {
 if ($object->id == $user->id) {
 	$permissionnote = $user->hasRight("user", "self", "write"); // Used by the include of actions_setnotes.inc.php
 } else {
-	$permissionnote = ($user->admin || $user->hasRight("user", "user", "write")); // Used by the include of actions_setnotes.inc.php
+	$permissionnote = $user->hasRight("user", "user", "write")); // Used by the include of actions_setnotes.inc.php
 }
 
 // Security check

--- a/htdocs/user/note.php
+++ b/htdocs/user/note.php
@@ -59,7 +59,11 @@ if (($object->id != $user->id) && (!$user->hasRight("user", "user", "read"))) {
 }
 
 // Permissions
-$permissionnote = $user->hasRight("user", "self", "write"); // Used by the include of actions_setnotes.inc.php
+if ($object->id == $user->id) {
+	$permissionnote = $user->hasRight("user", "self", "write"); // Used by the include of actions_setnotes.inc.php
+} else {
+	$permissionnote = ($user->admin || $user->hasRight("user", "user", "write")); // Used by the include of actions_setnotes.inc.php
+}
 
 // Security check
 $socid = 0;


### PR DESCRIPTION
# FIX: #39063 prevent self-edit users updating other notes

Fixes #39063.

`htdocs/user/note.php` allowed a user with the self-edit permission to submit note updates for another user account.

Keep self-edit permission for the current user's own notes, but require admin or the standard other-user write permission when the target account is different.
