### PR TITLE
FIX: #37711 add stock movement batch index

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
+FIX: #37711 Add an index for stock movement lookup by batch, warehouse and movement type.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,6 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
-FIX: #37711 Add an index for stock movement lookup by batch, warehouse and movement type.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -50,6 +50,7 @@ ALTER TABLE llx_categorie_project_task DROP FOREIGN KEY fk_categorie_project_tas
 -- VPGSQL8.2 DROP INDEX idx_categorie_project_fk_task;
 ALTER TABLE llx_categorie_project_task ADD INDEX idx_categorie_project_fk_task (fk_project_task);
 ALTER TABLE llx_categorie_project_task ADD CONSTRAINT fk_categorie_project_task_rowid FOREIGN KEY (fk_project_task) REFERENCES llx_projet_task (rowid);
+ALTER TABLE llx_stock_mouvement ADD INDEX idx_stock_mouvement_batch_entrepot_type_datem (batch, fk_entrepot, type_mouvement, datem);
 
 -- V24 migration
 ALTER TABLE llx_expensereport_det ADD COLUMN tcheck_file	integer DEFAULT NULL after fk_ecm_files;

--- a/htdocs/install/mysql/tables/llx_stock_mouvement.key.sql
+++ b/htdocs/install/mysql/tables/llx_stock_mouvement.key.sql
@@ -21,3 +21,5 @@
 ALTER TABLE llx_stock_mouvement ADD INDEX idx_stock_mouvement_fk_product (fk_product);
 
 ALTER TABLE llx_stock_mouvement ADD INDEX idx_stock_mouvement_fk_entrepot (fk_entrepot);
+
+ALTER TABLE llx_stock_mouvement ADD INDEX idx_stock_mouvement_batch_entrepot_type_datem (batch, fk_entrepot, type_mouvement, datem);


### PR DESCRIPTION
# FIX: #37711 add stock movement batch index

Fixes #37711.

`Productbatch::findAll()` can join `llx_stock_mouvement` by batch, warehouse and movement type when `SHIPPING_DISPLAY_STOCK_ENTRY_DATE` is enabled.

Add a composite index on `(batch, fk_entrepot, type_mouvement, datem)` for new installs and upgrades.
