### PR TITLE
FIX: enforce document upload access checks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
+FIX: Prevent API document upload from ignoring document write access checks.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,6 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
-FIX: Prevent API document upload from ignoring document write access checks.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -1104,6 +1104,9 @@ class Documents extends DolibarrApi
 				$relativefile = $tmpreldir.dol_sanitizeFileName((string) $object->ref);
 			}
 			$tmp = dol_check_secure_access_document($modulepart, $relativefile, $entity, DolibarrApiAccess::$user, $ref, 'write');
+			if (empty($tmp['accessallowed'])) {
+				throw new RestException(403, 'Access not allowed to upload file into this directory');
+			}
 			$upload_dir = $tmp['original_file']; // No dirname here, tmp['original_file'] is already the dir because dol_check_secure_access_document was called with param original_file that is only the dir
 			/*} else {
 				if (!DolibarrApiAccess::$user->hasRight('ecm', 'upload')) {
@@ -1127,6 +1130,9 @@ class Documents extends DolibarrApi
 			if ($modulepart != 'ecm') {
 				$relativefile = $subdir;
 				$tmp = dol_check_secure_access_document($modulepart, $relativefile, $entity, DolibarrApiAccess::$user, '', 'write');
+				if (empty($tmp['accessallowed'])) {
+					throw new RestException(403, 'Access not allowed to upload file into this directory');
+				}
 				$upload_dir = $tmp['original_file']; // No dirname here, tmp['original_file'] is already the dir because dol_check_secure_access_document was called with param original_file that is only the dir
 			} else {
 				if (!DolibarrApiAccess::$user->hasRight('ecm', 'upload')) {


### PR DESCRIPTION
# FIX: enforce document upload access checks

`POST /documents/upload` already asks `dol_check_secure_access_document(..., 'write')` where an upload may be written, but it did not stop when that check returned `accessallowed = 0`.

Return 403 when write access is denied, for both object-reference uploads and subdirectory uploads.
