### PR TITLE
FIX: escape cron command attributes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
+FIX: Escape cron command and parameter values in edit form attributes.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,6 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
-FIX: Escape cron command and parameter values in edit form attributes.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/htdocs/cron/card.php
+++ b/htdocs/cron/card.php
@@ -402,7 +402,7 @@ if (($action == "create") || ($action == "edit")) {
 
 	print '<tr class="blockmethod"><td>';
 	print $langs->trans('CronArgs')."</td><td>";
-	print '<input type="text" class="quatrevingtpercent" name="params" value="'.$object->params.'" spellcheck="false"> ';
+	print '<input type="text" class="quatrevingtpercent" name="params" value="'.dol_escape_htmltag($object->params).'" spellcheck="false"> ';
 	print "</td>";
 	print "<td>";
 	print $form->textwithpicto('', $langs->trans("CronArgsHelp"), 1, 'help');
@@ -411,7 +411,7 @@ if (($action == "create") || ($action == "edit")) {
 
 	print '<tr class="blockcommand"><td>';
 	print $langs->trans('CronCommand')."</td><td>";
-	print '<input type="text" class="minwidth150" name="command" value="'.$object->command.'"  spellcheck="false" /> ';
+	print '<input type="text" class="minwidth150" name="command" value="'.dol_escape_htmltag($object->command).'"  spellcheck="false" /> ';
 	print "</td>";
 	print "<td>";
 	print $form->textwithpicto('', $langs->trans("CronCommandHelp"), 1, 'help');


### PR DESCRIPTION
# FIX: escape cron command attributes

The cron job edit form already escapes most values before putting them into HTML `value` attributes. The `params` and `command` fields were the exceptions.

Escape those two values the same way as the surrounding fields.
