### PR TITLE
FIX: escape cron setup key

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,6 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
-FIX: Escape cron setup key value in form attributes.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
+FIX: Escape cron setup key value in form attributes.
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)
 NEW: New Stock transfer module stabilization and full functional coverage (#37557)

--- a/htdocs/cron/admin/cron.php
+++ b/htdocs/cron/admin/cron.php
@@ -103,9 +103,10 @@ $disabled = '';
 if (getDolGlobalInt('CRON_DISABLE_KEY_CHANGE') > 0) {
 	$disabled = ' disabled="disabled"';
 }
+$cronkeytoshow = (GETPOST('CRON_KEY') ? GETPOST('CRON_KEY') : getDolGlobalString('CRON_KEY'));
 print '<td>';
 if (getDolGlobalInt('CRON_DISABLE_KEY_CHANGE') != 1) {
-	print '<input type="text" class="flat minwidth300 widthcentpercentminusx"'.$disabled.' id="CRON_KEY" name="CRON_KEY" value="'.(GETPOST('CRON_KEY') ? GETPOST('CRON_KEY') : getDolGlobalString('CRON_KEY')).'">';
+	print '<input type="text" class="flat minwidth300 widthcentpercentminusx"'.$disabled.' id="CRON_KEY" name="CRON_KEY" value="'.dol_escape_htmltag($cronkeytoshow).'">';
 	if (getDolGlobalInt('CRON_DISABLE_KEY_CHANGE') == 0) {
 		if (!empty($conf->use_javascript_ajax)) {
 			print '&nbsp;'.img_picto($langs->trans('Generate'), 'refresh', 'id="generate_token" class="linkobject"');
@@ -115,8 +116,8 @@ if (getDolGlobalInt('CRON_DISABLE_KEY_CHANGE') != 1) {
 		print '&nbsp;'.img_picto($langs->trans("WarningChangingThisMayBreakStopTaskScheduler"), 'info');
 	}
 } else {
-	print getDolGlobalString('CRON_KEY');
-	print '<input type="hidden" id="CRON_KEY" name="CRON_KEY" value="'.(GETPOST('CRON_KEY') ? GETPOST('CRON_KEY') : getDolGlobalString('CRON_KEY')).'">';
+	print dol_escape_htmltag(getDolGlobalString('CRON_KEY'));
+	print '<input type="hidden" id="CRON_KEY" name="CRON_KEY" value="'.dol_escape_htmltag($cronkeytoshow).'">';
 }
 print '</td>';
 print '<td>&nbsp;</td>';


### PR DESCRIPTION
# FIX: escape cron setup key

The cron setup page prints the configured cron key into a visible input, and into a hidden input when the key is locked.

Escape the value before rendering it in either place.
