### PR TITLE
FIX: encode backtourl in Google OAuth callback URL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Encode backtourl in Google OAuth callback URL.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/ChangeLog
+++ b/ChangeLog
@@ -168,7 +168,6 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
-FIX: Encode backtourl in Google OAuth callback URL.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/core/login/functions_googleoauth.php
+++ b/htdocs/core/login/functions_googleoauth.php
@@ -93,7 +93,7 @@ function check_user_password_googleoauth($usertotest, $passwordtotest, $entityto
 			$backtourl = preg_replace('/#.*$/i', '', $backtourl);	// We remove part after the #...
 
 
-			$url = $urlwithroot.'/core/modules/oauth/google_oauthcallback.php?shortscope='.urlencode($shortscope).'&state='.urlencode('forlogin-'.$shortscope.'-'.$oauthstateanticsrf).'&username='.urlencode($usertotest).'&backtourl='.urldecode($backtourl);
+			$url = $urlwithroot.'/core/modules/oauth/google_oauthcallback.php?shortscope='.urlencode($shortscope).'&state='.urlencode('forlogin-'.$shortscope.'-'.$oauthstateanticsrf).'&username='.urlencode($usertotest).'&backtourl='.urlencode($backtourl);
 
 			// we go on oauth provider authorization page
 			header('Location: '.$url);


### PR DESCRIPTION
# FIX: encode backtourl in Google OAuth callback URL

The Google OAuth login redirect builds a callback URL with `backtourl` as a query parameter.

Encode this value before appending it to the callback URL, like the other query parameters in the same URL.
