### PR TITLE
FIX: escape session list fields

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,7 +168,6 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
-FIX: Escape session list fields.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Escape session list fields.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/admin/tools/listsessions.php
+++ b/htdocs/admin/tools/listsessions.php
@@ -228,10 +228,10 @@ if ($savehandler == 'files') {
 		print '<td>'.$sessionentry['age'].'</td>';
 
 		// Remote IP
-		print '<td>'.dol_escape_htmltag($sessionentry['remote_ip']).'</td>';
+		print '<td>'.dol_escape_htmltag((string) $sessionentry['remote_ip']).'</td>';
 
 		// User Agent
-		print '<td class="nowrap left">'.dol_escape_htmltag($sessionentry['user_agent']).'</td>';
+		print '<td class="nowrap left">'.dol_escape_htmltag((string) $sessionentry['user_agent']).'</td>';
 		print '<td>&nbsp;</td>';
 		print "</tr>\n";
 		$i++;

--- a/htdocs/admin/tools/listsessions.php
+++ b/htdocs/admin/tools/listsessions.php
@@ -157,7 +157,7 @@ if ($savehandler == 'files') {
 		print '<tr class="oddeven">';
 
 		// Login
-		print '<td>'.$sessionentry['login'].'</td>';
+		print '<td>'.dol_escape_htmltag($sessionentry['login']).'</td>';
 
 		// ID
 		print '<td class="nowrap left">';
@@ -207,7 +207,7 @@ if ($savehandler == 'files') {
 		print '<tr class="oddeven">';
 
 		// Login
-		print '<td>'.$sessionentry['login'].'</td>';
+		print '<td>'.dol_escape_htmltag($sessionentry['login']).'</td>';
 
 		// ID
 		print '<td class="nowrap left">';
@@ -228,10 +228,10 @@ if ($savehandler == 'files') {
 		print '<td>'.$sessionentry['age'].'</td>';
 
 		// Remote IP
-		print '<td>'.$sessionentry['remote_ip'].'</td>';
+		print '<td>'.dol_escape_htmltag($sessionentry['remote_ip']).'</td>';
 
 		// User Agent
-		print '<td class="nowrap left">'.$sessionentry['user_agent'].'</td>';
+		print '<td class="nowrap left">'.dol_escape_htmltag($sessionentry['user_agent']).'</td>';
 		print '<td>&nbsp;</td>';
 		print "</tr>\n";
 		$i++;


### PR DESCRIPTION
# FIX: escape session list fields

The sessions administration page prints session values into the HTML table.

Escape the displayed login, remote IP and user agent values before rendering them.
