### PR TITLE
FIX: restrict dictionary line deletion to admin users

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Restrict dictionary line deletion to admin users.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -1119,7 +1119,7 @@ if (empty($reshook)) {
 		}
 	}
 
-	if ($action == 'confirm_delete' && $confirm == 'yes') {       // delete
+	if ($action == 'confirm_delete' && $confirm == 'yes' && $user->admin) {       // delete
 		if ($tabrowid[$id]) {
 			$rowidcol = $tabrowid[$id];
 		} else {


### PR DESCRIPTION
# FIX: restrict dictionary line deletion to admin users

Some dictionary pages can be opened by non-admin users with accounting rights.

The delete button is only shown to admin users, so apply the same admin check in the delete confirmation handler.
