### PR TITLE
FIX: check document list read permissions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Check read permissions before listing API documents for more module parts.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/ChangeLog
+++ b/ChangeLog
@@ -168,7 +168,6 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
-FIX: Check read permissions before listing API documents for more module parts.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -742,6 +742,10 @@ class Documents extends DolibarrApi
 			$modulepart = 'contrat';
 			require_once DOL_DOCUMENT_ROOT . '/contrat/class/contrat.class.php';
 
+			if (!DolibarrApiAccess::$user->hasRight('contrat', 'lire')) {
+				throw new RestException(403);
+			}
+
 			$object = new Contrat($this->db);
 			$result = $object->fetch($id, $ref);
 			if (!$result) {
@@ -753,6 +757,10 @@ class Documents extends DolibarrApi
 			$modulepart = 'ficheinter';
 			require_once DOL_DOCUMENT_ROOT . '/fichinter/class/fichinter.class.php';
 
+			if (!DolibarrApiAccess::$user->hasRight('ficheinter', 'lire')) {
+				throw new RestException(403);
+			}
+
 			$object = new Fichinter($this->db);
 			$result = $object->fetch($id, $ref);
 			if (!$result) {
@@ -763,6 +771,10 @@ class Documents extends DolibarrApi
 		} elseif ($modulepart == 'projet' || $modulepart == 'project') {
 			$modulepart = 'project';
 			require_once DOL_DOCUMENT_ROOT . '/projet/class/project.class.php';
+
+			if (!DolibarrApiAccess::$user->hasRight('projet', 'lire')) {
+				throw new RestException(403);
+			}
 
 			$object = new Project($this->db);
 			$result = $object->fetch($id, $ref);
@@ -795,6 +807,10 @@ class Documents extends DolibarrApi
 			$modulepart = 'mrp';
 			require_once DOL_DOCUMENT_ROOT . '/mrp/class/mo.class.php';
 
+			if (!DolibarrApiAccess::$user->hasRight('mrp', 'read')) {
+				throw new RestException(403);
+			}
+
 			$object = new Mo($this->db);
 			$result = $object->fetch($id, $ref);
 			if (!$result) {
@@ -805,6 +821,10 @@ class Documents extends DolibarrApi
 		} elseif ($modulepart == 'contact' || $modulepart == 'socpeople') {
 			$modulepart = 'contact';
 			require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+
+			if (!DolibarrApiAccess::$user->hasRight('societe', 'contact', 'lire')) {
+				throw new RestException(403);
+			}
 
 			$object = new Contact($this->db);
 			$result = $object->fetch($id?$id:$ref);


### PR DESCRIPTION
# FIX: check document list read permissions

The documents API already checks read permissions for several module parts before listing their files.

Apply the same check for contracts, interventions, projects, manufacturing orders and contacts.
