### PR TITLE
FIX: scope login API token reset to user row

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,7 +168,6 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
-FIX: Scope login API token reset to fetched user row.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Scope login API token reset to fetched user row.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/api/class/api_login.class.php
+++ b/htdocs/api/class/api_login.class.php
@@ -163,7 +163,7 @@ class Login
 			// We store API token into database
 			$sql = "UPDATE ".MAIN_DB_PREFIX."user";
 			$sql .= " SET api_key = '".$this->db->escape(dolEncrypt($token, '', '', 'dolibarr'))."'";
-			$sql .= " WHERE login = '".$this->db->escape($login)."'";
+			$sql .= " WHERE rowid = ".((int) $tmpuser->id);
 
 			dol_syslog(get_class($this)."::login", LOG_DEBUG); // No log
 			$result = $this->db->query($sql);


### PR DESCRIPTION
# FIX: scope login API token reset to user row

The login API loads the authenticated user before resetting the API token.

Update the token on that fetched user row instead of updating rows by login only.
