### PR TITLE
FIX: filter email template API fetch by entity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Add entity filter when fetching email template by id.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/core/class/cemailtemplate.class.php
+++ b/htdocs/core/class/cemailtemplate.class.php
@@ -508,6 +508,7 @@ class CEmailTemplate extends CommonObject
 		$sql .= " e.content_lines FROM ".$this->db->prefix().$this->table_element." as e";
 		if ($id) {
 			$sql .= " WHERE e.rowid = ".((int) $id);
+			$sql .= " AND e.entity IN (".getEntity($this->table_element).")";
 		} else {
 			$sql .= " WHERE e.entity IN (".getEntity($this->table_element).")";
 			if ($label) {


### PR DESCRIPTION
# FIX: filter email template API fetch by entity

The email template API already filters label lookups by entity.

Apply the same entity filter when fetching an email template by id.
