### PR TITLE
FIX: restrict module enable and disable API to admin users

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Restrict module enable and disable API to admin users.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -3336,9 +3336,8 @@ class Setup extends DolibarrApi
 	{
 		global $db;
 
-		if (!DolibarrApiAccess::$user->admin
-			&& (!getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES') || DolibarrApiAccess::$user->login != getDolGlobalString('API_LOGINS_ALLOWED_FOR_GET_MODULES'))) {
-			throw new RestException(403, 'Error API open to admin users only or to the users with logins defined into constant API_LOGINS_ALLOWED_FOR_GET_MODULES');
+		if (!DolibarrApiAccess::$user->admin) {
+			throw new RestException(403, 'Error API open to admin users only');
 		}
 
 		$modulesdir = dolGetModulesDirs();


### PR DESCRIPTION
# FIX: restrict module enable and disable API to admin users

The setup API has a read allowlist for module status endpoints.

Do not reuse that read allowlist for module enable and disable actions; keep those actions restricted to admin users.
