### PR TITLE
FIX: restrict establishment setup API to admin users

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Restrict establishment setup API to admin users.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/ChangeLog
+++ b/ChangeLog
@@ -168,7 +168,6 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
-FIX: Restrict establishment setup API to admin users.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/api/class/api_setup.class.php
+++ b/htdocs/api/class/api_setup.class.php
@@ -2744,6 +2744,9 @@ class Setup extends DolibarrApi
 	public function getEstablishments()
 	{
 		$list = array();
+		if (!DolibarrApiAccess::$user->admin) {
+			throw new RestException(403, 'Error API open to admin users only');
+		}
 
 		$limit = 0;
 
@@ -2782,12 +2785,19 @@ class Setup extends DolibarrApi
 	 */
 	public function getEtablishmentByID($id)
 	{
+		if (!DolibarrApiAccess::$user->admin) {
+			throw new RestException(403, 'Error API open to admin users only');
+		}
+
 		$establishment = new Establishment($this->db);
 
 		$result = $establishment->fetch($id);
 		if ($result < 0) {
 			throw new RestException(503, 'Error when retrieving establishment : '.$establishment->error);
 		} elseif ($result == 0) {
+			throw new RestException(404, 'Establishment not found');
+		}
+		if (!in_array($establishment->entity, explode(',', getEntity('establishment')))) {
 			throw new RestException(404, 'Establishment not found');
 		}
 


### PR DESCRIPTION
# FIX: restrict establishment setup API to admin users

The setup API exposes establishment records from configuration data.

Require admin access for the establishment list and by-id endpoints, and keep the by-id response inside the current entity scope.
