### PR TITLE
FIX: restrict ECM database build action

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Restrict ECM database build action to setup permission and known elements.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/ecm/ajax/ecmdatabase.php
+++ b/htdocs/ecm/ajax/ecmdatabase.php
@@ -49,6 +49,7 @@ $action = GETPOST('action', 'aZ09');
 $element = GETPOST('element', 'alpha');
 
 $permissiontoread = $user->hasRight('ecm', 'read');
+$permissiontosetup = $user->hasRight('ecm', 'setup');
 
 $error = 0;
 
@@ -70,7 +71,7 @@ top_httphead();
 
 // Load original field value
 if (isset($action) && !empty($action)) {
-	if ($action == 'build' && !empty($element) && $permissiontoread) {
+	if ($action == 'build' && !empty($element) && $permissiontosetup && in_array($element, array('ecm', 'medias'))) {
 		require_once DOL_DOCUMENT_ROOT.'/ecm/class/ecmdirectory.class.php';
 
 		$ecmdirstatic = new EcmDirectory($db);


### PR DESCRIPTION
Summary:
- Require ECM setup permission before running the ECM database build action.
- Restrict the dynamic element parameter to known ECM roots.

Testing:
- php -l htdocs/ecm/ajax/ecmdatabase.php
- git diff --check
