### PR TITLE
FIX: correct security event entity SQL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Remove extra parenthesis from security event entity filter.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/ChangeLog
+++ b/ChangeLog
@@ -168,7 +168,6 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
-FIX: Remove extra parenthesis from security event entity filter.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/admin/tools/listevents.php
+++ b/htdocs/admin/tools/listevents.php
@@ -224,7 +224,7 @@ $sql .= " u.login, u.admin, u.email, u.entity, u.firstname, u.lastname, u.gender
 $sql .= " FROM ".MAIN_DB_PREFIX."events as e";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."user as u ON u.rowid = e.fk_user";
 if ($search_entity > 0) {
-	$sql .= " WHERE e.entity = ".((int) $search_entity).")";
+	$sql .= " WHERE e.entity = ".((int) $search_entity);
 } else {
 	$sql .= " WHERE e.entity IN (".getEntity('event', (GETPOSTINT('search_current_entity') ? 0 : 1)).")";
 }


### PR DESCRIPTION
Summary:
- Fix the security event list SQL generated for positive entity filters.
- Removes the stray closing parenthesis that breaks the audit log query for entity-scoped admins.

Testing:
- php -l htdocs/admin/tools/listevents.php
- git diff --check
