### PR TITLE
FIX: scope cron jobs by entity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -168,6 +168,7 @@ NEW: Add delivery date in supplier order linked object block (#38351)
 NEW: A lot of look and feel enhancement in the immutable log pages.
 NEW: Enhance the tools to check file integrity.
 NEW: The OAuth login with Google stay on the requested page after the redirect instead of reaching the home page.
+FIX: Scope cron job fetch, update and delete by entity.
 NEW: Add shipment online url to substitution array
 NEW: ModuleBuilder - selectable object tabs (+ fixes for multi-object generation)
 NEW: Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail

--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -557,6 +557,7 @@ class Cronjob extends CommonObject
 		$sql .= " FROM ".MAIN_DB_PREFIX."cronjob as t";
 		if ($id > 0) {
 			$sql .= " WHERE t.rowid = ".((int) $id);
+			$sql .= " AND t.entity IN(0, ".getEntity('cron').")";
 		} elseif ($label) {
 			$sql .= " WHERE t.entity IN(0, ".getEntity('cron').")";
 			$sql .= " AND t.label = '".$this->db->escape($label)."'";
@@ -935,6 +936,7 @@ class Cronjob extends CommonObject
 		$sql .= " libname=".(isset($this->libname) ? "'".$this->db->escape($this->libname)."'" : "null").",";
 		$sql .= " test=".(isset($this->test) ? "'".$this->db->escape($this->test)."'" : "null");
 		$sql .= " WHERE rowid=".((int) $this->id);
+		$sql .= " AND entity IN(0, ".getEntity('cron').")";
 
 		$this->db->begin();
 
@@ -975,6 +977,7 @@ class Cronjob extends CommonObject
 
 		$sql = "DELETE FROM ".MAIN_DB_PREFIX."cronjob";
 		$sql .= " WHERE rowid=".((int) $this->id);
+		$sql .= " AND entity IN(0, ".getEntity('cron').")";
 
 		dol_syslog(get_class($this)."::delete", LOG_DEBUG);
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
Summary:
- Apply the cron entity scope to cron job row-id fetches.
- Keep updates and deletes constrained to the same cron entity scope.

Testing:
- php -l htdocs/cron/class/cronjob.class.php
- git diff --check
