### PR TITLE
FIX checkES loops past end of weights array

### DIFF
--- a/htdocs/core/lib/bank.lib.php
+++ b/htdocs/core/lib/bank.lib.php
@@ -503,7 +503,7 @@ function checkES($IentOfi, $InumCta)
 
 	$sum = 0;
 
-	for ($i = 0; $i < 11; $i++) {
+	for ($i = 0; $i < 10; $i++) {
 		$sum += $values[$i] * (int) substr($InumCta, $i, 1); //int to cast result of substr to a number
 	}
 


### PR DESCRIPTION
## FIX checkES() reads past the end of the bank-key weights array

`checkES()` (`htdocs/core/lib/bank.lib.php`) computes the two control digits of a Spanish (ES) bank account. Its account-number checksum loop uses `for ($i = 0; $i < 11; $i++)`, but `$values` holds only 10 weights (`array(1, 2, 4, 8, 5, 10, 9, 7, 3, 6)`, indexes 0..9) and `$InumCta` is validated to be exactly 10 digits. On the last pass it reads `$values[10]` and `substr($InumCta, 10, 1)`, raising `Warning: Undefined array key 10` under PHP 8 every time a Spanish account key is computed (e.g. via `checkBanForAccount()`).

Both extra terms evaluate to 0, so the returned control key is unchanged — this only removes the spurious warning. The bound now matches the sibling entity/office loop just above (already `$i < 10`) and the size of `$values` / `$InumCta`.

Verified with a standalone PHP 8 harness: before, every call emits `Undefined array key 10` (and the returned key is `06`); after, the warning is gone and the returned key is byte-for-byte identical (`06`) across an exhaustive sample of inputs.

Prepared with AI assistance (Claude); reviewed and verified by me.
