### PR TITLE
Fix extrafield hidden field not ecaped value

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -8971,7 +8971,7 @@ abstract class CommonObject
 					} elseif (($mode == 'edit') && !in_array(abs($visibility), array(1, 3, 4))) {
 						// We need to make sure, that the values of hidden extrafields are also part of $_POST. Otherwise, they would be empty after an update of the object. See also getOptionalsFromPost
 						$ef_name = 'options_' . $key;
-						$ef_value = $this->array_options[$ef_name];
+						$ef_value = dol_htmlentities($this->array_options[$ef_name], ENT_QUOTES | ENT_SUBSTITUTE);
 						$out .= '<input type="hidden" name="' . $ef_name . '" id="' . $ef_name . '" value="' . $ef_value . '" />' . "\n";
 						continue; // <> -1 and <> 1 and <> 3 = not visible on forms, only on list and <> 4 = not visible at the creation
 					} elseif ($mode == 'view' && empty($visibility)) {


### PR DESCRIPTION
# Fix HTML escaping for hidden extrafield inputs

When an extrafield is rendered as a hidden input containing a JSON string, the value is inserted into the HTML without being properly escaped.

As a result, double quotes (`"`) are not HTML-encoded, which breaks the `value` attribute and allows HTML/content injection into the page.

Before:

<img width="618" height="66" alt="image" src="https://github.com/user-attachments/assets/2af06d83-f48a-46d5-9034-f8f40abc47ce" />

After:

<img width="619" height="65" alt="image" src="https://github.com/user-attachments/assets/b08fee6c-23c3-42a9-8855-2e709a0b24f0" />