### PR TITLE
FIX #39113 CSV export: decode HTML entities in header labels

### DIFF
--- a/htdocs/core/modules/export/exportcsv.class.php
+++ b/htdocs/core/modules/export/exportcsv.class.php
@@ -210,6 +210,11 @@ class ExportCsv extends ModeleExports
 
 			$newvalue = $array_export_fields_label[$code];
 
+			// Label may be stored HTML encoded (for example extrafield labels saved through Translate::trans()),
+			// so decode entities and remove HTML to keep the header consistent with the data cells.
+			$newvalue = dol_string_nohtmltag($newvalue);
+			$decodedlabel = $newvalue;
+
 			// Clean data and add encloser if required (depending on value of USE_STRICT_CSV_RULES)
 			include_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 			$newvalue = csvClean($newvalue, $outputlangs->charset_output, $this->separator);
@@ -218,7 +223,9 @@ class ExportCsv extends ModeleExports
 			$typefield = isset($array_types[$code]) ? $array_types[$code] : '';
 
 			if (preg_match('/^Select:/i', $typefield) && $typefield = substr($typefield, 7)) {
-				$selectlabel[$code."_label"] = $newvalue."_label";
+				// Append the "_label" suffix before cleaning so the derived column stays valid CSV
+				// even when the decoded label contains the separator or a quote.
+				$selectlabel[$code."_label"] = csvClean($decodedlabel."_label", $outputlangs->charset_output, $this->separator);
 			}
 		}
 


### PR DESCRIPTION
## Fix #39113

CSV export: the header line (`write_title()` in `htdocs/core/modules/export/exportcsv.class.php`) did not decode HTML entities in field labels, while data cells were fine.

### Root cause

Extrafield labels are stored HTML encoded in `llx_extrafields.label`, because modules create them through `Translate::trans()`, which runs the string through `htmlentities()` (native DataPolicy module and third-party RGPD modules do this). `write_title()` wrote the label straight into `csvClean()`, and `csvClean()` does not decode entities (its `dol_string_nohtmltag()` call is commented out). So a label such as:

```
Consentement recueilli pour le traitement des donn&eacute;es &agrave; caract&egrave;re personnel
```

appeared in the header instead of:

```
Consentement recueilli pour le traitement des données à caractère personnel
```

As a side effect, since each entity ends with `;`, when the CSV separator is `;` the label was also wrapped in double quotes.

### Fix

Decode entities and remove HTML with `dol_string_nohtmltag()` before `csvClean()`, so the header is consistent with the (plain-text) data cells. This mirrors what the TSV (`tsv_clean()`) and Excel (`export_excel2007`) drivers already do.

### Test

Exporting a Third parties dataset that includes an extrafield whose label contains accented characters now produces a readable header line, with no spurious quoting when the separator is `;`.
