### PR TITLE
FIX phan and phpstan errors on 21.0 static analysis

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -2613,7 +2613,7 @@ class Societe extends CommonObject
 				$discount->amount_ht = price2num((float) $remise / (1 + (float) $vatrate / 100), 'MT');
 				$discount->amount_tva = price2num((float) $discount->amount_ttc - (float) $discount->amount_ht, 'MT');
 
-				$discount->multicurrency_amount_ttc = price2num($remise * (float) $discount->multicurrency_tx, 'MT');
+				$discount->multicurrency_amount_ttc = price2num((float) $remise * (float) $discount->multicurrency_tx, 'MT');
 				$discount->multicurrency_amount_ht = price2num(((float) $remise / (1 + (float) $vatrate / 100)) * (float) $discount->multicurrency_tx, 'MT');
 				$discount->multicurrency_amount_tva = price2num(((float) $discount->amount_ttc - (float) $discount->amount_ht) * (float) $discount->multicurrency_tx, 'MT');
 			} else {
@@ -2621,7 +2621,7 @@ class Societe extends CommonObject
 				$discount->amount_tva = price2num((float) $remise * (float) $vatrate / 100, 'MT');
 				$discount->amount_ttc = price2num((float) $discount->amount_ht + (float) $discount->amount_tva, 'MT');
 
-				$discount->multicurrency_amount_ht = price2num($remise * (float) $discount->multicurrency_tx, 'MT');
+				$discount->multicurrency_amount_ht = price2num((float) $remise * (float) $discount->multicurrency_tx, 'MT');
 				$discount->multicurrency_amount_tva = price2num(((float) $remise * (float) $vatrate / 100) * (float) $discount->multicurrency_tx, 'MT');
 				$discount->multicurrency_amount_ttc = price2num(((float) $discount->amount_ht + (float) $discount->amount_tva) * (float) $discount->multicurrency_tx, 'MT');
 			}

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -211,7 +211,7 @@ if ($reshook < 0) {
 // (delete, quantity, price, discount). Adding a line, a free zone or a note is gated by
 // the "run" permission elsewhere and must stay available to a plain cashier (#38949).
 if (in_array($action, array('deleteline', 'updateqty', 'updateprice', 'updatereduction', 'update_reduction_global')) && !$user->hasRight('takepos', 'editlines')) {
-	dol_htmloutput_errors($langs->trans("NotEnoughPermissions", "TakePos"), null, 1);
+	dol_htmloutput_errors($langs->trans("NotEnoughPermissions", "TakePos"), array(), 1);
 	$action = '';
 }
 


### PR DESCRIPTION
## What

Fix the two static-analysis errors currently failing the **phan** and **phpstan** CI jobs on the `21.0` branch. They were surfaced by today's automated pullmerge from the `18.0` to `20.0` branches and now fail on every open pull request targeting `21.0`, independently of the PR content.

## Changes

- `htdocs/takepos/invoice.php`: `dol_htmloutput_errors()` expects `array<string>` as its second argument; it was called with `null`. Pass `array()` instead (the function default).
- `htdocs/societe/class/societe.class.php`: the `@param float $remise` value comes in as a string, so `$remise * (float) $discount->multicurrency_tx` triggers `PhanTypeInvalidLeftOperandOfNumericOp`. Cast it with `(float) $remise`, consistent with the neighbouring lines that already do so (2 occurrences).

No behaviour change: `null` was already treated as an empty array by `dol_htmloutput_errors()`, and PHP already coerced the string to float in the multiplication. This only makes the static analysis pass.
