### PR TITLE
FIX #38928 Extrafields: preserve select option keys with non-aZ09 chars

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2827,7 +2827,7 @@ class ExtraFields
 				} elseif ($key_type == 'select') {
 					// to detect if we are in search context
 					if (GETPOSTISARRAY($keyprefix."options_".$key.$keysuffix)) {
-						$value_arr = GETPOST($keyprefix."options_".$key.$keysuffix, 'array:aZ09');
+						$value_arr = GETPOST($keyprefix."options_".$key.$keysuffix, 'array:alphanohtml');
 						// Make sure we get an array even if there's only one selected
 						$value_arr = (array) $value_arr;
 						$value_key = implode(',', $value_arr);


### PR DESCRIPTION
## Fix #38928

When saving a multiple-select extrafield, `getOptionalsFromPost()` (in `htdocs/core/class/extrafields.class.php`) sanitized the posted keys with the `array:aZ09` filter.

### Real mechanism

`aZ09` does not strip characters one by one: it empties the whole value as soon as it contains a single character outside `[a-z0-9_-.]` (see `sanitizeVal()`). So option keys like `option_one` or `my-value` are fine (underscore, hyphen and dot are allowed), but a key that contains a space, an accent, a slash, a colon, `+`, etc. makes the entire selected value fall back to empty, and the selection is lost on save.

Verified on a 24.0.0-beta install through the real GETPOST path:

| Option key | `array:aZ09` (current) | `array:alphanohtml` (fix) |
| --- | --- | --- |
| `option_one`, `my-value`, `dot.key` | kept | kept |
| `option one`, `café`, `a/b`, `a+b`, `a:b` | emptied | kept |
| `a"b`, `a<b>c` | emptied | `ab`, `ac` (HTML stripped) |

### Fix

Use `array:alphanohtml`, the same sanitizer the single-value `select` branch a few lines below already relies on (the `GETPOST()` default is `alphanohtml`). It keeps the full range of printable characters while still stripping HTML tags and dangerous sequences (`"`, `../`, encoded entities), so it is not a security regression compared to `aZ09`.

### Known limitation (multiselect search)

Option keys are stored comma-joined and the list filter routes a multi-value `select` criterion to `natural_search(..., 4)`, which splits on both space and comma. So an option key that contains a **space** or a **comma** cannot be represented by the multiselect search encoding, independently of this change. This PR fixes the concrete data-loss on save for the common special characters (accents, `/`, `+`, `:`, ...); supporting spaces/commas in keys would need a broader change to the search encoding and is out of scope here.
