### PR TITLE
FIX #37540 DST distorts working day count in num_public_holiday

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -1003,7 +1003,12 @@ function num_public_holiday($timestampStart, $timestampEnd, $country_code = '', 
 		}
 
 		// Increase number of days (on go up into loop)
-		$timestampStart = dol_time_plus_duree($timestampStart, 1, 'd');
+		// Advance by exactly one GMT day. Do not use dol_time_plus_duree() here: when dates in memory
+		// are not GMT, it adds a wall-clock day in the server timezone, so crossing a DST boundary
+		// moves the GMT timestamp by only 23 hours, the same GMT day is then evaluated twice and the
+		// holiday count is wrong. Inputs of this function are GMT dates (checked above), so a day
+		// is always exactly 86400 seconds.
+		$timestampStart += 86400;
 		//var_dump($jour.' '.$mois.' '.$annee.' '.$timestampStart);
 
 		$i++;


### PR DESCRIPTION
## Fix #37540

`num_public_holiday()` (in `htdocs/core/lib/date.lib.php`) advanced its day loop with `dol_time_plus_duree($timestampStart, 1, 'd')`. On 21.0 and 22.0, `dol_time_plus_duree()` only forces UTC when `MAIN_DATE_IN_MEMORY_ARE_GMT` is set (opt-in), so by default the `P1D` interval is applied as a wall-clock day in the **server timezone**.

When the requested range crosses a DST boundary (for Europe, the last Sunday of March), adding a wall-clock day moves the GMT timestamp by only 23 hours. The loop then lands on the **same GMT day twice**: that day is counted as a non-working day twice, and the working day after the boundary is never examined.

### Reproduction (real dictionary data, byte-copied 21.0 functions)

Leave request Sat 28/03/2026 to Mon 30/03/2026 (DST switch on Sunday 29/03), country FR, GMT midnight timestamps exactly as `holiday/card.php` builds them:

| Server timezone | holidays counted (current 21.0) | working days | holidays counted (this fix) | working days |
| --- | --- | --- | --- | --- |
| UTC | 2 | 1 | 2 | 1 |
| Europe/Paris | 3 (Sunday counted twice) | **0** | 2 | **1** |
| America/New_York | 2 (US DST is 08/03, outside range) | 1 | 2 | 1 |

This is exactly the report: 28/03 to 30/03 gives "no working day", while 30/03 alone gives 1. It also explains why the bug is not seen on UTC servers (docker images) and why @pixodeo found the develop chain UTC-safe: since 23.0, `dol_time_plus_duree()` defaults to UTC (`MAIN_DATE_IN_MEMORY_ARE_NOT_GMT` opt-out), which incidentally protects this loop. On 21.0 and 22.0 the default is still the server timezone.

### Fix

Advance the loop by exactly `86400` seconds. The function already enforces GMT-aligned inputs (the modulo-86400 check at the top returns an error otherwise), and a GMT day is always exactly 86400 seconds, in every timezone and independently of any conf. Verified that the patched function returns the same result in UTC, Europe/Paris, Pacific/Auckland and America/Santiago, on both the March (spring forward) and October (fall back) European DST boundaries, and matches the develop behaviour.
