### PR TITLE
FIX #37026 Chart of accounts export drops root and cross-chart accounts

### DIFF
--- a/htdocs/core/modules/modAccounting.class.php
+++ b/htdocs/core/modules/modAccounting.class.php
@@ -250,10 +250,12 @@ class modAccounting extends DolibarrModules
 
 		$this->export_sql_start[$r] = 'SELECT DISTINCT ';
 		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'accounting_account as aa';
-		$this->export_sql_end[$r] .= ' ,'.MAIN_DB_PREFIX.'accounting_system as ac';
-		$this->export_sql_end[$r] .= ' ,'.MAIN_DB_PREFIX.'accounting_account as aa2';
-		$this->export_sql_end[$r] .= ' WHERE ac.pcg_version = aa.fk_pcg_version AND aa.entity IN ('.getEntity('accounting').')';
-		$this->export_sql_end[$r] .= ' AND aa2.rowid = aa.account_parent AND aa2.active = 1 AND ac.pcg_version = aa2.fk_pcg_version AND aa2.entity IN ('.getEntity('accounting').')';
+		$this->export_sql_end[$r] .= ' INNER JOIN '.MAIN_DB_PREFIX.'accounting_system as ac ON ac.pcg_version = aa.fk_pcg_version';
+		// LEFT JOIN on the parent account: keep accounts that have no parent (root accounts) or whose parent is
+		// inactive or belongs to another chart (common when a custom chart is derived from a base one). The previous
+		// comma join with aa2.active = 1 and ac.pcg_version = aa2.fk_pcg_version silently dropped all those accounts.
+		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'accounting_account as aa2 ON aa2.rowid = aa.account_parent AND aa2.entity IN ('.getEntity('accounting').')';
+		$this->export_sql_end[$r] .= ' WHERE aa.entity IN ('.getEntity('accounting').')';
 
 
 		// Imports

--- a/htdocs/core/modules/modAccounting.class.php
+++ b/htdocs/core/modules/modAccounting.class.php
@@ -253,7 +253,6 @@ class modAccounting extends DolibarrModules
 		$this->export_sql_end[$r] .= ' INNER JOIN '.MAIN_DB_PREFIX.'accounting_system as ac ON ac.pcg_version = aa.fk_pcg_version';
 		// LEFT JOIN on the parent account: keep accounts that have no parent (root accounts) or whose parent is
 		// inactive or belongs to another chart (common when a custom chart is derived from a base one). The previous
-		// comma join with aa2.active = 1 and ac.pcg_version = aa2.fk_pcg_version silently dropped all those accounts.
 		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'accounting_account as aa2 ON aa2.rowid = aa.account_parent AND aa2.entity IN ('.getEntity('accounting').')';
 		$this->export_sql_end[$r] .= ' WHERE aa.entity IN ('.getEntity('accounting').')';
 

--- a/htdocs/core/modules/modAccounting.class.php
+++ b/htdocs/core/modules/modAccounting.class.php
@@ -252,7 +252,7 @@ class modAccounting extends DolibarrModules
 		$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'accounting_account as aa';
 		$this->export_sql_end[$r] .= ' INNER JOIN '.MAIN_DB_PREFIX.'accounting_system as ac ON ac.pcg_version = aa.fk_pcg_version';
 		// LEFT JOIN on the parent account: keep accounts that have no parent (root accounts) or whose parent is
-		// inactive or belongs to another chart (common when a custom chart is derived from a base one). The previous
+		// inactive or belongs to another chart (common when a custom chart is derived from a base one).
 		$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'accounting_account as aa2 ON aa2.rowid = aa.account_parent AND aa2.entity IN ('.getEntity('accounting').')';
 		$this->export_sql_end[$r] .= ' WHERE aa.entity IN ('.getEntity('accounting').')';
 


### PR DESCRIPTION
## Fix #37026

The **Tools > Export > Chart of accounts** dataset (`htdocs/core/modules/modAccounting.class.php`) built its parent-account join with an old-style comma join:

```sql
FROM accounting_account aa , accounting_system ac , accounting_account aa2
WHERE ac.pcg_version = aa.fk_pcg_version AND aa.entity IN (...)
  AND aa2.rowid = aa.account_parent AND aa2.active = 1
  AND ac.pcg_version = aa2.fk_pcg_version AND aa2.entity IN (...)
```

Because `aa2` is an inner join, every account whose parent does not satisfy all of `aa2.rowid = aa.account_parent`, `aa2.active = 1` and `ac.pcg_version = aa2.fk_pcg_version` is silently dropped from the export. That is:

- **root accounts** (`account_parent = 0`), which have no parent row at all,
- accounts whose parent has been **deactivated**,
- accounts whose parent lives in **another chart**, which is exactly what happens with a custom chart derived from a base one (the derived accounts keep their base parents). This is the reporter's case: only the self-consistent base chart (`PCG_SUISSE`) came through instead of the active custom chart (`PCG_SUISSE_BEXIO`).

### Reproduction (real dictionary data, on a standard install)

Running the current dataset SQL vs the fixed one against the shipped charts:

| | accounts exported |
| --- | --- |
| accounts in a registered chart (expected) | **3171** |
| current dataset SQL (inner parent join) | 3087 |
| fixed dataset SQL (left parent join) | **3171** |

84 accounts (root + inactive/cross-chart parents) were missing. Verified the fixed query emits no duplicate rows (3171 rows = 3171 distinct `aa.rowid`), and root accounts now export with an empty parent number.

### Fix

Use an explicit `INNER JOIN accounting_system` for the chart and a `LEFT JOIN accounting_account aa2 ON aa2.rowid = aa.account_parent` for the parent, so accounts export whatever their parent is. The parent's account number is simply left empty when there is no matching parent.

Credit to @pixodeo, who traced the parent join as the suspect on the issue.
