### PR TITLE
Fix #38963 enforce website write right on legacy filemanager (22.0)

### DIFF
--- a/htdocs/core/filemanagerdol/connectors/php/config.inc.php
+++ b/htdocs/core/filemanagerdol/connectors/php/config.inc.php
@@ -36,6 +36,7 @@ require_once '../../../../main.inc.php';
 
 /**
  * @var Conf $conf
+ * @var User $user
  *
  * @var string $dolibarr_main_data_root
  * @var string $dolibarr_main_url_root
@@ -48,6 +49,13 @@ if ($pos == '/') {
 }
 //define('DOL_URL_ROOT', $pos);
 $entity = ((!empty($_SESSION['dol_entity']) && $_SESSION['dol_entity'] > 1) ? $_SESSION['dol_entity'] : null);
+
+// This connector browses and writes into the medias directory, so it must be
+// restricted the same way as on the newer branches. Without this check any
+// authenticated user (even with no module right) could reach the file manager.
+if (empty($user->admin) && !$user->hasRight('website', 'write')) {
+	accessforbidden('Need to be admin or having write permission on website module');
+}
 
 // SECURITY: You must explicitly enable this "connector". (Set it to "true").
 // WARNING: don't just set "$Config['Enabled'] = true ;", you must be sure that only


### PR DESCRIPTION
Fixes #38963 on 21.0/22.0. The legacy FCKeditor file manager connector (`htdocs/core/filemanagerdol/connectors/php/config.inc.php`, also included by browser.php and connector.php) only calls main.inc.php and checks no module right on these branches, so any authenticated user, even without any permission, can reach the connector, browse the medias directory and upload files.

The same guard already exists on 23.0/develop (added in f1b2dd6481e then 0d068d3cb6b) but was never backported. This adds it: a non-admin without website write right is refused, matching the newer branches.

Note: the reporter's public PR #38968 targets develop where the guard already exists and is a no-op there; the actually vulnerable branches are 21.0 and 22.0, which this PR covers. Reported by Abderrahmane Aksoum.