### PR TITLE
Fix #39147 generate expense report PDF on validate

### DIFF
--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2439,6 +2439,7 @@ class ExpenseReport extends CommonObject
 		$outputlangs->load("trips");
 
 		if (!dol_strlen($modele)) {
+			$modele = 'standard';
 			if (!empty($this->model_pdf)) {
 				$modele = $this->model_pdf;
 			} elseif (!empty($this->modelpdf)) {	// deprecated


### PR DESCRIPTION
Fixes #39147. When an expense report is validated, the PDF is not generated automatically, while the manual Generate button works. ExpenseReport::generateDocument() has no hard default model, so when EXPENSEREPORT_ADDON_PDF is empty (an upgrade gap) the auto-generation at validate produces nothing. Facture::generateDocument() already guards against this with a hard 'crabe' default; this mirrors it with 'standard' (the only available expense report model), so validation always produces the document regardless of the constant.