### PR TITLE
Fix #39020 avoid duplicate MO when BOM has a sub-BOM

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -1923,8 +1923,10 @@ class MoLine extends CommonObjectLine
 		$sqlwhere = array();
 		if (count($filter) > 0) {
 			foreach ($filter as $key => $value) {
-				if ($key == 't.rowid') {
+				if ($key == 't.rowid' || $key == 'fk_mo' || $key == 'origin_id') {
 					$sqlwhere[] = $key." = ".((int) $value);
+				} elseif ($key == 'origin_type') {
+					$sqlwhere[] = $key." = '".$this->db->escape($value)."'";
 				} elseif (strpos($key, 'date') !== false) {
 					$sqlwhere[] = $key." = '".$this->db->idate($value)."'";
 				} elseif ($key == 'customsql') {

--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -155,10 +155,10 @@ if (empty($reshook)) {
 			$objectbomchildline->fetch($id_bom_line);
 
 			// Find the consume line of the parent MO generated from this BOM line.
-			// The lookup must be scoped to the parent MO and use an exact match, otherwise
-			// the 'origin_id LIKE %..%' filter can return an unrelated line (or none), which
-			// would let the child MO be created from the leftover parent POST data (duplicate MO).
-			$TMoLines = $moline->fetchAll('DESC', 'rowid', '1', '', array('customsql' => 'fk_mo = '.((int) $mo_parent->id).' AND origin_id = '.((int) $id_bom_line)." AND origin_type = 'bomline'"));
+			// The lookup must be scoped to the parent MO and use an exact match on origin_id/origin_type,
+			// otherwise the default 'origin_id LIKE %..%' filter can return an unrelated line (or none),
+			// which would let the child MO be created from the leftover parent POST data (duplicate MO).
+			$TMoLines = $moline->fetchAll('DESC', 'rowid', '1', '', array('fk_mo' => $mo_parent->id, 'origin_id' => $id_bom_line, 'origin_type' => 'bomline'));
 
 			if (empty($TMoLines)) {
 				continue;

--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -154,7 +154,15 @@ if (empty($reshook)) {
 
 			$objectbomchildline->fetch($id_bom_line);
 
-			$TMoLines = $moline->fetchAll('DESC', 'rowid', '1', '', array('origin_id' => $id_bom_line));
+			// Find the consume line of the parent MO generated from this BOM line.
+			// The lookup must be scoped to the parent MO and use an exact match, otherwise
+			// the 'origin_id LIKE %..%' filter can return an unrelated line (or none), which
+			// would let the child MO be created from the leftover parent POST data (duplicate MO).
+			$TMoLines = $moline->fetchAll('DESC', 'rowid', '1', '', array('customsql' => 'fk_mo = '.((int) $mo_parent->id).' AND origin_id = '.((int) $id_bom_line)." AND origin_type = 'bomline'"));
+
+			if (empty($TMoLines)) {
+				continue;
+			}
 
 			foreach ($TMoLines as $tmpmoline) {
 				$_POST['fk_bom'] = $objectbomchildline->fk_bom_child;


### PR DESCRIPTION
Fixes #39020. Generating a child MO for a sub-BOM line looks up the parent consume line with fetchAll(array('origin_id' => $id_bom_line)), which MoLine::fetchAll compiles to origin_id LIKE '%id%' with no fk_mo or origin_type scope. When it returns nothing, the inner loop that sets the child POST values is skipped but the create action still runs on the leftover parent POST, producing a second MO identical to the parent. The lookup is now scoped to the parent MO with an exact origin_id/origin_type match, and the iteration is skipped when empty.