### PR TITLE
Fix #38389 use real PDF path for supplier invoice mass merge

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -778,7 +778,7 @@ if (!$error && $massaction == "builddoc" && $permissiontoread && !GETPOST('butto
 		$basename = dol_sanitizeFileName($basename);
 		foreach ($listoffiles as $filefound) {
 			if (strstr($filefound["name"], $basename)) {
-				$files[] = $uploaddir.'/'.$basename.'/'.$filefound["name"];
+				$files[] = $filefound['fullname'];
 				break;
 			}
 		}


### PR DESCRIPTION
Fixes #38389 on 18.0. The mass-action PDF merge (builddoc) rebuilt each file path as uploaddir/ref/name, which is wrong for supplier invoices whose PDFs live under a get_exdir() subpath (dir_output/xy/z/ref/ref.pdf). The rebuilt path pointed at a nonexistent file, so pdftk produced nothing and the TCPDF import branch threw a 500. Customer invoices store PDFs directly under dir_output/ref, which is why the old code happened to work for them. This uses the fullname already resolved by dol_dir_list (which recurses into exdir), matching what 21.0 and later branches already do - so it is a backport of the existing fix to 18.0.