### PR TITLE
Fix #38909 persist delivery date when marking supplier order received

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -2565,6 +2565,9 @@ class CommandeFournisseur extends CommonOrder
 
 				$sql = "UPDATE ".MAIN_DB_PREFIX."commande_fournisseur";
 				$sql .= " SET fk_statut = ".((int) $statut);
+				if (!empty($date)) {
+					$sql .= ", date_livraison = '".$this->db->idate($date)."'";
+				}
 				$sql .= " WHERE rowid = ".((int) $this->id);
 				$sql .= " AND fk_statut IN (".self::STATUS_ORDERSENT.",".self::STATUS_RECEIVED_PARTIALLY.")"; // Process running or Partially received
 
@@ -2575,6 +2578,10 @@ class CommandeFournisseur extends CommonOrder
 					$old_statut = $this->statut;
 					$this->statut = $statut;
 					$this->actionmsg2 = $comment;
+					if (!empty($date)) {
+						$this->date_livraison = $date;
+						$this->delivery_date = $date;
+					}
 
 					// Call trigger
 					$result_trigger = $this->call_trigger('ORDER_SUPPLIER_RECEIVE', $user);


### PR DESCRIPTION
Fixes #38909. When marking a supplier order as received, CommandeFournisseur::Livraison() receives the picked delivery date as parameter but its UPDATE only set fk_statut, so date_livraison was never written and the order header kept showing the current date instead of the value chosen in the Receive form. The UPDATE now writes date_livraison alongside fk_statut when a date is provided, and the in-memory delivery_date / date_livraison properties are refreshed. Matches the V21 behaviour the report says was lost in V22.