### PR TITLE
Fix #38860 build valid ldap URI for scheme-less host on PHP 8.3+

### DIFF
--- a/htdocs/core/class/ldap.class.php
+++ b/htdocs/core/class/ldap.class.php
@@ -358,7 +358,10 @@ class Ldap
 						dol_syslog(get_class($this)."::connectBind serverPing true, we try ldap_connect to ".$host, LOG_DEBUG);
 					}
 					if (version_compare(PHP_VERSION, '8.3.0', '>=')) {
-						$uri = $host.':'.$this->serverPort;
+						// Since PHP 8.3, ldap_connect() expects a single URI argument. A scheme-less
+						// host (ex: localhost, 192.168.0.2) must be turned into a valid ldap:// URI,
+						// otherwise the host is parsed as the URI scheme and the later bind fails.
+						$uri = preg_match('/^ldaps?:\/\//i', $host) ? $host : 'ldap://'.$host.':'.$this->serverPort;
 						$this->connection = ldap_connect($uri);
 					} else {
 						$this->connection = ldap_connect($host, $this->serverPort);
@@ -371,7 +374,7 @@ class Ldap
 							dol_syslog(get_class($this)."::connectBind serverPing false, we try ldap_connect to ".$host, LOG_DEBUG);
 						}
 						if (version_compare(PHP_VERSION, '8.3.0', '>=')) {
-							$uri = $host.':'.$this->serverPort;
+							$uri = preg_match('/^ldaps?:\/\//i', $host) ? $host : 'ldap://'.$host.':'.$this->serverPort;
 							$this->connection = ldap_connect($uri);
 						} else {
 							$this->connection = ldap_connect($host, $this->serverPort);


### PR DESCRIPTION
Fixes #38860. Since PHP 8.3, ldap_connect() takes a single URI argument. connectBind() built it as host:port, which is a malformed URI for a scheme-less host (localhost, 192.168.0.2 - both documented as valid in LDAPServerExample): the host is then parsed as the URI scheme, the lazy handle is non-false but the following ldap_bind() fails. It also mis-appended :port to an already qualified ldaps:// URI. This prefixes scheme-less hosts with ldap:// and appends the port, while leaving ldap:// and ldaps:// URIs untouched. On PHP 8.2 the two-arg ldap_connect(host, port) accepted bare hosts, which is why this regressed on 8.3.