### PR TITLE
Qual: Update logToCheckStyle (now extracts PHP Lint error msg)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -157,7 +157,7 @@ jobs:
           ls -l ~/.cache/pre-commit/
 
       - name: Convert Raw Log to Annotations
-        uses: mdeweerd/logToCheckStyle@v2025.11.2
+        uses: mdeweerd/logToCheckStyle@v2026.7.1
         if: ${{ failure() }}
         with:
           in: ${{ env.RAW_LOG }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -192,7 +192,7 @@ jobs:
           for /f "tokens=2 delims==" %%A in ('doskey /m:err') do EXIT /B %%A
 
       - name: Convert Raw Log to Annotations
-        uses: mdeweerd/logToCheckStyle@v2025.11.2
+        uses: mdeweerd/logToCheckStyle@v2026.7.1
         if: ${{ failure() }}
         with:
           in: ${{ env.PHPUNIT_LOG }}


### PR DESCRIPTION
# Qual: Update logToCheckStyle (now extracts PHP Lint error msg)

logToCheckStyle  was updated to extract PHP Lint (php -l) errors. So they will show in the summary report and as annotations.
