### PR TITLE
Fix #38853 retained warranty display and per-invoice To pay on situation invoices

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5405,16 +5405,16 @@ if ($action == 'create') {
 		}
 
 		// Retained warranty : usualy use on construction industry
-		if (!empty($object->situation_final) && !empty($object->retained_warranty) && $displayWarranty) {
-			// Billed - retained warranty
-			if ($object->type == Facture::TYPE_SITUATION) {
-				$retainedWarranty = $total_global_ttc * $object->retained_warranty / 100;
-			} else {
-				// Because one day retained warranty could be used on standard invoices
-				$retainedWarranty = $object->total_ttc * $object->retained_warranty / 100;
-			}
+		// Use the same rules as PDF generation and accountancy journal (model methods) so screen, PDF and journal stay consistent
+		// and so retained warranty is shown on every situation invoice unless INVOICE_RETAINED_WARRANTY_LIMITED_TO_FINAL_SITUATION is set.
+		if (!empty($object->retained_warranty) && $object->displayRetainedWarranty()) {
+			// Retained warranty shown on the dedicated line is the global amount held back over all situations (paid later).
+			$retainedWarranty = $object->getRetainedWarrantyAmount();
 
-			$billedWithRetainedWarranty = $object->total_ttc - $retainedWarranty;
+			// The amount held back on THIS invoice is the retained warranty of this invoice only (#38849),
+			// not the global one, so the "To pay" line must deduct total_ttc * rate, like the accountancy sells journal.
+			$retainedWarrantyThisInvoice = $object->total_ttc * $object->retained_warranty / 100;
+			$billedWithRetainedWarranty = $object->total_ttc - $retainedWarrantyThisInvoice;
 
 			print '<tr><td colspan="'.$nbcols.'" align="right">'.$langs->trans("ToPayOn", dol_print_date($object->date_lim_reglement, 'day')).' :</td><td align="right">'.price($billedWithRetainedWarranty).'</td><td>&nbsp;</td></tr>';
 

--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -1628,7 +1628,10 @@ class pdf_crabe extends ModelePDFFactures
 					$pdf->SetFillColor(255, 255, 255);
 
 					$retainedWarranty = $object->getRetainedWarrantyAmount();
-					$billedWithRetainedWarranty = $object->total_ttc - $retainedWarranty;
+					// The amount held back on THIS invoice is the retained warranty of this invoice only (#38849),
+					// not the global one, so the "To pay" line must deduct total_ttc * rate, like the accountancy sells journal.
+					$retainedWarrantyThisInvoice = $object->total_ttc * $object->retained_warranty / 100;
+					$billedWithRetainedWarranty = $object->total_ttc - $retainedWarrantyThisInvoice;
 
 					// Billed - retained warranty
 					$index++;

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -1920,7 +1920,10 @@ class pdf_sponge extends ModelePDFFactures
 					$pdf->SetFillColor(255, 255, 255);
 
 					$retainedWarranty = $object->getRetainedWarrantyAmount();
-					$billedWithRetainedWarranty = $object->total_ttc - $retainedWarranty;
+					// The amount held back on THIS invoice is the retained warranty of this invoice only (#38849),
+					// not the global one, so the "To pay" line must deduct total_ttc * rate, like the accountancy sells journal.
+					$retainedWarrantyThisInvoice = $object->total_ttc * $object->retained_warranty / 100;
+					$billedWithRetainedWarranty = $object->total_ttc - $retainedWarrantyThisInvoice;
 
 					// Billed - retained warranty
 					$index++;


### PR DESCRIPTION
Fixes #38853, and also #38848 and #38849 which are the same retained warranty block. Two related defects on the invoice card and in pdf_crabe / pdf_sponge:

1. Display (#38853 / #38848): the card hardcoded !empty(situation_final), so retained warranty only showed on the final situation and ignored INVOICE_RETAINED_WARRANTY_LIMITED_TO_FINAL_SITUATION. It now uses the model methods displayRetainedWarranty() / getRetainedWarrantyAmount(), like the PDF templates and the accountancy sells journal, so screen, PDF and journal stay consistent and retained warranty shows on every situation unless the constant limits it to the final one.

2. To pay amount (#38849): the 'To pay on' line deducted the global retained warranty (over all situations) from a single invoice total, which was wrong and could go negative. It now deducts the retained warranty of this invoice only (total_ttc * rate), like sellsjournal.php, while the dedicated retained warranty line still shows the global amount held back and paid later. For didi31's example (total_ttc 8001.95, 5%) the To pay becomes 7601.85.

Verified the display logic on a running instance: with the constant off retained warranty shows on every situation, with it on only on the final one; no regression on the final situation.