### PR TITLE
Fix #39143 store computed extrafields with object context

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7009,6 +7009,8 @@ abstract class CommonObject
 
 			if (!empty($attrfieldcomputed)) {
 				if (getDolGlobalString('MAIN_STORE_COMPUTED_EXTRAFIELDS')) {
+					global $objectoffield;		// We set a global variable to $objectoffield so
+					$objectoffield = $this;		// we can use it inside the computed formula
 					$value = dol_eval((string) $attrfieldcomputed, 1, 0, '2');
 					dol_syslog($langs->trans("Extrafieldcomputed")." on ".$attributeLabel."(".$value.")", LOG_DEBUG);
 					$new_array_options[$key] = $value;
@@ -7488,6 +7490,8 @@ abstract class CommonObject
 			//dol_syslog("attributeType=".$attributeType, LOG_DEBUG);
 			if (!empty($attrfieldcomputed)) {
 				if (getDolGlobalString('MAIN_STORE_COMPUTED_EXTRAFIELDS')) {
+					global $objectoffield;		// We set a global variable to $objectoffield so
+					$objectoffield = $this;		// we can use it inside the computed formula
 					$value = dol_eval((string) $attrfieldcomputed, 1, 0, '2');
 					dol_syslog($langs->trans("Extrafieldcomputed")." on ".$attributeLabel."(".$value.")", LOG_DEBUG);
 

--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -76,8 +76,10 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 					$value = (isset($obj->$tmpkey) ? $obj->$tmpkey :
 						(isset($obj->array_options[$tmpkey]) ? $obj->array_options[$tmpkey] : ''));
 				}
-				// If field is a computed field, we make computation to get value
-				if ($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]) {
+				// If field is a computed field, we make computation to get value.
+				// But when MAIN_STORE_COMPUTED_EXTRAFIELDS is enabled, the value stored in database is used instead,
+				// because the raw row available in a list has no object context (like $objectoffield->array_options) that the formula may rely on.
+				if ($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key] && !getDolGlobalString('MAIN_STORE_COMPUTED_EXTRAFIELDS')) {
 					$objectoffield = $object; // For compatibility with the computed formula. $objectoffield is exported by dol_eval().
 					$value = dol_eval((string) $extrafields->attributes[$extrafieldsobjectkey]['computed'][$key], 1, 1, '2');
 					if (is_numeric(price2num($value)) && $extrafields->attributes[$extrafieldsobjectkey]['totalizable'][$key]) {


### PR DESCRIPTION
Fixes #39143. When MAIN_STORE_COMPUTED_EXTRAFIELDS is enabled, a computed extrafield whose formula reads the object (e.g. $objectoffield->array_options) was stored as 0/empty on insert and update, because insertExtraFields() and updateExtraField() call dol_eval() without setting the $objectoffield global that the formula relies on. fetch_optionals() already sets 'global $objectoffield; $objectoffield = $this;' before dol_eval(); this applies the same pattern to the insert and update paths.

Also, the list template recomputed the formula in list context where only a raw DB row is available (no object context), producing a wrong displayed value even when the stored value is correct; it now uses the stored DB value when MAIN_STORE_COMPUTED_EXTRAFIELDS is enabled.

Verified on a running instance: a formula reading $objectoffield->array_options returns 0 without the fix and the correct value with it.