### PR TITLE
FIX #37775 Improve extra fields merge when creating invoice from template

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -619,12 +619,11 @@ class Facture extends CommonInvoice
 			$this->note_private = trim($this->note_private);
 			$this->note_private = dol_concatdesc($this->note_private, $langs->trans("GeneratedFromRecurringInvoice", $_facrec->ref));
 
-			// Keep POSTed extrafields if the caller already populated array_options
-			// (htdocs/compta/facture/card.php:1235 calls setOptionalsFromPost before
-			// create()). Falling back to the template values when nothing was POSTed
-			// preserves cron behavior for auto-generated recurring invoices (#37775).
-			if (empty($this->array_options)) {
-				$this->array_options = $_facrec->array_options;
+			// Use template extra fields as fallback only - form values (already set) take precedence
+			foreach ($_facrec->array_options as $key => $val) {
+				if (!isset($this->array_options[$key]) || $this->array_options[$key] === '' || $this->array_options[$key] === null) {
+					$this->array_options[$key] = $val;
+				}
 			}
 
 			if (!$this->mode_reglement_id) {

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -621,7 +621,7 @@ class Facture extends CommonInvoice
 
 			// Use template extra fields as fallback only - form values (already set) take precedence
 			foreach ($_facrec->array_options as $key => $val) {
-				if (!isset($this->array_options[$key]) || $this->array_options[$key] === '' || $this->array_options[$key] === null) {
+				if (!isset($this->array_options[$key]) || $this->array_options[$key] === '') {
 					$this->array_options[$key] = $val;
 				}
 			}


### PR DESCRIPTION
# FIX Fix #37775 Improve extra fields merge when creating invoice from template

The fix introduced in #38814 used `if (empty($this->array_options))` to avoid overwriting POSTed extra fields with template values. However this check is too coarse: if the user fills in any single extra field in the form, the entire                                                                                                                                                                    
`array_options` is considered non-empty and all template extra field values are discarded, even for fields the user left untouched.     
                                                                                                                                                                                                                                           
This replaces the all-or-nothing check with a field-by-field merge: for each extra field coming from the template, the value is used only if the corresponding key is not already set (or is empty/null) in `$this->array_options`. This way POST values                                                                                                                                                             
always take precedence while the template still provides fallback values for fields not filled in the form, and cron-generated recurring invoices (no POST data) continue to work as before