### PR TITLE
FIX dol_string_nohtmltag() skips double-space collapsing when string starts with a double space

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8248,9 +8248,9 @@ function dol_string_nohtmltag($stringtoclean, $removelinefeed = 1, $pagecodeto =
 		$temp = str_replace(array("\r\n", "\r", "\n"), " ", $temp);
 	}
 
-	// And double quotes
+	// And double spaces
 	if ($removedoublespaces) {
-		while (strpos($temp, "  ")) {
+		while (strpos($temp, "  ") !== false) {
 			$temp = str_replace("  ", " ", $temp);
 		}
 	}


### PR DESCRIPTION
`dol_string_nohtmltag()`'s double-space removal loop used `while (strpos($temp, "  "))`. `strpos()` returns `0` (falsy) when the first double space is at index 0, so the loop never runs and interior double spaces are left uncollapsed — for example text whose leading `<br><br>` becomes two leading spaces via the `removelinefeed` step just above.

Fixed with the standard `!== false` idiom; strings not starting with a double space are unchanged. Also corrected the adjacent comment ("double quotes" → "double spaces").

Verified on PHP 8.5 with a harness requiring the real lib file: before, `"  Total  amount  due"` → `"Total  amount  due"` (interior doubles survive); after, → `"Total amount due"`. Includes DCO sign-off.
