### PR TITLE
fix: if user cannot create supplier invoice then it cannot create payment

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -4258,7 +4258,7 @@ if ($action == 'create') {
 				}
 
 				// Create payment
-				if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE && $object->status == FactureFournisseur::STATUS_VALIDATED && $object->paid == 0) {
+				if ($object->type != FactureFournisseur::TYPE_CREDIT_NOTE && $object->status == FactureFournisseur::STATUS_VALIDATED && $object->paid == 0 && $usercancreate) {
 					print '<a class="butAction" href="'.DOL_URL_ROOT.'/fourn/facture/paiement.php?facid='.$object->id.'&action=create'.($object->fk_account > 0 ? '&accountid='.$object->fk_account : '').'">'.$langs->trans('DoPayment').'</a>'; // must use facid because id is for payment id not invoice
 				}
 
@@ -4268,7 +4268,7 @@ if ($action == 'create') {
 					if ($object->type == FactureFournisseur::TYPE_CREDIT_NOTE && $object->status == 1 && $object->paid == 0) {
 						if ($resteapayer == 0) {
 							print '<span class="butActionRefused classfortooltip" title="'.$langs->trans("DisabledBecauseRemainderToPayIsZero").'">'.$langs->trans('DoPaymentBack').'</span>';
-						} else {
+						} elseif ($usercancreate) {
 							print '<a class="butAction" href="'.DOL_URL_ROOT.'/fourn/facture/paiement.php?facid='.$object->id.'&action=create&accountid='.$object->fk_account.'">'.$langs->trans('DoPaymentBack').'</a>';
 						}
 					}


### PR DESCRIPTION
in htdocs/fourn/facture/paiement.php test permission for [_add_paiement_](https://github.com/Dolibarr/dolibarr/blob/b97959e5f07e8420430f33a03783ec78b0c4ef66/htdocs/fourn/facture/paiement.php#L167) is 


https://github.com/Dolibarr/dolibarr/blob/b97959e5f07e8420430f33a03783ec78b0c4ef66/htdocs/fourn/facture/paiement.php#L126


so there is no reason to display "Create Payment" button in htdocs/fourn/facture/card.php if these permissions are not set for the user