### PR TITLE
Fix empty SET clause in insertExtraFields UPDATE (invoice from shipment)

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7001,6 +7001,15 @@ abstract class CommonObject
 		// if the extrafields row already exists for the object, we update it
 		if ($this->db->getRow("SELECT 1 FROM {$extrafieldsTable} WHERE fk_object = ".((int) $this->id))) {
 			array_shift($sqlColumnValues); // drop the 'fk_object' column because its value won't change
+			if (empty($sqlColumnValues)) {
+				// No column of the target element to update. This happens when the object was created from
+				// another element whose extrafields do not exist on this element (e.g. invoice created from a
+				// shipment: the source line extrafields are copied into array_options but none match facturedet).
+				// The existing row is already correct, so there is nothing to update: avoid an empty "SET" clause
+				// that would produce an invalid SQL statement.
+				$this->db->commit();
+				return 1;
+			}
 			$sqlColumnValueString = implode(
 				',',
 				/**


### PR DESCRIPTION
## What

Fixes a MariaDB syntax error that aborts invoice creation from a shipment (and, more generally, any object created from another element that has different extrafields).

## Symptom

Creating an invoice from a delivery/shipment fails with:

```
DB_ERROR_SYNTAX You have an error in your SQL syntax; ... near 'WHERE fk_object = <id>' at line 1
SQL: UPDATE llx_facturedet_extrafields SET  WHERE fk_object = <id>
```

The `SET` clause is empty.

## Root cause

`CommonObject::insertExtraFields()` (UPDATE branch). The top-level guard only checks `empty($this->array_options)`. But `$new_array_options` is `array_options` **filtered to the target element's own extrafields**.

When an invoice is created from a shipment, the source (shipment line) extrafield keys are copied into the new `facturedet` line's `array_options`. Those keys do not exist on `facturedet`, so:

- `array_options` is non-empty → passes the top guard,
- after filtering, **no column belongs to the target element** → `$sqlColumnValues` reduces to just `fk_object`, which `array_shift()` then removes, leaving it empty,
- if an extrafields row already exists for the line, the UPDATE branch builds `UPDATE ... SET  WHERE fk_object = X` → invalid SQL.

This was introduced when the DELETE+INSERT logic was replaced by UPDATE-if-exists / INSERT (multicompany data-loss fix #34022). Present on 22.0, 23.0 and develop; 20.0/21.0 still use the old DELETE+INSERT and are not affected.

## Fix

In the UPDATE branch, when there is no target-element column to update, commit and return without running the query — the existing row is already correct. This avoids the empty `SET` clause and keeps the multicompany fix (UPDATE instead of DELETE+INSERT) untouched.

## How to reproduce / verify

On an install with extrafields defined on `facturedet`, create an invoice from a shipment whose lines carry extrafields that don't exist on `facturedet`.

Verified on 22.0 against a real DB by calling `insertExtraFields()` on a `FactureLigne` that already has an extrafields row, with `array_options` holding only a non-`facturedet` key: before → returns -1 with the `near 'WHERE fk_object = ...'` error; after → returns 1, no error.
