### PR TITLE
FIX getWeekNumbersOfMonth() drops the last week when the month ends on a Monday

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -1178,7 +1178,7 @@ function getWeekNumbersOfMonth($month, $year)
 {
 	$nb_days = cal_days_in_month(CAL_GREGORIAN, $month, $year);
 	$TWeek = array();
-	for ($day = 1; $day < $nb_days; $day++) {
+	for ($day = 1; $day <= $nb_days; $day++) {
 		$week_number = getWeekNumber($day, $month, $year);
 		$TWeek[$week_number] = $week_number;
 	}


### PR DESCRIPTION
`getWeekNumbersOfMonth()` looped `for ($day = 1; $day < $nb_days; ...)`, so the last day of the month was never inspected. When that last day is a Monday it begins a new ISO week that no earlier day of the month belongs to, so its week number was silently missing from the returned array.

This shows up in the project **time spent per month** view (`htdocs/projet/activity/permonth.php`), which builds one column per week from this list — the final week column is dropped for those months. Over 2015–2035, 35 months are affected (e.g. August 2015 returned weeks 31–35 but omitted 36, the week of Monday 2015-08-31).

**Fix:** iterate up to and including the last day (`$day <= $nb_days`).

Verified locally (PHP 8.5) against the real `date.lib.php`: before, August 2015 → 31,32,33,34,35 (week 36 missing); after → 31,32,33,34,35,36. Output now exactly matches an independent full-month ISO-week set for all 252 months tested. Includes DCO sign-off.

*Disclosure: prepared with AI assistance (Claude) and human-reviewed.*
