### PR TITLE
FIX #37826 country_code must be an ISO code, not a label

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8032,12 +8032,20 @@ class Form
 		//exit;
 
 		// Define list of countries to use to search VAT rates to show
-		// First we defined code_country to use to find list
-		if (is_object($societe_vendeuse)) {
-			$code_country = "'" . $societe_vendeuse->country_code . "'";
-		} else {
-			$code_country = "'" . $mysoc->country_code . "'"; // Pour compatibilite ascendente
+		// First we defined code_country to use to find list.
+		// country_code must be a c_country ISO code (e.g. 'FR', 'CH'). In some setups it may hold a
+		// country label (e.g. 'Suisse') instead, which would make the "c.code IN (...)" lookup done by
+		// load_cache_vatrates() match nothing and wrongly force the VAT rate to 0%. When the value is
+		// not a known country code, we recover the ISO code from the authoritative country id.
+		$sellercountrycode = is_object($societe_vendeuse) ? $societe_vendeuse->country_code : $mysoc->country_code;
+		$sellercountryid = is_object($societe_vendeuse) ? $societe_vendeuse->country_id : $mysoc->country_id;
+		if (!empty($sellercountrycode) && (int) $sellercountryid > 0 && (int) dol_getIdFromCode($this->db, $sellercountrycode, 'c_country', 'code', 'rowid') <= 0) {
+			$tmpcountrycode = dol_getIdFromCode($this->db, (string) $sellercountryid, 'c_country', 'rowid', 'code');
+			if (!empty($tmpcountrycode) && !is_numeric($tmpcountrycode)) {
+				$sellercountrycode = $tmpcountrycode;
+			}
 		}
+		$code_country = "'" . $sellercountrycode . "'"; // Pour compatibilite ascendente
 
 		if ($societe_vendeuse == $mysoc && getDolGlobalString('SERVICE_ARE_ECOMMERCE_200238EC')) {    // If option to have vat for end customer for services is on
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -8035,11 +8035,13 @@ class Form
 		// First we defined code_country to use to find list.
 		// country_code must be a c_country ISO code (e.g. 'FR', 'CH'). In some setups it may hold a
 		// country label (e.g. 'Suisse') instead, which would make the "c.code IN (...)" lookup done by
-		// load_cache_vatrates() match nothing and wrongly force the VAT rate to 0%. When the value is
-		// not a known country code, we recover the ISO code from the authoritative country id.
+		// load_cache_vatrates() match nothing and wrongly force the VAT rate to 0%. A valid ISO code is
+		// always 2 chars, so when the value is not a well formed ISO code (empty or a label) and we have
+		// a valid country id, we recover the ISO code from the authoritative country id. This way we do
+		// not run any SQL on each page access when we already have a valid ISO code.
 		$sellercountrycode = is_object($societe_vendeuse) ? $societe_vendeuse->country_code : $mysoc->country_code;
 		$sellercountryid = is_object($societe_vendeuse) ? $societe_vendeuse->country_id : $mysoc->country_id;
-		if (!empty($sellercountrycode) && (int) $sellercountryid > 0 && (int) dol_getIdFromCode($this->db, $sellercountrycode, 'c_country', 'code', 'rowid') <= 0) {
+		if ((int) $sellercountryid > 0 && strlen((string) $sellercountrycode) != 2) {
 			$tmpcountrycode = dol_getIdFromCode($this->db, (string) $sellercountryid, 'c_country', 'rowid', 'code');
 			if (!empty($tmpcountrycode) && !is_numeric($tmpcountrycode)) {
 				$sellercountrycode = $tmpcountrycode;

--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -4771,11 +4771,14 @@ class Societe extends CommonObject
 		if (getDolGlobalString('MAIN_INFO_SOCIETE_COUNTRY')) {
 			$tmp = explode(':', getDolGlobalString('MAIN_INFO_SOCIETE_COUNTRY'));
 			$country_id =  (is_numeric($tmp[0])) ? (int) $tmp[0] : 0;
-			if (!empty($tmp[1])) {   // If $conf->global->MAIN_INFO_SOCIETE_COUNTRY is "id:code:label"
+			if (!empty($tmp[1]) && !empty($tmp[2])) {   // MAIN_INFO_SOCIETE_COUNTRY is the canonical "id:code:label"
 				$country_code = $tmp[1];
 				$country_label = $tmp[2];
-			} else {
-				// For backward compatibility
+			} elseif ($country_id > 0) {
+				// For backward compatibility. The value is "id" only, or a legacy "id:label" where the
+				// second token is a country label (e.g. 'Suisse') and not an ISO code. In both cases we
+				// must not keep a label in country_code (it would break code-based lookups like VAT rates),
+				// so we rebuild code and label from the authoritative country id.
 				dol_syslog("Your country setup use an old syntax. Reedit it using setup area.", LOG_WARNING);
 				include_once DOL_DOCUMENT_ROOT.'/core/lib/company.lib.php';
 				$country_code = getCountry($country_id, '2', $this->db); // This need a SQL request, but it's the old feature that should not be used anymore

--- a/test/phpunit/SocieteTest.php
+++ b/test/phpunit/SocieteTest.php
@@ -568,4 +568,50 @@ class SocieteTest extends CommonClassTest
 		print __METHOD__." result=".$result."\n";
 		return $result;
 	}
+
+	/**
+	 * Test that Societe::setMysoc() always resolves country_code to an ISO country code.
+	 *
+	 * Regression test for issue #37826: when MAIN_INFO_SOCIETE_COUNTRY uses the legacy
+	 * "id:label" (2-token) syntax, the second token is a country label (e.g. 'France'),
+	 * not an ISO code. setMysoc() must not leave that label in country_code (it would break
+	 * code-based lookups such as VAT rates and force a 0% rate), but rebuild it from the id.
+	 *
+	 * @return void
+	 */
+	public function testSetMysocCountryCode()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		require_once dirname(__FILE__).'/../../htdocs/core/lib/company.lib.php';
+
+		$frid = (int) getCountry('FR', '3', $db);
+		$this->assertGreaterThan(0, $frid, 'Country FR must exist in dictionary c_country');
+
+		$savcountryconst = getDolGlobalString('MAIN_INFO_SOCIETE_COUNTRY');
+
+		// Canonical 3-token syntax "id:code:label".
+		$conf->global->MAIN_INFO_SOCIETE_COUNTRY = $frid.':FR:France';
+		$soc3 = new Societe($db);
+		$soc3->setMysoc($conf);
+
+		// Legacy 2-token syntax "id:label" (the #37826 case), second token is a label not a code.
+		$conf->global->MAIN_INFO_SOCIETE_COUNTRY = $frid.':France';
+		$soc2 = new Societe($db);
+		$soc2->setMysoc($conf);
+
+		// Restore the constant before asserting so a failure does not leak state to other tests.
+		$conf->global->MAIN_INFO_SOCIETE_COUNTRY = $savcountryconst;
+
+		$this->assertEquals('FR', $soc3->country_code, 'country_code must be the ISO code from a 3-token constant');
+		$this->assertEquals($frid, $soc3->country_id);
+		$this->assertEquals('FR', $soc2->country_code, 'country_code must be an ISO code, not a label, from a legacy 2-token constant (#37826)');
+		$this->assertEquals($frid, $soc2->country_id);
+
+		print __METHOD__." ok\n";
+	}
 }


### PR DESCRIPTION
# FIX #37826 country_code must be an ISO code, not a label

## Problem
On a proposal/order, adding the 2nd+ product line shows VAT **0%** with the error
*"Error, no vat rates defined for country 'France'/'Suisse'"*. The seller `country_code`
sometimes holds a translated **country label** (`Suisse`, `France`) instead of the ISO
code (`CH`, `FR`), so the `c.code IN (...)` lookup in `Form::load_cache_vatrates()`
matches nothing → VAT forced to 0%.

## Root cause
`Societe::setMysoc()` parses `MAIN_INFO_SOCIETE_COUNTRY`. The canonical value is the
3-token `id:code:label` (e.g. `6:CH:Suisse`), but a legacy 2-token `id:label` value
(e.g. `6:Suisse`) made it take the **label** token as the code. `Societe::fetch()`
guarantees `country_code` is the ISO code — `setMysoc()` was breaking that invariant,
and every downstream `country_code`-based lookup (VAT rates, etc.) then misbehaves.

## Fix
- **`Societe::setMysoc()`** (root cause): only treat the value as `id:code:label` when
  it really has both a code **and** a label token; otherwise rebuild code/label from the
  authoritative country **id** (reusing the existing `getCountry($id, '2')` backward-compat
  path). Because `setMysoc()` runs on every request, existing affected installs self-heal
  on the next page load — no data migration needed.
- **`Form::load_tva()`** (defense in depth): if the seller `country_code` is not a known
  `c_country` code, recover the ISO code from its country id before building the VAT query,
  so a bad value from any source can never silently force VAT to 0%.

Canonical 3-token setups are completely unchanged (no extra query).

## How to reproduce
1. Make the "my company" country be stored in the legacy 2-token form, e.g.
   `MAIN_INFO_SOCIETE_COUNTRY = '<country_id>:France'` (an old value from an upgraded install).
2. Create a proposal/order and add a product line.
3. **Before:** the line VAT combo shows *"no vat rates defined for country 'France'"* / 0%.

## How to verify the fix
- `$mysoc->country_code` resolves to the ISO code (`FR`) instead of the label.
- The line VAT dropdown lists the country's rates again.

Verified on a fresh `dolibarr:develop` install (MariaDB). With
`MAIN_INFO_SOCIETE_COUNTRY = '1:France'`, calling `Form::load_tva()` for the "my company"
seller returned:

| | `$mysoc->country_code` | VAT rates found |
|---|---|---|
| Before | `France` (label) | **0** (error / 0%) |
| After  | `FR` (ISO code)  | **5** (0 / 2.1 / 5.5 / 10 / 20 %) |

The `load_tva()` guard alone was also verified independently: a seller passed with
`country_code = 'France'` and a valid country id still resolves to 5 rates.
A regression unit test is added: `test/phpunit/SocieteTest.php::testSetMysocCountryCode`.

## Before / after
![#37826 VAT dropdown before/after](https://raw.githubusercontent.com/JamBalaya56562/dolibarr/pr37826-assets/.github/pr-assets/pr37826_before_after.png)

## Notes
- The bug is present in maintenance branches too (reported on 22.0.4); this PR targets `develop` and applies cleanly there.
- Atomic change: one concern (seller country code held a label → wrong VAT), no refactor/rename.

Signed-off-by: Jam Balaya <jambalaya.pyoncafe@outlook.jp>
