### PR TITLE
Qual: Fix PHPStan for 23.0 + pre-commit backports

### DIFF
--- a/.github/scripts/get_changed_php.sh
+++ b/.github/scripts/get_changed_php.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# Copyright (C) 2025		MDW	<mdeweerd@users.noreply.github.com>
+# Copyright (C) 2025-2026	MDW	<mdeweerd@users.noreply.github.com>
+
+# shellcheck disable=2129,2128,2034,2016
 
 set -euo pipefail
 
@@ -20,11 +22,11 @@ if [[ -z "${GITHUB_TOKEN:-}" ]]; then
 fi
 if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
 	echo "GITHUB_REPOSITORY is not set" >&2
-	exit 1
+	exit 2
 fi
 if [[ -z "${GITHUB_EVENT_PATH:-}" ]]; then
 	echo "GITHUB_EVENT_PATH is not set" >&2
-	exit 1
+	exit 3
 fi
 
 # Extract the pull request number from the event payload
@@ -34,7 +36,6 @@ if [[ "$pr_number" == "null" ]]; then
 	exit 0
 fi
 
-# Split repository into owner and repo name
 # Split repository into owner and repo name using Bash parameter expansion
 owner="${GITHUB_REPOSITORY%%/*}"  # Extract text before the first '/'
 repo="${GITHUB_REPOSITORY##*/}"   # Extract text after the last '/'
@@ -42,15 +43,33 @@ repo="${GITHUB_REPOSITORY##*/}"   # Extract text after the last '/'
 page=1
 per_page=100
 changed_php_files=()
+changed_phan_files=()
+changed_lang_files=()
+
+# Get phan path configuration
+phan_directory_list=$(php -r '$config = require("dev/tools/phan/config.php"); echo "^".implode("|",$config["directory_list"]);')
+phan_exclude_directory=$(php -r '$config = require("dev/tools/phan/config.php"); echo "^".implode("|",$config["exclude_analysis_directory_list"]);')
+
+phan_exclude_file_regex=$(php -r '$config = require("dev/tools/phan/config.php"); echo $config["exclude_file_regex"];')
+phan_exclude_file_regex=${phan_exclude_file_regex#@}
+phan_exclude_file_regex=${phan_exclude_file_regex%@}
 
 # Loop through all pages to gather changed files
 while true; do
 	response=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
 		"https://api.github.com/repos/${owner}/${repo}/pulls/${pr_number}/files?per_page=${per_page}&page=${page}")
 
+
+
 	# Filter for files ending with .php and add them to the list
-	mapfile -t files < <(echo "$response" | jq -r '.[] | select(.filename | test("\\.php$")) | .filename')
+	mapfile -t files < <(echo "$response" | jq -r '.[] | select((.filename | test("\\.php$")) and (.filename | test("^dev/") | not)) | .filename')
 	changed_php_files+=("${files[@]}")
+
+	mapfile -t files < <(echo "$response" | jq -r '.[] | select((.filename | test("\\.php$")) and (.filename | test("'"$phan_directory_list"'"))) | .filename' | grep -vP "$phan_exclude_file_regex")
+	changed_phan_files+=("${files[@]}")
+
+	mapfile -t files < <(echo "$response" | jq -r '.[] | select(.filename | test("\\.lang$")) | .filename')
+	changed_lang_files+=("${files[@]}")
 
 	# Check if we have reached the last page (less than per_page results)
 	count=$(echo "$response" | jq 'length')
@@ -61,26 +80,51 @@ while true; do
 done
 
 
-# Build a space-separated string of changed PHP files
+# Build a space-separated string of changed PHP and lang files
 # This does not cope with files that have spaces.
+
 # But such files do not exist in the project (at least not for the
 # files we are filtering).
 all_changed_files=$(IFS=" " ; echo "${changed_php_files[*]}")
+all_changed_lang=$(IFS=" " ; echo "${changed_lang_files[*]}")
+phan_changed_files=$(IFS=" " ; echo "${changed_phan_files[*]}")
 
 
-# Determine changed files flag
-if [ -z "$all_changed_files" ]; then
+forbidden_files=""
+#forbidden_files=$(echo "$all_changed_lang" | grep -E 'htdocs/langs/([^/]+)/.*\.lang$' | grep -v 'htdocs/langs/en_US/')
+#if [ -n "$forbidden_files" ]; then
+#  echo "You tried to modify one or more language files that are not allowed to be modified in Pull requests."
+#  echo "$forbidden_files"
+#  echo "To modify translations that are not the source language (en_US), you must modify them from transifex.com"
+#  exit 10
+#fi
+
+
+# Determine changed files flags
+if [ -z "${all_changed_files}" ]; then
     any_changed="false"
 else
     any_changed="true"
 fi
 
+if [ -z "${phan_changed_files}" ]; then
+    phan_changed="false"
+else
+    phan_changed="true"
+fi
+
 # Set outputs for GitHub Actions if GITHUB_OUTPUT is available
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
 	echo "any_changed=${any_changed}" >> "$GITHUB_OUTPUT"
+	echo "phan_changed=${phan_changed}" >> "$GITHUB_OUTPUT"
 	echo "all_changed_files=${all_changed_files}" >> "$GITHUB_OUTPUT"
+	echo "phan_changed_files=${phan_changed_files[*]}" >> "$GITHUB_OUTPUT"
+	echo "forbidden_files=${forbidden_files}" >> "$GITHUB_OUTPUT"
 else
 	# Otherwise, print the outputs
 	echo "any_changed=${any_changed}"
+	echo "phan_changed=${phan_changed}"
+	echo "phan_changed_files=${phan_changed_files[*]}"
 	echo "all_changed_files=${all_changed_files}"
+	echo "forbidden_files=${forbidden_files}"
 fi

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,6 +21,7 @@ env:
   gh_event: ${{ inputs.gh_event || github.event_name }}
   CACHE_KEY_PART: ${{ ( inputs.gh_event == 'pull_request' || github.event_name == 'pull_request' ) && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}
   GITHUB_JSON: ${{ toJSON(github) }}  # Helps in debugging Github Action
+  DUMMY_FILE: htdocs/theme/md/progress.inc.php
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job
@@ -45,7 +46,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none # disable xdebug, pcov
-          tools: phpstan:2.1.12, cs2pr
+          tools: phpstan:2.1.12, cs2pr:1.8.6
           extensions: calendar, json, imagick, gd, zip, mbstring, intl, opcache, imap,
             mysql, pgsql, sqlite3, ldap, xml, mcrypt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,9 @@ repos:
         exclude_types: [markdown]
       # Fix the end of file
       - id: end-of-file-fixer
+        exclude: |
+          (?x)^(htdocs/public/includes/tinymce/.*
+               )$
       # Check that there are no completely merged file conflicts
       - id: check-merge-conflict
         stages: [pre-rebase, pre-commit, pre-merge-commit]
@@ -60,23 +63,25 @@ repos:
 
   # Gitleaks is a SAST tool for detecting and preventing hardcoded secrets like passwords, api keys, and tokens in git repos
   - repo: https://github.com/gitleaks/gitleaks.git
-    rev: v8.29.0
+    rev: v8.30.0
     hooks:
       - id: gitleaks
 
-  # Check github actions
-  #- repo: https://github.com/rhysd/actionlint
-  #  rev: v1.7.8
-  #  hooks:
-  #    - id: actionlint
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        stages: [manual]  # To run: pre-commit run -a --hook-stage=manual actionlint
 
   # Beautify shell scripts
   #- repo: https://github.com/lovesegfault/beautysh.git
-  #  rev: v6.2.1
+  #  rev: v6.4.1
   #  hooks:
   #    - id: beautysh
   #      exclude: |
   #        (?x)^(dev/setup/git/hooks/pre-commit
+  #             |dev/initdemo/initdemo.sh          # indent/outdent mismatch
+  #             |dev/build/debian/dolibarr.postrm  # indent/outdent mismatch
   #             )$
   #      args: [--tab]
 
@@ -193,7 +198,7 @@ repos:
 
   # Check format of yaml files
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         args:
@@ -244,16 +249,16 @@ repos:
           - --uri-ignore-words-list
           - ned
 
-  # Check some shell scripts
-  #- repo: https://github.com/shellcheck-py/shellcheck-py
-  #  rev: v0.11.0.1
-  #  hooks:
-  #    - id: shellcheck
-  #      args: [-W, "100"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        stages: [manual]  # To run: `pre-commit run -a --hook-stage=manual shellcheck`
+        args: [-W, "100"]
 
   # Check sql file syntax
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 3.3.1
+    rev: 4.2.0
     hooks:
       - id: sqlfluff-lint
         #stages: [pre-commit, manual]  # manual needed for ci
@@ -262,8 +267,7 @@ repos:
           (dev/initdemo/mysqldump_.*\.sql
           |htdocs/core/menus/init_menu_auguria\.sql
           |htdocs/includes/.*
-          |htdocs/install/doctemplates/websites/.*_template
-          |htdocs/install/doctemplates/websites/website_template.*\.sql
+          |htdocs/install/doctemplates/websites/.*
           |htdocs/install/mysql/data/llx_20_c_departements\.sql
           |htdocs/install/mysql/data/llx_accounting_account_.*\.sql
           |htdocs/install/mysql/migration/3\..*\.sql

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # `codespell` can be run as a standalone program from the CLI
 # with the appropriate default options.
 
-skip = "*/.*/*,*/langs/*,*/dev/build/exe/*,**.log,*.pdf,*.PDF,*dev/resources/*,*.phar,*.z,*.gz,*.sql,*.svg,*htdocs/includes/*,*/textiso.txt,*.js,*README-*,*build/rpm/*spec,*build/pad/*ml,*htdocs/includes/phpoffice/*,*htdocs/includes/tecnickcom/*,*dev/initdemo/removeconfdemo.sh,*dev/tools/codespell/*,*dev/trans*/ignore_translation_keys.lst,*pyproject.toml,*build/exe/*,*fontawe*,*htdocs/theme/*/flags-sprite.inc.php,*dev/setup/codetemplates/codetemplates.xml,*/php.ini,*/html_cerfafr.*,*/lessc.class.php,*.asciidoc,*.xml,*opensurvey/css/style.css,*dev/tools/phan/stubs/*,*/documents,phpstan.*"
+skip = "*/.*/*,*/langs/*,*/dev/build/exe/*,**.log,*.pdf,*.PDF,*dev/resources/*,*.phar,*.z,*.gz,*.sql,*.svg,*htdocs/includes/*,*/textiso.txt,*.js,*README-*,*build/rpm/*spec,*build/pad/*ml,*htdocs/includes/phpoffice/*,*htdocs/includes/tecnickcom/*,*dev/initdemo/removeconfdemo.sh,*dev/tools/codespell/*,*dev/trans*/ignore_translation_keys.lst,*pyproject.toml,*build/exe/*,*fontawe*,*htdocs/theme/*/flags-sprite.inc.php,*dev/setup/codetemplates/codetemplates.xml,*/php.ini,*/html_cerfafr.*,*/lessc.class.php,*.asciidoc,*.xml,*opensurvey/css/style.css,*dev/tools/phan/stubs/*,*/documents,phpstan.*,*dev/initdemo/documents_demo/blockedlog/archives/*"
 
 check-hidden = true
 quiet-level=2
@@ -61,7 +61,7 @@ processes = -1
 #verbose = 1
 #exclude_rules = "LT01,CP01,RF04"
 # RF04 | Keywords should not be used as identifiers. (rowid, login, position, ...)
-exclude_rules = "LT01,LT02,LT05,LT12,LT13,LT14,CP01,CP02,CP04,CP05,RF04"
+exclude_rules = "LT01,LT02,LT05,LT12,LT13,LT14,LT15,CP01,CP02,CP04,CP05,RF04"
 dialect = "mysql"
 # Default byte limit is 20000, must set limit - some files are too big.
 large_file_skip_byte_limit = 100000


### PR DESCRIPTION
# Qual: Fix PHPStan for 23.0 + pre-commit backports

Fix https://github.com/Dolibarr/dolibarr/pull/39183#issuecomment-4986603802 .  Essential change: get_changed_php.sh .
Backport "dummy file" hack for phpstan as well (when none of the select changed files need phpstan analysis).

+ backported some pre-commit related configurations (avoids installation of hook versions different from develop, adds some exclusions as in develop) that should not result in merge conflicts.