### PR TITLE
Fix: API createfromorder could invoice draft, canceled or already-billed orders

### DIFF
--- a/htdocs/compta/facture/class/api_invoices.class.php
+++ b/htdocs/compta/facture/class/api_invoices.class.php
@@ -442,6 +442,12 @@ class Invoices extends DolibarrApi
 			throw new RestException(404, 'Order not found');
 		}
 
+		// Refuse orders that cannot be billed, to mirror the GUI (order card "CreateBill" button and list mass action):
+		// this excludes draft and canceled orders, as well as orders already classified as billed.
+		if ($order->status <= Commande::STATUS_DRAFT || !empty($order->billed)) {
+			throw new RestException(405, 'Order '.$order->ref.' is not eligible for invoicing: its status does not allow creating an invoice');
+		}
+
 		$result = $this->invoice->createFromOrder($order, DolibarrApiAccess::$user);
 		if ($result < 0) {
 			throw new RestException(405, $this->invoice->error);


### PR DESCRIPTION
# Fix

  The REST endpoint `POST /invoices/createfromorder/{orderid}` had no check on the
  source order state: it happily created an invoice from a draft order, a canceled
  order, or an order already classified as billed.

  This is inconsistent with the GUI, which prevents all three cases:
  - the "Create invoice" button on the order card is only shown when
    `status > STATUS_DRAFT` and the order is not billed;
  - the "Bill orders" mass action in the orders list skips such orders since #39015.

  This PR applies the same eligibility check in the API, right after fetching the
  order:

  - `status <= Commande::STATUS_DRAFT` covers draft (0) and canceled (-1) orders;
  - `!empty($order->billed)` covers orders already classified as billed.

  Non-eligible orders now get a `405` with an explicit message ("Order XXX is not
  eligible for invoicing..."), the same HTTP code this method already uses when
  `createFromOrder()` fails.