### PR TITLE
FIX : broken jquery selector prevents default model auto-select

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4411,17 +4411,17 @@ if ($action == 'create') {
 			print '<script type="text/javascript">
 					$(document).ready(function() {
 						var listType = {'.$jsListType.'};
-						$("[name=\'type\'").change(function() {
+						$("[name=\'type\']").change(function() {
 							console.log("change name=type");
 							if ($( this ).prop("checked"))
 							{
 								if(($( this ).val() in listType))
 								{
-									$("#model").val(listType[$( this ).val()]);
+									$("#model").val(listType[$( this ).val()]).trigger("change");
 								}
 								else
 								{
-									$("#model").val("' . getDolGlobalString('FACTURE_ADDON_PDF').'");
+									$("#model").val("' . getDolGlobalString('FACTURE_ADDON_PDF').'").trigger("change");
 								}
 							}
 						});


### PR DESCRIPTION
# FIX Broken jQuery selector prevents auto-selection of default PDF model per invoice type

The selector `$("[name='type'")` used in the `INVOICE_USE_DEFAULT_DOCUMENT` block (hidden conf) was missing its closing bracket. As a result, the `change` handler bound to the invoice type radios (`name="type"`) never triggered, so the `#model` select was never updated to the per-type default configured in **Setup > Invoices > Bills PDF modules according to invoice type** (`FACTURE_ADDON_PDF_<type>`) — for example when choosing "First situation invoice" instead of a standard invoice.

Since `#model` is enhanced with select2, `.val()` alone also only updates the underlying `<select>` without refreshing the select2 label shown to the user, which made the field look like it still displayed the wrong model even when the correct value was actually going to be submitted. A `.trigger("change")` is now called after `.val()` so select2 reflects the change visually.

Fixes:
- `$("[name='type'")` → `$("[name='type']")`
- `$("#model").val(...)` → `$("#model").val(...).trigger("change")`
