### PR TITLE
FIX : situation invoice credit note wrong amount in progressive mode

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1397,7 +1397,10 @@ if (empty($reshook)) {
 								$source_fk_prev_id = $line->fk_prev_id; // temporary storing situation invoice fk_prev_id
 								$line->fk_prev_id  = $line->id; // The new line of the new credit note we are creating must be linked to the situation invoice line it is created from
 
-								if (!empty($facture_source->tab_previous_situation_invoice)) {
+								// The subtraction below assumes total_ht/situation_percent are stored cumulative on situation invoice lines
+								// (INVOICE_USE_SITUATION = 1, legacy). In progressive mode (INVOICE_USE_SITUATION = 2), each line already
+								// holds its own delta, so subtracting the previous invoice's line here would credit the wrong amount.
+								if (getDolGlobalInt('INVOICE_USE_SITUATION') != 2 && !empty($facture_source->tab_previous_situation_invoice)) {
 									// search the last standard invoice in cycle and the possible credit note between this last and facture_source
 									// TODO Move this out of loop of $facture_source->lines
 									$tab_jumped_credit_notes = array();


### PR DESCRIPTION
# FIX Situation invoice credit note wrong amount in progressive mode

When creating a credit note "with same lines" from a situation invoice, the code always subtracts the previous situation invoice's line values before inverting the sign, assuming lines are stored cumulative (`INVOICE_USE_SITUATION = 1`, legacy mode).

In progressive mode (`INVOICE_USE_SITUATION = 2`), each situation invoice line already stores its own delta amount and percent, so this extra subtraction credits the wrong amount and percent (e.g. 60% / 1272 instead of the correct 20% / 424 on a real cycle).

Skip the subtraction in progressive mode so the credit note reuses the source line's own delta values, as expected.
