### PR TITLE
FIX getFirstDayOfEachWeek() returns days of the wrong year when the month overlaps 2 years

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -1200,11 +1200,20 @@ function getWeekNumbersOfMonth($month, $year)
 function getFirstDayOfEachWeek($TWeek, $year)
 {
 	$TFirstDayOfWeek = array();
+	// When a month overlaps 2 years, the weeks 52/53 of previous year and the week 01 of next year are present together in $TWeek.
+	// If $TWeek starts with week 52 or 53 (a January), these first weeks belong to previous year.
+	// If $TWeek ends with week 01 (a December), this last week belongs to next year.
+	$startwithweeksofpreviousyear = ((int) reset($TWeek) >= 52 && in_array('01', $TWeek));
 	foreach ($TWeek as $weekNb) {
-		if (in_array('01', $TWeek) && in_array('52', $TWeek) && $weekNb == '01') {
-			$year++; //Si on a la 1re semaine et la semaine 52 c'est qu'on change d'année
+		$yeartouse = $year;
+		if ($startwithweeksofpreviousyear) {
+			if ((int) $weekNb >= 52) {
+				$yeartouse = $year - 1;
+			}
+		} elseif ($weekNb == '01' && in_array('52', $TWeek)) {
+			$yeartouse = $year + 1;
 		}
-		$TFirstDayOfWeek[$weekNb] = date('d', strtotime($year.'W'.$weekNb));
+		$TFirstDayOfWeek[$weekNb] = date('d', strtotime($yeartouse.'W'.$weekNb));
 	}
 	return $TFirstDayOfWeek;
 }
@@ -1219,8 +1228,18 @@ function getFirstDayOfEachWeek($TWeek, $year)
 function getLastDayOfEachWeek($TWeek, $year)
 {
 	$TLastDayOfWeek = array();
+	// Same rule as in getFirstDayOfEachWeek() to find the year each week belongs to
+	$startwithweeksofpreviousyear = ((int) reset($TWeek) >= 52 && in_array('01', $TWeek));
 	foreach ($TWeek as $weekNb) {
-		$TLastDayOfWeek[$weekNb] = date('d', strtotime($year.'W'.$weekNb.'+6 days'));
+		$yeartouse = $year;
+		if ($startwithweeksofpreviousyear) {
+			if ((int) $weekNb >= 52) {
+				$yeartouse = $year - 1;
+			}
+		} elseif ($weekNb == '01' && in_array('52', $TWeek)) {
+			$yeartouse = $year + 1;
+		}
+		$TLastDayOfWeek[$weekNb] = date('d', strtotime($yeartouse.'W'.$weekNb.'+6 days'));
 	}
 	return $TLastDayOfWeek;
 }

--- a/test/phpunit/DateLibTest.php
+++ b/test/phpunit/DateLibTest.php
@@ -496,6 +496,54 @@ class DateLibTest extends CommonClassTest
 		return 1;
 	}
 
+	/**
+	 * testGetFirstDayOfEachWeek
+	 *
+	 * @return int
+	 */
+	public function testGetFirstDayOfEachWeek()
+	{
+		// June 2026 (no year overlap): weeks 23 to 27
+		$TWeek = getWeekNumbersOfMonth(6, 2026);
+		$this->assertEquals(array('23' => '01', '24' => '08', '25' => '15', '26' => '22', '27' => '29'), getFirstDayOfEachWeek($TWeek, 2026));
+
+		// December 2025 ends with week 01 of 2026: week 01 starts on monday 2025-12-29
+		$TWeek = getWeekNumbersOfMonth(12, 2025);
+		$this->assertEquals(array('49' => '01', '50' => '08', '51' => '15', '52' => '22', '01' => '29'), getFirstDayOfEachWeek($TWeek, 2025));
+
+		// January 2022 starts with week 52 of 2021 (monday 2021-12-27). Week 01 of 2022 starts on monday the 3rd,
+		// week 02 on the 10th, ... (weeks 01 to 05 must not be shifted to next year)
+		$TWeek = getWeekNumbersOfMonth(1, 2022);
+		$this->assertEquals(array('52' => '27', '01' => '03', '02' => '10', '03' => '17', '04' => '24', '05' => '31'), getFirstDayOfEachWeek($TWeek, 2022));
+
+		// January 2021 starts with week 53 of 2020 (monday 2020-12-28)
+		$TWeek = getWeekNumbersOfMonth(1, 2021);
+		$this->assertEquals(array('53' => '28', '01' => '04', '02' => '11', '03' => '18', '04' => '25'), getFirstDayOfEachWeek($TWeek, 2021));
+
+		return 1;
+	}
+
+	/**
+	 * testGetLastDayOfEachWeek
+	 *
+	 * @return int
+	 */
+	public function testGetLastDayOfEachWeek()
+	{
+		// June 2026 (no year overlap): weeks 23 to 27
+		$TWeek = getWeekNumbersOfMonth(6, 2026);
+		$this->assertEquals(array('23' => '07', '24' => '14', '25' => '21', '26' => '28', '27' => '05'), getLastDayOfEachWeek($TWeek, 2026));
+
+		// December 2025 ends with week 01 of 2026: week 01 ends on sunday 2026-01-04
+		$TWeek = getWeekNumbersOfMonth(12, 2025);
+		$this->assertEquals(array('49' => '07', '50' => '14', '51' => '21', '52' => '28', '01' => '04'), getLastDayOfEachWeek($TWeek, 2025));
+
+		// January 2022 starts with week 52 of 2021: week 52 ends on sunday 2022-01-02
+		$TWeek = getWeekNumbersOfMonth(1, 2022);
+		$this->assertEquals(array('52' => '02', '01' => '09', '02' => '16', '03' => '23', '04' => '30', '05' => '06'), getLastDayOfEachWeek($TWeek, 2022));
+
+		return 1;
+	}
 
 	/**
 	 * testDolGetFirstHour


### PR DESCRIPTION
`getFirstDayOfEachWeek()` mishandles months spanning two years. For a January that starts with week 52/53 of the previous year (e.g. January 2022, where Jan 1-2 belong to week 52 of 2021), the `in_array('01', $TWeek) && in_array('52', $TWeek)` heuristic wrongly shifts week `01` to the next year, and because `$year++` mutates the loop variable, all following weeks of the month are computed on the wrong year too. For January 2022 it returns `['52'=>'26','01'=>'02','02'=>'09','03'=>'16','04'=>'23','05'=>'30']` instead of `['52'=>'27','01'=>'03','02'=>'10','03'=>'17','04'=>'24','05'=>'31']`. `getLastDayOfEachWeek()` has no year handling at all, so weeks 52/53 shown in January (and week 01 shown in December) are resolved in the wrong year as well.

Impact: the time-spent-per-month view (`projet/activity/permonth.php`) displays wrong day ranges next to week numbers, links to the wrong week in perweek.php, and computes the weekly holiday overlap on wrong `$weekstart`/`$weekend` dates for such months (January 2021, 2022, 2027, 2033, ...).

Fix: determine the year each week belongs to instead of mutating `$year`: leading weeks >= 52 together with week 01 (January case) belong to `$year - 1`; a week 01 together with week 52 otherwise (December case) belongs to `$year + 1` (the previously intended behavior). Same rule applied to `getLastDayOfEachWeek()`. Verified against independently computed expected values (DateTime::setISODate) for every month from 2015 to 2040: 34 wrong results before, 0 after. PHPUnit tests added in `test/phpunit/DateLibTest.php`.

Note: this fix was prepared with the assistance of an AI tool (Claude); the bug, fix and tests were verified by running the code.
