### PR TITLE
FIX Stripe payout: store payout reference (po_) in bank transfer

### DIFF
--- a/htdocs/public/stripe/ipn.php
+++ b/htdocs/public/stripe/ipn.php
@@ -267,7 +267,7 @@ if ($event->type == 'payout.created' && getDolGlobalString('STRIPE_AUTO_RECORD_P
 			$typefrom = 'PRE';
 			$typeto = 'VIR';
 
-			$numChqOrOpe = '';	// TODO Store the po ref from $event->data
+			$numChqOrOpe = $event->data->object->id;	// Store the payout reference (po_...) as the bank transfer number
 
 			$db->begin();
 


### PR DESCRIPTION
## Bug

The `payout.paid` webhook handler in `htdocs/public/stripe/ipn.php` (used when `STRIPE_AUTO_RECORD_PAYOUT` is enabled) records the bank-to-bank transfer with an **empty** `num_chq`. The code carried an explicit placeholder:

```php
$numChqOrOpe = '';	// TODO Store the po ref from $event->data
```

As a result, auto-recorded Stripe payouts have no reference on the bank line, so they cannot be traced or reconciled back to Stripe (e.g. by a reconciliation module matching payouts by their `po_` id).

## Fix

The Stripe payout id (`po_...`) is available in the event payload as `$event->data->object->id`. Store it as the transfer number, resolving the existing TODO:

```php
$numChqOrOpe = $event->data->object->id;
```

One-line change. The value is only used for the two `addline()` calls of the transfer; no behaviour change other than populating the previously-empty reference.

## How to test

1. Enable `STRIPE_AUTO_RECORD_PAYOUT`.
2. Receive a `payout.paid` Stripe webhook.
3. The created bank transfer lines now carry the `po_...` reference in `Numéro` (num_chq) instead of being empty.

Backwards compatible (PHP 7.1+), no new dependency. Same TODO exists on 23.0/develop (merge-up).

> Draft — opened for discussion / review of the approach.