### PR TITLE
Qual: factorize resource busy-check SQL into getBusyResourcesInPeriod() (supersedes #31644)

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -55,6 +55,7 @@ require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
 require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 require_once DOL_DOCUMENT_ROOT.'/projet/class/task.class.php';
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/resource.lib.php';
 
 // Load translation files required by the page
 $langs->loadLangs(["companies", "other", "commercial", "bills", "orders", "agenda", "mails"]);
@@ -634,47 +635,20 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 								}
 							}
 
-							$sql = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-							$sql .= " FROM " . MAIN_DB_PREFIX . "element_resources as er";
-							$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "resource as r ON r.rowid = er.resource_id AND er.resource_type = '" . $db->escape($resource_type) . "'";
-							$sql .= " INNER JOIN " . MAIN_DB_PREFIX . "actioncomm as ac ON ac.id = er.element_id AND er.element_type = '" . $db->escape($object->element) . "'";
-							$sql .= " WHERE er.resource_id = " . ((int) $resource_id);
-							$sql .= " AND er.busy = 1";
-							$sql .= " AND (";
-
-							// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-							$sql .= " (ac.datep <= '" . $db->idate($eventDateStart) . "' AND (ac.datep2 IS NULL OR ac.datep2 >= '" . $db->idate($eventDateStart) . "'))";
-							// event date end between ac.datep and ac.datep2
-							if (!empty($eventDateEnd)) {
-								$sql .= " OR (ac.datep <= '" . $db->idate($eventDateEnd) . "' AND (ac.datep2 >= '" . $db->idate($eventDateEnd) . "'))";
-							}
-							// event date start before ac.datep and event date end after ac.datep2
-							$sql .= " OR (";
-							$sql .= "ac.datep >= '" . $db->idate($eventDateStart) . "'";
-							if (!empty($eventDateEnd)) {
-								$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '" . $db->idate($eventDateEnd) . "')";
-							}
-							$sql .= ")";
-
-							$sql .= ")";
-							$resql = $db->query($sql);
-							if (!$resql) {
+							$conflicts = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, $resource_id, 0, 0, $resource_type, $object->element, 0, getDolGlobalInt('RESOURCE_SELECT_LIMIT', 100));
+							if ($conflicts === null) {
 								$error++;
 								$object->error = $db->lasterror();
 								$object->errors[] = $object->error;
-							} else {
-								if ($db->num_rows($resql) > 0) {
-									// Resource already in use
-									$error++;
-									$object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
-									while ($obj = $db->fetch_object($resql)) {
-										$object->error .= '<br> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
-									}
-									$object->errors[] = $object->error;
-
-									setEventMessages($object->error, null, 'errors');
+							} elseif (count($conflicts) > 0) {
+								// Resource already in use
+								$error++;
+								$object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
+								foreach ($conflicts as $obj) {
+									$object->error .= '<br> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
 								}
-								$db->free($resql);
+								$object->errors[] = $object->error;
+								setEventMessages($object->error, null, 'errors');
 							}
 						}
 
@@ -1107,51 +1081,19 @@ if (empty($reshook) && $action == 'update' && $usercancreate) {
 				$eventDateStart = $object->datep;
 				$eventDateEnd = $object->datef;
 
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($object->element)."'";
-				$sql .= " WHERE ac.id <> ".((int) $object->id);
-				$sql .= " AND er.resource_id IN (";
-				$sql .= " SELECT resource_id FROM ".MAIN_DB_PREFIX."element_resources";
-				$sql .= " WHERE element_id = ".((int) $object->id);
-				$sql .= " AND element_type = '".$db->escape($object->element)."'";
-				$sql .= " AND busy = 1";
-				$sql .= ")";
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
-
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
+				$conflicts = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, 0, $object->id, $object->id, 'dolresource', $object->element, 0, getDolGlobalInt('RESOURCE_SELECT_LIMIT', 100));
+				if ($conflicts === null) {
 					$error++;
 					$object->error = $db->lasterror();
 					$object->errors[] = $object->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$object->errors[] = $object->error;
+				} elseif (count($conflicts) > 0) {
+					// Resource already in use
+					$error++;
+					$object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
+					foreach ($conflicts as $obj) {
+						$object->error .= '<br> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
 					}
-					$db->free($resql);
+					$object->errors[] = $object->error;
 				}
 
 				if ($error) {
@@ -1295,51 +1237,19 @@ if (empty($reshook) && GETPOST('actionmove', 'alpha') == 'mupdate' && $usercancr
 				$eventDateStart = $object->datep;
 				$eventDateEnd = $object->datef;
 
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($object->element)."'";
-				$sql .= " WHERE ac.id <> ".((int) $object->id);
-				$sql .= " AND er.resource_id IN (";
-				$sql .= " SELECT resource_id FROM ".MAIN_DB_PREFIX."element_resources";
-				$sql .= " WHERE element_id = ".((int) $object->id);
-				$sql .= " AND element_type = '".$db->escape($object->element)."'";
-				$sql .= " AND busy = 1";
-				$sql .= ")";
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
-
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
+				$conflicts = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, 0, $object->id, $object->id, 'dolresource', $object->element, 0, getDolGlobalInt('RESOURCE_SELECT_LIMIT', 100));
+				if ($conflicts === null) {
 					$error++;
 					$object->error = $db->lasterror();
 					$object->errors[] = $object->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$object->errors[] = $object->error;
+				} elseif (count($conflicts) > 0) {
+					// Resource already in use
+					$error++;
+					$object->error = $langs->trans('ErrorResourcesAlreadyInUse') . ' : ';
+					foreach ($conflicts as $obj) {
+						$object->error .= '<br> - ' . $langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label . ' [' . $obj->ac_id . ']');
 					}
-					$db->free($resql);
+					$object->errors[] = $object->error;
 				}
 
 				if ($error) {

--- a/htdocs/core/lib/resource.lib.php
+++ b/htdocs/core/lib/resource.lib.php
@@ -146,3 +146,86 @@ function resource_admin_prepare_head()
 
 	return $head;
 }
+
+/**
+ * Return the "busy" resource bookings that overlap a given period.
+ *
+ * Shared conflict-detection query used before linking a resource to an event when the option
+ * RESOURCE_USED_IN_EVENT_CHECK is enabled. This function only runs the SELECT and returns the
+ * conflicting rows; the caller keeps ownership of the fullday-event date adjustment, of
+ * incrementing its own $error and of building the translated ErrorResourcesAlreadyInUse /
+ * ErrorResourceUseInEvent message.
+ *
+ * The date-overlap test uses inclusive comparisons (>=, <=), exactly as the historical inline
+ * copies did. Pass $resourceId to check a single resource, or $selfBusyElementId (with
+ * $resourceId = 0) to reproduce the "resources currently busy for this event" IN (SELECT ...)
+ * sub-query used by the update/drag flows.
+ *
+ * @param	int		$dateStart					Event start date (timestamp). Required.
+ * @param	int		$dateEnd					Event end date (timestamp). 0 if the event has no end.
+ * @param	int		$resourceId					If > 0, restrict to this single resource (er.resource_id = X).
+ * @param	int		$selfBusyElementId			If > 0 and $resourceId <= 0, restrict to resources currently busy for this element id, via IN (SELECT ...).
+ * @param	int		$excludeActionId			If > 0, exclude this actioncomm id (ac.id <> X) so an event does not conflict with itself.
+ * @param	string	$resourceType				Value matched on er.resource_type. Default 'dolresource'.
+ * @param	string	$elementType				Value matched on er.element_type and on the actioncomm element_type. Default 'action'.
+ * @param	int		$matchNullEndOnEndOverlap	If 1, the "event end within booking" clause also matches bookings with a NULL end date. Set to 1 only to reproduce the update_linked_resource behavior.
+ * @param	int		$limit						Max number of rows returned (0 = no limit). Does not change the block/no-block decision when >= 1.
+ * @return	stdClass[]|null						Conflicting rows (rowid, r_ref, ac_id, ac_label); empty array if none; null on SQL error.
+ */
+function getBusyResourcesInPeriod($dateStart, $dateEnd, $resourceId = 0, $selfBusyElementId = 0, $excludeActionId = 0, $resourceType = 'dolresource', $elementType = 'action', $matchNullEndOnEndOverlap = 0, $limit = 0)
+{
+	global $db;
+
+	$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
+	$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = '".$db->escape($resourceType)."'";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($elementType)."'";
+	$sql .= " WHERE er.busy = 1";
+	if ($resourceId > 0) {
+		$sql .= " AND er.resource_id = ".((int) $resourceId);
+	} elseif ($selfBusyElementId > 0) {
+		$sql .= " AND er.resource_id IN (";
+		$sql .= " SELECT resource_id FROM ".MAIN_DB_PREFIX."element_resources";
+		$sql .= " WHERE element_id = ".((int) $selfBusyElementId);
+		$sql .= " AND element_type = '".$db->escape($elementType)."'";
+		$sql .= " AND busy = 1";
+		$sql .= ")";
+	}
+	if ($excludeActionId > 0) {
+		$sql .= " AND ac.id <> ".((int) $excludeActionId);
+	}
+	$sql .= " AND (";
+	// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
+	$sql .= " (ac.datep <= '".$db->idate($dateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($dateStart)."'))";
+	// event date end between ac.datep and ac.datep2
+	if (!empty($dateEnd)) {
+		if (!empty($matchNullEndOnEndOverlap)) {
+			$sql .= " OR (ac.datep <= '".$db->idate($dateEnd)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($dateEnd)."'))";
+		} else {
+			$sql .= " OR (ac.datep <= '".$db->idate($dateEnd)."' AND (ac.datep2 >= '".$db->idate($dateEnd)."'))";
+		}
+	}
+	// event date start before ac.datep and event date end after ac.datep2
+	$sql .= " OR (";
+	$sql .= "ac.datep >= '".$db->idate($dateStart)."'";
+	if (!empty($dateEnd)) {
+		$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($dateEnd)."')";
+	}
+	$sql .= ")";
+	$sql .= ")";
+
+	$sql .= $db->plimit($limit);
+
+	$resql = $db->query($sql);
+	if (!$resql) {
+		return null;
+	}
+
+	$conflicts = array();
+	while ($obj = $db->fetch_object($resql)) {
+		$conflicts[] = $obj;
+	}
+	$db->free($resql);
+
+	return $conflicts;
+}

--- a/htdocs/resource/element_resource.php
+++ b/htdocs/resource/element_resource.php
@@ -32,6 +32,7 @@ require '../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/resource/class/dolresource.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/fichinter/class/fichinter.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/resource.lib.php';
 if (isModEnabled('project')) {
 	require_once DOL_DOCUMENT_ROOT.'/projet/class/project.class.php';
 	require_once DOL_DOCUMENT_ROOT.'/core/class/html.formprojet.class.php';
@@ -155,45 +156,19 @@ if (empty($reshook)) {
 					}
 				}
 
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = '".$db->escape($resource_type)."'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($objstat->element)."'";
-				$sql .= " WHERE er.resource_id = ".((int) $resource_id);
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
-
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
+				$conflicts = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, $resource_id, 0, 0, $resource_type, $objstat->element, 0, getDolGlobalInt('RESOURCE_SELECT_LIMIT', 100));
+				if ($conflicts === null) {
 					$error++;
-					$objstat->error    = $db->lasterror();
+					$objstat->error = $db->lasterror();
 					$objstat->errors[] = $objstat->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$objstat->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$objstat->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$objstat->errors[] = $objstat->error;
+				} elseif (count($conflicts) > 0) {
+					// Resource already in use
+					$error++;
+					$objstat->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
+					foreach ($conflicts as $obj) {
+						$objstat->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
 					}
-					$db->free($resql);
+					$objstat->errors[] = $objstat->error;
 				}
 			}
 
@@ -230,46 +205,19 @@ if (empty($reshook)) {
 					}
 				}
 
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = '".$db->escape($object->resource_type)."'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($object->element_type)."'";
-				$sql .= " WHERE er.resource_id = ".((int) $object->resource_id);
-				$sql .= " AND ac.id <> ".((int) $object->element_id);
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
-
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
+				$conflicts = getBusyResourcesInPeriod($eventDateStart, $eventDateEnd, $object->resource_id, 0, $object->element_id, $object->resource_type, $object->element_type, 1, getDolGlobalInt('RESOURCE_SELECT_LIMIT', 100));
+				if ($conflicts === null) {
 					$error++;
 					$object->error = $db->lasterror();
 					$object->errors[] = $object->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$object->errors[] = $object->error;
+				} elseif (count($conflicts) > 0) {
+					// Resource already in use
+					$error++;
+					$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
+					foreach ($conflicts as $obj) {
+						$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
 					}
-					$db->free($resql);
+					$object->errors[] = $object->error;
 				}
 			}
 


### PR DESCRIPTION
## Description

The busy-resource conflict-detection `SELECT` used when `RESOURCE_USED_IN_EVENT_CHECK` is enabled is currently duplicated in **5 places**:

- `htdocs/comm/action/card.php` — event **add**, **update** and **drag&drop move**
- `htdocs/resource/element_resource.php` — `add_element_resource` and `update_linked_resource`

This PR extracts that query into a single shared helper `getBusyResourcesInPeriod()` in `htdocs/core/lib/resource.lib.php`, and replaces the 5 inline copies with calls to it (net **-59 lines**).

This is the **refactor part of #31644** (author @EnjoyFelix). The conflict-check *feature* from that PR is already present in `develop`, so only the de-duplication remained. The maintainer review left on #31644 is incorporated: the function uses the camelCase name `getBusyResourcesInPeriod` and builds its limit with `plimit(getDolGlobalInt('RESOURCE_SELECT_LIMIT', 100))`.

Supersedes #31644.

## No behavior change

- Inclusive date-overlap operators (`>=`, `<=`) are preserved exactly.
- The `update_linked_resource`-only "booking with a NULL end date" branch is preserved via a parameter (`$matchNullEndOnEndOverlap`).
- The update/drag "resources currently busy for this event" `IN (SELECT ...)` sub-query is kept as-is (via `$selfBusyElementId`), so empty/edge cases behave identically.
- Each caller keeps its own fullday-event date adjustment, `$error` handling and translated `ErrorResourcesAlreadyInUse` / `ErrorResourceUseInEvent` message building.
- The helper runs only the `SELECT` and returns the conflicting rows (or `null` on SQL error); it uses the standard `query()` + `fetch_object()` loop.

The **only** intentional difference is that each query now ends with `LIMIT 100` (default `RESOURCE_SELECT_LIMIT`). This does **not** change the block / no-block decision (it stays "any conflicting row → block"); it only caps how many conflicts are listed in the error message.

## Tests

- `php -l` passes on the 3 changed files.
- Behavior parity is by construction (see above). Reviewers can diff old vs new SQL by temporarily passing `0` as the last argument (no `LIMIT`).
- Suggested manual check (with `RESOURCE_USED_IN_EVENT_CHECK` on and a busy resource already booked): creating, updating, drag-moving an event, and assigning/updating a linked resource on an overlapping time frame all still block; non-overlapping ones still succeed. Please also confirm the `update_linked_resource` case with a booking whose end date (`datep2`) is NULL.

Co-authored-by: EnjoyFelix
