### PR TITLE
FIX #35658 leading-zero account numbers dropped from personalized group totals

### DIFF
--- a/htdocs/accountancy/class/accountancycategory.class.php
+++ b/htdocs/accountancy/class/accountancycategory.class.php
@@ -624,7 +624,7 @@ class AccountancyCategory // extends CommonObject
 	/**
 	 * Function to set the property ->sdc (and ->sdcperaccount) that is the result of an accounting account from the ledger with a direction and a period
 	 *
-	 * @param int|array<?string>	$cpt 	Accounting account or array of accounting account
+	 * @param string|int|array<?string>	$cpt 	Accounting account or array of accounting account
 	 * @param int 		$date_start			Date start
 	 * @param int	 	$date_end			Date end
 	 * @param int<0,1>	$sens 				Sens of the account:  0: credit - debit (use this by default), 1: debit - credit

--- a/htdocs/compta/resultat/clientfourn.php
+++ b/htdocs/compta/resultat/clientfourn.php
@@ -386,7 +386,7 @@ if ($modecompta == 'BOOKKEEPING') {
 					$cpts = $AccCat->getCptsCat(0, $tmppredefinedgroupwhere);
 
 					foreach ($cpts as $j => $cpt) {
-						$return = $AccCat->getSumDebitCredit((int) $cpt['account_number'], $date_start, $date_end, (empty($cpt['dc']) ? 0 : $cpt['dc']));
+						$return = $AccCat->getSumDebitCredit($cpt['account_number'], $date_start, $date_end, (empty($cpt['dc']) ? 0 : $cpt['dc']));
 						if ($return < 0) {
 							setEventMessages(null, $AccCat->errors, 'errors');
 							$resultN = 0;

--- a/htdocs/compta/resultat/result.php
+++ b/htdocs/compta/resultat/result.php
@@ -560,7 +560,7 @@ if ($modecompta == 'CREANCES-DETTES') {
 						) {
 							//var_dump($monthtoprocess.'_'.$yeartoprocess);
 							if (isset($cpt['account_number'])) {
-								$return = $AccCat->getSumDebitCredit((int) $cpt['account_number'], $date_start, $date_end, empty($cat['dc']) ? 0 : $cat['dc'], 'nofilter', $monthtoprocess, $yeartoprocess);
+								$return = $AccCat->getSumDebitCredit($cpt['account_number'], $date_start, $date_end, empty($cat['dc']) ? 0 : $cat['dc'], 'nofilter', $monthtoprocess, $yeartoprocess);
 								if ($return < 0) {
 									setEventMessages(null, $AccCat->errors, 'errors');
 									$resultM = 0;


### PR DESCRIPTION
## Fixes #35658

Targeted at **22.0**, the oldest maintained version affected (21.0 does not contain the cast; 22.0/23.0/develop do), per the CONTRIBUTING branch policy. This replaces my earlier develop PR #39206, which I will close in favour of this one so the fix can be merged forward normally.

### Problem

In a personalized accounting group, accounts whose number starts with `0` (e.g. `0510`) are silently dropped from the group total on `compta/resultat/result.php` (current-year and per-month columns) and on `compta/resultat/clientfourn.php`, so the subtotal is short by those accounts' amounts.

### Root cause

Both reports cast the account number to `(int)` before passing it to `AccountancyCategory::getSumDebitCredit()`:

```php
$AccCat->getSumDebitCredit((int) $cpt['account_number'], ...);
```

But `getSumDebitCredit()` compares the code **as a string**:

```php
$sql .= " AND t.numero_compte = '".$this->db->escape((string) $cpt)."'";
```

So `(int) '0510'` → `510` → `'510'`, which never matches the stored `'0510'`. `numero_compte` and `account_number` are both `varchar(32)`, so leading zeros are significant. The previous-year column was already correct because it passes a **string array** to the same function (array branch builds `'0510','512',...`), which is why only the current-year/month figures were wrong — an asymmetry within the same screen.

The `(int)` cast has no functional purpose: it was introduced only to silence a phan notice in *"Qual: Fix phan notices"* (#33484), inadvertently causing this data loss.

### Fix

- Remove the `(int)` cast at the two call sites, passing the raw string `$cpt['account_number']`.
- Widen the `getSumDebitCredit()` `@param` to `string|int|array<?string>` so the string argument is accepted by static analysis (otherwise the exact phan notice #33484 silenced would reappear) and the cast is not reintroduced.

Numeric codes are unaffected — the callee already stringifies the scalar with `(string) $cpt`, so `'512'` behaves identically to before; only leading-zero codes change (from dropped to counted). The array branch and the previous-year column are untouched. 3 lines changed, no refactoring.

### Tests

- `php -l` passes on the 3 changed files.
- No existing PHPUnit coverage for `getSumDebitCredit()` (a DB-query method), so no test is updated.
- Manual check: with the Accounting module enabled, a personalized account group containing an account like `0510` that has bookkeeping entries in the period now includes that account's amount in the group total on `result.php` (and its per-account row on `clientfourn.php`), instead of omitting it.
