### PR TITLE
FIX #39190 wrong unit price when invoicing time spent with one line per declaration

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -616,7 +616,9 @@ if ($action == 'confirm_generateinvoice') {
 					$arrayoftasks[$object->timespent_id]['fk_product'] = $object->timespent_fk_product;
 				}
 
+				$pu_ht_base = $pu_ht;	// Save the base unit price (price of the selected product/service if any, 0 otherwise)
 				foreach ($arrayoftasks as $timespent_id => $value) {
+					$pu_ht = $pu_ht_base;	// Reset for each line, so a line does not inherit the unit price computed for the previous one
 					$userid = $value['user'];
 					//$pu_ht = $value['timespent'] * $fuser->thm;
 
@@ -625,7 +627,9 @@ if ($action == 'confirm_generateinvoice') {
 
 					// If no unit price known
 					if (empty($pu_ht)) {
-						$pu_ht = price2num($value['totalvaluetodivideby3600'] / 3600, 'MU');
+						if ($value['timespent']) {
+							$pu_ht = price2num(($value['totalvaluetodivideby3600'] / $value['timespent']), 'MU');
+						}
 					}
 
 					// Add lines

--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -616,9 +616,9 @@ if ($action == 'confirm_generateinvoice') {
 					$arrayoftasks[$object->timespent_id]['fk_product'] = $object->timespent_fk_product;
 				}
 
-				$pu_ht_base = $pu_ht;	// Save the base unit price (price of the selected product/service if any, 0 otherwise)
+				$pu_ht_saved = $pu_ht;	// Save the base unit price (price of the selected product/service if any, 0 otherwise)
 				foreach ($arrayoftasks as $timespent_id => $value) {
-					$pu_ht = $pu_ht_base;	// Reset for each line, so a line does not inherit the unit price computed for the previous one
+					$pu_ht = $pu_ht_saved;	// Reset for each line, so a line does not inherit the unit price computed for the previous one
 					$userid = $value['user'];
 					//$pu_ht = $value['timespent'] * $fuser->thm;
 


### PR DESCRIPTION
## Fixes #39190

Targeted at **21.0** following the CONTRIBUTING branch policy (bug fix → oldest affected version; `N - 2` is given as the tip when many versions are affected). The expression is present at least as far back as 12.0, so 21.0 is the practical N-2 target and the fix can be merged forward from there.

### Problem

When generating an invoice from a project's time spent with the mode **"One line for each time spent declaration"** (`onelineperperiod`), the Unit Price of the generated lines is wrong and the time ends up over-billed.

### Root cause

`htdocs/projet/tasks/time.php`, `onelineperperiod` branch:

```php
$pu_ht = price2num($value['totalvaluetodivideby3600'] / 3600, 'MU');
```

`totalvaluetodivideby3600` is `timespent_duration` (**seconds**) × `timespent_thm` (**hourly rate**). Dividing it by `3600` therefore gives `hours × rate` — that is the **line total**, not a unit price.

The quantity passed to `addline()` is the number of hours, so the line is billed:

```
hours × (hours × rate)     instead of     hours × rate
```

i.e. **over-billed by a factor equal to the number of hours** (correct only for exactly 1 h; 8 h is billed 8×).

### Why this is clearly a leftover

The sibling modes already do it correctly — they divide by the recorded number of **seconds**:

- `onelineperuser`: `price2num(($timespent_data['totalvaluetodivideby3600'] / $timespent_data['timespent']), 'MU')`
- `onelinepertask`: same pattern

Up to **16.0**, `onelineperuser` contained the very same `/ 3600` expression. It was corrected there, and `onelineperperiod` was simply left behind. This PR aligns it with that reference implementation, including the same guard against a zero duration.

### Second defect fixed: unit price leaking between lines

`$pu_ht` is initialized **once** before the loops (with the price of the selected product/service, or `0`). `onelineperperiod` only tested `if (empty($pu_ht))`, so as soon as a price was computed for the first line, **every following line reused it** — lines belonging to users with a different hourly rate were billed at the first line's rate. This is the same reported symptom ("incorrect Unit Price"), so it is fixed here too.

A plain `$pu_ht = 0;` at the top of the loop would break the existing behaviour where a selected product/service price must be used, so the base value is saved before the loop and restored on each iteration instead.

### Scope

5 lines added, 1 changed, in a single file. Deliberately **not** included: porting the `PROJECT_USE_REAL_COST_FOR_TIME_INVOICING` / `$fuser->thm` price-selection block that `onelineperuser` has — that is closer to a feature change and does not belong in a maintenance-branch PR. It can be proposed separately for develop.

### Tests

- `php -l` passes on the changed file.
- There is no existing PHPUnit coverage for this path (the logic lives inline in the page's action handler, so it cannot be unit-tested without refactoring), hence no test is added.
- Manual check: on a project task, record several time-spent entries for a user having an hourly rate (THM), select them, then **Generate invoice** with mode *"One line for each time spent declaration"*. The Unit Price of each generated line must equal the hourly rate (before the fix it was `hours × rate`). With entries from users having **different** hourly rates, each line must now use its own rate (before the fix, every line reused the first one's).
