### PR TITLE
FIX #38615 Accountancy export API returns generated file metadata

### DIFF
--- a/htdocs/accountancy/class/api_accountancy.class.php
+++ b/htdocs/accountancy/class/api_accountancy.class.php
@@ -78,7 +78,7 @@ class Accountancy extends DolibarrApi
 	 * @param		int			$alreadyexport			[=0] by default export data only if it's not yet exported or 1 already exported (always export data even if 'date_export" is set)
 	 * @param		int			$notnotifiedasexport	[=0] by default notified as exported or 1 not notified as exported (when the export is done, notified or not the column 'date_export')
 	 *
-	 * @return	string
+	 * @return	array{modulepart:string,relative_path:string,filename:string,mimetype:string}	Generated file metadata
 	 *
 	 * @url		GET exportdata
 	 *
@@ -271,7 +271,24 @@ class Accountancy extends DolibarrApi
 				throw new RestException(500, 'Error accountancy export : '.implode(',', $accountancyexport->errors));
 			} else {
 				$this->db->commit();
-				exit();
+
+				$filedata = $accountancyexport->generatedfiledata;
+				if (empty($filedata['downloadFilePath']) || empty($filedata['downloadFileFullName'])) {
+					throw new RestException(500, 'Accounting export generated no downloadable file');
+				}
+
+				$outputdir = !empty($conf->accounting->multidir_output[$conf->entity]) ? $conf->accounting->multidir_output[$conf->entity] : $conf->accounting->dir_output;
+				$outputdir = rtrim($outputdir, '/').'/';
+				if (strpos($filedata['downloadFilePath'], $outputdir) !== 0) {
+					throw new RestException(500, 'Accounting export generated a file outside the accounting output directory');
+				}
+
+				return array(
+					'modulepart' => 'export_compta',
+					'relative_path' => substr($filedata['downloadFilePath'], strlen($outputdir)),
+					'filename' => basename($filedata['downloadFileFullName']),
+					'mimetype' => $filedata['downloadFileMimeType'],
+				);
 			}
 		}
 	}

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3570,7 +3570,7 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		}
 	} elseif ($modulepart == 'export_compta' && !empty($conf->accounting->dir_output)) {
 		// Wrapping for accounting exports
-		if ($fuser->hasRight('accounting', 'bind', 'write') || preg_match('/^specimen/i', $original_file)) {
+		if ($fuser->hasRight('accounting', 'bind', 'write') || $fuser->hasRight('accounting', 'mouvements', 'export') || preg_match('/^specimen/i', $original_file)) {
 			$accessallowed = 1;
 		}
 		$original_file = $conf->accounting->dir_output.'/'.$original_file;

--- a/test/phpunit/FilesLibTest.php
+++ b/test/phpunit/FilesLibTest.php
@@ -489,6 +489,45 @@ class FilesLibTest extends CommonClassTest
 	}
 
 	/**
+	 * Check that a user allowed to export the ledger can download the generated accounting export.
+	 *
+	 * @return void
+	 */
+	public function testDolCheckSecureAccessAccountingExport()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$savpermbindwrite = $user->hasRight('accounting', 'bind', 'write');
+		$savpermexport = $user->hasRight('accounting', 'mouvements', 'export');
+
+		if (empty($user->rights->accounting)) {
+			$user->rights->accounting = new stdClass();
+		}
+		if (empty($user->rights->accounting->bind)) {
+			$user->rights->accounting->bind = new stdClass();
+		}
+		if (empty($user->rights->accounting->mouvements)) {
+			$user->rights->accounting->mouvements = new stdClass();
+		}
+
+		$user->rights->accounting->bind->write = 0;
+		$user->rights->accounting->mouvements->export = 1;
+		$result = dol_check_secure_access_document('export_compta', 'export/1/general_ledger.csv', 0, $user, '', 'read');
+		$this->assertEquals(1, $result['accessallowed']);
+
+		$user->rights->accounting->mouvements->export = 0;
+		$result = dol_check_secure_access_document('export_compta', 'export/1/general_ledger.csv', 0, $user, '', 'read');
+		$this->assertEquals(0, $result['accessallowed']);
+
+		$user->rights->accounting->bind->write = $savpermbindwrite;
+		$user->rights->accounting->mouvements->export = $savpermexport;
+	}
+
+	/**
 	 * testDolDirMove
 	 *
 	 * @return void


### PR DESCRIPTION
# FIX #38615 Accountancy export API returns generated file metadata

The accountancy export API generated the CSV file but ended with
`exit()`, resulting in an empty API response.

The endpoint now returns the generated file metadata, including the
module part, relative path, filename and MIME type. Users with the
accounting export permission can also download the file through the
documents API.

Tested on a running instance: the export endpoint returned the file
metadata and the documents endpoint returned the generated CSV content.