### PR TITLE
FIX isInt() does not detect sized integer types (tinyint, bigint)

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -10059,7 +10059,7 @@ abstract class CommonObject
 	public function isInt($info)
 	{
 		if (is_array($info)) {
-			if (isset($info['type']) && (preg_match('/(^int|int$)/i', $info['type']))) {
+			if (isset($info['type']) && (preg_match('/^(?:tiny|small|medium|big)?int|int$/i', $info['type']))) {
 				return true;
 			} else {
 				return false;

--- a/test/phpunit/CommonObjectTest.php
+++ b/test/phpunit/CommonObjectTest.php
@@ -117,4 +117,38 @@ class CommonObjectTest extends CommonClassTest
 		$this->assertLessThanOrEqual($result, 0);
 		return $result;
 	}
+
+	/**
+	 *  testIsInt
+	 *
+	 *  @return void
+	 */
+	public function testIsInt()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$localobject = new Commande($db);
+
+		// Integer types, with or without a size/unsigned suffix, must be detected.
+		$this->assertTrue($localobject->isInt(array('type' => 'int')), 'int');
+		$this->assertTrue($localobject->isInt(array('type' => 'int(11)')), 'int(11)');
+		$this->assertTrue($localobject->isInt(array('type' => 'integer')), 'integer');
+		$this->assertTrue($localobject->isInt(array('type' => 'tinyint(4)')), 'tinyint(4)');
+		$this->assertTrue($localobject->isInt(array('type' => 'smallint(6)')), 'smallint(6)');
+		$this->assertTrue($localobject->isInt(array('type' => 'bigint(20)')), 'bigint(20)');
+		// Dolibarr foreign-key column syntax "integer:Class:path" must keep being detected.
+		$this->assertTrue($localobject->isInt(array('type' => 'integer:User:user/class/user.class.php')), 'integer:User:...');
+
+		// Non-integer types must not be detected, including strings that merely contain "int".
+		$this->assertFalse($localobject->isInt(array('type' => 'varchar(255)')), 'varchar(255)');
+		$this->assertFalse($localobject->isInt(array('type' => 'double(24,8)')), 'double(24,8)');
+		$this->assertFalse($localobject->isInt(array('type' => 'date')), 'date');
+		$this->assertFalse($localobject->isInt(array('type' => 'sellist:llx_c_typent:libelle:id')), 'sellist:...');
+
+		print __METHOD__." OK\n";
+	}
 }


### PR DESCRIPTION
# FIX isInt() does not detect sized integer types (tinyint, bigint)

> **Supersedes #34380.** This is a re-implementation of that stale PR, rebased onto the `21.0` maintenance branch and reworked to address the review feedback from @eldy (see the "false positives" note below). It also adds unit tests and covers `smallint(N)` / `mediumint(N)`, which #34380 missed.

## Problem

`CommonObject::isInt()` uses the regex `/(^int|int$)/i` to decide whether a field is an integer.
This drives the **numeric search mode** of columns on list pages (`$mode_search = ($object->isInt(...) || $object->isFloat(...)) ? 1 : 0`) and is also involved when resolving `$this->id`.

The regex fails on sized integer types such as `tinyint(4)` and `bigint(20)`, because those strings **neither start nor end with `int`** (the size suffix `(4)`/`(20)` is at the end). As a result:

- Columns declared as `tinyint(4)` fall back to text search instead of numeric search. This is not a corner case — `tinyint(4)` is used in several **core** `$fields` definitions, e.g. `societe.class.php`, `contact.class.php`, `product/stock/class/entrepot.class.php`, `societe/class/companypaymentmode.class.php`.
- ModuleBuilder-generated tables that use `bigint(20)` for `rowid` do not get recognised as int, so `$this->id` is not populated.

## Fix

```diff
- if (isset($info['type']) && (preg_match('/(^int|int$)/i', $info['type']))) {
+ if (isset($info['type']) && (preg_match('/^(?:tiny|small|medium|big)?int|int$/i', $info['type']))) {
```

The new pattern matches `int`, `int(11)`, `integer`, `tinyint(4)`, `smallint(6)`, `mediumint(9)`, `bigint(20)`, `int(10) unsigned`, etc.

### On the concern raised in #34380 (false positives)

A previous attempt (#34380) got stuck on the valid worry that `type` can be a long string that merely *contains* `int` (e.g. `sellist:Table:Label:...`). This fix keeps the original anchoring philosophy: it only adds **start** anchors for `tiny/small/medium/big int`, and keeps the `int$` alternative. Therefore:

- `sellist:llx_c_typent:libelle:id`, `varchar(255)`, `double(24,8)`, `date`, `text`, `price`, `real`, `boolean`, `html` → still **not** matched (no new false positives).
- The Dolibarr foreign-key syntax `integer:User:user/class/user.class.php` → still matched (a fully end-anchored regex would have regressed this, so it was deliberately avoided).

## Tests

Adds `testIsInt()` to `test/phpunit/CommonObjectTest.php` (the first unit test for this method) covering the positive types above and the negative / false-positive cases.

## Target branch

Submitted against `21.0` per the contributing guidelines (bug fix → oldest maintained affected version, recommended N-2). The bug is present on `21.0` through `develop`.
