### PR TITLE
FIX Accountancy: truncated doc ref not readable in ledger by account

### DIFF
--- a/htdocs/accountancy/bookkeeping/listbyaccount.php
+++ b/htdocs/accountancy/bookkeeping/listbyaccount.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2013-2020  Florian Henry       <florian.henry@open-concept.pro>
  * Copyright (C) 2013-2024  Alexandre Spangaro  <aspangaro@easya.solutions>
  * Copyright (C) 2018       Frédéric France     <frederic.france@netlogic.fr>
+ * Copyright (C) 2026       Jose Martinez       <jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1223,7 +1224,7 @@ while ($i < min($num, $limit)) {
 		} elseif ($line->doc_type == 'bank') {
 			print $objectstatic->getNomUrl(1);
 			$bank_ref = strstr($line->doc_ref, '-');
-			print " " . $bank_ref;
+			print ' <span class="classfortooltip" title="'.dol_escape_htmltag($line->doc_ref).'">'.dol_escape_htmltag($bank_ref).'</span>';
 		} else {
 			print $line->doc_ref;
 		}


### PR DESCRIPTION
## Bug

In `htdocs/accountancy/bookkeeping/listbyaccount.php` (Ledger by account / Grand livre auxiliaire), the **Piece** column cell is printed with class `tdoverflowmax250`:

```css
.tdoverflowmax250 {
    max-width: 250px;
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
}
```

For `doc_type == 'bank'` entries, the part of the label following the bank line ref is printed as a **bare text node**, with no `title` attribute and no `classfortooltip`:

```php
} elseif ($line->doc_type == 'bank') {
    print $objectstatic->getNomUrl(1);
    $bank_ref = strstr($line->doc_ref, '-');
    print " " . $bank_ref;
}
```

Because the cell clips its content to a single line, the truncated text is **unreadable and unreachable**: no tooltip appears on hover. Only the bank line ref itself (rendered by `getNomUrl()`) carries a tooltip, showing just the ref and amount.

This is very visible on bank entries whose label references many invoices, e.g.:

```
1234 - Supplier payment INV-0001 INV-0002 INV-0003 ... INV-0025
```

Everything past the first few refs simply cannot be consulted.

## Regression

Before 19.0 the cell used `maxwidth400`, which only sets `max-width: 400px` — no `overflow: hidden`, no `white-space: nowrap`. The label wrapped onto several lines and stayed **fully readable**, so no tooltip was needed.

The switch to `tdoverflowmax250` in 19.0 introduced the clipping without adding a matching tooltip. Notably, the neighbouring **Label** column already handles this correctly in the same file:

```php
print '<td class="small tdoverflowmax350 classfortooltip" title="'.dol_escape_htmltag($line->label_operation).'">'...
```

Verified still present in 19.0, 20.0, 21.0, 22.0, 23.0 and develop (24.0.0-beta) — the code is identical in all of them.
See below:
<img width="2810" height="1336" alt="image" src="https://github.com/user-attachments/assets/c75f1c73-4865-4194-b6d7-ec85c1b35f08" />

## Fix

Wrap `$bank_ref` in a span carrying `classfortooltip` and the full `doc_ref` as `title`, aligning this column with its neighbour:

```php
print ' <span class="classfortooltip" title="'.dol_escape_htmltag($line->doc_ref).'">'.dol_escape_htmltag($bank_ref).'</span>';
```

- **Rendering is unchanged** — the cell still truncates at 250px exactly as before.
- Hovering the truncated text now reveals the complete label.
- No nesting issue: the span is a sibling of the `<a>` produced by `getNomUrl()`, not a parent, so the two tooltips do not conflict.
- The output is now escaped with `dol_escape_htmltag()`; it was previously printed raw.

## Steps to reproduce

1. Accounting > Ledger by account (`accountancy/bookkeeping/listbyaccount.php`)
2. Display an entry of type `bank` whose label is longer than the column width (typically a supplier payment covering many invoices)
3. Hover the truncated text in the **Piece** column → nothing happens; the full label cannot be read

## Branch

Targets `19.0`, the oldest maintained branch affected (18.0 is not affected — it still uses `maxwidth400`).
