### PR TITLE
FIX: Fix variable collision in foreach loop causing "Remove from cycle" button to be always disabled

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -5887,9 +5887,9 @@ if ($action == 'create') {
 				$total_next_ht = $total_next_ttc = 0;
 
 				foreach ($object->tab_next_situation_invoice as $next_invoice) {
-					$totalpaid = $next_invoice->getSommePaiement(0);
-					$totalcreditnotes = $next_invoice->getSumCreditNotesUsed(0);
-					$totaldeposits = $next_invoice->getSumDepositsUsed(0);
+					$next_totalpaid = $next_invoice->getSommePaiement(0);
+					$next_totalcreditnotes = $next_invoice->getSumCreditNotesUsed(0);
+					$next_totaldeposits = $next_invoice->getSumDepositsUsed(0);
 					$total_next_ht += $next_invoice->total_ht;
 					$total_next_ttc += $next_invoice->total_ttc;
 
@@ -5902,7 +5902,7 @@ if ($action == 'create') {
 					}
 					print '<td class="right"><span class="amount">'.price($next_invoice->total_ht).'</span></td>';
 					print '<td class="right"><span class="amount">'.price($next_invoice->total_ttc).'</span></td>';
-					print '<td class="right">'.$next_invoice->getLibStatut(3, $totalpaid + $totalcreditnotes + $totaldeposits).'</td>';
+					print '<td class="right">'.$next_invoice->getLibStatut(3, $next_totalpaid + $next_totalcreditnotes + $next_totaldeposits).'</td>';
 					print '</tr>';
 				}
 
@@ -6637,7 +6637,7 @@ if ($action == 'create') {
 				&& $object->is_last_in_cycle()
 				&& $usercanunvalidate
 			) {
-				if (($object->total_ttc - $totalcreditnotes) == 0) {
+				if (price2num($object->total_ttc - $totalcreditnotes, 'MT') == 0) {
 					print '<a id="butSituationOut" class="butAction" href="'.$_SERVER['PHP_SELF'].'?facid='.$object->id.'&action=situationout">'.$langs->trans("RemoveSituationFromCycle").'</a>';
 				} else {
 					print '<a id="butSituationOutRefused" class="butActionRefused classfortooltip" href="#" title="'.$langs->trans("DisabledBecauseNotEnouthCreditNote").'" >'.$langs->trans("RemoveSituationFromCycle").'</a>';


### PR DESCRIPTION
# FIX|Fix "Remove situation invoice from cycle" button always disabled when credit note is applied

In `htdocs/compta/facture/card.php`, the `foreach` loop over `$object->tab_next_situation_invoice` was overwriting the outer scope variables `$totalpaid`, `$totalcreditnotes` and `$totaldeposits` with values from each `$next_invoice`. As a result, after the loop, `$totalcreditnotes` was set to the value (or NULL) from the last next invoice instead of the current `$object`, causing the condition that enables the "Remove from cycle" button to always fail.

Fix: renamed the loop variables to `$next_totalpaid`, `$next_totalcreditnotes` and `$next_totaldeposits` to avoid the collision with the outer scope.

Also fixed a floating point comparison: replaced `($object->total_ttc - $totalcreditnotes) == 0` with `price2num($object->total_ttc - $totalcreditnotes, 'MT') == 0` to correctly handle string-typed amounts returned by the database.