### PR TITLE
FIX phpstan: Societe::$client (int<0,3>) does not accept -1

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1049,7 +1049,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 		// Define if customer/prospect or supplier status is set or not
 		if (GETPOST("type", 'aZ') != 'f') {
-			$object->client = -1;
+			$object->client = 0;
 			if (getDolGlobalString('THIRDPARTY_CUSTOMERPROSPECT_BY_DEFAULT')) {
 				$object->client = 3;
 			}


### PR DESCRIPTION
## Problem

The `develop` PHPStan CI (`php-stan (8.2)`, level 10) fails with:

```
Property Societe::$client (int<0, 3>) does not accept -1.
```

at `htdocs/societe/card.php:1052`.

`Societe::$client` is annotated in `societe/class/societe.class.php`:

```php
/**
 * 0=no customer, 1=customer, 2=prospect, 3=customer and prospect
 * @var int<0,3>
 */
public $client = 0;
```

The thirdparty **create form** in `societe/card.php` pre-set this property to `-1` as a transient "nothing pre-selected" placeholder, which is outside the declared `int<0,3>` domain. (This annotation only exists on `develop`, so the error is develop-only.)

## Fix

```diff
 		if (GETPOST("type", 'aZ') != 'f') {
-			$object->client = -1;
+			$object->client = 0;
 			if (getDolGlobalString('THIRDPARTY_CUSTOMERPROSPECT_BY_DEFAULT')) {
 				$object->client = 3;
 			}
```

This is behavior-preserving:

- The value is **never persisted** — the save paths recompute `client` as `0..3` (`card.php:402-406` on add, `GETPOSTINT('client')` on update).
- The only reader is the `switch ($selected)` that builds the form (`card.php:~1485`); `-1` and `0` both fall through the identical `default` case (no checkbox pre-checked).
- `0` is already the property's declared default and matches the `int<0,3>` type and the DB column (`client tinyint DEFAULT 0`).

Preferred over widening the annotation to `int<-1,3>`, which would contradict the documented domain (`0/1/2/3`) and the DB comment, and mask that `update()` has no `-1` guard.

## Notes

This clears the remaining PHPStan failure on `develop` not covered by #39226 (which fixes the two `pdf_standard_evaluation::printLine()` int/float errors in the same CI run).

## Target branch

`develop` — the strict annotation and thus the error exist only there.