### PR TITLE
FIX #34667 checkUserAccessToObject: skip entity check for non-multientity objects (multicompany)

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1187,7 +1187,7 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 					$sql .= " AND dbt.entity IN (".getEntity($sharedelement, 1).")";
 					$sql .= " AND (sc.fk_user = ".((int) $user->id)." OR sc.fk_user IS NULL)";
 				}
-			} elseif (isModEnabled('multicompany')) {
+			} elseif (isModEnabled('multicompany') && (!empty($object->ismultientitymanaged) || !isset($object->ismultientitymanaged))) {
 				// If multicompany, and user is an internal user with all permissions, check that object is in correct entity
 				$sql = "SELECT COUNT(dbt.".$dbt_select.") as nb";
 				$sql .= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";


### PR DESCRIPTION
## Problem

With the **multicompany** module enabled, `checkUserAccessToObject()` (called by `restrictedArea()`, e.g. from an ajax tooltip) runs an entity check **unconditionally** in its default / custom-object branch:

```php
} elseif (isModEnabled('multicompany')) {
    // ... check that object is in correct entity
    $sql  = "SELECT COUNT(dbt.".$dbt_select.") as nb";
    $sql .= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";
    $sql .= " WHERE dbt.".$dbt_select." IN (".$db->sanitize($objectid, 1).")";
    $sql .= " AND dbt.entity IN (".getEntity($sharedelement, 1).")";
}
```

For a **custom object whose table has no `entity` column** (i.e. the object is not multi-entity managed, `ismultientitymanaged = 0`), this builds `AND dbt.entity IN (...)` against a non-existent column. The query fails, `nb` comes back `0`, and access is **wrongly denied** (the ajax tooltip / `restrictedArea` returns 0).

## Fix

Guard that branch so the entity check only runs when the object is actually multi-entity managed:

```diff
-			} elseif (isModEnabled('multicompany')) {
+			} elseif (isModEnabled('multicompany') && (!empty($object->ismultientitymanaged) || !isset($object->ismultientitymanaged))) {
```

Behavior:

- `ismultientitymanaged = 1` or `'field@table'` → entity check runs (unchanged).
- Property **unset / null** (legacy classes that never define it) → `!isset(...)` keeps the entity check (unchanged, backward compatible).
- `$object` is a non-object (the param default is the scalar `0`) → `!isset(...)` is true, so the check is kept — no behavior change and no PHP warning (`empty()`/`isset()` are warning-safe on scalars).
- `ismultientitymanaged = 0` (explicitly not multi-entity managed) → **entity check skipped**, fixing the bug.

The two sibling `elseif (isModEnabled('multicompany'))` branches (the `societe`/`checksoc` and `checkparentsoc` cases) are intentionally left unchanged — those operate on tables that always carry an `entity` column.

## Notes

- Supersedes the stale #34667 (by @jyhere) and applies the exact condition requested by @eldy in its review (only disable the test when the property is explicitly `0`, keep it for old classes that never set it).
- Reproduction: enable the multicompany module, create a custom module object whose table has no `entity` column (`ismultientitymanaged = 0`), and trigger `restrictedArea()` on it (e.g. via an ajax tooltip) as an internal user — access is denied before this fix, allowed after.

## Target branch

`21.0` per the CONTRIBUTING branch policy (bug fix → N-2). The bug is present unchanged from `21.0` through `develop`, so the fix propagates upward via the normal merge-up flow.