### PR TITLE
Fix: init deposit percent input when default payment term has a deposit

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4682,18 +4682,31 @@ class Form
 			$out .= '
 				<script nonce="' . getNonce() . '">
 					$(document).ready(function () {
-						$("#' . $htmlname . '").change(function () {
-							let $selected = $(this).find("option:selected");
-							let depositPercent = $selected.attr("data-deposit_percent");
+						let $select = $("#' . $htmlname . '");
+						let $container = $("#' . $htmlname . '_deposit_percent_container");
+						let $input = $("#' . $htmlname . '_deposit_percent");
+
+						function refreshDepositPercent(isInit) {
+							let depositPercent = $select.find("option:selected").attr("data-deposit_percent") || "";
 
 							if (depositPercent.length > 0) {
-								$("#' . $htmlname . '_deposit_percent_container").show().find("#' . $htmlname . '_deposit_percent").val(depositPercent);
+								$container.show();
+								// On page load, keep an existing (possibly customized) value; on user change use the payment term default
+								if (!isInit || !parseFloat($input.val())) {
+									$input.val(depositPercent);
+								}
 							} else {
-								$("#' . $htmlname . '_deposit_percent_container").hide();
+								$container.hide();
 							}
+						}
 
+						$select.change(function () {
+							refreshDepositPercent(false);
 							return true;
 						});
+
+						// Initialize on load so a default payment term with a deposit is reflected without a manual change
+						refreshDepositPercent(true);
 					});
 				</script>';
 		}


### PR DESCRIPTION
## FIX | Fix

> **Supersedes #30622** (by @TitCaz), which stalled waiting for a reproduction description. This PR provides the reproduction steps below and adds two robustness fixes on top of the original one-line change.

When a payment term that has an associated deposit percent is preselected in the "Payment conditions" dropdown, but the object's own `deposit_percent` is still empty, the deposit percent input stayed empty (and sometimes hidden) until the user manually re-selected the term. This initializes it on page load.

### Steps to reproduce
1. Go to **Setup → Dictionaries → Payment terms** (`c_payment_term`) and create/edit a payment term with a **Deposit percent** value, e.g. `30`.
2. Edit a customer (thirdparty) and set its **default payment term** to that deposit term, but leave the thirdparty **Deposit percent** field empty.
3. Create a **new order** (or proposal) for that thirdparty.
4. Look at the **Payment conditions** field.

### Actual behavior (before)
The deposit payment term is preselected, but the **Deposit percent** input next to it is empty / `0`. The correct percent (`30`) only appears after manually re-selecting the same term. This happens because the change handler that copies the term's `data-deposit_percent` into the input is only bound, never fired on load (`getSelectConditionsPaiements()` in `htdocs/core/class/html.form.class.php`).

### Expected behavior (after)
On page load the deposit percent input is initialized from the preselected term, so it already shows `30` without any manual interaction.

### Changes
- Fire the initialization on load so a default payment term with a deposit is reflected immediately.
- Guard against options that have no `data-deposit_percent` attribute (the empty option rendered when `addempty` is set), avoiding a `TypeError` on load.
- On load, keep an already set (customized) deposit percent value instead of overwriting it with the payment term default; on an explicit user change the term default is applied as before.

Only `htdocs/core/class/html.form.class.php` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
