### PR TITLE
FIX : treasury journal never matches transferred entries (fk_docdet)

### DIFF
--- a/htdocs/accountancy/journal/treasuryjournal.php
+++ b/htdocs/accountancy/journal/treasuryjournal.php
@@ -1165,10 +1165,10 @@ if ($action == 'writebookkeeping' /* && $user->hasRight('accounting', 'bind', 'w
 
 				$bookkeepingToCreate = new BookKeeping($db);
 
-				// Unique key is on couple: $payment_id, $objectInfos['id']
-				// For record in llx_accountaing_bookkeeping, for record with doc_type = 'bank', the value of fk_doc is ID in llx_bank and fk_docdet too. Wetry a fix this way;
-				//$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountInfos['account_number'], $tabaccountingaccount[$accountInfos['account_number']]['label'], $accountInfos['account_ref'], $amount, $journal, $journal_label, '');
-				$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, 0, $accountInfos['account_number'], $tabaccountingaccount[$accountInfos['account_number']]['label'], $accountInfos['account_ref'], $amount, $journal, $journal_label, '');
+				// For doc_type='bank', fk_doc is the bank line id and fk_docdet is the source document id (invoice, expense report, salary, ...).
+				// The couple (fk_doc, fk_docdet) must match the binding/read queries below (ab.fk_doc=bu.fk_bank AND ab.fk_docdet=<doc>.rowid),
+				// otherwise the "already transferred" filter never matches and re-transfer wrongly reports "already recorded".
+				$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountInfos['account_number'], $tabaccountingaccount[$accountInfos['account_number']]['label'], $accountInfos['account_ref'], $amount, $journal, $journal_label, '');
 
 				if ($result < 0) {
 					$errorforline++;
@@ -1214,8 +1214,7 @@ if ($action == 'writebookkeeping' /* && $user->hasRight('accounting', 'bind', 'w
 					$total_check -= (float) $amount;
 
 					$bookkeepingToCreate = new BookKeeping($db);
-					//$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountancy_code, $accountingAccountInfos['label'], (!empty($operation['label']) ? $operation['label'] : $accountingAccountInfos['label']), -$amount, $journal, $journal_label, '');
-					$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, 0, $accountancy_code, $accountingAccountInfos['label'], (!empty($operation['label']) ? $operation['label'] : $accountingAccountInfos['label']), - (float) $amount, $journal, $journal_label, '');
+					$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountancy_code, $accountingAccountInfos['label'], (!empty($operation['label']) ? $operation['label'] : $accountingAccountInfos['label']), - (float) $amount, $journal, $journal_label, '');
 					if ($result < 0) {
 						$errorforline++;
 
@@ -1263,8 +1262,7 @@ if ($action == 'writebookkeeping' /* && $user->hasRight('accounting', 'bind', 'w
 						$total_check -= $amount;
 
 						$bookkeepingToCreate = new BookKeeping($db);
-						//$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountancy_code, $accountingAccountInfos['label'], $langs->trans('VAT').' '.price($vat_infos['tva_tx']).'%', -$amount, $journal, $journal_label, '');
-						$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, 0, $accountancy_code, $accountingAccountInfos['label'], $langs->trans('VAT').' '.price($vat_infos['tva_tx']).'%', -$amount, $journal, $journal_label, '');
+						$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountancy_code, $accountingAccountInfos['label'], $langs->trans('VAT').' '.price($vat_infos['tva_tx']).'%', -$amount, $journal, $journal_label, '');
 						if ($result < 0) {
 							$errorforline++;
 
@@ -1286,8 +1284,7 @@ if ($action == 'writebookkeeping' /* && $user->hasRight('accounting', 'bind', 'w
 				$total_check += $amount;
 
 				$bookkeepingToCreate = new BookKeeping($db);
-				//$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountInfos['account_number'], $tabaccountingaccount[$accountInfos['account_number']]['label'], $accountInfos['account_ref'], $amount, $journal, $journal_label, '');
-				$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, 0, $accountInfos['account_number'], $tabaccountingaccount[$accountInfos['account_number']]['label'], $accountInfos['account_ref'], $amount, $journal, $journal_label, '');
+				$result = $bookkeepingToCreate->createFromValues($payment["date"], $objectInfos['ref'], 'bank', $payment_id, $objectInfos['id'], $accountInfos['account_number'], $tabaccountingaccount[$accountInfos['account_number']]['label'], $accountInfos['account_ref'], $amount, $journal, $journal_label, '');
 				if ($result < 0) {
 					$errorforline++;
 

--- a/htdocs/accountancy/journal/treasuryjournal.php
+++ b/htdocs/accountancy/journal/treasuryjournal.php
@@ -1165,6 +1165,8 @@ if ($action == 'writebookkeeping' /* && $user->hasRight('accounting', 'bind', 'w
 
 				$bookkeepingToCreate = new BookKeeping($db);
 
+				// Unique key is on couple: $payment_id, $objectInfos['id']
+				
 				// For doc_type='bank', fk_doc is the bank line id and fk_docdet is the source document id (invoice, expense report, salary, ...).
 				// The couple (fk_doc, fk_docdet) must match the binding/read queries below (ab.fk_doc=bu.fk_bank AND ab.fk_docdet=<doc>.rowid),
 				// otherwise the "already transferred" filter never matches and re-transfer wrongly reports "already recorded".

--- a/htdocs/accountancy/journal/treasuryjournal.php
+++ b/htdocs/accountancy/journal/treasuryjournal.php
@@ -1165,8 +1165,8 @@ if ($action == 'writebookkeeping' /* && $user->hasRight('accounting', 'bind', 'w
 
 				$bookkeepingToCreate = new BookKeeping($db);
 
-				// Unique key is on couple: $payment_id, $objectInfos['id']
-				
+				// Unique key in llx_accounting_bookkeeping is on couple: $payment_id, $objectInfos['id']
+
 				// For doc_type='bank', fk_doc is the bank line id and fk_docdet is the source document id (invoice, expense report, salary, ...).
 				// The couple (fk_doc, fk_docdet) must match the binding/read queries below (ab.fk_doc=bu.fk_bank AND ab.fk_docdet=<doc>.rowid),
 				// otherwise the "already transferred" filter never matches and re-transfer wrongly reports "already recorded".


### PR DESCRIPTION
**Bug**

With `ACCOUNTING_MODE = RECETTES-DEPENSES`, bank journals are handled by `treasuryjournal.php`. When transferring, records are written with `fk_docdet = 0`, while every read/binding query matches `ab.fk_doc = bu.fk_bank AND ab.fk_docdet = <document>.rowid`.

Consequences:
- the "Already transferred" filter always returns *"No record found"*, even though the entries exist;
- re-running the transfer wrongly reports *"already recorded"* and stops with `ErrorTooManyErrorsProcessStopped (>5)`.

**Root cause**

Write and read use different `fk_docdet` conventions. The write path passed a hardcoded `0` (a leftover the original code even commented as a tentative fix).

**Fix**

Write `fk_docdet = $objectInfos['id']` (the source document id) in the 4 `createFromValues()` calls, so write and read share the same `(fk_doc, fk_docdet)` couple. Verified consistent for all 11 payment types (invoice, supplier invoice, expense report, salary, social contribution, VAT, donation, loan, various, member, bank transfer) — each read JOIN targets `<document>.rowid`, which is exactly what `$objectInfos['id']` holds.

**Tested**

RECETTES-DEPENSES, customer invoice payment: after transfer the entry now has `fk_docdet` = invoice id (not 0) and appears under "Already transferred"; re-transfer behaves correctly.

**Known limitation**

Records previously written with `fk_docdet = 0` by the buggy code won't retroactively appear as transferred; a data remediation is needed for existing installs (out of scope of this PR).
