### PR TITLE
FIX mo_production: show very-short unit label instead of untranslated 'UnitPShort'

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1097,7 +1097,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						print '<td class="right nowraponall">';
 						$useunit = (($tmpproduct->type == Product::TYPE_PRODUCT && getDolGlobalInt('PRODUCT_USE_UNITS')) || (($tmpproduct->type == Product::TYPE_SERVICE) && ($line->fk_unit)));
 						if ($useunit) {
-							print measuringUnitString($line->fk_unit, '', '', 2);
+							print measuringUnitString($line->fk_unit, '', '', 1);
 						}
 						print '</td>';
 
@@ -1187,7 +1187,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						print '<td class="right nowraponall">';
 						$useunit = (($tmpproduct->type == Product::TYPE_PRODUCT && getDolGlobalInt('PRODUCT_USE_UNITS')) || (($tmpproduct->type == Product::TYPE_SERVICE) && ($line->fk_unit)));
 						if ($useunit) {
-							print measuringUnitString($line->fk_unit, '', '', 2);
+							print measuringUnitString($line->fk_unit, '', '', 1);
 						}
 						print '</td>';
 


### PR DESCRIPTION
## Problem

In the MO **production** view (`htdocs/mrp/mo_production.php`), the "Unit" column of the consume and produce tables renders the unit with:

```php
print measuringUnitString($line->fk_unit, '', '', 2);
```

`use_short_label = 2` makes `measuringUnitString()` return `transnoentitiesnoconv(ucfirst($label).'Short')`, i.e. it translates a `<Label>Short` key. But for the standard units (`llx_c_units`) the `label` column is values like `Piece`, `WeightUnitkg`, `SizeUnitm`, … so param `2` looks up keys such as **`PieceShort`**, **`WeightUnitkgShort`**, **`SizeUnitmShort`** — which **do not exist** in the language files (only a few time units happen to have them, e.g. `HourShort=H`). So a product measured in *pieces* displays the raw untranslated key **`PieceShort`** instead of `p`, kg displays `WeightUnitkgShort`, etc.

## Fix

Use `use_short_label = 1`, which returns the DB `short_label` column (the very-short label: `p`, `kg`, `h`, …). This is the convention used by the sibling "Unit" column in this same file and by ~17 other call sites across the codebase — these two calls were the only `2` in the whole project.

```diff
-							print measuringUnitString($line->fk_unit, '', '', 2);
+							print measuringUnitString($line->fk_unit, '', '', 1);
```

Applied to both the consume table and the produce table. The `measuringUnitString(..., 1)` call a bit earlier in the file that feeds `convertDurationtoHour()` (a computation) is intentionally **left untouched**.

## Before / After

Real Dolibarr 21.0.4, real `measuringUnitString()` against real `llx_c_units` data (the exact code path of the MO production "Unit" cell):

![MO production Unit column — before vs after](https://raw.githubusercontent.com/JamBalaya56562/dolibarr/assets-screenshots/docs/screenshots/mo_unit_before_after.png)

## Supersedes #31706

This replaces the stale #31706 (by @Humml87), which had the same goal (consistent short unit labels) but changed the calls the **opposite** way (`1` → `2`). As @eldy noted there — *"we must save spaces, so we ask to use the very short label; for 'piece' we should get 'p'; if using 2 we will get PieceShort. So 1 seems the correct value"* — param `1` is the right one. Param `2` would also have shown the untranslated `…Short` keys, and (in #31706) would additionally have broken the `convertDurationtoHour()` computation. This PR applies exactly the direction @eldy requested, minimally.

## Target branch

`21.0` per the CONTRIBUTING branch policy (bug fix → N-2). Present unchanged through `develop`, so it propagates upward via the normal merge-up flow.

## Reproduction

Enable `PRODUCT_USE_UNITS`, create a Manufacturing Order whose BOM/lines use a product in a non-time unit (e.g. *piece*), open the MO production tab → the Unit column shows `PieceShort` before this fix, `p` after.