### PR TITLE
FIX #32217 Fire BILL_CREATE with create-form extrafields on next situation invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2087,19 +2087,18 @@ if (empty($reshook)) {
 
 				$object->situation_counter += 1;
 
+				// Set extrafields from the create form BEFORE createFromCurrent(), so they are already
+				// present when create() inserts them and fires the BILL_CREATE trigger. This avoids firing
+				// BILL_CREATE a second time just to expose the extrafields (#32217).
+				$extrafields->fetch_name_optionals_label($object->table_element);
+				$extrafields->setOptionalsFromPost(null, $object);
+
 				$id = $object->createFromCurrent($user);
 				if ($id <= 0) {
 					$mesg = $object->error;
 				} else {
 					$nextSituationInvoice = new Facture($db);
 					$nextSituationInvoice->fetch($id);
-
-					// create extrafields with data from create form
-					$extrafields->fetch_name_optionals_label($nextSituationInvoice->table_element);
-					$ret = $extrafields->setOptionalsFromPost(null, $nextSituationInvoice);
-					if ($ret > 0) {
-						$nextSituationInvoice->insertExtraFields();
-					}
 
 					// Hooks
 					$parameters = array('origin_type' => $object->origin_type, 'origin_id' => $object->origin_id);

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1178,7 +1178,10 @@ class Facture extends CommonInvoice
 
 		// Retrieve all extrafield
 		// fetch optionals attributes and labels
-		$this->fetch_optionals();
+		// (unless the caller already set array_options, e.g. from a create form, so we don't overwrite them)
+		if (empty($this->array_options)) {
+			$this->fetch_optionals();
+		}
 
 		if (!empty($this->array_options)) {
 			$facture->array_options = $this->array_options;


### PR DESCRIPTION
## Problem

When creating the **next situation invoice** (invoice card, `type=situation`), the extrafields entered in the create form are saved like this (`htdocs/compta/facture/card.php`):

```php
$id = $object->createFromCurrent($user);      // -> Facture::create() fires BILL_CREATE here
...
$nextSituationInvoice->fetch($id);
$extrafields->setOptionalsFromPost(null, $nextSituationInvoice);
$nextSituationInvoice->insertExtraFields();    // extrafields saved AFTER BILL_CREATE, no trigger
```

`createFromCurrent()` calls `Facture::create()`, which fires the **`BILL_CREATE`** trigger (`facture.class.php`). The create-form extrafields are only written *afterwards*, by a plain `insertExtraFields()` (no trigger). So any module reacting to `BILL_CREATE` never sees the extrafields that were entered on the form.

## Why the original one-liner was not merged

The initial proposal (#32217) changed the last line to `insertExtraFields('BILL_CREATE')`. As @eldy pointed out in review, `BILL_CREATE` **was already fired** inside `createFromCurrent()`, so this would fire it **twice**. @eldy suggested instead setting the extrafields *before* `createFromCurrent()` and removing the post-create block.

That direction is right, but the literal version does not work on its own: `createFromCurrent()` starts with `$this->fetch_optionals();`, which **resets `array_options` from the source invoice in DB**, discarding any form values set beforehand.

## Fix

Two minimal changes so `BILL_CREATE` fires **once**, with the form extrafields already present:

1. `htdocs/compta/facture/card.php` — set the extrafields on `$object` *before* `createFromCurrent()`, and drop the post-create `insertExtraFields()` block.
2. `htdocs/compta/facture/class/facture.class.php` — in `createFromCurrent()`, only call `fetch_optionals()` when the caller has not already populated `array_options`, so the form values are not overwritten:

```diff
-		$this->fetch_optionals();
+		if (empty($this->array_options)) {
+			$this->fetch_optionals();
+		}
```

The new invoice's `create()` now inserts the form extrafields and fires `BILL_CREATE` a single time with them set. Final DB state is unchanged (still the form values); only the trigger timing/content is fixed.

The two other `createFromCurrent()` callers (replacement invoice in the same file, and `fourn/facture/card.php`) do **not** pre-set `array_options`, so `fetch_optionals()` still runs for them — no behaviour change.

## Supersedes #32217

Implements @eldy's suggested approach, adapted so the create-form extrafields are actually preserved (the `fetch_optionals()` overwrite the literal suggestion missed).

## Target branch

`21.0` per the CONTRIBUTING branch policy (bug fix -> N-2). The code is identical up to `develop`, so the fix propagates upward via the normal merge-up flow.

## Reproduction

With an extrafield defined on invoices and a trigger/module hooking `BILL_CREATE`: create a situation invoice, then create its next situation invoice while filling the extrafield on the form. Before this fix, `BILL_CREATE` fires without the extrafield value (it is written afterwards); after, it fires once with the value present.