### PR TITLE
FIX commande/stats: do not default "Created by" filter to current user

### DIFF
--- a/htdocs/commande/stats/index.php
+++ b/htdocs/commande/stats/index.php
@@ -390,7 +390,10 @@ if (isModEnabled('category')) {
 // User
 print '<tr><td>'.$langs->trans("CreatedBy").'</td><td>';
 print img_picto('', 'user', 'class="pictofixedwidth"');
-print $form->select_dolusers($userid, 'userid', 1, null, 0, '', '', '0', 0, 0, '', 0, '', 'widthcentpercentminusx maxwidth300');
+// Pass -1 (not 0) when no user is selected so the combo keeps its empty entry instead of defaulting to the
+// current user. The statistics query below is not filtered on the current user by default, so preselecting
+// them here wrongly suggests the displayed figures are limited to that user while they are actually global.
+print $form->select_dolusers(($userid > 0 ? $userid : -1), 'userid', 1, null, 0, '', '', '0', 0, 0, '', 0, '', 'widthcentpercentminusx maxwidth300');
 // Status
 print '<tr><td>'.$langs->trans("Status").'</td><td>';
 if ($mode == 'customer') {


### PR DESCRIPTION
## Bug

On the order statistics page (`commande/stats/index.php`), on first page load the
statistics query is **not** filtered on the current user, so the figures and graphs
shown are global (all users).

However the **"Created by"** filter combo defaulted to the current user: when the
passed value is empty, `Form::select_dolusers()` auto-selects `$user->id` (unless
`SOCIETE_DISABLE_DEFAULT_SALESREPRESENTATIVE` is set).

Result: the form displays "Created by: \<current user\>" while the data shown is
actually global — this wrongly suggests the statistics are limited to that user.

## Fix

Pass `-1` instead of `0` to `select_dolusers()` when no user is selected, so the
combo keeps its empty entry and reflects the unfiltered query.

`-1` is neither `< -4` nor `empty()`, so the "default to current user" branch is
skipped and the empty option (`value="-1"`) stays selected. The empty option posts
`-1`, which the query below turns back into "no user filter" (`$userid > 0 ? ... : 0`),
so the round-trip remains consistent after a refresh. Selecting a real user still
works as before.

Applies to both `customer` and `supplier` modes (shared code path).

## How to reproduce

1. Open `commande/stats/index.php`.
2. Notice the "Created by" filter is pre-filled with the current user, while the
   figures shown are global.
3. With the fix, the filter is empty on arrival, matching the global data.
