### PR TITLE
FIX avoid MRP foreign key when module table is absent

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -107,7 +107,6 @@ ALTER TABLE llx_categorie_mo ADD INDEX idx_categorie_mo_fk_categorie (fk_categor
 ALTER TABLE llx_categorie_mo ADD INDEX idx_categorie_mo_fk_mo (fk_mo);
 
 ALTER TABLE llx_categorie_mo ADD CONSTRAINT fk_categorie_mo_categorie_rowid FOREIGN KEY (fk_categorie) REFERENCES llx_categorie (rowid);
-ALTER TABLE llx_categorie_mo ADD CONSTRAINT fk_categorie_mo_fk_mo_rowid FOREIGN KEY (fk_mo) REFERENCES llx_mrp_mo (rowid);
 
 ALTER TABLE llx_facture ADD COLUMN fk_thirdparty_rib_id integer NULL;
 ALTER TABLE llx_facture_fourn ADD COLUMN fk_thirdparty_rib_id integer NULL;


### PR DESCRIPTION
The 23.0.0 to 24.0.0 migration creates `llx_categorie_mo` unconditionally and also adds a foreign key to `llx_mrp_mo`.

MRP table files are module-specific (`*-mrp.sql`), so `llx_mrp_mo` does not exist when MRP has never been enabled. MySQL then aborts the migration request with `DB_ERROR_1824`.

The module key file already creates this foreign key when MRP is initialized. This change therefore removes only the unconditional migration constraint.

Tested on MySQL 8 by running the category migration block with `llx_categorie` present and all MRP tables absent.