### PR TITLE
FIX e-invoice marketplace search on admin home

### DIFF
--- a/htdocs/admin/index.php
+++ b/htdocs/admin/index.php
@@ -167,8 +167,8 @@ print '<br>';
 
 $arrayofeinvoiceneed = array(
 	'FR' => array('module' => array('einvoice', 'pdpconnectfr'), 'search' => 'e-invoice'),
-	'ES' => array('search' => array('verifactu')),
-	'BE' => array('search' => array('peppol')),
+	'ES' => array('search' => 'verifactu'),
+	'BE' => array('search' => 'peppol'),
 	'PL' => array('module' => array('ksef'), 'search' => 'ksef')
 );
 


### PR DESCRIPTION
The admin home defines the Spanish and Belgian e-invoice marketplace search terms as arrays, while the URL builder passes them directly to `urlencode()`.

On PHP 8 this throws a `TypeError` and returns HTTP 500 for authenticated administrators in those countries.

This change makes both search terms strings, consistently with the French and Polish entries.

Validated with `php -l htdocs/admin/index.php` and reproduced on PHP 8.4.