### PR TITLE
FIX #30846 Email subject: keep diacritics on manual send

### DIFF
--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -341,7 +341,7 @@ if (($action == 'send' || $action == 'relance') && !GETPOST('addfile') && !GETPO
 			$replyto = dol_string_nospecial(GETPOST('replytoname'), ' ', array(",")).' <'.GETPOST('replytomail').'>';
 
 			$message = GETPOST('message', 'restricthtml');
-			$subject = GETPOST('subject', 'restricthtml');
+			$subject = GETPOST('subject', 'alphanohtml');
 
 			// Make a change into HTML code to allow to include images from medias directory with an external reabable URL.
 			// <img alt="" src="/dolibarr_dev/htdocs/viewimage.php?modulepart=medias&amp;entity=1&amp;file=image/ldestailleur_166x166.jpg" style="height:166px; width:166px" />


### PR DESCRIPTION
## FIX | Fix

> **Supersedes #33269 and #33268** (by @HLFH), which stalled with the *Discussion* label. This PR keeps the same one-line fix but adds a concrete reproduction, the root-cause mechanism, an explicit security rationale, and — importantly — an honest scope statement, so the open questions that stalled the previous PR are answered up front.

On the manual **Send email** form, the subject was sanitized with `GETPOST('subject', 'restricthtml')`. `restricthtml` is intended for **HTML textarea bodies**, not for a plain-text header, and it strips diacritics from the subject.

### Steps to reproduce
1. Enable the hardening option `MAIN_RESTRICTHTML_ONLY_VALID_HTML` (Home → Setup → Other, or via `llx_const`). This is the option that triggers the corruption.
2. Open any object with an email form (e.g. an **invoice** card) → **Send email**.
3. Set the subject to a value with diacritics, e.g. `Připomenutí splatné faktury` (Czech) or `Référence à é è` (French), and send.

### Actual behavior (before)
The accented characters are dropped/garbled in the received subject (e.g. `Pipomenut splatn faktury`).

### Expected behavior (after)
The subject is delivered intact.

### Screenshots — reproduced on Dolibarr 21.0.4 (Docker) with Mailpit as SMTP catcher
Same input `Připomenutí splatné faktury` typed in the thirdparty **Send email** form; only `htdocs/core/actions_sendmails.inc.php` differs between the two runs.

![Before/after comparison of the received email subject](https://raw.githubusercontent.com/Marukome0743/dolibarr/pr39278-assets/docs-assets/pr39278/comparison.png)

- **Before** (`restricthtml`): received subject `P;ipomenut&iacute; splatn&eacute; faktury` — `ř` dropped, `í`/`é` turned into raw entities.
- **After** (`alphanohtml`): received subject `Připomenutí splatné faktury` — diacritics preserved.

### Root cause
`restricthtml` → `dol_htmlwithnojs()`. With `MAIN_RESTRICTHTML_ONLY_VALID_HTML` on, the value is round-tripped through `DOMDocument`, which converts non-ASCII letters into numeric HTML entities (`&#345;` …). `realCharForNumericEntities()` (`htdocs/main.inc.php`) only restores **ASCII A-Z/a-z**, and `htdocs/core/lib/functions.lib.php` then deletes the remaining numeric entities with `preg_replace('/&#x?[0-9]+/i', '', $out)` — so the diacritics disappear.

The mailer `CMailFile::encodetorfc2822()` base64-encodes the **raw** subject under the UTF-8 charset, i.e. it expects a raw UTF-8 string. The correct sanitizer for this field is therefore `alphanohtml`, which strips all HTML but decodes entities back to real UTF-8 and preserves accented characters (it is the `GETPOST` default and the recommended mode for scalar parameters).

### Change
```diff
-			$subject = GETPOST('subject', 'restricthtml');
+			$subject = GETPOST('subject', 'alphanohtml');
```
Only `htdocs/core/actions_sendmails.inc.php` is touched. The message body keeps `restricthtml` (it is legitimate HTML).

### Scope (please note)
This fixes the **manual send path** only. The **cron/reminder** scenario originally described in #30846 builds its subject from the email template in `facture.class.php` / `fournisseur.facture.class.php` and calls `CMailFile` directly, so it does **not** go through `actions_sendmails.inc.php` and is intentionally **out of scope** here. Happy to open a separate PR for the cron path if wanted.

### Security
`alphanohtml` removes **all** HTML tags, so it is stricter than the `restricthtml` whitelist — no XSS regression. The subject is never rendered as HTML in this file (the only HTML use of `$subject` is commented out), and the global WAF (`testSqlAndScriptInject`) still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
