### PR TITLE
Sec: Fix potential injection with cast to int (timespent_duration)

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1895,7 +1895,7 @@ class Task extends CommonObjectLine
 
 		if (!$error) {
 			$sql = "UPDATE ".MAIN_DB_PREFIX."projet_task";
-			$sql .= " SET duration_effective = duration_effective - ".$this->db->escape($this->timespent_duration ? $this->timespent_duration : 0);
+			$sql .= " SET duration_effective = duration_effective - ".((int) $this->timespent_duration);
 			$sql .= " WHERE rowid = ".((int) $this->id);
 
 			dol_syslog(get_class($this)."::delTimeSpent", LOG_DEBUG);


### PR DESCRIPTION
# Sec: Fix potential injection with cast to int (timespent_duration)

timespent_duration is in principle an int,  but was unquoted string in sql expression presenting some risk.
Fixed by casting to int.