### PR TITLE
NEW Standalone receptions: usable line edition (supplier block, buying price, warehouse, batch) + FIX no stock movement for standalone lines

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -138,12 +138,14 @@ if ($nolinesbefore) {
 			<div id="add"></div><span class="hideonsmartphone"><?php echo $langs->trans('AddNewLine'); ?></span>
 		</td>
 		<?php
-		if ($object->element == 'supplier_proposal' || $object->element == 'order_supplier' || $object->element == 'invoice_supplier' || $object->element == 'invoice_supplier_rec') {	// We must have same test in printObjectLines
+		if ($object->element == 'supplier_proposal' || $object->element == 'order_supplier' || $object->element == 'invoice_supplier' || $object->element == 'invoice_supplier_rec' || $object->element == 'reception') {	// We must have same test in printObjectLines
 			?>
 			<td class="linecolrefsupplier"><span id="title_fourn_ref"><?php echo $langs->trans('SupplierRef'); ?></span></td>
 			<?php
 		} ?>
+		<?php if ($object->element != 'reception') { ?>
 		<td class="linecolvat right"><span id="title_vat"><?php echo $langs->trans('VAT'); ?></span></td>
+		<?php } ?>
 		<td class="linecoluht right"><span id="title_up_ht"><?php echo $langs->trans('PriceUHT'); ?></span></td>
 		<?php if (isModEnabled("multicurrency") && $this->multicurrency_code && $this->multicurrency_code != $conf->currency) { ?>
 			<td class="linecoluht_currency right"><span id="title_up_ht_currency"><?php echo $langs->trans('PriceUHT').'&nbsp;<span class="opacitymedium">('.$langs->getCurrencySymbol($this->multicurrency_code).')</span>'; ?></span></td>
@@ -370,8 +372,8 @@ if ($nolinesbefore) {
 					echo '<span class="fa fa-plus-circle valignmiddle paddingleft"></span>';
 					echo '</a>';
 					echo '<div class="dropdown-menu" aria-labelledby="dropdownAddProductAndServiceLink" style="top:auto; left:auto;">';
-					echo '<a class="dropdown-item" href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=0&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'"> '.$langs->trans("NewProduct").'</a>';
-					echo '<a class="dropdown-item" href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=1&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'"> '.$langs->trans("NewService").'</a>';
+					echo '<a class="dropdown-item" href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=0&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id.($object->element == 'reception' ? '&idprodfournprice=idprod___ID__' : '')).'"> '.$langs->trans("NewProduct").'</a>';
+					echo '<a class="dropdown-item" href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=1&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id.($object->element == 'reception' ? '&idprodfournprice=idprod___ID__' : '')).'"> '.$langs->trans("NewService").'</a>';
 					echo '</div>';
 					echo '</div>';
 				} else {
@@ -384,7 +386,7 @@ if ($nolinesbefore) {
 							// @phan-suppress-next-line PhanPluginSuspiciousParamOrder
 							print dolButtonToOpenUrlInDialogPopup('addproduct', $langs->transnoentitiesnoconv('AddProduct'), $newbutton, $url, '', '', $jsonclode);
 						} else {
-							print '<a href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=0&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'" title="'.dol_escape_htmltag($langs->trans("NewProduct")).'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
+							print '<a href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=0&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id.($object->element == 'reception' ? '&idprodfournprice=idprod___ID__' : '')).'" title="'.dol_escape_htmltag($langs->trans("NewProduct")).'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
 						}
 					}
 					if ($addserviceon) {
@@ -396,7 +398,7 @@ if ($nolinesbefore) {
 							// @phan-suppress-next-line PhanPluginSuspiciousParamOrder
 							print dolButtonToOpenUrlInDialogPopup('addproduct', $langs->transnoentitiesnoconv('AddService'), $newbutton, $url, '', '', $jsonclode);
 						} else {
-							print '<a href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=1&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'" title="'.dol_escape_htmltag($langs->trans("NewService")).'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
+							print '<a href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=1&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id.($object->element == 'reception' ? '&idprodfournprice=idprod___ID__' : '')).'" title="'.dol_escape_htmltag($langs->trans("NewService")).'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
 						}
 					}
 				}
@@ -479,11 +481,12 @@ if ($nolinesbefore) {
 			}
 		}
 		echo '</td>';
-		if ($object->element == 'supplier_proposal' || $object->element == 'order_supplier' || $object->element == 'invoice_supplier' || $object->element == 'invoice_supplier_rec') {	// We must have same test in printObjectLines
+		if ($object->element == 'supplier_proposal' || $object->element == 'order_supplier' || $object->element == 'invoice_supplier' || $object->element == 'invoice_supplier_rec' || $object->element == 'reception') {	// We must have same test in printObjectLines
 			$coldisplay++; ?>
 	<td class="nobottom linecolrefsupplier"><input id="fourn_ref" name="fourn_ref" class="flat minwidth50 maxwidth100 maxwidth125onsmartphone" value="<?php echo(GETPOSTISSET("fourn_ref") ? GETPOST("fourn_ref", 'alpha', 2) : ''); ?>"></td>
 					<?php
 		}
+		if ($object->element != 'reception') {	// Receptions have no VAT on lines
 		print '<td class="nobottom linecolvat right">';
 		$coldisplay++;
 		$type_tva = 0;
@@ -499,6 +502,7 @@ if ($nolinesbefore) {
 		}
 		?>
 	</td>
+	<?php } ?>
 
 	<td class="nobottom linecoluht right"><?php $coldisplay++; ?>
 		<input type="text" name="price_ht" id="price_ht" class="flat right width50" value="<?php echo(GETPOSTISSET("price_ht") ? GETPOST("price_ht", 'alpha', 2) : ''); ?>">
@@ -544,9 +548,23 @@ if ($nolinesbefore) {
 		$remise_percent = $seller->remise_supplier_percent;
 	}
 	$coldisplay++;
+	if ($object->element == 'reception') {	// Destination warehouse and batch per line instead of discount
+		print '<td class="nobottom linecolwarehouse right">';
+		require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
+		$formproductcreate = new FormProduct($object->db);
+		print $formproductcreate->selectWarehouses(GETPOSTINT('entrepot_id') > 0 ? GETPOSTINT('entrepot_id') : 'ifone', 'entrepot_id', '', 1, 0, 0, '', 1);
+		print '</td>';
+		if (isModEnabled('productbatch')) {
+			$coldisplay++;
+			print '<td class="nobottom linecolbatch">';
+			print '<input size="8" type="text" class="flat" name="batch" id="batch" placeholder="'.dol_escape_htmltag($langs->trans('Batch')).'" value="'.(GETPOSTISSET('batch') ? dol_escape_htmltag(GETPOST('batch', 'alphanohtml')) : '').'">';
+			print '</td>';
+		}
+	} else {
 	?>
 
 	<td class="nobottom nowrap linecoldiscount right"><input type="text" name="remise_percent" id="remise_percent" class="flat width40 right" value="<?php echo(GETPOSTISSET("remise_percent") ? GETPOST("remise_percent", 'alpha', 2) : ($remise_percent ? $remise_percent : '')); ?>"><span class="opacitymedium hideonsmartphone">%</span></td>
+	<?php } ?>
 	<?php
 	if (isset($this->situation_cycle_ref) && $this->situation_cycle_ref) {
 		$coldisplay++;

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -574,3 +574,6 @@ UPDATE llx_const SET name = __ENCRYPT('ACCOUNTANCY_AUXACCOUNT_USE_SEARCH_TO_SELE
 ALTER TABLE llx_adherent MODIFY COLUMN societe VARCHAR(128);
 
 -- end of migration
+
+-- Add supplier ref on reception lines (standalone receptions)
+ALTER TABLE llx_receptiondet_batch ADD COLUMN ref_fourn varchar(128) NULL AFTER cost_price;

--- a/htdocs/install/mysql/tables/llx_receptiondet_batch.sql
+++ b/htdocs/install/mysql/tables/llx_receptiondet_batch.sql
@@ -44,6 +44,7 @@ create table llx_receptiondet_batch
   datec          datetime,
   tms            timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   cost_price     double(24,8) DEFAULT 0,
+  ref_fourn      varchar(128),									-- supplier ref of the product for this reception line
   rang 			 integer  DEFAULT 0,							-- Position of line
   extraparams	 varchar(255)				 					-- to stock other parameters in json format
 )ENGINE=innodb;

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -814,6 +814,25 @@ if (empty($reshook)) {
 
 			if (!$error) {
 				$result = $object->updatelinefree(GETPOSTINT('lineid'), (float) $qty, $element_type, $fk_product, GETPOSTINT('units'), $rang, $description, 0, $array_options);
+				// Update buying price, supplier ref, destination warehouse and batch of the line
+				if ($result >= 0) {
+					$setparts = array();
+					if (GETPOSTISSET('cost_price')) {
+						$setparts[] = "cost_price = ".((float) price2num(GETPOST('cost_price', 'alpha')));
+					}
+					if (GETPOSTISSET('fourn_ref')) {
+						$setparts[] = "ref_fourn = '".$db->escape(GETPOST('fourn_ref', 'alphanohtml'))."'";
+					}
+					if (GETPOSTISSET('batch')) {
+						$setparts[] = "batch = '".$db->escape(GETPOST('batch', 'alphanohtml'))."'";
+					}
+					if (GETPOSTINT('entrepot_id') > 0) {
+						$setparts[] = "fk_entrepot = ".GETPOSTINT('entrepot_id');
+					}
+					if (count($setparts)) {
+						$db->query("UPDATE ".MAIN_DB_PREFIX."receptiondet_batch SET ".implode(', ', $setparts)." WHERE rowid = ".GETPOSTINT('lineid'));
+					}
+				}
 
 				if ($result >= 0) {
 					if (!getDolGlobalString('MAIN_DISABLE_PDF_AUTOUPDATE')) {
@@ -953,10 +972,32 @@ if (empty($reshook)) {
 		$fk_entrepot = '';
 		$rang = '';
 		$prod_entry_mode = GETPOST('prod_entry_mode', 'aZ09');
+		$cost_price_from_pfp = 0;
+		$reffourn_from_pfp = '';
 		if ($prod_entry_mode == 'free') {
 			$idprod = 0;
 		} else {
 			$idprod = GETPOSTINT('idprod');
+			if (empty($idprod) && GETPOSTISSET('idprodfournprice')) {
+				// The supplier product combo posts idprodfournprice (id of supplier price, or 'idprod_x' if product has no supplier price)
+				require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
+				$ipfp = GETPOST('idprodfournprice', 'alpha');
+				$reg = array();
+				if (preg_match('/^idprod_([0-9]+)$/', $ipfp, $reg)) {
+					$idprod = (int) $reg[1];
+				} elseif ((int) $ipfp > 0) {
+					$productsupplier = new ProductFournisseur($db);
+					$idprod = $productsupplier->get_buyprice((int) $ipfp, price2num(GETPOST('qty', 'alpha'), 'MS'));
+					if ($idprod > 0) {
+						$cost_price_from_pfp = price2num($productsupplier->fourn_unitprice);
+						$reffourn_from_pfp = $productsupplier->ref_supplier;
+					}
+				}
+			}
+			if ($prod_entry_mode != 'free' && $idprod <= 0) {
+				setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("ProductOrService")), null, 'errors');
+				$error++;
+			}
 			if (getDolGlobalString('MAIN_DISABLE_FREE_LINES') && $idprod <= 0) {
 				setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("ProductOrService")), null, 'errors');
 				$error++;
@@ -1095,7 +1136,21 @@ if (empty($reshook)) {
 
 			if (!$error) {
 				// Insert line
-				$result = $object->addlinefree((float) $qty, $element_type, $idprod, $fk_unit, min($rank, count($object->lines) + 1), $description, $array_options);
+				// Buying price: typed value first (field of the supplier add-line block), then known supplier price
+				$typedcost = price2num(GETPOST('cost_price', 'alpha'));
+				if (!(float) $typedcost) {
+					$typedcost = price2num(GETPOST('price_ht', 'alpha'));
+				}
+				$finalcost = ((float) $typedcost > 0) ? (float) $typedcost : (float) $cost_price_from_pfp;
+				$reffourn_line = GETPOST('fourn_ref', 'alphanohtml');
+				if ($reffourn_line === '' && !empty($reffourn_from_pfp)) {
+					$reffourn_line = $reffourn_from_pfp;
+				}
+				$wh_line = GETPOSTINT('entrepot_id');
+				if (empty($wh_line)) {
+					$wh_line = getDolGlobalInt('MAIN_DEFAULT_WAREHOUSE');
+				}
+				$result = $object->addlinefree((float) $qty, $element_type, $idprod, $fk_unit, min($rank, count($object->lines) + 1), $description, $array_options, (float) $finalcost, $reffourn_line, $wh_line, GETPOST('batch', 'alphanohtml'));
 
 				if ($result > 0) {
 					$ret = $object->fetch($object->id); // Reload to get new records
@@ -2443,6 +2498,7 @@ if ($action == 'create' && $permissiontoadd) {
 						setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 					}
 					if (empty($reshook)) {
+						$senderissupplier = 2;	// Use the same add-line block as supplier orders; 2 = also list products without supplier price for this supplier
 						$object->formAddObjectLine(0, $mysoc, $soc);
 					}
 				}

--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -686,14 +686,14 @@ class Reception extends CommonObject
 
 			// Loop on each product line to add a stock movement
 			// TODO in future, reception lines may not be linked to order line
-			$sql = "SELECT cd.fk_product, cd.subprice, cd.remise_percent,";
+			$sql = "SELECT COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) as fk_product, cd.subprice, cd.remise_percent,";
 			$sql .= " ed.rowid, ed.qty, ed.fk_entrepot,";
 			$sql .= " ed.eatby, ed.sellby, ed.batch,";
 			$sql .= " ed.fk_elementdet, ed.cost_price";
-			$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd,";
-			$sql .= " ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+			$sql .= " FROM ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = ed.fk_elementdet";
 			$sql .= " WHERE ed.fk_reception = ".((int) $this->id);
-			$sql .= " AND cd.rowid = ed.fk_elementdet";
+			$sql .= " AND COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) IS NOT NULL";
 
 			dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 			$resql = $this->db->query($sql);
@@ -1053,7 +1053,7 @@ class Reception extends CommonObject
 	 * @param	array<string,mixed>		$array_options		extrafields array
 	 * @return	int											Return integer <0 if KO, >0 if OK
 	 */
-	public function addlinefree($qty, $element_type, $fk_product, $fk_unit, $rang, $description, $array_options = [])
+	public function addlinefree($qty, $element_type, $fk_product, $fk_unit, $rang, $description, $array_options = [], $cost_price = 0, $ref_fourn = '', $fk_entrepot = 0, $batch = '')
 	{
 		global $mysoc, $langs, $user;
 
@@ -1083,6 +1083,14 @@ class Reception extends CommonObject
 			$this->line->qty = (float) $qty;
 			$this->line->fk_unit = $fk_unit;
 			$this->line->rang = $ranktouse;
+			$this->line->cost_price = (float) $cost_price;
+			$this->line->ref_fourn = trim((string) $ref_fourn);
+			if ((int) $fk_entrepot > 0) {
+				$this->line->fk_entrepot = (int) $fk_entrepot;
+			}
+			if ((string) $batch !== '') {
+				$this->line->batch = trim((string) $batch);
+			}
 
 			if (is_array($array_options) && count($array_options) > 0) {
 				$this->line->array_options = $array_options;
@@ -1213,7 +1221,7 @@ class Reception extends CommonObject
 
 		$this->lines = array();
 
-		$sql = 'SELECT rc.rowid, rc.fk_reception, rc.fk_entrepot, rc.fk_product, rc.fk_unit, rc.description, rc.fk_elementdet, rc.fk_element, rc.element_type, rc.qty, rc.rang';
+		$sql = 'SELECT rc.rowid, rc.fk_reception, rc.fk_entrepot, rc.fk_product, rc.fk_unit, rc.description, rc.fk_elementdet, rc.fk_element, rc.element_type, rc.qty, rc.rang, rc.cost_price, rc.ref_fourn, rc.batch, rc.eatby, rc.sellby';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'receptiondet_batch as rc';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product as p ON (p.rowid = rc.fk_product)';
 		$sql .= ' WHERE rc.fk_reception = '.((int) $this->id);
@@ -1238,6 +1246,11 @@ class Reception extends CommonObject
 				$line->description      = $objp->description;
 				$line->qty              = $objp->qty;
 				$line->fk_entrepot      = $objp->fk_entrepot;
+				$line->cost_price       = $objp->cost_price;
+				$line->ref_fourn        = $objp->ref_fourn;
+				$line->batch            = $objp->batch;
+				$line->eatby            = $objp->eatby;
+				$line->sellby           = $objp->sellby;
 				$line->fk_product       = $objp->fk_product;
 
 				$line->rang             = $objp->rang;
@@ -1434,11 +1447,11 @@ class Reception extends CommonObject
 			$langs->load("agenda");
 
 			// Loop on each product line to add a stock movement
-			$sql = "SELECT cd.fk_product, cd.subprice, ed.qty, ed.fk_entrepot, ed.eatby, ed.sellby, ed.batch, ed.rowid as receptiondet_batch_id";
-			$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd,";
-			$sql .= " ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+			$sql = "SELECT COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) as fk_product, cd.subprice, ed.qty, ed.fk_entrepot, ed.eatby, ed.sellby, ed.batch, ed.rowid as receptiondet_batch_id";
+			$sql .= " FROM ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = ed.fk_elementdet";
 			$sql .= " WHERE ed.fk_reception = ".((int) $this->id);
-			$sql .= " AND cd.rowid = ed.fk_elementdet";
+			$sql .= " AND COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) IS NOT NULL";
 
 			dol_syslog(get_class($this)."::delete select details", LOG_DEBUG);
 			$resql = $this->db->query($sql);
@@ -2058,14 +2071,14 @@ class Reception extends CommonObject
 
 				// Loop on each product line to add a stock movement
 				// TODO possibilite de receptionner a partir d'une propale ou autre origine ?
-				$sql = "SELECT cd.fk_product, cd.subprice,";
+				$sql = "SELECT COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) as fk_product, cd.subprice,";
 				$sql .= " ed.rowid, ed.qty, ed.fk_entrepot,";
 				$sql .= " ed.eatby, ed.sellby, ed.batch,";
 				$sql .= " ed.fk_elementdet, ed.cost_price";
-				$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd,";
-				$sql .= " ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+				$sql .= " FROM ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = ed.fk_elementdet";
 				$sql .= " WHERE ed.fk_reception = ".((int) $this->id);
-				$sql .= " AND cd.rowid = ed.fk_elementdet";
+				$sql .= " AND COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) IS NOT NULL";
 
 				dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 				$resql = $this->db->query($sql);
@@ -2219,14 +2232,14 @@ class Reception extends CommonObject
 
 				// Loop on each product line to add a stock movement
 				// TODO possibilite de receptionner a partir d'une propale ou autre origine
-				$sql = "SELECT ed.fk_product, cd.subprice,";
+				$sql = "SELECT COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) as fk_product, cd.subprice,";
 				$sql .= " ed.rowid, ed.qty, ed.fk_entrepot,";
 				$sql .= " ed.eatby, ed.sellby, ed.batch,";
 				$sql .= " ed.fk_elementdet, ed.cost_price";
-				$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd,";
-				$sql .= " ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+				$sql .= " FROM ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = ed.fk_elementdet";
 				$sql .= " WHERE ed.fk_reception = ".((int) $this->id);
-				$sql .= " AND cd.rowid = ed.fk_elementdet";
+				$sql .= " AND COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) IS NOT NULL";
 
 				dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 				$resql = $this->db->query($sql);
@@ -2356,14 +2369,14 @@ class Reception extends CommonObject
 
 				// Loop on each product line to add a stock movement
 				// TODO possibilite de receptionner a partir d'une propale ou autre origine
-				$sql = "SELECT cd.fk_product, cd.subprice,";
+				$sql = "SELECT COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) as fk_product, cd.subprice,";
 				$sql .= " ed.rowid, ed.qty, ed.fk_entrepot,";
 				$sql .= " ed.eatby, ed.sellby, ed.batch,";
 				$sql .= " ed.fk_elementdet, ed.cost_price";
-				$sql .= " FROM ".MAIN_DB_PREFIX."commande_fournisseurdet as cd,";
-				$sql .= " ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+				$sql .= " FROM ".MAIN_DB_PREFIX."receptiondet_batch as ed";
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."commande_fournisseurdet as cd ON cd.rowid = ed.fk_elementdet";
 				$sql .= " WHERE ed.fk_reception = ".((int) $this->id);
-				$sql .= " AND cd.rowid = ed.fk_elementdet";
+				$sql .= " AND COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product) IS NOT NULL";
 
 				dol_syslog(get_class($this)."::valid select details", LOG_DEBUG);
 				$resql = $this->db->query($sql);

--- a/htdocs/reception/class/receptionlinebatch.class.php
+++ b/htdocs/reception/class/receptionlinebatch.class.php
@@ -174,6 +174,11 @@ class ReceptionLineBatch extends CommonObjectLine
 	 * @var int|float
 	 */
 	public $cost_price = 0;
+
+	/**
+	 * @var string Supplier ref for the product on this reception line
+	 */
+	public $ref_fourn;
 	/**
 	 * @var int rang of line
 	 */
@@ -283,7 +288,8 @@ class ReceptionLineBatch extends CommonObjectLine
 		$sql .= "description,";
 		$sql .= "rang,";
 		$sql .= "fk_reception,";
-		$sql .= "cost_price";
+		$sql .= "cost_price,";
+		$sql .= "ref_fourn";
 		$sql .= ") VALUES (";
 		$sql .= " ".(!isset($this->fk_product) ? 'NULL' : (int) $this->fk_product).",";
 		$sql .= " ".(!isset($this->fk_element) ? 'NULL' : (int) $this->fk_element).",";
@@ -302,7 +308,8 @@ class ReceptionLineBatch extends CommonObjectLine
 		$sql .= ", '".(empty($this->description) ? '' : $this->db->escape($this->description))."'";
 		$sql .= ", ".((int) $ranktouse).",";
 		$sql .= " ".((int) $this->fk_reception).",";
-		$sql .= " ".(!isset($this->cost_price) ? '0' : (float) $this->cost_price);
+		$sql .= " ".(!isset($this->cost_price) ? '0' : (float) $this->cost_price).",";
+		$sql .= " ".(!isset($this->ref_fourn) ? 'NULL' : "'".$this->db->escape($this->ref_fourn)."'");
 		$sql .= ")";
 
 		$this->db->begin();

--- a/htdocs/reception/tpl/objectline_edit.tpl.php
+++ b/htdocs/reception/tpl/objectline_edit.tpl.php
@@ -128,12 +128,28 @@ print '</td>';
 
 $coldisplay++;
 
+print '<td class="nobottom linecolrefsupplier">';
+print '<input id="fourn_ref" name="fourn_ref" class="flat minwidth50 maxwidth100" value="'.dol_escape_htmltag((string) (!empty($line->ref_fourn) ? $line->ref_fourn : '')).'">';
+print '</td>';
+print '<td class="nobottom linecolcostprice right">';
+print '<input size="6" type="text" class="flat right" name="cost_price" id="cost_price" value="'.(!empty($line->cost_price) ? price2num($line->cost_price) : '').'">';
+print '</td>';
 print '<td class="nobottom linecolqty right">';
 
 if (((int) $line->info_bits & 2) != 2) {
 	print '<input size="3" type="text" class="flat right" name="qty" id="qty" value="'.$line->qty.'">';
 }
 print '</td>';
+print '<td class="nobottom linecolwarehouse right">';
+require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
+$formproductline = new FormProduct($object->db);
+print $formproductline->selectWarehouses(!empty($line->fk_entrepot) ? $line->fk_entrepot : 'ifone', 'entrepot_id', '', 1, 0, (!empty($line->fk_product) ? $line->fk_product : 0), '', 1);
+print '</td>';
+if (isModEnabled('productbatch')) {
+	print '<td class="nobottom linecolbatch">';
+	print '<input size="8" type="text" class="flat" name="batch" id="batch" value="'.dol_escape_htmltag((string) (!empty($line->batch) ? $line->batch : '')).'">';
+	print '</td>';
+}
 
 
 if (getDolGlobalString('PRODUCT_USE_UNITS')) {

--- a/htdocs/reception/tpl/objectline_title.tpl.php
+++ b/htdocs/reception/tpl/objectline_title.tpl.php
@@ -74,7 +74,13 @@ if (getDolGlobalString('MAIN_VIEW_LINE_NUMBER')) {
 print '<th class="linecoldescription">'.$langs->trans('Description');
 
 // Qty
+print '<th class="linecolrefsupplier">'.$langs->trans('RefSupplier').'</th>';
+print '<th class="linecolcostprice right">'.$langs->trans('BuyingPrice').'</th>';
 print '<th class="linecolqty right">'.$langs->trans('Qty').'</th>';
+print '<th class="linecolwarehouse right">'.$langs->trans('Warehouse').'</th>';
+if (isModEnabled('productbatch')) {
+	print '<th class="linecolbatch">'.$langs->trans('Batch').'</th>';
+}
 
 
 // Unit

--- a/htdocs/reception/tpl/objectline_view.tpl.php
+++ b/htdocs/reception/tpl/objectline_view.tpl.php
@@ -102,7 +102,9 @@ print '<td class="linecoldescription line minwidth300imp tdoverflowmax300">';
 print '<div id="line_'.$line->id.'"></div>';
 $coldisplay++;
 $tmpproduct = new Product($object->db);
-$tmpproduct->fetch($line->fk_product);
+if (!empty($line->fk_product)) {
+	$tmpproduct->fetch($line->fk_product);
+}
 $tmprecep = new Reception($object->db);
 if ($line->fk_product > 0) {
 	print $tmpproduct->getNomUrl(1);
@@ -113,10 +115,33 @@ if ($line->fk_product > 0) {
 print '</td>';
 
 // Qty
+print '<td class="linecolrefsupplier">';
+print dol_escape_htmltag((string) (!empty($line->ref_fourn) ? $line->ref_fourn : ''));
+if (!empty($line->fk_product) && !empty($object->socid)) {
+	// Icon to open the buying prices of the product (standard page) in a popup, prefiltered on the reception supplier
+	$urlpfp = DOL_URL_ROOT.'/product/price_suppliers.php?id='.((int) $line->fk_product).'&socid='.((int) $object->socid).'&dol_hide_topmenu=1&dol_hide_leftmenu=1';
+	$jspfp = "jQuery('<div></div>').append(jQuery('<iframe>', {src: '".dol_escape_js($urlpfp)."', style: 'width:100%;height:100%;border:0'}))";
+	$jspfp .= ".dialog({modal: true, width: '85%', height: jQuery(window).height()*0.85, title: '".dol_escape_js($langs->trans('BuyingPrices'))."', close: function() { location.reload(); }}); return false;";
+	print ' <a href="'.$urlpfp.'" onclick="'.dol_escape_htmltag($jspfp).'" title="'.dol_escape_htmltag($langs->trans('BuyingPrices')).'">'.img_picto('', 'edit', 'class="paddingleft"').'</a>';
+}
+print '</td>';
+print '<td class="linecolcostprice nowrap right">'.(!empty($line->cost_price) ? price($line->cost_price) : '').'</td>';
 print '<td class="linecolqty nowrap right">';
 $coldisplay++;
 echo price($line->qty, 0, '', 0, 0); // Yes, it is a quantity, not a price, but we just want the formatting role of function price
 print '</td>';
+print '<td class="linecolwarehouse nowrap right">';
+if (!empty($line->fk_entrepot)) {
+	require_once DOL_DOCUMENT_ROOT.'/product/stock/class/entrepot.class.php';
+	$tmpwarehouse = new Entrepot($object->db);
+	if ($tmpwarehouse->fetch($line->fk_entrepot) > 0) {
+		print $tmpwarehouse->getNomUrl(1);
+	}
+}
+print '</td>';
+if (isModEnabled('productbatch')) {
+	print '<td class="linecolbatch">'.dol_escape_htmltag((string) (!empty($line->batch) ? $line->batch : '')).'</td>';
+}
 
 // Unit
 if (getDolGlobalInt('PRODUCT_USE_UNITS')) {		// For product, unit is shown only if option PRODUCT_USE_UNITS is on


### PR DESCRIPTION
## Context

`RECEPTION_STANDALONE` allows creating receptions without a supplier order, but the screen was not really usable (tested on a real retail database):

- The add-line form used the **customer** block (VAT / sale price / discount columns) while the reception line templates have a different column set → **broken table layout**.
- The generic product combo could not search by supplier ref or supplier barcode, and with the supplier combo mode 1, **products not referenced at this supplier could not be added at all** (silent failure, no error message).
- Lines had **no buying price, no supplier ref, no destination warehouse, no batch** — although `llx_receptiondet_batch` has the columns and the stock movement code at validation consumes `ed.fk_entrepot` and `ed.cost_price`.
- **CRITICAL BUG**: `Reception::valid()`, `setClosed()` and the other status-change methods only generated stock movements for lines linked to a supplier order line (`INNER JOIN commande_fournisseurdet` — see the existing `TODO in future, reception lines may not be linked to order line`). **A validated standalone reception never moved stock**, with `STOCK_CALCULATE_ON_RECEPTION` or `STOCK_CALCULATE_ON_RECEPTION_CLOSE`.

## What this PR does

**Reuse the supplier-order add-line block** (no new UI): `reception/card.php` sets `$senderissupplier = 2` so the core `objectline_create.tpl.php` shows the same block as supplier orders — supplier product combo (searches supplier ref + supplier barcode, lists also products without supplier price), *Ref. supplier* and *Buying price* fields, free-line + WYSIWYG description, 'create product/service' links (with autoselect of the created product through the existing `__ID__` backtopage substitution).

**Reception-specific cells in the core tpl** (guarded by `$object->element == 'reception'`, no impact on other modules): VAT and discount cells are skipped (receptions have neither), replaced by **destination warehouse** (with stock shown) and **batch** (if productbatch is on) — same spirit as the dispatch screen.

**Line data**: `addlinefree()` gets optional `$cost_price, $ref_fourn, $fk_entrepot, $batch` parameters; new column `llx_receptiondet_batch.ref_fourn` (+ migration); `fetch_lines_free()` hydrates cost_price/ref_fourn/batch/eatby/sellby. Line templates display Ref supplier / Buying price / Warehouse / Batch, all editable on the line, with a popup (dialog+iframe on `product/price_suppliers.php`) to manage the product's buying prices explicitly — the buying-price catalog is never written implicitly.

**Stock movements**: the 5 status-change queries now use a `LEFT JOIN` on `commande_fournisseurdet` with `COALESCE(NULLIF(ed.fk_product, 0), cd.fk_product)`, so standalone lines generate their movements (with the line's warehouse, cost price and batch); free-text lines without product are excluded.

## Notes for review

- Draft: the `updateline` persistence of the 4 new line fields is still a direct UPDATE in card.php — will be moved into `ReceptionLineBatch::update()` if the approach is approved.
- Companion fix #39284 (supplier barcode missing in the generic combo supplier search) stays relevant for the generic combo.
- Tested end-to-end on a 23.0.3 instance (add by supplier ref/barcode, products with and without supplier price, per-line warehouse/batch, validation creating the movements, PMP fed by the line cost price).
