### PR TITLE
FIX Accountancy - Hook to name generate file is not working

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2015		Florian Henry				<florian.henry@open-concept.pro>
  * Copyright (C) 2015		Raphaël Doursenaud			<rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2016		Pierre-Henry Favre			<phf@atm-consulting.fr>
- * Copyright (C) 2016-2025	Alexandre Spangaro			<alexandre@inovea-conseil.com>
+ * Copyright (C) 2016-2026	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2022		Lionel Vessiller			<lvessiller@open-dsi.fr>
  * Copyright (C) 2013-2017	Olivier Geffroy				<jeff@jeffinfo.com>
  * Copyright (C) 2017		Elarifr. Ari Elbaz			<github@accedinfo.com>
@@ -378,7 +378,8 @@ class AccountancyExport
 		global $search_date_end; 	// Used into /accountancy/tpl/export_journal.tpl.php
 
 		// Define name of file to save
-		$filename = 'general_ledger-'.$this->getFormatCode($formatexportset);
+		$formatcode = $this->getFormatCode($formatexportset);
+		$filename = 'general_ledger-'.(!empty($formatcode) ? $formatcode : $formatexportset);
 		$type_export = 'general_ledger';
 
 		$completefilename = '';
@@ -449,6 +450,11 @@ class AccountancyExport
 					$langs->load('errors');
 					$this->errors[] = $langs->trans('ErrorDirNotFound', $outputDir);
 					return -1;
+				}
+
+				// Fallback if template did not set $completefilename
+				if (empty($completefilename)) {
+					$completefilename = dol_sanitizeFileName($filename).'_'.dol_print_date(dol_now(), '%Y%m%d%H%M%S').'.txt';
 				}
 
 				if (!empty($completefilename)) {
@@ -541,11 +547,18 @@ class AccountancyExport
 				break;
 			default:
 				global $hookmanager;
-				$parameters = array('format' => $formatexportset);
-				// file contents will be created in the hooked function via print
+				$parameters = array(
+					'format' => $formatexportset,
+					'file' => $exportFile,
+					'filepath' => $exportFilePath,
+					'filefullname' => $exportFileFullName,
+				);
 				$reshook = $hookmanager->executeHooks('export', $parameters, $TData);
 				if ($reshook != 1) {
 					$this->errors[] = $langs->trans('accountancy_error_modelnotfound');
+				} elseif (!empty($hookmanager->resArray['downloadFileFullName']) && !empty($hookmanager->resArray['downloadFilePath'])) {
+					$exportFileFullName = $hookmanager->resArray['downloadFileFullName'];
+					$exportFilePath = $hookmanager->resArray['downloadFilePath'];
 				}
 				break;
 		}

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -457,28 +457,26 @@ class AccountancyExport
 					$completefilename = dol_sanitizeFileName($filename).'_'.dol_print_date(dol_now(), '%Y%m%d%H%M%S').'.txt';
 				}
 
-				if (!empty($completefilename)) {
-					// create export file
-					$exportFileFullName = $completefilename;
-					$exportFileBaseName = basename($exportFileFullName);
-					$exportFileName = pathinfo($exportFileBaseName, PATHINFO_FILENAME);
-					$exportFilePath = $outputDir . '/' . $exportFileFullName;
-					$exportFile = fopen($exportFilePath, 'w');
-					if (!$exportFile) {
-						$this->errors[] = $langs->trans('ErrorFileNotFound', $exportFilePath);
-						return -1;
-					}
+				// create export file
+				$exportFileFullName = $completefilename;
+				$exportFileBaseName = basename($exportFileFullName);
+				$exportFileName = pathinfo($exportFileBaseName, PATHINFO_FILENAME);
+				$exportFilePath = $outputDir . '/' . $exportFileFullName;
+				$exportFile = fopen($exportFilePath, 'w');
+				if (!$exportFile) {
+					$this->errors[] = $langs->trans('ErrorFileNotFound', $exportFilePath);
+					return -1;
+				}
 
-					if ($withAttachment == 1) {
-						$archiveFileList[0] = array(
-							'path' => $exportFilePath,
-							'name' => $exportFileFullName,
-						);
+				if ($withAttachment == 1) {
+					$archiveFileList[0] = array(
+						'path' => $exportFilePath,
+						'name' => $exportFileFullName,
+					);
 
-						// archive name and path
-						$archiveFullName = $exportFileName . '.zip';
-						$archivePath = $outputDir . '/' . $archiveFullName;
-					}
+					// archive name and path
+					$archiveFullName = $exportFileName . '.zip';
+					$archivePath = $outputDir . '/' . $archiveFullName;
 				}
 			}
 		}


### PR DESCRIPTION
## Fix: hooked export formats not returned with correct filename/content

### Problem
When a custom export format is handled via the `export` hook (`case default:` in `AccountancyExport::export()`), the file written by the hook was never properly linked back to the download logic:

- `$parameters` passed to the hook did not include the file handle/path already opened by the core, forcing hook implementations to open a second, disconnected file.
- After `executeHooks('export', ...)`, the core never read back `$hookmanager->resArray`, so any filename/path returned by the hook (e.g. after a rename to match FEC naming conventions) was silently ignored.
- As a result, downloaded files were either empty (wrong file read) or had a generic name (`general_ledger-_<timestamp>.txt`) instead of the expected format-specific name.

### Fix
- Pass `file`, `filepath`, and `filefullname` to the hook via `$parameters` so hook implementations can write directly into the core-managed file.
- After calling `executeHooks('export', ...)`, read `$hookmanager->resArray['downloadFileFullName']` / `['downloadFilePath']` if set by the hook, and use them to override `$exportFileFullName` / `$exportFilePath` before the download step.
- Added a fallback for `$completefilename` in case a hook-based format doesn't set it via the template.

### Impact
- No change to native export formats (FEC, FEC2, Quadratus, etc.).
- Hook-based custom export formats can now write into the correct file and control the final downloaded filename, without breaking file output when the hook doesn't set a custom name.