### PR TITLE
Fix Standalone reception creation

### DIFF
--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -1306,9 +1306,8 @@ if ($action == 'create' && $permissiontoadd) {
 		// Here $object can be of an object Reception
 		$extrafields->fetch_name_optionals_label($object->table_element);
 		if (empty($reshook) && !empty($extrafields->attributes[$object->table_element]['label'])) {
-			// copy from order
-			if ($objectsrc->fetch_optionals() > 0) {
-				$recept->array_options = array_merge($recept->array_options, $objectsrc->array_options);
+			if ($object->fetch_optionals() > 0) {
+				$recept->array_options = array_merge($recept->array_options, $object->array_options);
 			}
 			print $recept->showOptionals($extrafields, 'create', $parameters);
 		}


### PR DESCRIPTION
Fatal error: Uncaught Error: Call to a member function fetch_optionals() on null

