### PR TITLE
FIX supplier product combo does not preselect a product without supplier price ('idprod_ID' value)

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -4425,6 +4425,13 @@ class Form
 				$producttmpselect->fetch((int) $selected);
 				$selected_input_value = $producttmpselect->ref;
 				unset($producttmpselect);
+			} elseif (preg_match('/^idprod_([0-9]+)$/', (string) $selected, $regtmpsel)) {
+				// Preselect when a product without supplier price was just created ('idprod_ID' value, used by backtopage of creation popup)
+				require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
+				$producttmpselect = new Product($this->db);
+				$producttmpselect->fetch((int) $regtmpsel[1]);
+				$selected_input_value = $producttmpselect->ref;
+				unset($producttmpselect);
 			}
 
 			// mode=2 means suppliers products

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -27,6 +27,7 @@
  * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  * Copyright (C) 2026		Lenin Rivas				<lenin.rivas777@gmail.com>
  * Copyright (C) 2026		Open-Dsi				<support@open-dsi.fr>
+ * Copyright (C) 2026		Jose MARTINEZ				<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -1049,7 +1049,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 		// Define if customer/prospect or supplier status is set or not
 		if (GETPOST("type", 'aZ') != 'f') {
-			$object->client = -1;
+			$object->client = 0;
 			if (getDolGlobalString('THIRDPARTY_CUSTOMERPROSPECT_BY_DEFAULT')) {
 				$object->client = 3;
 			}


### PR DESCRIPTION
`Form::select_produits_fournisseurs()` only fills the ajax search input when the selected value is a supplier price id (`(int) $selected > 0`). When the value is `idprod_ID` — the format **documented for the \$selected parameter** ("must be 'id' in product_fournisseur_price or 'idprod_IDPROD'") and produced by the `__ID__` backtopage substitution after creating a product from the add-line block — nothing was preselected in the combo.

Handle the `idprod_ID` form: fetch the product and use its ref as the search input value (the hidden field already carried the right value).

Benefits every supplier document (supplier proposal/order/invoice, reception): after creating a product from the '+' button, it is now really preselected even when it has no supplier price yet.