### PR TITLE
FIX : change mark rate on all lines would display an error if some lines are free lines.

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1742,7 +1742,7 @@ if (empty($reshook)) {
 				} else {
 					setEventMessages($prod->error, $prod->errors, 'errors');
 				}
-			} else {
+			} elseif ($line->fk_product) { // Display errors only for non-free lines
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -828,7 +828,7 @@ if (empty($reshook)) {
 				} else {
 					setEventMessages($prod->error, $prod->errors, 'errors');
 				}
-			} else {
+			} elseif ($line->fk_product) { // Display errors only for non-free lines
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2903,7 +2903,7 @@ if (empty($reshook)) {
 				} else {
 					setEventMessages($prod->error, $prod->errors, 'errors');
 				}
-			} else {
+			} elseif ($line->fk_product) { // Display errors only for non-free lines
 				setEventMessages($prod->error, $prod->errors, 'errors');
 			}
 			// Manage $line->subprice and $line->multicurrency_subprice


### PR DESCRIPTION
# FIX : change mark rate on all lines would display an error if some lines are free lines.

When changing "mark rate" for all lines, the interface displays an error but the changes are saved as expected.
Expected behavior : don't display the error.

Bug seen on DLB 22.0 and develop, brobably all versions inbetween.

To reproduce : 
- enable "Margin" module
- enable "Display mark rate"
- create a propal, order, invoice (bug is on all three objects)
- add a **free** line
- try to change the mark rate for all lines
- see that : 
  - the computation is right
  - an error is displayed

<img width="948" height="683" alt="image" src="https://github.com/user-attachments/assets/1c93a74b-b211-4d41-835e-6ec6704b1481" />

