### PR TITLE
NEW Product/service creation in a dialog popup from the add-line block ('@FIXME Not working yet')

### DIFF
--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -376,25 +376,21 @@ if ($nolinesbefore) {
 					echo '</div>';
 				} else {
 					if ($addproducton) {
-						$url = '/product/card.php?leftmenu=product&action=create&type=0&backtopage='.urlencode($_SERVER["PHP_SELF"]);
+						$url = '/product/card.php?leftmenu=product&action=create&type=0&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id);
 						$newbutton = '<span class="fa fa-plus-circle valignmiddle paddingleft" title="'.$langs->trans("NewProduct").'"></span>';
 						if (getDolGlobalInt('MAIN_FEATURES_LEVEL') >= 2) {
-							// @FIXME Not working yet
-							$jsonclode = 'jsRefreshProductCombo';
-							// @phan-suppress-next-line PhanPluginSuspiciousParamOrder
-							print dolButtonToOpenUrlInDialogPopup('addproduct', $langs->transnoentitiesnoconv('AddProduct'), $newbutton, $url, '', '', $jsonclode);
+							// The popup child page (product/card.php) reloads the parent itself after a successful creation
+							print dolButtonToOpenUrlInDialogPopup('addproduct', $langs->transnoentitiesnoconv('AddProduct'), $newbutton, $url);
 						} else {
 							print '<a href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=0&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'" title="'.dol_escape_htmltag($langs->trans("NewProduct")).'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
 						}
 					}
 					if ($addserviceon) {
-						$url = '/product/card.php?leftmenu=product&action=create&type=1&backtopage='.urlencode($_SERVER["PHP_SELF"]);
+						$url = '/product/card.php?leftmenu=product&action=create&type=1&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id);
 						$newbutton = '<span class="fa fa-plus-circle valignmiddle paddingleft" title="'.$langs->trans("NewService").'"></span>';
 						if (getDolGlobalInt('MAIN_FEATURES_LEVEL') >= 2) {
-							// @FIXME Not working yet
-							$jsonclode = 'jsRefreshServiceCombo';
-							// @phan-suppress-next-line PhanPluginSuspiciousParamOrder
-							print dolButtonToOpenUrlInDialogPopup('addproduct', $langs->transnoentitiesnoconv('AddService'), $newbutton, $url, '', '', $jsonclode);
+							// The popup child page (product/card.php) reloads the parent itself after a successful creation
+							print dolButtonToOpenUrlInDialogPopup('addproduct', $langs->transnoentitiesnoconv('AddService'), $newbutton, $url);
 						} else {
 							print '<a href="'.DOL_URL_ROOT.'/product/card.php?action=create&type=1&backtopage='.urlencode($_SERVER["PHP_SELF"].'?id='.$object->id).'" title="'.dol_escape_htmltag($langs->trans("NewService")).'"><span class="fa fa-plus-circle valignmiddle paddingleft"></span></a>';
 						}

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -14,6 +14,7 @@
  * Copyright (C) 2024       Alexandre Spangaro  <alexandre@inovea-conseil.com>
  * Copyright (C) 2025-2026	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Lenin Rivas			<lenin.rivas777@gmail.com>
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1491,7 +1491,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 			print '<input type="hidden" name="barcode_auto" value="1">';
 		}
 		print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
-print '<input type="hidden" name="dol_openinpopup" value="'.dol_escape_htmltag($dol_openinpopup).'">';
+		print '<input type="hidden" name="dol_openinpopup" value="'.dol_escape_htmltag($dol_openinpopup).'">';
 
 		if ($type == 1) {
 			$picto = 'service';

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -22,6 +22,7 @@
  * Copyright (C) 2022       Vincent de Grandpré     <vincent@de-grandpre.quebec>
  * Copyright (C) 2024-2026	MDW                     <mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		William Mead			<william@m34d.com>
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -119,6 +119,7 @@ $type = (GETPOSTISSET('type') ? GETPOSTINT('type') : Product::TYPE_PRODUCT);
 $action = (GETPOST('action', 'alpha') ? GETPOST('action', 'alpha') : 'view');
 $cancel = GETPOST('cancel', 'alpha');
 $backtopage = GETPOST('backtopage', 'alpha');
+$dol_openinpopup = GETPOST('dol_openinpopup', 'aZ09');
 $confirm = GETPOST('confirm', 'alpha');
 $socid = GETPOSTINT('socid');
 $duration_value = GETPOST('duration_value') === '' ? null : GETPOSTINT('duration_value');	// duration value can be an empty string
@@ -756,6 +757,13 @@ if (empty($reshook)) {
 						$backtopage .= '&productid='.$object->id; // Old method
 					}
 
+					if (!empty($dol_openinpopup)) {
+						// Created from a popup dialog: reload the parent page instead (backtopage, with the new id substituted, can autoselect the product)
+						print '<script nonce="'.getNonce().'">';
+						print "window.parent.location.href = '".dol_escape_js($backtopage)."';";
+						print '</script>';
+						exit;
+					}
 					header("Location: ".$backtopage);
 					exit;
 				} else {
@@ -1482,6 +1490,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 			print '<input type="hidden" name="barcode_auto" value="1">';
 		}
 		print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
+print '<input type="hidden" name="dol_openinpopup" value="'.dol_escape_htmltag($dol_openinpopup).'">';
 
 		if ($type == 1) {
 			$picto = 'service';
@@ -2019,7 +2028,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 
 		print dol_get_fiche_end();
 
-		print $form->buttonsSaveCancel("Create");
+		print $form->buttonsSaveCancel("Create", "Cancel", array(), false, '', $dol_openinpopup);
 
 		print '</form>';
 	} elseif ($object->id > 0) {


### PR DESCRIPTION
The add-line block has popup buttons to create a product/service (`MAIN_FEATURES_LEVEL >= 2`), but the path was marked `// @FIXME Not working yet`. Three causes:

1. The callback `jsRefreshProductCombo` / `jsRefreshServiceCombo` was **never defined anywhere**, and was passed in the **$jsonopen slot instead of $jsonclose** (see the `@phan-suppress-next-line PhanPluginSuspiciousParamOrder` that silenced the warning).
2. `product/card.php` was **not popup-aware** (unlike `societe/card.php`): the flag was not propagated into the creation form, Cancel did not close the dialog, and after a successful creation the `backtopage` redirect navigated **the whole application inside the iframe**.
3. The popup URL's backtopage did not carry the object id.

## Fix

- `product/card.php`: read `dol_openinpopup` (added to the URL by `dolButtonToOpenUrlInDialogPopup()`), propagate it as a hidden field, close the dialog on Cancel via `buttonsSaveCancel(..., $dol_openinpopup)`, and after a successful creation **reload the parent page** on backtopage (with the created id substituted) instead of navigating inside the iframe — same philosophy as thirdparty creation in popup.
- add-line block: drop the ghost callback (the child page now drives the parent), backtopage now carries `?id=` — so combined with #39300, the created product can be **autoselected in the combo** when backtopage carries the `idprod___ID__` convention.

The `MAIN_FEATURES_LEVEL >= 2` gate is left as-is (can be lifted separately once validated). Tested end-to-end on a real 23.0.3 database: dropdown → popup form → Create → parent reloads with the new product preselected in the supplier combo.

Related: #39300 (combo preselection of 'idprod_ID'), #39295 (standalone reception UI, whose creation buttons use this popup).