### PR TITLE
NEW Add rounding mode '2' to update_price() for foreign currency documents

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -22,6 +22,7 @@
  * Copyright (C) 2025		Alexandre Janniaux	<alexandre.janniaux@gmail.com>
  * Copyright (C) 2025		Vincent Maury		<vmaury@timgroup.fr>
  * Copyright (C) 2026		Pierre Ardoin		<developpeur@lesmetiersdubatiment.fr>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
 *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -4011,9 +4012,10 @@ abstract class CommonObject
 	 *  @param  'none'|'auto'|'0'|'1'	$roundingadjust		'none'=Do nothing (when properties are already correctly set), 'auto'=Use default method (MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND if defined, or '0'), '0'=Force mode Total of rounding, '1'=Force mode Rounding of total
 	 *  @param	int<0,1>				$nodatabaseupdate	1=Do not update database total fields of the main object. Update only properties in memory. Can be used to save SQL when this method is called several times, so we can do it only once at end.
 	 *  @param	?Societe				$seller				If roundingadjust is '0' or '1' or maybe 'auto', it means we recalculate total for lines before calculating total for object and for this, we need seller object (used to analyze lines to check corrupted data).
+	 *  @param  'auto'|'0'|'1'			$followforeigncurrency	For a document in a foreign currency: 'auto'=Use MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY (or its _SUPPLIER variant), '1'=Totals in the company currency are the exact conversion of the multicurrency totals, '0'=Totals are the sum of the lines. Ignored when the document has no foreign currency.
 	 *	@return	int<-1,1>									Return integer <0 if KO, >0 if OK
 	 */
-	public function update_price($exclspec = 0, $roundingadjust = 'auto', $nodatabaseupdate = 0, $seller = null)
+	public function update_price($exclspec = 0, $roundingadjust = 'auto', $nodatabaseupdate = 0, $seller = null, $followforeigncurrency = 'auto')
 	{
 		// phpcs:enable
 		global $conf, $hookmanager, $action;
@@ -4029,6 +4031,7 @@ abstract class CommonObject
 		// Some external module want no update price after a trigger because they have another method to calculate the total (ex: with an extrafield)
 		$isElementForSupplier = false;
 		$roundTotalConstName = 'MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND'; // const for customer by default
+		$followCurrencyConstName = 'MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY'; // const for customer by default
 		$MODULE = "";
 		if ($this->element == 'propal') {
 			$MODULE = "MODULE_DISALLOW_UPDATE_PRICE_PROPOSAL";
@@ -4048,6 +4051,7 @@ abstract class CommonObject
 		}
 		if ($isElementForSupplier) {
 			$roundTotalConstName = 'MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER'; // const for supplier
+			$followCurrencyConstName = 'MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY_SUPPLIER'; // const for supplier
 		}
 
 		if (!empty($MODULE)) {
@@ -4068,6 +4072,12 @@ abstract class CommonObject
 			$forcedroundingmode = getDolGlobalString($roundTotalConstName);
 		} elseif ($forcedroundingmode == 'auto') {
 			$forcedroundingmode = '0';
+		}
+
+		// Which currency is the reference for the totals. This is independent from the VAT rounding
+		// method above: both questions can be answered separately on the same document.
+		if ($followforeigncurrency == 'auto') {
+			$followforeigncurrency = getDolGlobalString($followCurrencyConstName, '0');
 		}
 
 		$error = 0;
@@ -4301,6 +4311,19 @@ abstract class CommonObject
 						}
 					}
 				}
+			}
+
+			// On a document in a foreign currency, the totals in the company currency are the sum of the
+			// converted lines, while the multicurrency totals are the sum of the same lines in the foreign
+			// currency. Each currency being rounded on its own lines, dividing one by the exchange rate does
+			// not always give back the other: both are correct, they just answer different questions.
+			// When the amount due in the foreign currency is the reference (a supplier invoice received in
+			// USD for instance), the totals in the company currency can be set to its exact conversion.
+			if ($followforeigncurrency == '1' && !empty($multicurrency_tx) && $multicurrency_tx != 1) {
+				$this->total_ht = (float) price2num($this->multicurrency_total_ht / $multicurrency_tx);
+				$this->total_ttc = (float) price2num($this->multicurrency_total_ttc / $multicurrency_tx);
+				// VAT absorbs the rounding difference so the total incl. tax stays equal to what is due
+				$this->total_tva = (float) price2num($this->total_ttc - $this->total_ht - $this->total_localtax1 - $this->total_localtax2);
 			}
 
 			// Clean total

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2101,7 +2101,12 @@ if (empty($reshook)) {
 
 		$object->fetch($id);
 		$object->fetch_thirdparty();
-		$result = $object->update_price(0, (($calculationrule == 'totalofround') ? '0' : '1'), 0, $object->thirdparty);
+		if ($calculationrule == 'alignoncurrency' || $calculationrule == 'linesum') {
+			// Only switch which currency drives the totals, keep the VAT rounding method untouched
+			$result = $object->update_price(0, 'auto', 0, $object->thirdparty, ($calculationrule == 'alignoncurrency') ? '1' : '0');
+		} else {
+			$result = $object->update_price(0, (($calculationrule == 'totalofround') ? '0' : '1'), 0, $object->thirdparty);
+		}
 		if ($result <= 0) {
 			dol_print_error($db, $object->error, $object->errors);
 			exit;
@@ -3716,6 +3721,36 @@ if ($action == 'create') {
 			print '<table class="border tableforfield centpercent">';
 
 			include DOL_DOCUMENT_ROOT.'/core/tpl/object_currency_amount.tpl.php';
+
+			// Which currency drives the totals. Shown next to the currency and the exchange rate, as it is a
+			// property of that relation, and only where the recalculation action is available.
+			if (isModEnabled("multicurrency") && !empty($object->multicurrency_code) && $object->multicurrency_code != $conf->currency
+				&& !empty($object->multicurrency_tx) && $object->multicurrency_tx != 1) {
+				$exactconversion = (float) price2num((float) $object->multicurrency_total_ttc / (float) $object->multicurrency_tx, 'MT');
+				$isalignedoncurrency = (abs((float) $object->total_ttc - $exactconversion) < 0.005);
+				$lblLines = $langs->trans("TotalsFromLines");
+				$lblCurrency = $langs->trans("TotalsAlignedOnForeignCurrency", $object->multicurrency_code);
+				print '<tr><td>' . $langs->trans("TotalsReference") . '</td>';
+				print '<td colspan="2">';
+				if ($object->getVentilExportCompta() == 0) {
+					// Same pattern as the VAT calculation rule above: the active choice is plain text,
+					// the other one is the link that switches to it.
+					$s = '<span class="hideonsmartphone opacitymedium">' . $langs->trans("ReCalculate") . ' </span>';
+					$s .= $isalignedoncurrency
+						? '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&action=calculate&token=' . newToken() . '&calculationrule=linesum">' . $lblLines . '</a>'
+						: '<span class="opacitymedium">' . $lblLines . '</span>';
+					$s .= ' / ';
+					$s .= $isalignedoncurrency
+						? '<span class="opacitymedium">' . $lblCurrency . '</span>'
+						: '<a href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&action=calculate&token=' . newToken() . '&calculationrule=alignoncurrency">' . $lblCurrency . '</a>';
+					print '<div class="inline-block">';
+					print $form->textwithtooltip($s, $langs->trans("TotalsReferenceDesc", $object->multicurrency_code, price($exactconversion, 0, $langs, 0, -1, -1, $conf->currency)), 2, 1, img_picto('', 'help', 'class="paddingleft paddingright"'), '', 3, '', 0, 'recalculatecurrency');
+					print '</div>';
+				} else {
+					print $isalignedoncurrency ? $lblCurrency : $lblLines;
+				}
+				print '</td></tr>';
+			}
 
 			print '<tr>';
 			print '<td class="titlefieldmiddle">' . $langs->trans('AmountHT') . '</td>';

--- a/htdocs/langs/en_US/compta.lang
+++ b/htdocs/langs/en_US/compta.lang
@@ -348,3 +348,7 @@ VATExemptionCodeDesc=If the VAT rate is 0, you can enter here the code of the re
 VATExemptionCodeDesc2=You can pick any valid value among the list on https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/ or keep it empty to use the default code.
 VATExemptionCodeDesc3=This code is not used for accounting. It is used only if your are using an E-invoice generation module.
 WeWillUseThisValueAsNumber=We will use this value as full registration number
+TotalsReferenceDesc=Totals in the company currency are the sum of the converted lines, so they may differ by a few cents from the exact conversion of the total in %s, which is %s. Align them on that conversion when the amount due in the foreign currency is the reference. This can be undone as long as the invoice has not been transferred to accounting.
+TotalsAlignedOnForeignCurrency=Aligned on %s
+TotalsReference=Totals reference
+TotalsFromLines=Sum of the lines

--- a/htdocs/langs/fr_FR/compta.lang
+++ b/htdocs/langs/fr_FR/compta.lang
@@ -348,3 +348,7 @@ VATExemptionCodeDesc=Si le code TVA taux est 0, vous pouvez saisir ici le code d
 VATExemptionCodeDesc2=Vous pouvez choisir n'importe quelle valeur valide parmi la liste sur https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/ ou la laisser vide pour utiliser le code par défaut.
 VATExemptionCodeDesc3=Ce code n'est pas utilisé pour Comptabilité. Il est utilisé uniquement si vous utilisez un module de génération E-facture.
 WeWillUseThisValueAsNumber=Nous utiliserons cette valeur comme numéro d'immatriculation complet.
+TotalsReferenceDesc=Les totaux en devise de la société sont la somme des lignes converties : ils peuvent différer de quelques centimes de la conversion exacte du total en %s, qui vaut %s. Alignez-les sur cette conversion lorsque le montant dû en devise fait foi. L'opération est réversible tant que la facture n'est pas transférée en comptabilité.
+TotalsAlignedOnForeignCurrency=Alignés sur le %s
+TotalsReference=Référence des totaux
+TotalsFromLines=Somme des lignes


### PR DESCRIPTION
## Context

When a document carries a foreign currency, `update_price()` builds two sets of totals from the same lines:

- the company-currency totals, as the sum of the lines' company-currency amounts
- the multicurrency totals, as the sum of the lines' foreign-currency amounts

Each currency is rounded on its own lines, so dividing the foreign total by the exchange rate does not always give back the company-currency total. The gap is a few cents and goes both ways.

**Both values are correct** — they answer different questions. This PR does not claim one is a bug.

## Why it matters

On a **supplier invoice received in a foreign currency**, the amount actually due is the one written on the supplier's document, in that currency. The company-currency total is only a conversion of it. In that situation it is legitimate to want that conversion to be exact, rather than a sum of individually converted lines.

There is no way to ask for this today.

A related limitation is already acknowledged in the code:

```php
if ($forcedroundingmode == '1') {	// ... TODO This works on the company currency but not on foreign currency
```

## What this PR does

**1. Core** — an optional `$followforeigncurrency` parameter on `CommonObject::update_price()`, with `MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY` (and its `_SUPPLIER` variant) as the default:

```php
if ($followforeigncurrency == '1' && !empty($multicurrency_tx) && $multicurrency_tx != 1) {
    $this->total_ht  = price2num($this->multicurrency_total_ht  / $multicurrency_tx);
    $this->total_ttc = price2num($this->multicurrency_total_ttc / $multicurrency_tx);
    $this->total_tva = price2num($this->total_ttc - $this->total_ht - $localtax1 - $localtax2);
}
```

VAT absorbs the rounding difference, so the total incl. tax stays equal to what is due.

**2. UI** — a "Totals reference" line in the currency block of the supplier invoice card, next to the currency and the exchange rate. Same pattern as the VAT calculation rule above it (`ReCalculate` prefix, active choice as plain text, the other as a link, tooltip), with explicit labels rather than numbered modes so the two lines cannot be confused. Switches both ways, and only while the invoice has not been transferred to accounting.

## Compatibility

Defaults to `'0'`: nothing changes unless a caller or a setup asks for it. The parameter is optional and last, so every existing call is unaffected. The block is skipped entirely on documents without a foreign currency.

## Design question for maintainers

The alignment could also have been formalised as a **`'2'` value of the existing `MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND[_SUPPLIER]`** constant, which would mean one setting instead of two. I went for a separate constant, and I would rather ask than assume.

Reasons for keeping them separate:

- **Measured side effect.** A production instance running a home-made `'2'` in the rounding constant was checked: on its **236 supplier invoices in a foreign currency** the behaviour is the intended one, but the constant is global, so it also applies to **893 domestic supplier invoices with VAT** that have no foreign currency at all. On those, `'2'` short-circuits both the `'0'` and `'1'` branches: 20 of them end up differing from mode `'0'`, 47 from mode `'1'` — they follow neither documented method.
- **The two axes are orthogonal.** Making `'2'` safe requires falling back to `'0'` for the line computation, which shows it is really "mode 0 + currency alignment", a combination rather than a third exclusive mode. With a single constant, "mode 1 + currency alignment" becomes impossible to express.
- **Semantics.** Overloading a historical constant with `'2'` changes its meaning for any code reading it (`== '1'`, `empty()`, external modules), where `'2'` is truthy and falls into unintended branches.

Happy to switch to the `'2'` form if you prefer it.

## Measurements on a production database

239 supplier invoices in foreign currency (128 USD, 80 TWD, 31 GBP), over four years:

| | |
|---|---|
| Invoices where the two totals diverge | 28 (12%) |
| Amplitude | 0.01 to 0.03 EUR |
| Cumulative gap | 0.35 EUR |
| Direction | both ways (+ and -) |

The symmetry confirms this is rounding noise inherent to dual-currency representation, not a systematic bias.

Verified on three real invoices, one per currency:

| Currency | Rate | Before | With the option on |
|---|---|---|---|
| TWD | 31.8708 | 31176.33 | **31176.31** |
| GBP | 0.8600 | 982.54 | **982.56** |
| USD | 1.0899 | 37111.54 | **37111.52** |

Each result matches the exact conversion of the foreign-currency total. A document without a foreign currency is unchanged with the option on or off.

## Notes

Marked as draft pending your opinion on the constant question above.
