### PR TITLE
fix PHP Warnings

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -9354,7 +9354,7 @@ abstract class CommonObject
 						// Otherwise, they would be empty after an update of the object. See also getOptionalsFromPost
 						// TODO: We should not have this hidden field, and action='update' should be done only if field was POSTED by form.
 						$ef_name = 'options_' . $key;
-						$ef_value = $this->array_options[$ef_name];
+						$ef_value = isset($this->array_options[$ef_name]) ? $this->array_options[$ef_name] : '';
 						$out .= '<input type="hidden" name="' . $ef_name . '" id="' . $ef_name . '" value="' . dolPrintHTMLForAttribute($ef_value) . '" />' . "\n";
 						continue; // <> -1 and <> 1 and <> 3 = not visible on forms, only on list and <> 4 = not visible at the creation
 					} elseif ($mode == 'view' && empty($visibility)) {
@@ -9723,7 +9723,7 @@ abstract class CommonObject
 			return $user->hasRight($module, $element);
 		}
 
-		return $user->rights->$element;
+		return isset($user->rights->$element) ? $user->rights->$element : null;
 	}
 
 	/**

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6025,7 +6025,7 @@ class Form
 						$moreattr = (!empty($input['moreattr']) ? ' ' . $input['moreattr'] : '');
 						$morecss = (!empty($input['morecss']) ? ' ' . $input['morecss'] : '');
 
-						$more .= '<input type="hidden" id="' . dol_escape_htmltag($input['name']) . '" name="' . dol_escape_htmltag($input['name']) . '" value="' . dol_escape_htmltag($input['value']) . '" class="' . $morecss . '"' . $moreattr . '>' . "\n";
+						$more .= '<input type="hidden" id="' . dol_escape_htmltag($input['name']) . '" name="' . dol_escape_htmltag($input['name']) . '" value="' . dol_escape_htmltag(isset($input['value']) ? $input['value'] : '') . '" class="' . $morecss . '"' . $moreattr . '>' . "\n"; // 'value' non fourni par tous les appelants
 					}
 				}
 			}
@@ -6077,10 +6077,10 @@ class Form
 						$more .= '<div class="tagtr">';
 						$more .= '<div class="tagtd' . (empty($input['tdclass']) ? '' : (' ' . $input['tdclass'])) . '"><label for="' . dol_escape_htmltag($input['name']) . '">' . $input['label'] . '</label></div><div class="tagtd">';
 						$more .= '<input type="checkbox" class="flat' . ($morecss ? ' ' . $morecss : '') . '" id="' . dol_escape_htmltag($input['name']) . '" name="' . dol_escape_htmltag($input['name']) . '"' . $moreattr;
-						if (!is_bool($input['value']) && $input['value'] != 'false' && $input['value'] != '0' && $input['value'] != '') {
+						if (isset($input['value']) && !is_bool($input['value']) && $input['value'] != 'false' && $input['value'] != '0' && $input['value'] != '') {
 							$more .= ' checked';
 						}
-						if (is_bool($input['value']) && $input['value']) {
+						if (isset($input['value']) && is_bool($input['value']) && $input['value']) {
 							$more .= ' checked';
 						}
 						if (isset($input['disabled'])) {
@@ -6741,7 +6741,7 @@ class Form
 		} else {
 			if ($selected) {
 				$this->load_cache_types_paiements();
-				$out .= $this->cache_types_paiements[$selected]['label'];
+				$out .= isset($this->cache_types_paiements[$selected]['label']) ? $this->cache_types_paiements[$selected]['label'] : '';
 			} else {
 				$out .= "&nbsp;";
 			}

--- a/htdocs/supplier_proposal/index.php
+++ b/htdocs/supplier_proposal/index.php
@@ -359,7 +359,7 @@ if (isModEnabled('supplier_proposal') && $user->hasRight('supplier_proposal', 'l
 				print $supplier_proposalstatic->getNomUrl(1);
 				print '</td>';
 				print '<td width="18" class="nobordernopadding nowrap">';
-				if ($db->jdate($obj->dfv) < ($now - $conf->supplier_proposal->cloture->warning_delay)) {
+				if (isset($obj->dfv) && $db->jdate($obj->dfv) < ($now - $conf->supplier_proposal->cloture->warning_delay)) {
 					print img_warning($langs->trans("Late"));
 				}
 				print '</td>';


### PR DESCRIPTION
commonobject.class.php:9398 — Undefined array key "options_pos": direct access to $this->array_options[$ef_name] without checking its existence → added an isset() with fallback to an empty string.

commonobject.class.php:9767 (getRights() method) — Undefined property: stdClass::$shipping: $user->rights->$element accessed without checking that the module has registered this property (e.g., shipping module not active for this user) → added an isset(), returns null otherwise.

html.form.class.php:6088-6091 — Undefined array key "value": the $input array passed to formconfirm/multiSelect may not contain a value key for a checkbox field → added an isset($input['value']) on both conditions.

html.form.class.php:6752 (method form_modes_reglement()) — Undefined array key 2 / access on null: $selected corresponds to a payment method not in the cache cache_types_paiements → add an isset().

supplier_proposal/index.php:362 — Undefined property: stdClass::$dfv: the SQL query in the block (line 316) does not select the field fin_validite/dfv (unlike comm/propal/index.php which selects p.fin_validite as dfv) — this field does not even exist in llx_supplier_proposal. In addition to the warning, this bug systematically displayed the "Delay" icon (PHP8 comparison '' < number always true) → addition of an isset($obj->dfv) which properly neutralizes the test as long as this field is not returned by the request.