### PR TITLE
Update card.php

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -523,7 +523,7 @@ if (empty($reshook)) {
 		}
 	} elseif ($action == 'setretainedwarrantydatelimit' && $usercancreate) {
 		$object->fetch($id);
-		$result = $object->setRetainedWarrantyDateLimit(GETPOSTINT('retained_warranty_date_limit'));
+		$result = $object->setRetainedWarrantyDateLimit(GETPOST('retained_warranty_date_limit'));
 		if ($result < 0) {
 			dol_print_error($db, $object->error);
 		}


### PR DESCRIPTION
A bug in the display of the date for the retention of guarantee (displaying 01/01/1970 regardless of the entered date) is found on line 526 of card.php, in the handler of the setretainedwarrantydatelimit action:

$result = $object->setRetainedWarrantyDateLimit(GETPOSTINT('retained_warranty_date_limit'));

The corresponding HTML field (card.php:5639) is a single <input type="date"> (no day/month/year triplet):

print '<input name="retained_warranty_date_limit" type="date" ... value="'.dol_print_date($defaultDate, '%Y-%m-%d').'" >';

An <input type="date"> submits a string in the format "2026-07-28". GETPOSTINT() casts (int) to this string: PHP only reads the leading digits up to the first non-numeric character, so (int)"2026-07-28" = 2026. This value 2026 is then treated as a raw Unix timestamp (2026 seconds after epoch) by Facture::setRetainedWarrantyDateLimit() (facture.class.php:6141): $sql .= " SET ".$fieldname." = ".(strval($timestamp) != '' ? "'.$this->db->idate($timestamp)."'" : 'null'); ... .(strval($timestamp) != '' ? "'.$this->db->idate($timestamp)."'" : 'null');

$this->db->idate($timestamp)."'" : 'null'); → 2026 seconds after 01/01/1970 00:00:00 UTC ≈ 01/01/1970 00:33 → hence the systematic recording close to 01/01/1970, regardless of the date chosen in the calendar. The retained_warranty_date_limit field, already stored in the database for invoice 5966, therefore has a value of 0 or a value close to the epoch — this is why the initial display already shows 01/01/1970 even before any modification.

Proposed fix:
Invoice::setRetainedWarrantyDateLimit() already accepts a second parameter, $dateYmd, specifically designed for an YYYY-MM-DD string (it internally calls $this->db->jdate($dateYmd), which handles this format very well). Therefore, we simply need to change the call on line 526 to pass the raw string instead of the entire cast: $result = $object->setRetainedWarrantyDateLimit(0, GETPOST('retained_warranty_date_limit', 'alpha'));