### PR TITLE
Qual: Rename $from as $from_line (filecheck_diff.php)

### DIFF
--- a/htdocs/blockedlog/admin/filecheck_diff.php
+++ b/htdocs/blockedlog/admin/filecheck_diff.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -263,9 +264,9 @@ function filecheckCollapseContext($diff, $context = 3)
 	$keep = array_fill(0, $n, false);
 	for ($i = 0; $i < $n; $i++) {
 		if ($diff[$i][0] !== ' ') {
-			$from = max(0, $i - $context);
-			$to = min($n - 1, $i + $context);
-			for ($k = $from; $k <= $to; $k++) {
+			$from_line = max(0, $i - $context);
+			$to_line = min($n - 1, $i + $context);
+			for ($k = $from_line; $k <= $to_line; $k++) {
 				$keep[$k] = true;
 			}
 		}
@@ -385,7 +386,7 @@ llxFooterFragment();
 /**
  * Close the fragment output and stop the script.
  *
- * @return void
+ * @return never
  */
 function llxFooterFragment()
 {


### PR DESCRIPTION
# Qual: Rename $from as $from_line (filecheck_diff.php)

SqlInjectionPlugin is configured to consider that '$from' is an SQL expression and requires that assignments to it are protected from Sql Injection.

Renaming '$from' fixes false positives.