### PR TITLE
Correct bug when merging clients having common products

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -7154,8 +7154,7 @@ class Product extends CommonObject
 	{
 		/* we firstly delete origin product prices existing in destination before update */
 		$sql = ' DELETE p_old FROM '.$dbs->prefix().'product_customer_price p_old ';
-		$sql .= '	 WHERE p_old.fk_soc = '.(int) $origin_id.' AND ';
-		$sql .= '		 EXISTS (SELECT 1 FROM '.$dbs->prefix().'product_customer_price p_new WHERE p_new.fk_product = p_old.fk_product AND p_new.fk_soc = '.(int) $dest_id.')';
+		$sql .= '	 WHERE p_old.fk_soc = '.(int) $origin_id;
 
 		if (!$dbs->query($sql)) {
 			return false;

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -7152,6 +7152,15 @@ class Product extends CommonObject
 	 */
 	public static function replaceThirdparty(DoliDB $dbs, $origin_id, $dest_id)
 	{
+		/* we firstly delete origin product prices existing in destination before update */
+		$sql = ' DELETE p_old FROM '.$dbs->prefix().'product_customer_price p_old ';
+		$sql .= '	 WHERE p_old.fk_soc = '.(int) $origin_id.' AND ';
+		$sql .= '		 EXISTS (SELECT 1 FROM '.$dbs->prefix().'product_customer_price p_new WHERE p_new.fk_product = p_old.fk_product AND p_new.fk_soc = '.(int) $dest_id.')';
+
+		if (!$dbs->query($sql)) {
+			return false;
+		}
+
 		$tables = array(
 			'product_customer_price',
 			'product_customer_price_log'

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -7153,8 +7153,9 @@ class Product extends CommonObject
 	public static function replaceThirdparty(DoliDB $dbs, $origin_id, $dest_id)
 	{
 		/* we firstly delete origin product prices existing in destination before update */
-		$sql = ' DELETE p_old FROM '.$dbs->prefix().'product_customer_price p_old ';
-		$sql .= '	 WHERE p_old.fk_soc = '.(int) $origin_id;
+		$sql = ' DELETE FROM '.$dbs->prefix().'product_customer_price p_old ';
+		$sql .= '	 WHERE p_old.fk_soc = '.(int) $origin_id.' AND ';
+		$sql .= '		 EXISTS (SELECT 1 FROM '.$dbs->prefix().'product_customer_price p_new WHERE p_new.fk_product = p_old.fk_product AND p_new.fk_soc = '.(int) $dest_id.')';
 
 		if (!$dbs->query($sql)) {
 			return false;


### PR DESCRIPTION
If specific prices by customer are activated, when merging 2 thirdparties having common products, there is an errorr (with no details).

In dollibar.log :
2026-07-29 15:54:24 ERR     x.x.x.x   715490   1030  DoliDBMysqli::query SQL Error query: UPDATE llx_product_customer_price SET fk_soc= 4630 WHERE fk_soc = 1515
2026-07-29 15:54:24 ERR     x.x.x.x   715490   1030  DoliDBMysqli::query SQL Error message: DB_ERROR_RECORD_ALREADY_EXISTS Duplicate entry '165-4630' for key 'uk_customer_price_fk_product_fk_soc' From /my_paht/htdocs/core/class/commonobject.class.php:9337.

