### PR TITLE
FIX Fatal error when deleting a line of a standalone shipment

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -816,6 +816,7 @@ if (empty($reshook)) {
 		setEventMessages($object->error, $object->errors, 'errors');
 	} elseif ($action == 'deleteline' && !empty($line_id) && $permissiontoadd) {
 		// delete a line
+		$error = 0;
 		$object->fetch($id);
 		$lines = $object->lines;
 		$line = new ExpeditionLigne($db);
@@ -824,7 +825,9 @@ if (empty($reshook)) {
 		$num_prod = count($lines);
 		for ($i = 0; $i < $num_prod; $i++) {
 			if ($lines[$i]->id == $line_id) {
-				if (count($lines[$i]->details_entrepot) > 1) {
+				// A standalone shipment (SHIPMENT_STANDALONE) loads its lines with fetch_lines_free(),
+				// which does not set details_entrepot, so count() must not be called on it blindly.
+				if (is_array($lines[$i]->details_entrepot) && count($lines[$i]->details_entrepot) > 1) {
 					// delete multi warehouse lines
 					foreach ($lines[$i]->details_entrepot as $details_entrepot) {
 						$line->id = $details_entrepot->line_id;


### PR DESCRIPTION
## Bug

With `SHIPMENT_STANDALONE` enabled, deleting a line of a shipment that has no origin order returns a HTTP 500 instead of removing the line.

`Expedition::fetch()` loads the lines of such a shipment with `fetch_lines_free()`, which never sets `$line->details_entrepot` — only `fetch_lines()`, the order based path, does. The `deleteline` handler in `htdocs/expedition/card.php` then calls `count()` on that property without a guard:

```php
if (count($lines[$i]->details_entrepot) > 1) {
```

On PHP 8 this is fatal:

```
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given
```

The line is never deleted and nothing is written to the Dolibarr log beyond the access entry, so it is easy to mistake for a hang.

## Steps to reproduce

1. Set `SHIPMENT_STANDALONE` to 1.
2. Create a shipment from Shipments > New (not from an order).
3. Add a free line (description + quantity).
4. Click the delete icon on that line.

Result: blank page / HTTP 500. Expected: the line is removed.

## Fix

Guard the `count()` with `is_array()` so a line without warehouse details falls through to the existing single line branch. Also initialise `$error`, which the same block reads a few lines below without ever setting it.

## Environment

Reproduced on 23.0.2, PHP 8.2, MySQL 8.0. The same code is present in `develop`.