### PR TITLE
FIX : Prevent editing another user's private quickmemo note via update_note

### DIFF
--- a/htdocs/quickmemo/interface.php
+++ b/htdocs/quickmemo/interface.php
@@ -662,6 +662,11 @@ function quickMemoIntefaceActionUpdateNote($jsonResponse)
 		return false;
 	}
 
+	if ($user->id != $memo->fk_user_creat && $memo->private) {
+		$jsonResponse->msg = $langs->trans('QuickMemoCantChangeThisPrivateNote');
+		return false;
+	}
+
 	$memo->quick_note = GETPOST("note", "alphanohtml");
 	$memo->tms = dol_now();
 	$memo->fk_user_modif = $user->id;


### PR DESCRIPTION
The `update_note` action in `htdocs/quickmemo/interface.php` was the only write action of the QuickMemo module that did not check note ownership before applying the change. Every other action (`archive`, `delete`, `update-color`, `update-private`, `update-shared-on-element`...) already refuses to act on a memo marked `private` when the caller is not its creator (`fk_user_creat`), but `update_note` skipped this check entirely.

Any user holding the generic `quickmemo->memo->write` permission could therefore overwrite the text content of any memo — including private ones belonging to other users — by calling the `update_note` action with an arbitrary memo `id`.

This PR aligns `update_note` with the ownership check already used by the rest of the module. No functional change for the normal case (editing your own memo, or a non-private memo).