### PR TITLE
FIX : Unarchive mass action on quickmemo ignores write permission and wrong privacy field

### DIFF
--- a/htdocs/quickmemo/memo_list.php
+++ b/htdocs/quickmemo/memo_list.php
@@ -223,7 +223,7 @@ if (empty($reshook)) {
 	// You can add more action here
 	// if ($action == 'xxx' && $permissiontoxxx) ...
 
-	if ($massaction === 'unarchive') {
+	if ($massaction === 'unarchive' && $permissiontoadd) {
 		if (!empty($toselect)) {
 			$countUnarchived = 0;
 			foreach ($toselect as $idMemo) {
@@ -240,7 +240,7 @@ if (empty($reshook)) {
 					continue;
 				}
 
-				if ($user->id != $selectdModel->fk_user_creat && $selectdModel->private_tpl) {
+				if ($user->id != $selectdModel->fk_user_creat && $selectdModel->private) {
 					setEventMessage($langs->trans('QuickMemoCantChangeThisPrivateNote').' : '. (int) $idMemo, 'errors');
 					continue;
 				}


### PR DESCRIPTION
The `unarchive` mass action in `htdocs/quickmemo/memo_list.php` had two combined issues:

1. It was not guarded by `$permissiontoadd` (write permission), unlike other write mass actions. The list page only requires `quickmemo->memo->read` to be displayed, so a read-only user could trigger it.
2. The ownership check tested `private_tpl` (a field dedicated to templates) instead of `private` (the field actually used to flag a private note). Since `private_tpl` is `0` by default on a regular archived note, the check was effectively always false, letting any user unarchive a private note belonging to someone else.

This PR requires write permission for the mass action and fixes the field checked to `private`.