### PR TITLE
NEW printObjectRightToolbar hook on object event pages (propal, ticket) + modulebuilder

### DIFF
--- a/htdocs/comm/propal/agenda.php
+++ b/htdocs/comm/propal/agenda.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2023 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -265,6 +266,15 @@ if ($object->id > 0) {
 		require_once DOL_DOCUMENT_ROOT . '/core/lib/memory.lib.php';
 		$cachekey = 'count_events_propal_' . $object->id;
 		$nbEvent = dol_getcache($cachekey);
+
+		// Hook to let external modules add buttons to the object right toolbar. Works on any object page; the hook gets the context (elementtype) so a module can scope itself (e.g. only on event pages).
+		$parameters = array('morehtmlright' => &$morehtmlright, 'elementtype' => $object->element);
+		$reshook = $hookmanager->executeHooks('printObjectRightToolbar', $parameters, $object, $action);
+		if ($reshook < 0) {
+			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+		} else {
+			$morehtmlright .= $hookmanager->resPrint;
+		}
 
 		print_barre_liste($langs->trans("ActionsOnPropal") . (is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">(' . $nbEvent . ')</span>' : ''), 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, '', 0, -1, '', 0, $morehtmlright, '', 0, 1, 0);
 		//print_barre_liste($langs->trans("ActionsOnPropal"), 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, '', 0, -1, '', 0, $morehtmlright, '', 0, 1, 1);

--- a/htdocs/comm/propal/messaging.php
+++ b/htdocs/comm/propal/messaging.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025       Valentin Grimal         <valentin.grimal@pichinov.com>
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -236,6 +237,15 @@ if (!empty($object->id)) {
 	$titlelist = $langs->trans("ActionsOnPropal") . (is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">(' . $nbEvent . ')</span>' : ''); // Changed from ActionsOnProject
 	if (!empty($conf->dol_optimize_smallscreen)) {
 		$titlelist = $langs->trans("Actions") . (is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">(' . $nbEvent . ')</span>' : '');
+	}
+
+	// Hook to let external modules add buttons to the object right toolbar. Works on any object page; the hook gets the context (elementtype) so a module can scope itself (e.g. only on event pages).
+	$parameters = array('morehtmlright' => &$morehtmlright, 'elementtype' => $object->element);
+	$reshook = $hookmanager->executeHooks('printObjectRightToolbar', $parameters, $object, $action);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	} else {
+		$morehtmlright .= $hookmanager->resPrint;
 	}
 
 	print_barre_liste($titlelist, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, '', 0, -1, '', 0, $morehtmlright, '', 0, 1, 0);

--- a/htdocs/modulebuilder/template/myobject_agenda.php
+++ b/htdocs/modulebuilder/template/myobject_agenda.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2017       Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) ---Replace with your own copyright and developer email---
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -360,6 +361,15 @@ if ($object->id > 0) {
 		$titlelist = $langs->trans("Actions").(is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">('.$nbEvent.')</span>' : '');
 		if (!empty($conf->dol_optimize_smallscreen)) {
 			$titlelist = $langs->trans("Actions").(is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">('.$nbEvent.')</span>' : '');
+		}
+
+		// Hook to let external modules add buttons to the object right toolbar. Works on any object page; the hook gets the context (elementtype) so a module can scope itself (e.g. only on event pages).
+		$parameters = array('morehtmlright' => &$morehtmlright, 'elementtype' => $object->element);
+		$reshook = $hookmanager->executeHooks('printObjectRightToolbar', $parameters, $object, $action);
+		if ($reshook < 0) {
+			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+		} else {
+			$morehtmlright .= $hookmanager->resPrint;
 		}
 
 		print_barre_liste($titlelist, 0, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', 0, -1, '', 0, $morehtmlright, '', 0, 1, 0);

--- a/htdocs/ticket/agenda.php
+++ b/htdocs/ticket/agenda.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2013-2016	Jean-François FERRY		<hello@librethic.io>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -293,6 +294,15 @@ if (!empty($object->id)) {
 	$titlelist = $langs->trans("ActionsOnTicket").(is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">('.$nbEvent.')</span>' : '');
 	if (!empty($conf->dol_optimize_smallscreen)) {
 		$titlelist = $langs->trans("Actions").(is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">('.$nbEvent.')</span>' : '');
+	}
+
+	// Hook to let external modules add buttons to the object right toolbar. Works on any object page; the hook gets the context (elementtype) so a module can scope itself (e.g. only on event pages).
+	$parameters = array('morehtmlright' => &$morehtmlright, 'elementtype' => $object->element);
+	$reshook = $hookmanager->executeHooks('printObjectRightToolbar', $parameters, $object, $action);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	} else {
+		$morehtmlright .= $hookmanager->resPrint;
 	}
 
 	print_barre_liste($titlelist, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, '', 0, -1, '', 0, $morehtmlright, '', 0, 1, 0);

--- a/htdocs/ticket/messaging.php
+++ b/htdocs/ticket/messaging.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2013-2016	Jean-François FERRY		<hello@librethic.io>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -291,6 +292,15 @@ if (!empty($object->id)) {
 	$titlelist = $langs->trans("ActionsOnTicket").(is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">('.$nbEvent.')</span>' : '');
 	if (!empty($conf->dol_optimize_smallscreen)) {
 		$titlelist = $langs->trans("Actions").(is_numeric($nbEvent) ? '<span class="opacitymedium colorblack paddingleft">('.$nbEvent.')</span>' : '');
+	}
+
+	// Hook to let external modules add buttons to the object right toolbar. Works on any object page; the hook gets the context (elementtype) so a module can scope itself (e.g. only on event pages).
+	$parameters = array('morehtmlright' => &$morehtmlright, 'elementtype' => $object->element);
+	$reshook = $hookmanager->executeHooks('printObjectRightToolbar', $parameters, $object, $action);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	} else {
+		$morehtmlright .= $hookmanager->resPrint;
 	}
 
 	print_barre_liste($titlelist, 0, $_SERVER["PHP_SELF"], '', $sortfield, $sortorder, '', 0, -1, '', 0, $morehtmlright, '', 0, 1, 0);


### PR DESCRIPTION
## What

Add a new hook `printObjectEventToolbar` in the dedicated object event pages — `comm/propal/messaging.php`, `comm/propal/agenda.php`, `ticket/messaging.php`, `ticket/agenda.php` — right before `print_barre_liste()`. It passes `morehtmlright` by reference and the object `elementtype`, so external modules can add buttons to the events toolbar without patching/overriding core pages.

## Why

The object **card** fiche title already exposes a generic extension point for its toolbar via `showActionsLoadFicheTitre` (in `FormActions::showactions()`). But the dedicated conversation/list event pages (`messaging.php` / `agenda.php`) build their `$morehtmlright` toolbar inline and offer **no** extension point. A module that wants to add an object-specific action to these pages (e.g. a CRM-style *send message* button on proposals) currently has to fork or override the core page.

This hook fills that gap, consistently with the existing `showActionsLoadFicheTitre` pattern.

## Notes

- Additive and backward compatible: no behaviour change when no module listens.
- Applied to both `propal` and `ticket` event pages to keep the pattern generic; `elementtype` is passed so a listener can scope itself to a given object.
- **WIP**: opened as draft to agree on the hook name / placement before finalizing (docs + any other event pages can be added).
