### PR TITLE
FIX Stock at date: label the Movements column and show the record count

### DIFF
--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -19,6 +19,7 @@ Stock=Stock
 Stocks=Stocks
 MissingStocks=Missing stocks
 StockAtDate=Stocks at date
+ProductValuesAndMovements=Product values and movements
 StockAtDateInPast=Date in the past
 StockAtDateInFuture=Date in the future
 StocksByLotSerial=Stocks by lot/serial

--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -99,6 +99,7 @@ RealStockDesc=Physical/real stock is the stock currently in the warehouses.
 RealStockWillAutomaticallyWhen=The real stock will be modified according to this rule (as defined in the Stock module):
 VirtualStock=Virtual stock
 VirtualStockAtDate=Virtual stock at a future date
+MovementsSinceDate=Movements since the date
 VirtualStockAtDateDesc=Virtual stock once all the pending orders that are planned to be processed before the chosen date will be finished
 VirtualStockDesc=Virtual stock is the stock that will remain after all open/pending actions (that affect stocks) have been performed (purchase orders received, sales orders shipped, manufacturing orders produced, etc)
 AtDate=At date

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -19,6 +19,7 @@ Stock=Stock
 Stocks=Stocks
 MissingStocks=Stocks manquants
 StockAtDate=Stock à date
+ProductValuesAndMovements=Valeurs et mouvements produits
 StockAtDateInPast=Date dans le passé
 StockAtDateInFuture=Date dans le futur
 StocksByLotSerial=Stocks par lot/série

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -99,6 +99,7 @@ RealStockDesc=Le stock physique ou réel est le stock présent dans les entrepô
 RealStockWillAutomaticallyWhen=Le stock réel sera modifié selon ces règles (voir la configuration du module Stock) :
 VirtualStock=Stock virtuel
 VirtualStockAtDate=Stock virtuel à une date future
+MovementsSinceDate=Mouvements depuis la date
 VirtualStockAtDateDesc=Stock virtuel une fois que tous les ordres en attente, prévus d'être traités avant la date choisie, soient terminés
 VirtualStockDesc=Le stock virtuel est la quantité de produit en stock après que toutes les opérations ouvertes/en cours (et qui affectent les stocks) soient terminées (réceptions de commandes fournisseurs, expéditions de commandes clients, production des ordres de fabrications, etc)
 AtDate=À date

--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2016		Juanjo Menent		<jmenent@2byte.es>
  * Copyright (C) 2016		ATM Consulting		<support@atm-consulting.fr>
  * Copyright (C) 2019-2021  Frédéric France         <frederic.france@netlogic.fr>
+ * Copyright (C) 2026		Jose MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -439,8 +440,7 @@ if (GETPOST('dateyear', 'int') > 0) {
 	$param .= '&dateyear='.GETPOST('dateyear', 'int');
 }
 
-// TODO Move this into the title line ?
-print_barre_liste('', $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, $nbtotalofrecords, 'stock', 0, '', '', $limit, 0, 0, 1);
+print_barre_liste($langs->trans('ProductValuesAndMovements'), $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, $nbtotalofrecords, 'stock', 0, '', '', $limit, 0, 0, 1);
 
 print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
 print '<table class="liste centpercent">';
@@ -513,7 +513,7 @@ if ($mode == 'future') {
 	print_liste_field_titre($stocklabel, $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ');
 	print_liste_field_titre("EstimatedStockValue", $_SERVER["PHP_SELF"], "estimatedvalue", '', $param, '', $sortfield, $sortorder, 'right ', $langs->trans("AtDate"), 1);
 	print_liste_field_titre("EstimatedStockValueSell", $_SERVER["PHP_SELF"], "", '', $param, '', $sortfield, $sortorder, 'right ', $langs->trans("AtDate"), 1);
-	print_liste_field_titre('', $_SERVER["PHP_SELF"]);
+	print_liste_field_titre('Movements', $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ');
 	print_liste_field_titre('CurrentStock', $_SERVER["PHP_SELF"], $fieldtosortcurrentstock, $param, '', '', $sortfield, $sortorder, 'right ');
 }
 

--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -440,7 +440,7 @@ if (GETPOST('dateyear', 'int') > 0) {
 	$param .= '&dateyear='.GETPOST('dateyear', 'int');
 }
 
-print_barre_liste($langs->trans('ProductValuesAndMovements'), $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, $nbtotalofrecords, 'stock', 0, '', '', $limit, 0, 0, 1);
+print_barre_liste(($mode == 'future' ? $langs->trans('VirtualStockAtDate') : $langs->trans('ProductValuesAndMovements')), $page, $_SERVER["PHP_SELF"], $param, $sortfield, $sortorder, '', $num, $nbtotalofrecords, 'stock', 0, '', '', $limit, 0, 0, 1);
 
 print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you dont need reserved height for your table
 print '<table class="liste centpercent">';
@@ -513,7 +513,7 @@ if ($mode == 'future') {
 	print_liste_field_titre($stocklabel, $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ');
 	print_liste_field_titre("EstimatedStockValue", $_SERVER["PHP_SELF"], "estimatedvalue", '', $param, '', $sortfield, $sortorder, 'right ', $langs->trans("AtDate"), 1);
 	print_liste_field_titre("EstimatedStockValueSell", $_SERVER["PHP_SELF"], "", '', $param, '', $sortfield, $sortorder, 'right ', $langs->trans("AtDate"), 1);
-	print_liste_field_titre('Movements', $_SERVER["PHP_SELF"], '', $param, '', '', $sortfield, $sortorder, 'right ');
+	print_liste_field_titre('Movements', $_SERVER["PHP_SELF"], '', '', $param, '', $sortfield, $sortorder, 'right ', 'MovementsSinceDate', 1);
 	print_liste_field_titre('CurrentStock', $_SERVER["PHP_SELF"], $fieldtosortcurrentstock, $param, '', '', $sortfield, $sortorder, 'right ');
 }
 


### PR DESCRIPTION
## What

The "Stock at date" list (`product/stock/stockatdate.php`) had two small display gaps:

1. **The Movements column had no header.** Its value cell already renders a "Movements" link and the CSV export already uses the `Movements` label, but the HTML column header was `print_liste_field_titre('')` (empty).
2. **The record count was never shown.** `print_barre_liste()` was called with an empty title, and the `(N)` qualified-records badge is only rendered when a non-empty title is passed — so the total count / pagination summary never appeared.

## Changes

- Label the Movements column header (`'Movements'`, right-aligned to match its cell).
- Give the list a dedicated title via a new lang key `ProductValuesAndMovements` ("Product values and movements" / "Valeurs et mouvements produits"), passed to `print_barre_liste()`, so the count and pagination total show. The page keeps its existing "Stock at date" banner on top, so the new list title is descriptive rather than a duplicate.
- This also resolves the pre-existing `// TODO Move this into the title line ?` note.

## Notes

Targeted at `18.0` (LTS) as the oldest maintained affected branch. No behaviour change beyond the two display fixes.
