### PR TITLE
qual: Update Phan baseline and suppress duplicate array key warnings

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -9,18 +9,17 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredProperty : 370+ occurrences
+    // PhanUndeclaredProperty : 340+ occurrences
     // PhanTypeMismatchArgument : 25+ occurrences
     // PhanUndeclaredGlobalVariable : 20+ occurrences
     // PhanTypeMismatchProperty : 15+ occurrences
     // PhanTypeInvalidDimOffset : 10+ occurrences
     // PhanTypeMismatchDimFetch : 10+ occurrences
     // PhanTypeArraySuspiciousNull : 5 occurrences
-    // PhanTypeExpectedObjectPropAccess : 5 occurrences
     // PhanUndeclaredMethod : 5 occurrences
-    // PhanPluginDuplicateArrayKey : 4 occurrences
-    // PhanTypeMismatchArgumentNullable : 3 occurrences
+    // PhanTypeExpectedObjectPropAccess : 4 occurrences
     // PhanPluginUndeclaredVariableIsset : 2 occurrences
+    // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanParamTooMany : 1 occurrence
     // PhanTypeExpectedObjectPropAccessButGotNull : 1 occurrence
@@ -61,12 +60,11 @@ return [
         'htdocs/core/class/emailsenderprofile.class.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/class/html.formcompany.class.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/class/html.formmail.class.php' => ['PhanUndeclaredProperty'],
-        'htdocs/core/class/openid.class.php' => ['PhanTypeMismatchArgument'],
         'htdocs/core/class/timespent.class.php' => ['PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
         'htdocs/core/lib/admin.lib.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/lib/files.lib.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/lib/functions2.lib.php' => ['PhanUndeclaredProperty'],
-        'htdocs/core/lib/pdf.lib.php' => ['PhanTypeMismatchArgumentNullable', 'PhanUndeclaredProperty'],
+        'htdocs/core/lib/pdf.lib.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/lib/product.lib.php' => ['PhanTypeMismatchArgument'],
         'htdocs/core/lib/project.lib.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/lib/xcal.lib.php' => ['PhanUndeclaredProperty'],
@@ -96,7 +94,6 @@ return [
         'htdocs/core/modules/supplier_order/doc/pdf_muscadet.modules.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchProperty', 'PhanUndeclaredProperty'],
         'htdocs/core/modules/supplier_proposal/doc/pdf_aurore.modules.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchProperty', 'PhanUndeclaredProperty'],
         'htdocs/core/modules/supplier_proposal/doc/pdf_zenith.modules.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchProperty', 'PhanUndeclaredProperty'],
-        'htdocs/core/modules/syslog/mod_syslog_file.php' => ['PhanPluginDuplicateArrayKey'],
         'htdocs/core/modules/workstation/mod_workstation_advanced.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/multicompany_page.php' => ['PhanTypeMismatchArgument'],
         'htdocs/core/tpl/massactions_pre.tpl.php' => ['PhanTypeMismatchArgumentNullable', 'PhanUndeclaredProperty'],
@@ -137,7 +134,6 @@ return [
         'htdocs/loan/note.php' => ['PhanUndeclaredProperty'],
         'htdocs/loan/payment/payment.php' => ['PhanUndeclaredProperty'],
         'htdocs/mrp/tpl/linkedobjectblock.tpl.php' => ['PhanUndeclaredProperty'],
-        'htdocs/multicurrency/class/multicurrency.class.php' => ['PhanTypeExpectedObjectPropAccess'],
         'htdocs/partnership/class/partnership.class.php' => ['PhanUndeclaredProperty'],
         'htdocs/partnership/core/modules/partnership/mod_partnership_advanced.php' => ['PhanUndeclaredProperty'],
         'htdocs/partnership/partnership_card.php' => ['PhanUndeclaredGlobalVariable'],

--- a/htdocs/core/modules/syslog/mod_syslog_file.php
+++ b/htdocs/core/modules/syslog/mod_syslog_file.php
@@ -1,7 +1,10 @@
 <?php
-/* Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+/* Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
  */
+
+// File ignore as individual 'suppress' is not extremely effective.
+// @phan-file-suppress PhanPluginDuplicateArrayKey
 
 require_once DOL_DOCUMENT_ROOT.'/core/modules/syslog/logHandler.php';
 
@@ -160,7 +163,6 @@ class mod_syslog_file extends LogHandler
 	 * @param	array{level:int,ip:string,ospid:string,osuser:string,message:string}	$content 	Array containing the info about the message
 	 * @param	string	$suffixinfilename	When output is a file, append this suffix into default log filename.
 	 * @return	void
-	 * @phan-suppress PhanPluginDuplicateArrayKey
 	 */
 	public function export($content, $suffixinfilename = '')
 	{

--- a/htdocs/multicurrency/class/multicurrency.class.php
+++ b/htdocs/multicurrency/class/multicurrency.class.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2016       Pierre-Henry Favre  <phf@atm-consulting.fr>
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -718,7 +718,7 @@ class MultiCurrency extends CommonObject
 				}
 				return 1;
 			} else {
-				if (isset($response->error->info)) {
+				if (isset($response->error->info)) {  // @phan-suppress-current-line PhanTypeExpectedObjectPropAccess
 					$error_info_syslog = $response->error->info;  // @phan-suppress-current-line PhanTypeExpectedObjectPropAccess
 					$error_info = $error_info_syslog;
 				} else {


### PR DESCRIPTION
# QUAL: Update Phan baseline and suppress duplicate array key warnings

- Updated the Phan baseline to reflect reduced occurrences of certain issues
- Removed entries for fixed issues in the baseline file
- Added file-level suppression for PhanPluginDuplicateArrayKey in mod_syslog_file.php