### PR TITLE
Fix: Replace db->escape with db->sanitize in SQL query construction

### DIFF
--- a/htdocs/comm/mailing/class/mailing.class.php
+++ b/htdocs/comm/mailing/class/mailing.class.php
@@ -527,7 +527,7 @@ class Mailing extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/core/class/cgenericdic.class.php
+++ b/htdocs/core/class/cgenericdic.class.php
@@ -258,7 +258,7 @@ class CGenericDic extends CommonDict
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= " WHERE ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= " WHERE ".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/core/class/cleadstatus.class.php
+++ b/htdocs/core/class/cleadstatus.class.php
@@ -216,7 +216,7 @@ class CLeadStatus extends CommonDict
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= " AND ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= " AND ".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/core/class/cproductnature.class.php
+++ b/htdocs/core/class/cproductnature.class.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2007-2011  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2020       Florian HENRY           <florian.henry@scopen.fr>
- * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -189,7 +189,7 @@ class CProductNature extends CommonDict
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= " AND ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= " AND ".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/core/class/ctyperesource.class.php
+++ b/htdocs/core/class/ctyperesource.class.php
@@ -226,7 +226,7 @@ class Ctyperesource extends CommonDict
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= " AND ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= " AND ".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/core/class/cunits.class.php
+++ b/htdocs/core/class/cunits.class.php
@@ -272,7 +272,7 @@ class CUnits extends CommonDict
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/core/class/defaultvalues.class.php
+++ b/htdocs/core/class/defaultvalues.class.php
@@ -274,7 +274,7 @@ class DefaultValues extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -629,7 +629,7 @@ class EcmFiles extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND '.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= ' AND '.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/eventorganization/class/conferenceorbooth.class.php
+++ b/htdocs/eventorganization/class/conferenceorbooth.class.php
@@ -351,7 +351,7 @@ class ConferenceOrBooth extends ActionComm
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -477,7 +477,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/knowledgemanagement/class/knowledgerecord.class.php
+++ b/htdocs/knowledgemanagement/class/knowledgerecord.class.php
@@ -434,7 +434,7 @@ class KnowledgeRecord extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -546,7 +546,7 @@ class Mo extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/mrp/class/moline.class.php
+++ b/htdocs/mrp/class/moline.class.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2017  Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2020  Lenin Rivas		   <lenin@leninrivas.com>
  * Copyright (C) 2023-2026  Frédéric France     <frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		William Mead		<william.mead@manchenumerique.fr>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -315,7 +315,7 @@ class MoLine extends CommonObjectLine
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/partnership/class/partnership.class.php
+++ b/htdocs/partnership/class/partnership.class.php
@@ -530,7 +530,7 @@ class Partnership extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= " AND (".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= " AND (".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/product/class/productfournisseurprice.class.php
+++ b/htdocs/product/class/productfournisseurprice.class.php
@@ -449,7 +449,7 @@ class ProductFournisseurPrice extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND ('.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+				$sql .= ' AND ('.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 			}
 
 			$filter = '';

--- a/htdocs/product/stock/class/productstockentrepot.class.php
+++ b/htdocs/product/stock/class/productstockentrepot.class.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2015       Florian Henry       <florian.henry@open-concept.pro>
  * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2018-2025  Frédéric France     <frederic.france@free.fr>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -272,7 +272,7 @@ class ProductStockEntrepot extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= " AND ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= " AND ".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/reception/class/receptionlinebatch.class.php
+++ b/htdocs/reception/class/receptionlinebatch.class.php
@@ -887,7 +887,7 @@ class ReceptionLineBatch extends CommonObjectLine
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' WHERE '.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= ' WHERE '.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/website/class/website.class.php
+++ b/htdocs/website/class/website.class.php
@@ -422,7 +422,7 @@ class Website extends CommonObject
 				}
 			}
 			if (count($sqlwhere) > 0) {
-				$sql .= ' AND '.implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+				$sql .= ' AND '.implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 			}
 
 			$filter = '';

--- a/htdocs/website/class/websitepage.class.php
+++ b/htdocs/website/class/websitepage.class.php
@@ -519,9 +519,9 @@ class WebsitePage extends CommonObject
 			}
 			if (count($sqlwhere) > 0) {
 				if (!empty($websiteid)) {
-					$sql .= " AND (".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+					$sql .= " AND (".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 				} else {
-					$sql .= " WHERE ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+					$sql .= " WHERE ".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 				}
 			}
 
@@ -640,9 +640,9 @@ class WebsitePage extends CommonObject
 			}
 			if (count($sqlwhere) > 0) {
 				if (!empty($websiteid)) {
-					$sql .= " AND (".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere).')';
+					$sql .= " AND (".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere).')';
 				} else {
-					$sql .= " WHERE ".implode(' '.$this->db->escape($filtermode).' ', $sqlwhere);
+					$sql .= " WHERE ".implode(' '.$this->db->sanitize($filtermode).' ', $sqlwhere);
 				}
 			}
 


### PR DESCRIPTION
# Fix: Replace db->escape with db->sanitize in SQL query construction

Replaced all instances of `$this->db->escape($filtermode)` with `$this->db->sanitize($filtermode)` in SQL query construction across multiple classes to ensure proper SQL sanitization and prevent potential SQL injection vulnerabilities.