### PR TITLE
NEW Totals of a document in a foreign currency can follow that currency

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -23,6 +23,7 @@
  * Copyright (C) 2025		Vincent Maury		<vmaury@timgroup.fr>
  * Copyright (C) 2026		Pierre Ardoin		<developpeur@lesmetiersdubatiment.fr>
  * Copyright (C) 2026		Anthony Berton		<anthony.berton@bb2a.fr>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
 
  *
  * This program is free software; you can redistribute it and/or modify
@@ -4061,9 +4062,10 @@ abstract class CommonObject
 	 *  @param  'none'|'auto'|'0'|'1'	$roundingadjust		'none'=Do nothing (when properties are already correctly set), 'auto'=Use default method (MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND if defined, or '0'), '0'=Force mode Total of rounding, '1'=Force mode Rounding of total
 	 *  @param	int<0,1>				$nodatabaseupdate	1=Do not update database total fields of the main object. Update only properties in memory. Can be used to save SQL when this method is called several times, so we can do it only once at end.
 	 *  @param	?Societe				$seller				If roundingadjust is '0' or '1' or maybe 'auto', it means we recalculate total for lines before calculating total for object and for this, we need seller object (used to analyze lines to check corrupted data).
+	 *  @param  'auto'|'0'|'1'			$followforeigncurrency	For a document in a foreign currency: 'auto'=Use MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY (or its _SUPPLIER variant), '1'=Totals in the company currency are the exact conversion of the multicurrency totals, '0'=Totals are the sum of the lines. Ignored when the document has no foreign currency.
 	 *	@return	int<-1,1>									Return integer <0 if KO, >0 if OK
 	 */
-	public function update_price($exclspec = 0, $roundingadjust = 'auto', $nodatabaseupdate = 0, $seller = null)
+	public function update_price($exclspec = 0, $roundingadjust = 'auto', $nodatabaseupdate = 0, $seller = null, $followforeigncurrency = 'auto')
 	{
 		// phpcs:enable
 		global $conf, $hookmanager, $action;
@@ -4079,6 +4081,7 @@ abstract class CommonObject
 		// Some external module want no update price after a trigger because they have another method to calculate the total (ex: with an extrafield)
 		$isElementForSupplier = false;
 		$roundTotalConstName = 'MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND'; // const for customer by default
+		$followCurrencyConstName = 'MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY'; // const for customer by default
 		$MODULE = "";
 		if ($this->element == 'propal') {
 			$MODULE = "MODULE_DISALLOW_UPDATE_PRICE_PROPOSAL";
@@ -4098,6 +4101,7 @@ abstract class CommonObject
 		}
 		if ($isElementForSupplier) {
 			$roundTotalConstName = 'MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND_SUPPLIER'; // const for supplier
+			$followCurrencyConstName = 'MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY_SUPPLIER'; // const for supplier
 		}
 
 		if (!empty($MODULE)) {
@@ -4118,6 +4122,12 @@ abstract class CommonObject
 			$forcedroundingmode = getDolGlobalString($roundTotalConstName);
 		} elseif ($forcedroundingmode == 'auto') {
 			$forcedroundingmode = '0';
+		}
+
+		// Which currency is the reference for the totals. This is independent from the VAT rounding
+		// method above: both questions can be answered separately on the same document.
+		if ($followforeigncurrency == 'auto') {
+			$followforeigncurrency = getDolGlobalString($followCurrencyConstName, '0');
 		}
 
 		$error = 0;
@@ -4351,6 +4361,19 @@ abstract class CommonObject
 						}
 					}
 				}
+			}
+
+			// On a document in a foreign currency, the totals in the company currency are the sum of the
+			// converted lines, while the multicurrency totals are the sum of the same lines in the foreign
+			// currency. Each currency being rounded on its own lines, dividing one by the exchange rate does
+			// not always give back the other: both are correct, they just answer different questions.
+			// When the amount due in the foreign currency is the reference (a supplier invoice received in
+			// USD for instance), the totals in the company currency can be set to its exact conversion.
+			if ($followforeigncurrency == '1' && !empty($multicurrency_tx) && $multicurrency_tx != 1) {
+				$this->total_ht = (float) price2num($this->multicurrency_total_ht / $multicurrency_tx);
+				$this->total_ttc = (float) price2num($this->multicurrency_total_ttc / $multicurrency_tx);
+				// VAT absorbs the rounding difference so the total incl. tax stays equal to what is due
+				$this->total_tva = (float) price2num($this->total_ttc - $this->total_ht - $this->total_localtax1 - $this->total_localtax2);
 			}
 
 			// Clean total

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -2133,6 +2133,20 @@ if (empty($reshook)) {
 	$permissiontoadd = $usercancreate;
 	include DOL_DOCUMENT_ROOT.'/core/actions_builddoc.inc.php';
 
+	// Set which currency drives the totals. Separate from the VAT calculation rule below:
+	// the two are independent, so they get their own action.
+	if ($action == 'settotalsreference' && $usercancreate) {
+		$object->fetch($id);
+		$object->fetch_thirdparty();
+		$result = $object->update_price(0, 'auto', 0, $object->thirdparty, (GETPOST('totalsreference', 'aZ09') == 'currency') ? '1' : '0');
+		if ($result <= 0) {
+			dol_print_error($db, $object->error, $object->errors);
+			exit;
+		}
+		header('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
+		exit;
+	}
+
 	// Make calculation according to calculationrule
 	if ($action == 'calculate' && $usercancreate) {
 		$calculationrule = GETPOST('calculationrule');
@@ -3754,6 +3768,33 @@ if ($action == 'create') {
 			print '<table class="border tableforfield centpercent">';
 
 			include DOL_DOCUMENT_ROOT.'/core/tpl/object_currency_amount.tpl.php';
+
+			// Which currency drives the totals. Shown next to the currency and the exchange rate, as it is a
+			// property of that relation, and only where the recalculation is available.
+			if (isModEnabled("multicurrency") && !empty($object->multicurrency_code) && $object->multicurrency_code != $conf->currency
+				&& !empty($object->multicurrency_tx) && $object->multicurrency_tx != 1) {
+				$exactconversion = (float) price2num((float) $object->multicurrency_total_ttc / (float) $object->multicurrency_tx, 'MT');
+				$isalignedoncurrency = (abs((float) $object->total_ttc - $exactconversion) < 0.005);
+				$lblLines = $langs->trans("TotalsFromLines");
+				$lblCurrency = $langs->trans("TotalsAlignedOnForeignCurrency", $object->multicurrency_code);
+				print '<tr><td>' . $langs->trans("TotalsReference") . '</td>';
+				print '<td colspan="2">';
+				if ($object->getVentilExportCompta() == 0) {
+					// Same pattern as the VAT calculation rule below: the active choice is plain text,
+					// the other one is the link that switches to it.
+					$url = $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&action=settotalsreference&token=' . newToken() . '&totalsreference=';
+					$s = '<span class="hideonsmartphone opacitymedium">' . $langs->trans("ReCalculate") . ' </span>';
+					$s .= $isalignedoncurrency ? '<a href="' . $url . 'lines">' . $lblLines . '</a>' : '<span class="opacitymedium">' . $lblLines . '</span>';
+					$s .= ' / ';
+					$s .= $isalignedoncurrency ? '<span class="opacitymedium">' . $lblCurrency . '</span>' : '<a href="' . $url . 'currency">' . $lblCurrency . '</a>';
+					print '<div class="inline-block">';
+					print $form->textwithtooltip($s, $langs->trans("TotalsReferenceDesc", $object->multicurrency_code, price($exactconversion, 0, $langs, 0, -1, -1, $conf->currency)), 2, 1, img_picto('', 'help', 'class="paddingleft paddingright"'), '', 3, '', 0, 'totalsreference');
+					print '</div>';
+				} else {
+					print $isalignedoncurrency ? $lblCurrency : $lblLines;
+				}
+				print '</td></tr>';
+			}
 
 			print '<tr>';
 			print '<td class="titlefieldmiddle">' . $langs->trans('AmountHT') . '</td>';

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -16,6 +16,7 @@
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Vincent de Grandpré		<vincent@de-grandpre.quebec>
  * Copyright (C) 2026		Lionel Vessiller		<lvessiller@open-dsi.fr>
+ * Copyright (C) 2026		José MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/langs/en_US/compta.lang
+++ b/htdocs/langs/en_US/compta.lang
@@ -348,3 +348,7 @@ VATExemptionCodeDesc=If the VAT rate is 0, you can enter here the code of the re
 VATExemptionCodeDesc2=You can pick any valid value among the list on https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/ or keep it empty to use the default code.
 VATExemptionCodeDesc3=This code is not used for accounting. It is used only if your are using an E-invoice generation module.
 WeWillUseThisValueAsNumber=We will use this value as full registration number
+TotalsReference=Totals reference
+TotalsFromLines=Sum of the lines
+TotalsAlignedOnForeignCurrency=Aligned on %s
+TotalsReferenceDesc=Totals in the company currency are the sum of the converted lines, so they may differ by a few cents from the exact conversion of the total in %s, which is %s. Align them on that conversion when the amount due in the foreign currency is the reference. This can be undone as long as the invoice has not been transferred to accounting.

--- a/htdocs/langs/fr_FR/compta.lang
+++ b/htdocs/langs/fr_FR/compta.lang
@@ -348,3 +348,7 @@ VATExemptionCodeDesc=Si le code TVA taux est 0, vous pouvez saisir ici le code d
 VATExemptionCodeDesc2=Vous pouvez choisir n'importe quelle valeur valide parmi la liste sur https://docs.peppol.eu/poacc/billing/3.0/codelist/vatex/ ou la laisser vide pour utiliser le code par défaut.
 VATExemptionCodeDesc3=Ce code n'est pas utilisé pour la comptabilité. Il est utilisé uniquement si vous utilisez un module de génération de factures électroniques.
 WeWillUseThisValueAsNumber=Nous utiliserons cette valeur comme numéro d'immatriculation complet.
+TotalsReference=Référence des totaux
+TotalsFromLines=Somme des lignes
+TotalsAlignedOnForeignCurrency=Alignés sur le %s
+TotalsReferenceDesc=Les totaux en devise de la société sont la somme des lignes converties : ils peuvent différer de quelques centimes de la conversion exacte du total en %s, qui vaut %s. Alignez-les sur cette conversion lorsque le montant dû en devise fait foi. L'opération est réversible tant que la facture n'est pas transférée en comptabilité.


### PR DESCRIPTION
## What this solves

On a document carrying a foreign currency, Dolibarr keeps two sets of totals:

- `total_ht` / `total_ttc`, the sum of the **lines converted** into the company currency,
- `multicurrency_total_ht` / `multicurrency_total_ttc`, the sum of the **same lines in the foreign currency**.

Each set is rounded on its own lines, so dividing the multicurrency total by the exchange rate does not always give back the total in the company currency. Both values are correct — they simply answer different questions — but only one of them can be the reference, and today that choice does not exist.

On a real base of **239 supplier invoices in a foreign currency** (TWD, USD, GBP), **28** show such a gap, the largest being **0.03 EUR**. Small, but they are the amounts that get transferred to accounting and reconciled against what was actually paid.

The two cases are genuinely different:

- an **invoice issued** in a foreign currency — the lines are the source, the converted total follows;
- an **invoice received** in a foreign currency — the amount due in that currency is contractual. It is what will be paid, and the total in the company currency is only its conversion.

## What it adds

**1. A fifth parameter on `update_price()`**

```php
$object->update_price(0, 'auto', 0, $seller, '1');   // totals follow the foreign currency
```

`'auto'` (the default) reads a constant, `'0'` keeps the current behaviour, `'1'` sets the totals in the company currency to the exact conversion of the multicurrency totals. VAT absorbs the rounding difference so the total incl. tax stays equal to what is due. The block is skipped entirely when the document carries no foreign currency.

**2. Two constants**, following the existing naming for this kind of choice:

- `MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY` (customer side)
- `MAIN_TOTALS_FOLLOW_FOREIGN_CURRENCY_SUPPLIER` (supplier side)

Unset means `'0'`, so **the PR is inert until someone opts in**.

**3. A switch on the supplier invoice card**, next to the currency and the exchange rate, since it is a property of that relation. It follows the same pattern as the existing *Mode 1 / Mode 2* links: the active choice is plain text, the other one is the link that switches to it. A tooltip states the exact conversion so the user sees what they are choosing between.

It is displayed only when the document really carries a foreign currency, and — like the existing VAT recalculation links — only while `getVentilExportCompta() == 0`, so an invoice already transferred to accounting is never recalculated. The choice is reversible until then.

## Relationship with the existing rounding rule

This is deliberately **separate** from `MAIN_ROUNDOFTOTAL_NOT_TOTALOFROUND` and the *Mode 1 / Mode 2* links. That setting answers *how is VAT rounded across the lines*; this one answers *which currency is the reference for the totals*. Both questions can be answered independently on the same document, so they get their own parameter, their own constant and their own action rather than a third value squeezed into `$roundingadjust`.

*(An earlier attempt of mine, #39313, did squeeze it in as a rounding mode `'2'`. I closed it: conflating the two made the domestic-document path fragile — measured on a production instance running such an overload, 893 domestic supplier invoices (no foreign currency) had both documented VAT modes bypassed: 20 differ from mode '0', 47 from mode '1'. This version keeps them apart.)*

## Compatibility

- No existing call site passes the new parameter, and the constants are unset by default, so **behaviour is unchanged out of the box**.
- No schema change, no new table, no migration.
- Documents without a foreign currency are untouched — the code path is guarded by `$multicurrency_tx != 1`.

## Tested on

Dolibarr `develop`, PHP 7.4, on real supplier invoices in TWD, USD and GBP: the totals in the company currency become the exact conversion of the amount due, and switching back restores the sum of the lines.

Here are 2 screenshots:
<img width="1140" height="370" alt="pr39358_etat1_somme_des_lignes" src="https://github.com/user-attachments/assets/eeaadb61-c267-4fe7-b624-9c97525f5240" />
<img width="1140" height="420" alt="pr39358_etat2_aligne_sur_devise" src="https://github.com/user-attachments/assets/ca247c9b-2707-4083-85c2-e826520c8e74" />

