### PR TITLE
FIX MySQL DB_ERROR_1055 on treasury journal

### DIFF
--- a/htdocs/accountancy/journal/treasuryjournal.php
+++ b/htdocs/accountancy/journal/treasuryjournal.php
@@ -234,7 +234,7 @@ if ($resql) {
 				$sql .= " AND fd.product_type IN (0,1)";
 				$sql .= " AND f.type IN (".Facture::TYPE_STANDARD.",".Facture::TYPE_REPLACEMENT.",".Facture::TYPE_CREDIT_NOTE.",".(!getDolGlobalString('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS') ? Facture::TYPE_DEPOSIT."," : "").Facture::TYPE_SITUATION.")";
 				$sql .= " AND bu.fk_bank IN (".$db->sanitize(implode(',', $ids)).")";
-				$sql .= " GROUP BY fd.rowid, bu.fk_bank, pf.amount, bu.url_id";	// TODO Must never have a GROUP BY on a field if field is not inside an aggregate function.
+				//$sql .= " GROUP BY fd.rowid, bu.fk_bank, pf.amount, bu.url_id, f.rowid, f.ref, f.total_ht, f.total_ttc, fd.total_ht, fd.total_tva, fd.total_localtax1, fd.total_localtax2, fd.tva_tx, fd.total_ttc, fd.vat_src_code, aa.account_number, aa.label, bu.type";
 				$sql .= " ORDER BY aa.account_number";
 
 				$resql = $db->query($sql);
@@ -351,7 +351,7 @@ if ($resql) {
 				$sql .= " AND ffd.product_type IN (0,1)";
 				$sql .= " AND ff.type IN (".FactureFournisseur::TYPE_STANDARD.",".FactureFournisseur::TYPE_REPLACEMENT.",".FactureFournisseur::TYPE_CREDIT_NOTE.",".(!getDolGlobalString('FACTURE_DEPOSITS_ARE_JUST_PAYMENTS') ? FactureFournisseur::TYPE_DEPOSIT."," : "").FactureFournisseur::TYPE_SITUATION.")";
 				$sql .= " AND bu.fk_bank IN (".$db->sanitize(implode(',', $ids)).")";
-				$sql .= " GROUP BY ffd.rowid, bu.fk_bank";
+				//$sql .= " GROUP BY ffd.rowid, bu.fk_bank, ff.rowid, ff.ref, ff.total_ht, ff.total_ttc, pff.amount, ffd.total_ht, ffd.tva, ffd.total_localtax1, ffd.total_localtax2, ffd.tva_tx, ffd.total_ttc, ffd.vat_src_code, aa.account_number, aa.label, bu.url_id, bu.type";
 				$sql .= " ORDER BY aa.account_number";
 
 				$resql = $db->query($sql);
@@ -462,7 +462,7 @@ if ($resql) {
 				}
 				$sql .= " AND er.fk_statut >= ".ExpenseReport::STATUS_APPROVED;
 				$sql .= " AND bu.fk_bank IN (".$db->sanitize(implode(',', $ids)).")";
-				$sql .= " GROUP BY erf.rowid, bu.fk_bank, per.amount, aa.label, bu.url_id";
+				//$sql .= " GROUP BY erf.rowid, bu.fk_bank, per.amount, aa.label, bu.url_id, er.rowid, er.ref, er.total_ht, er.total_ttc, erf.total_ht, erf.total_tva, erf.total_localtax1, erf.total_localtax2, erf.tva_tx, erf.total_ttc, erf.vat_src_code, ctf.accountancy_code, bu.type, aa.account_number";
 				$sql .= " ORDER BY aa.account_number";
 
 				$resql = $db->query($sql);


### PR DESCRIPTION
# FIX MySQL DB_ERROR_1055 on treasury journal

## Bug

On MySQL 8 with the default sql_mode (`ONLY_FULL_GROUP_BY` is on by default since MySQL 5.7), the **supplier invoices** query of the treasury journal (`htdocs/accountancy/journal/treasuryjournal.php`) fails with `DB_ERROR_1055`:

> Expression #5 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'pff.amount' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

`GROUP BY ffd.rowid, bu.fk_bank` leaves `pff.amount`, `bu.url_id`, `bu.type`, ... non-aggregated (`pff` is joined on the invoice, several payments can exist for one invoice, so those columns are not functionally dependent on the invoice line id). The customer invoices query happens to pass on MySQL because its GROUP BY includes `pf.amount` and `bu.url_id`, but it fails on PostgreSQL the same way (error 42803, see #38910).

Consequence in treasury accountancy mode (`ACCOUNTING_MODE = RECETTES-DEPENSES`): supplier payments are missing **both from the journal view and from the transfer into the ledger** — the ledger comes out with revenues only and no supplier expense, the only signal being one error line in the transfer report. Affects 22.0 and 23.0 on any MySQL 8 with factory settings; develop is already fixed.

## Fix

Backport of the resolution already on develop: #38910 first made the three GROUP BY exhaustive (for the same error on PostgreSQL), then commit 42840b47a removed them entirely — the queries contain no aggregate function, and the fetch loops already deduplicate rows (`isset()` guards on the object/payment keys, `$already_sum` check on the detail line id), so the GROUP BY is useless. The three replaced lines are byte-identical to develop, so the upward merge stays clean.

## Verification

On a 23.0.2 instance, MySQL 8 with factory sql_mode, real data:

- vanilla supplier query → `ERROR 1055 (42000)`;
- same query without GROUP BY → succeeds, and returns **the same rows, row for row**, as the exhaustive GROUP BY variant of #38910 (no duplicate introduced by the removal);
- full-year transfer into the ledger → balanced pieces, correct 6xx/7xx counterparts, and a re-transfer creates no duplicate.

Note: the open PR #39249 (`fk_docdet` on transferred entries) touches the same page but is a distinct issue.
