### PR TITLE
NEW Ticket API: allow postNewMessage to target ticket by id or ref

### DIFF
--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2016   Jean-François Ferry     <hello@librethic.io>
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez				<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -435,7 +436,14 @@ class Tickets extends DolibarrApi
 			$this->ticket->$field = $this->_checkValForAPI($field, $value, $this->ticket);
 		}
 		$ticketMessageText = $this->ticket->message;
-		$result = $this->ticket->fetch(0, '', $this->ticket->track_id);
+		// Allow targeting the ticket by id or ref, not only track_id
+		if (!empty($this->ticket->id)) {
+			$result = $this->ticket->fetch($this->ticket->id);
+		} elseif (!empty($this->ticket->ref)) {
+			$result = $this->ticket->fetch(0, $this->ticket->ref);
+		} else {
+			$result = $this->ticket->fetch(0, '', $this->ticket->track_id);
+		}
 		if (!$result) {
 			throw new RestException(404, 'Ticket not found');
 		}


### PR DESCRIPTION
## Summary
The REST endpoint `POST /tickets/newmessage` (`Tickets::postNewMessage`) can currently only reach a ticket through its `track_id` — the fetch is hardcoded to `fetch(0, '', $this->ticket->track_id)`. A caller that only knows the ticket **id** (or **ref**) cannot append a message.

This makes `postNewMessage` resolve the ticket by **id → ref → track_id** (track_id stays as the fallback, so existing behaviour is unchanged).

## Motivation
`get`, `put` and `delete` already accept an id; only `postNewMessage` was `track_id`-only. Integrations that store the Dolibarr ticket id on their side (e.g. a Zendesk ⇆ Dolibarr sync) need to append messages by id via the REST API.

## Changes
- `htdocs/ticket/class/api_tickets.class.php`: in `postNewMessage()`, fetch the ticket by id, else by ref, else by track_id.

## Backward compatibility
Fully backward compatible: with no id/ref provided, the original `track_id` lookup is used.

_Draft for review._
