### PR TITLE
FIX Removing an applied discount from a paid invoice sets it back to unpaid

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -392,6 +392,10 @@ if (empty($reshook)) {
 		$discount = new DiscountAbsolute($db);
 		$result = $discount->fetch(GETPOSTINT("discountid"));
 		$discount->unlink_invoice();
+		$object->fetch($id);
+		if ($object->paye == 1 && (float) $object->getRemainToPay() > 0) {
+			$object->setUnpaid($user);
+		}
 	} elseif ($action == 'valid' && $usercancreate) {
 		// Validation
 		$object->fetch($id);

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -23,6 +23,7 @@
  * Copyright (C) 2026		Vincent de Grandpré			<vincent@de-grandpre.quebec>
  * Copyright (C) 2026		Joachim Küter				<git-jk@bloxera.com>
  * Copyright (C) 2026		Lionel Vessiller			<lvessiller@open-dsi.fr>
+ * Copyright (C) 2026		José MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -368,6 +368,10 @@ if (empty($reshook)) {
 		$discount = new DiscountAbsolute($db);
 		$result = $discount->fetch(GETPOSTINT("discountid"));
 		$discount->unlink_invoice();
+		$object->fetch($id);
+		if ($object->paye == 1 && (float) $object->getRemainToPay() > 0) {
+			$object->setUnpaid($user);
+		}
 	} elseif ($action == 'confirm_paid' && $confirm == 'yes' && $usercancreate) {
 		$object->fetch($id);
 		$result = $object->setPaid($user);

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -16,6 +16,7 @@
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Vincent de Grandpré		<vincent@de-grandpre.quebec>
  * Copyright (C) 2026		Lionel Vessiller		<lvessiller@open-dsi.fr>
+ * Copyright (C) 2026		José MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## The bug

Apply a deposit or a credit note on an invoice, pay the remainder: the invoice is flagged **Paid**. Now remove the applied discount (action `unlinkdiscount`): a balance is due again, but the invoice **keeps its Paid status**. Nothing in the workflow puts it back to unpaid, and the amounts shown (remainder to pay > 0) contradict the status badge.

## The fix

Right after `DiscountAbsolute::unlink_invoice()`, refresh the invoice and call `setUnpaid()` when it was flagged paid and the remainder to pay is positive again. Applied to both the customer (`compta/facture/card.php`) and the supplier (`fourn/facture/card.php`) cards — the code path is identical.

The status then falls back to *Unpaid* (or *Started* when partial payments remain, which the status display already handles).

## Tested

Round-trip on a real invoice: paid with a deposit → remove the deposit → invoice goes back to unpaid with the correct remainder → re-apply → paid again. No behaviour change when the invoice was not paid.
