### PR TITLE
fix Bug: Massaction "Update Percent" on Situation Invoice not working…

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3343,7 +3343,7 @@ if (empty($reshook)) {
 				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
-	} elseif ($action == 'updatealllines' && $usercancreate && GETPOST('all_percent') == $langs->trans('Modify')) {	// Update all lines of situation invoice
+	} elseif ($action == 'updatealllines' && $usercancreate && GETPOSTISSET('all_percent')) {	// Update all lines of situation invoice
 		if (!$object->fetch($id) > 0) {
 			dol_print_error($db);
 		}


### PR DESCRIPTION
… on different languages (german)

Fixes #39367

Row 3346 on facture/card.php
... elseif ($action == 'updatealllines' && $usercancreate && GETPOST('all_percent') == $langs->trans('Modify')) { // Update all lines of situation invoice

`GETPOST('all_percent'): "Ändern" <-- German value`
`$langs->trans('Modify'): "&Auml;ndern" <-- Ä is convert to &Auml;`

I think its GETPOSTISSET('all_percent') works fine.
