### PR TITLE
FIX Ticket list: "Remove filter" button does not reset the Company filter

### DIFF
--- a/htdocs/ticket/list.php
+++ b/htdocs/ticket/list.php
@@ -235,6 +235,7 @@ if (empty($reshook)) {
 		}
 		$toselect = array();
 		$search_array_options = array();
+		$search_societe = '';
 		$search_date_start = '';
 		$search_date_end = '';
 		$search_dateread_start = '';


### PR DESCRIPTION
## Summary

- Fixes #39374: on the ticket list (`ticket/list.php`), clicking the "Remove filter" (X) button cleared all standard search filters but left the "Company" filter (`search_societe`) untouched.
- `$search_societe` is a standalone variable (not part of the generic `$search[...]` array built from `$object->fields`), because `fk_soc` is filtered via a JOIN against `llx_societe` (`s.nom`) rather than as a plain field. The "Purge search criteria" block resets the generic `$search[...]` entries plus a hand-maintained list of extra standalone variables (`$search_date_start`, `$search_dateread_start`, `$search_dateclose_start`, etc.) — `$search_societe` was missing from that list.
- One-line fix: reset `$search_societe = '';` alongside the other standalone search variables in the purge block.

## Test plan

- [x] Verified by code inspection that `$search_societe` is now included in the same reset block as the other standalone search variables (`$search_date_start`, etc.), following the existing pattern.
- [x] Manual verification: on the ticket list, entered a value in the "Company" filter, clicked "Remove filter" (X), confirmed the field is now cleared.
