### PR TITLE
FIX : Fatal error when fetching a workstation with an empty id

### DIFF
--- a/htdocs/workstation/class/workstationresource.class.php
+++ b/htdocs/workstation/class/workstationresource.class.php
@@ -95,7 +95,11 @@ class WorkstationResource extends CommonObject
 	{
 		global $db;
 		$obj = new self($db);
-		return array_map('intval', parent::getAllItemsLinkedByObjectID($fk_workstation, 'fk_resource', 'fk_workstation', $obj->table_element));
+		$TRes = parent::getAllItemsLinkedByObjectID($fk_workstation, 'fk_resource', 'fk_workstation', $obj->table_element);
+		if (!is_array($TRes)) {	// getAllItemsLinkedByObjectID() returns -1 when $fk_workstation is empty
+			return [];
+		}
+		return array_map('intval', $TRes);
 	}
 
 	/**

--- a/htdocs/workstation/class/workstationusergroup.class.php
+++ b/htdocs/workstation/class/workstationusergroup.class.php
@@ -95,7 +95,11 @@ class WorkstationUserGroup extends CommonObject
 		global $db;
 
 		$obj = new self($db);
-		return array_map('intval', parent::getAllItemsLinkedByObjectID($fk_workstation, 'fk_usergroup', 'fk_workstation', $obj->table_element));
+		$TRes = parent::getAllItemsLinkedByObjectID($fk_workstation, 'fk_usergroup', 'fk_workstation', $obj->table_element);
+		if (!is_array($TRes)) {	// getAllItemsLinkedByObjectID() returns -1 when $fk_workstation is empty
+			return [];
+		}
+		return array_map('intval', $TRes);
 	}
 
 	/**


### PR DESCRIPTION
## FIX: Fatal error when fetching a workstation with an empty id

### Problem

Opening a BOM card holding a **service line with no default workstation** (`llx_bom_bomline.fk_default_workstation` `NULL` or `0`) kills the page. The HTML stops in the middle of the line, so the action buttons and every block below are never printed.

```
PHP Fatal error:  Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array,
int given in htdocs/workstation/class/workstationusergroup.class.php:98
#1 workstation/class/workstation.class.php(356): WorkstationUserGroup::getAllGroupsOfWorkstation()
#2 bom/tpl/objectline_view.tpl.php(199): Workstation->fetch()
#3 bom/bom_card.php(693): CommonObject->printObjectLines()
```

### Root cause

`Workstation::fetch()` always calls `getAllGroupsOfWorkstation($this->id)` / `getAllResourcesOfWorkstation($this->id)`, even when `fetchCommon()` failed and left the id empty. `CommonObject::getAllItemsLinkedByObjectID()` returns `-1` for an empty id, and both getters now wrap it in `array_map('intval', …)` → `TypeError` on PHP 8.

That wrapper is new in 24.0, so 23.0 is not affected.

### Fix

Guard both getters, keeping the documented `@return int[]`:

```php
$TRes = parent::getAllItemsLinkedByObjectID($fk_workstation, 'fk_usergroup', 'fk_workstation', $obj->table_element);
if (!is_array($TRes)) {	// getAllItemsLinkedByObjectID() returns -1 when $fk_workstation is empty
	return [];
}
return array_map('intval', $TRes);
```

### How to reproduce

Enable **BOM** + **Workstation**, create a BOM with a **service** line and leave *Default workstation* empty, then open the BOM card.

After the patch, `fetch(0)` and `fetch(NULL)` return `-1` cleanly with empty `usergroups`/`resources`, `fetch(<valid id>)` is unchanged, and the card renders in full.
