### PR TITLE
FIX EmailCollector: DateTime/Carbon object passed as timestamp when MAIN_IMAP_USE_PHPIMAP is enabled

### DIFF
--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -2107,7 +2107,7 @@ class EmailCollector extends CommonObject
 					$sendtocc = empty($overview['cc']) ? '' : $overview['cc'];
 					$sendtobcc = empty($overview['bcc']) ? '' : $overview['bcc'];
 
-					$tmpdate = $overview['date']->toDate();  // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
+					$tmpdate = $overview['date']->toDate();  // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall,PhanUndeclaredMethod
 					$tmptimezone = $tmpdate->getTimezone()->getName();  // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
 
 					$dateemail = dol_stringtotime((string) $overview['date'], 'gmt');    // if $overview['timezone'] is "+00:00"

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1766,7 +1766,7 @@ class EmailCollector extends CommonObject
 				$headers = array_combine($matches[1], $matches[2]);
 
 
-				$richarrayofemail[] = array('imapemail' => $imapemail, 'header' => $header, 'headers' => $headers, 'overview' => $overview, 'date' => strtotime($headers['Date']));
+				$richarrayofemail[] = array('imapemail' => $imapemail, 'header' => $header, 'headers' => $headers, 'overview' => $overview, 'date' => empty($headers['Date']) ? false : strtotime($headers['Date']));
 			}
 
 
@@ -1971,7 +1971,9 @@ class EmailCollector extends CommonObject
 
 
 				if (getDolGlobalString('MAIN_IMAP_USE_PHPIMAP')) {
-					$dateformated = dol_print_date($overview['date'], 'dayrfc', 'gmt');		// May generate a warning "dol_print_date($overview['date'], 'dayrfc', 'gmt')" in log
+					// $overview['date'] is a DateTime/Carbon object when using the PHPIMAP driver, not a timestamp, so it must be converted first
+					$overviewdate = ($overview['date'] instanceof DateTimeInterface) ? $overview['date']->getTimestamp() : $overview['date'];
+					$dateformated = dol_print_date($overviewdate, 'dayrfc', 'gmt');
 					dol_syslog("msgid=".$overview['message_id']." date=".$dateformated." from=".$overview['from']." to=".$overview['to']." subject=".$overview['subject']);
 
 					// Removed emojis
@@ -3704,7 +3706,7 @@ class EmailCollector extends CommonObject
 					// Stop the loop to process email if we reach maximum collected per collect
 					if ($this->maxemailpercollect > 0 && $nbemailok >= $this->maxemailpercollect) {
 						dol_syslog("EmailCollect::doCollectOneCollector We reach maximum of ".$nbemailok." collected with success, so we stop this collector now.");
-						$datelastok = strtotime($headers['Date']); // Set datetime
+						$datelastok = empty($headers['Date']) ? false : strtotime($headers['Date']); // Set datetime
 						break;
 					}
 				} else {


### PR DESCRIPTION
## Summary
- \`\$overview['date']\` is a \`Carbon\`/\`DateTime\` object (not an int timestamp) when the collector uses the \`MAIN_IMAP_USE_PHPIMAP\` (Webklex php-imap) driver. Passing it straight to \`dol_print_date()\` silently produces a wrong date under PHP 8 (object-to-int cast warning, result becomes \`1\`) instead of the actual email date, with no visible error.
- Convert \`DateTimeInterface\` instances via \`->getTimestamp()\` before calling \`dol_print_date()\`, so both the PHPIMAP driver (object) and the native \`ext-imap\` driver (int) are handled correctly.
- Also guard the two \`strtotime(\$headers['Date'])\` calls against a missing \`Date\` header, which raised a PHP 8 deprecation notice (\`Passing null to parameter #1 (\$datetime) of type string is deprecated\`).

Fixes #39376

## Test plan
- [x] \`php -l\` on the modified file
- [x] Isolated verification that \`\$overview['date'] instanceof DateTimeInterface\` correctly extracts the real timestamp via \`->getTimestamp()\`, producing the correct date instead of \`1970-01-01\`
- [x] Verified the native \`ext-imap\` code path (integer timestamp) is unaffected by the added type check
- [ ] Manual collector run against a live IMAP mailbox with \`MAIN_IMAP_USE_PHPIMAP=1\` (please test in review if possible)