### PR TITLE
NEW element_element : add user & date creat/modif columns

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -66,7 +66,4 @@ ALTER TABLE llx_element_element ADD COLUMN date_creation datetime;
 ALTER TABLE llx_element_element ADD COLUMN fk_user_modif integer;
 ALTER TABLE llx_element_element ADD COLUMN tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 
-ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_creat FOREIGN KEY (fk_user_creat) REFERENCES llx_user (rowid);
-ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_modif FOREIGN KEY (fk_user_modif) REFERENCES llx_user (rowid);
-
 -- end of migration

--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -60,5 +60,13 @@ CREATE TABLE llx_links_extrafields
 ) ENGINE=innodb;
 ALTER TABLE llx_links_extrafields ADD UNIQUE INDEX uk_links_extrafields (fk_object);
 
+-- Add user/tms information to element_element
+ALTER TABLE llx_element_element ADD COLUMN fk_user_creat integer AFTER relationtype;
+ALTER TABLE llx_element_element ADD COLUMN date_creation datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER fk_user_creat;
+ALTER TABLE llx_element_element ADD COLUMN fk_user_modif integer AFTER date_creation;
+ALTER TABLE llx_element_element ADD COLUMN tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER fk_user_modif;
+
+ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_creat FOREIGN KEY (fk_user_creat) REFERENCES llx_user (rowid);
+ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_modif FOREIGN KEY (fk_user_modif) REFERENCES llx_user (rowid);
 
 -- end of migration

--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -61,10 +61,10 @@ CREATE TABLE llx_links_extrafields
 ALTER TABLE llx_links_extrafields ADD UNIQUE INDEX uk_links_extrafields (fk_object);
 
 -- Add user/tms information to element_element
-ALTER TABLE llx_element_element ADD COLUMN fk_user_creat integer AFTER relationtype;
-ALTER TABLE llx_element_element ADD COLUMN date_creation datetime NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER fk_user_creat;
-ALTER TABLE llx_element_element ADD COLUMN fk_user_modif integer AFTER date_creation;
-ALTER TABLE llx_element_element ADD COLUMN tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER fk_user_modif;
+ALTER TABLE llx_element_element ADD COLUMN fk_user_creat integer;
+ALTER TABLE llx_element_element ADD COLUMN date_creation datetime;
+ALTER TABLE llx_element_element ADD COLUMN fk_user_modif integer;
+ALTER TABLE llx_element_element ADD COLUMN tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 
 ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_creat FOREIGN KEY (fk_user_creat) REFERENCES llx_user (rowid);
 ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_modif FOREIGN KEY (fk_user_modif) REFERENCES llx_user (rowid);

--- a/htdocs/install/mysql/tables/llx_element_element.key.sql
+++ b/htdocs/install/mysql/tables/llx_element_element.key.sql
@@ -23,3 +23,6 @@ ALTER TABLE llx_element_element ADD UNIQUE INDEX idx_element_element_idx1 (fk_so
 ALTER TABLE llx_element_element ADD INDEX idx_element_element_fk_target (fk_target);
 
 -- Pas de contraite sur fk_source et fk_target car pointe sur differentes tables
+
+ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_creat FOREIGN KEY (fk_user_creat) REFERENCES llx_user (rowid);
+ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_modif FOREIGN KEY (fk_user_modif) REFERENCES llx_user (rowid);

--- a/htdocs/install/mysql/tables/llx_element_element.key.sql
+++ b/htdocs/install/mysql/tables/llx_element_element.key.sql
@@ -19,10 +19,10 @@
 
 ALTER TABLE llx_element_element ADD UNIQUE INDEX idx_element_element_idx1 (fk_source, sourcetype, fk_target, targettype);
 
-
 ALTER TABLE llx_element_element ADD INDEX idx_element_element_fk_target (fk_target);
 
--- Pas de contraite sur fk_source et fk_target car pointe sur differentes tables
+-- No constraint on fk_source and fk_target because they points to different tables
 
-ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_creat FOREIGN KEY (fk_user_creat) REFERENCES llx_user (rowid);
-ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_modif FOREIGN KEY (fk_user_modif) REFERENCES llx_user (rowid);
+-- No hard constraint on a link table as it breaks a lot of features
+--ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_creat FOREIGN KEY (fk_user_creat) REFERENCES llx_user (rowid);
+--ALTER TABLE llx_element_element ADD CONSTRAINT fk_element_element_fk_user_modif FOREIGN KEY (fk_user_modif) REFERENCES llx_user (rowid);

--- a/htdocs/install/mysql/tables/llx_element_element.sql
+++ b/htdocs/install/mysql/tables/llx_element_element.sql
@@ -27,5 +27,9 @@ create table llx_element_element
   sourcetype		varchar(64) NOT NULL,
   fk_target			integer NOT NULL,
   targettype		varchar(64) NOT NULL,
-  relationtype		varchar(64) DEFAULT NULL
+  relationtype		varchar(64) DEFAULT NULL,
+	fk_user_creat	  integer,							                                            -- User id making creation
+  date_creation	  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,                      -- Creation date
+	fk_user_modif	  integer,							                                            -- User id making last change
+	tms     		    timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP 	-- Last modification date
 ) ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_element_element.sql
+++ b/htdocs/install/mysql/tables/llx_element_element.sql
@@ -28,8 +28,8 @@ create table llx_element_element
   fk_target			integer NOT NULL,
   targettype		varchar(64) NOT NULL,
   relationtype		varchar(64) DEFAULT NULL,
-	fk_user_creat	  integer,							                                            -- User id making creation
-  date_creation	  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,                      -- Creation date
-	fk_user_modif	  integer,							                                            -- User id making last change
-	tms     		    timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP 	-- Last modification date
+  fk_user_creat	  	integer,							                                -- User id making creation
+  date_creation	  	datetime, 										                    -- Creation date
+  fk_user_modif	  	integer,							                                -- User id making last change
+  tms     		    timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP 	-- Last modification date
 ) ENGINE=innodb;


### PR DESCRIPTION
# Use case
If an external application synchronizes data from element_element for a period (by example data from the past year), it will be required to have access to creation/modification date of `llx_element_element` records, to avoid to synchronize all records each time. Synchronization could also be executed for a specific user only. This was not possible at this time, because `llx_element_element` did not have required columns.

# NEW add user & date creat/modif columns to `llx_element_element`
This requires to add new columns to `llx_element_element` table : 
- the user who create/update the element_element record (new columns : `fk_user_create` & `fk_user_modif`)
- the date of the creation/update of the element_element record (new columns : `date_creation` & `tms`)

This takes same column names as most of Dolibarr tables to manage creation and last modification information.

If this PR is accepted, another PR will be provided to patch parts of Dolibarr code adding/updating `llx_element_element` table.