### PR TITLE
FIX isValidTinForES() rejects almost every Spanish NIE starting with T

### DIFF
--- a/htdocs/core/lib/profid.lib.php
+++ b/htdocs/core/lib/profid.lib.php
@@ -227,7 +227,8 @@ function isValidTinForES($str)
 
 	//Check NIE T
 	if (preg_match('/^[T]{1}/', $str)) {
-		if ($num[8] == preg_match('/^[T]{1}[A-Z0-9]{8}$/', $str)) {
+		// A NIE starting with T has no control key to check, so the syntax check is enough.
+		if (preg_match('/^[T]{1}[A-Z0-9]{8}$/', $str)) {
 			return 3;
 		} else {
 			return -3;

--- a/test/phpunit/ProfidLibTest.php
+++ b/test/phpunit/ProfidLibTest.php
@@ -176,26 +176,30 @@ class ProfidLibTest extends CommonClassTest
 		$this->assertFalse(isValidTinForBE("ABCD.123.123"));		// not digits only
 	}
 
-	// TODO
 	/**
 	 * testIsValidTinForES
 	 *
 	 * @return void
 	 */
-	/*
 	public function testIsValidTinForES()
 	{
 		// Tests for NIF
-		$this->assertEquals(1, isValidTinForES(""));			// valid NIF
-		$this->assertEquals(-1, isValidTinForES(""));			// valid regex, but invalid control key
+		$this->assertEquals(1, isValidTinForES("12345678Z"));		// valid NIF
+		$this->assertEquals(-1, isValidTinForES("12345678A"));		// valid regex, but invalid control key
 		// Tests for CIF
-		$this->assertEquals(2, isValidTinForES(""));			// valid CIF
-		$this->assertEquals(-2, isValidTinForES(""));			// valid regex, but invalid control key
-		// Tests for NIE
-		$this->assertEquals(3, isValidTinForES(""));			// valid NIE
-		$this->assertEquals(-3, isValidTinForES(""));			// valid regex, but invalid control key
+		$this->assertEquals(2, isValidTinForES("A58818501"));		// valid CIF
+		$this->assertEquals(-2, isValidTinForES("A58818502"));		// valid regex, but invalid control key
+		// Tests for NIE starting with X, Y or Z (they have a control key)
+		$this->assertEquals(3, isValidTinForES("X1234567L"));		// valid NIE
+		$this->assertEquals(3, isValidTinForES(" x 1234567 l "));	// valid NIE, formatted with spaces and lowercase
+		$this->assertEquals(-3, isValidTinForES("X1234567A"));		// valid regex, but invalid control key
+		// Tests for NIE starting with T (they have no control key, so the syntax check is enough)
+		$this->assertEquals(3, isValidTinForES("T1234567A"));		// valid NIE
+		$this->assertEquals(3, isValidTinForES("T1234567Z"));		// valid NIE
+		$this->assertEquals(3, isValidTinForES("T12345671"));		// valid NIE
 		// Tests for unknown error
-		$this->assertEquals(-4, isValidTinForES(""));			// invalid regex for both NIF, CIF and NIE
+		$this->assertEquals(-4, isValidTinForES("I1234567A"));		// valid regex, but first letter is not a known NIF, CIF or NIE prefix
+		// Tests for bad syntax
+		$this->assertEquals(0, isValidTinForES("12345"));			// invalid regex for both NIF, CIF and NIE
 	}
-	*/
 }


### PR DESCRIPTION
The "Check NIE T" branch compared the control character of the TIN to the return value of `preg_match()` instead of using `preg_match()` as the condition:

```php
if ($num[8] == preg_match('/^[T]{1}[A-Z0-9]{8}$/', $str)) {
```

Execution only reaches that branch when the string already matched `/^[T]{1}/`, so `preg_match()` there always returns 1 and the test collapses to `$num[8] == 1`. A NIE of type T therefore validated only when its last character was literally `1`, and every other one was reported as `-3` (invalid control key) — 35 of the 36 possible final characters wrongly rejected.

A NIE starting with T has no control-key algorithm, so matching the documented syntax is the only check to perform.

Before / after, same inputs:

```
T1234567A   before: -3   after: 3
T1234567Z   before: -3   after: 3
T12345671   before:  3   after: 3
```

Also fills in and enables `testIsValidTinForES()` in `test/phpunit/ProfidLibTest.php`, which was committed commented-out with empty assertions. It now covers NIF, CIF and both NIE forms, valid and invalid control keys.

Prepared with AI assistance (Claude); verified by running the function before and after against known-valid Spanish TINs.
