### PR TITLE
fix: Update error message type in SMS sending process

### DIFF
--- a/htdocs/admin/sms.php
+++ b/htdocs/admin/sms.php
@@ -124,7 +124,7 @@ if ($action == 'send' && !$cancel) {
 			$smsfile = new CSMSFile($sendto, $smsfrom, $body, $deliveryreceipt, $deferred, $priority, $class); // This define OvhSms->login, pass, session and account
 		} catch (Exception $e) {
 			$error++;
-			setEventMessages($e->getMessage(), null, 'error');
+			setEventMessages($e->getMessage(), null, 'errors');
 		}
 		if (!$error) {
 			$result = $smsfile->sendfile(); // This send SMS


### PR DESCRIPTION
# FIX: Update error message type in SMS sending process

- Changed the error message type from 'error' to 'errors'

Discovered by #39383