### PR TITLE
FIX Missing include of ActionComm in doAutoRenewContracts

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -2753,6 +2753,7 @@ class Contrat extends CommonObject
 			$num = $this->db->num_rows($resql);
 
 			include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
+			include_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
 
 			$i = 0;
 			while ($i < $num) {


### PR DESCRIPTION
## Bug

`Contrat::doAutoRenewContracts()` instantiates `ActionComm` to log the `RENEW_CONTRACT` event, but `htdocs/contrat/class/contrat.class.php` never loads `comm/action/class/actioncomm.class.php`:

```
$ grep -c "actioncomm.class.php" htdocs/contrat/class/contrat.class.php
0
$ grep -n "new ActionComm" htdocs/contrat/class/contrat.class.php
2841:                            $actioncomm = new ActionComm($this->db);
```

From a web request the class is normally already loaded by some other include, so the bug stays hidden. **From the cron runner it is not.**

## Why it only breaks under cron

`scripts/cron/cron_run_jobs.php` loads only `master.inc.php`, `functionscli.lib.php`, `cronjob.class.php` and `user.class.php`. For a `jobtype=method` job, `cronjob.class.php` then loads only the job's own class via `dol_include_once($this->classesname)`. `ActionComm` is not in that include closure.

The three `require_once` of `actioncomm.class.php` in `core/lib/functions.lib.php` are all inside function bodies (`show_actions_messaging()` etc.), so they do not run on this path.

Reproduced on 23.0.3 by replaying the exact cron bootstrap:

```
DOL_VERSION      = 23.0.3
dol_include_once contrat = 1
class Contrat exists     = true
class ActionComm exists  = false     <-- "Class ActionComm not found"
```

## Impact

The fatal error occurs at line 2841, which is **after** the `UPDATE llx_contratdet SET date_fin_validite = ...` has been issued (line 2831) but **before** `$this->db->commit()` (line 2866). So:

- the open transaction is never committed and the renewal is silently lost;
- the scheduled job aborts, leaving every remaining contract line in the loop unprocessed;
- the only trace is a fatal error in the log — the contract simply never renews.

## Fix

One line, next to the include already present in the same method:

```php
include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
include_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
```

Kept method-local (matching the existing style in this file) rather than at file scope, so contract pages do not pay for the extra include.

After the patch, on the same cron bootstrap:

```
before: ActionComm = false
after : ActionComm = true
```

`php -l` clean. No GUI change. Present in 22.0, 23.0, 24.0 and develop (and back to at least 20.0); submitted against 22.0 so it propagates upward.
