### PR TITLE
FIX Missing bottom margin on dropdown action buttons in md theme

### DIFF
--- a/htdocs/theme/md/btn.inc.php
+++ b/htdocs/theme/md/btn.inc.php
@@ -81,7 +81,8 @@ div.tabsAction > div.divButAction > span.butActionDelete,
 div.tabsAction > div.divButAction > span.butActionRefused,
 div.tabsAction > div.divButAction > a.butAction,
 div.tabsAction > div.divButAction > a.butActionDelete,
-div.tabsAction > div.divButAction > a.butActionRefused {
+div.tabsAction > div.divButAction > a.butActionRefused,
+div.tabsAction > .dropdown > .dropdown-toggle {
 	margin-bottom: 1.4em !important;
 	margin-right: 0px !important;
 }


### PR DESCRIPTION
## Bug

In theme **md**, dropdown action buttons get no bottom margin, so when the action bar wraps onto several lines the rows touch each other.

`htdocs/theme/md/btn.inc.php` gives action buttons their spacing with:

```css
div.tabsAction > a.butAction, ... ,
div.tabsAction > div.divButAction > a.butActionRefused {
	margin-bottom: 1.4em !important;
	margin-right: 0px !important;
}
```

Every selector is either a direct child of `div.tabsAction` or a child of `div.divButAction`. But `dolGetButtonAction()` renders a dropdown button as:

```html
<div class="dropdown inline-block dropdown-holder">
	<a class="dropdown-toggle classfortooltip butAction" ...>
```

so the anchor is a **grandchild** of `div.tabsAction` and matches none of them. Computed `margin-bottom` is `0px` for dropdown buttons and `21.5px` (1.4em) for plain ones.

## Screenshots

Six dropdown buttons in a `div.tabsAction` wrapping onto two rows, rendered with the compiled md stylesheet.

Before — rows touch, the buttons merge into a solid block:

![before](https://raw.githubusercontent.com/f-hoedl/dolibarr/pr-assets/md-dropdown-before.png)

After:

![after](https://raw.githubusercontent.com/f-hoedl/dolibarr/pr-assets/md-dropdown-after.png)

Measured gap between the two rows: **0px before, 22px after**, which matches the 1.4em the plain buttons already get.

## Fix

Theme **eldy** already fixes exactly this, with exactly this selector, in `htdocs/theme/eldy/btn.inc.php`:

```css
div.tabsAction > .dropdown > .dropdown-toggle {
```

Theme md was never aligned with it. This PR adds the identical selector to md — one line.

Rows that mix plain and dropdown buttons are unaffected (same container height, same button positions before and after).

`php -l` clean.

Note: eldy received this fix in 23.0, so on 22.0 eldy is still affected too — I left that alone to keep this PR atomic and to avoid a conflict when 22.0 is merged up into 23.0, where the eldy rule already exists. md is missing it on **22.0, 23.0, 24.0 and develop**, so this propagates usefully all the way up.
