### PR TITLE
FIX Duplicate fk_user_modif assignment in SQL query

### DIFF
--- a/htdocs/compta/sociales/class/chargesociales.class.php
+++ b/htdocs/compta/sociales/class/chargesociales.class.php
@@ -418,7 +418,6 @@ class ChargeSociales extends CommonObject
 		if ($this->type > 0) {
 			$sql .= ", fk_type = ".((int) $this->type);
 		}
-		$sql .= ", fk_user_modif=".((int) $user->id);
 		$sql .= " WHERE rowid=".((int) $this->id);
 
 		dol_syslog(get_class($this)."::update", LOG_DEBUG);


### PR DESCRIPTION
Removed duplicate assignment of fk_user_modif in SQL update query.

# FIX

`ChargeSociales::update()` appends `fk_user_modif` to the UPDATE statement twice. Both assignments are unconditional and identical.

MySQL silently accepts this (last one wins), PostgreSQL rejects the whole query at rewrite time:
```
ERROR: 42601: multiple assignments to same column "fk_user_modif"
```

As a result, editing any social/fiscal contribution fails on PostgreSQL. Both code paths are affected, whether or not `$this->type > 0`.

Fix is trivial: drop the second occurrence.