### PR TITLE
FIX phone formatting dropping and duplicating digits for JO and PE

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4166,7 +4166,7 @@ function dol_print_phone($phone, $countrycode = '', $cid = 0, $socid = 0, $addli
 		}
 	} elseif (strtoupper($countrycode) == "JO") {//Jordanie
 		if (dol_strlen($phone) == 12) {//ex: +962_A_BCD_EF_GH
-			$newphone = substr($newphone, 0, 4).$separ.substr($newphone, 4, 1).$separ.substr($newphone, 5, 3).$separ.substr($newphone, 7, 2).$separ.substr($newphone, 9, 2);
+			$newphone = substr($newphone, 0, 4).$separ.substr($newphone, 4, 1).$separ.substr($newphone, 5, 3).$separ.substr($newphone, 8, 2).$separ.substr($newphone, 10, 2);
 		}
 	} elseif (strtoupper($countrycode) == "JM") {//Jamaïque
 		if (dol_strlen($newphone) == 12) {//ex: +1867_ABC_DEFG
@@ -4231,12 +4231,12 @@ function dol_print_phone($phone, $countrycode = '', $cid = 0, $socid = 0, $addli
 			$newphone = substr($newphone, 0, 3).$separ.substr($newphone, 3, 4);
 		} elseif (dol_strlen($phone) == 9) {// mobile add code and fix 9 chiffres +51_AAA_BBB_CCC
 			$newphonewa = '+51'.$newphone;
-			$newphone = substr($newphone, 0, 3).$separ.substr($newphone, 3, 3).$separ.substr($newphone, 6, 3).$separ.substr($newphone, 10, 3);
+			$newphone = substr($newphone, 0, 3).$separ.substr($newphone, 3, 3).$separ.substr($newphone, 6, 3);
 		} elseif (dol_strlen($phone) == 11) {// fix 11 chiffres +511_AAA_BBBB
-			$newphone = substr($newphone, 0, 4).$separ.substr($newphone, 4, 3).$separ.substr($newphone, 8, 4);
+			$newphone = substr($newphone, 0, 4).$separ.substr($newphone, 4, 3).$separ.substr($newphone, 7, 4);
 		} elseif (dol_strlen($phone) == 12) {// mobile +51_AAA_BBB_CCC
 			$newphonewa = $newphone;
-			$newphone = substr($newphone, 0, 3).$separ.substr($newphone, 3, 3).$separ.substr($newphone, 6, 3).$separ.substr($newphone, 10, 3).$separ.substr($newphone, 14, 3);
+			$newphone = substr($newphone, 0, 3).$separ.substr($newphone, 3, 3).$separ.substr($newphone, 6, 3).$separ.substr($newphone, 9, 3);
 		}
 	}
 

--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -1220,6 +1220,23 @@ class FunctionsLibTest extends CommonClassTest
 		$object->country_code = 'CA';
 		$phone = dol_print_phone('1234567890', $object->country_code, 0, 0, 0, ' ');
 		$this->assertEquals('<span style="margin-right: 10px;">(123) 456-7890</span>', $phone, 'Phone for CA 1');
+
+		// Every digit must appear exactly once, in order, whatever the country format
+		$object->country_code = 'JO';
+		$phone = dol_print_phone('+96212345678', $object->country_code, 0, 0, 0, ' ');
+		$this->assertEquals('<span style="margin-right: 10px;">+962 1 234 56 78</span>', $phone, 'Phone for JO 1');
+
+		$object->country_code = 'PE';
+		$phone = dol_print_phone('987654321', $object->country_code, 0, 0, 0, ' ');
+		$this->assertEquals('<span style="margin-right: 10px;">987 654 321</span>', $phone, 'Phone for PE 1');
+
+		$object->country_code = 'PE';
+		$phone = dol_print_phone('+5111234567', $object->country_code, 0, 0, 0, ' ');
+		$this->assertEquals('<span style="margin-right: 10px;">+511 123 4567</span>', $phone, 'Phone for PE 2');
+
+		$object->country_code = 'PE';
+		$phone = dol_print_phone('+51987654321', $object->country_code, 0, 0, 0, ' ');
+		$this->assertEquals('<span style="margin-right: 10px;">+51 987 654 321</span>', $phone, 'Phone for PE 3');
 	}
 
 


### PR DESCRIPTION
# FIX Phone numbers for Jordan and Peru are displayed with the wrong digits

`dol_print_phone()` formats a number by slicing it with a chain of `substr()` calls. In four branches the offsets do not line up with the preceding segment lengths, so a digit gets repeated and another falls off the end. The number shown to the user is not the number stored.

Actual output on 20.0, separator forced to a space for readability:

| Country | Input | Before | After |
|---|---|---|---|
| JO | `+96212345678` | `+962 1 234 45 67` | `+962 1 234 56 78` |
| PE | `987654321` | `987 654 321 ` (trailing separator) | `987 654 321` |
| PE | `+5111234567` | `+511 123 567` | `+511 123 4567` |
| PE | `+51987654321` | `+51 987 654 21 ` | `+51 987 654 321` |

For JO the third segment ends at 8 but the fourth starts at 7, so digit 7 is printed twice and digit 11 is never printed. For PE the 9 and 12 digit branches have a trailing `substr()` that reads past the end of the string, which yields an empty segment preceded by a separator, and the 11 digit branch starts its last segment at 8 instead of 7, dropping a digit.

## Fix

Adjusted the offsets so each segment starts where the previous one ended, and dropped the two out-of-range segments. Only these four lines change, the segment lengths and the documented layout comments are untouched.

I checked the whole function for the same class of error by walking every `substr()` chain and comparing each offset against the running position. These four were the only mismatches. Every other country is contiguous and consumes exactly `dol_strlen($phone)` characters.

## Tests

Extended `testDolPrintPhone` in `test/phpunit/FunctionsLibTest.php` with the four cases above. The existing FR and CA assertions are unchanged and still pass, and IN is unaffected.

Verified by calling `dol_print_phone()` directly against this branch: the four new assertions fail before the change and pass after, with FR, CA and IN identical either way.

Targeting 20.0 as the oldest maintained branch that carries the bug (present in 20.0 through develop).

## AI disclosure

Written with Claude (Claude Code). I verified the before and after output locally and reviewed the offset scan results across all countries in the function.