### PR TITLE
NEW element_element : manage impacts of add user & date creat/modif columns

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4411,16 +4411,26 @@ abstract class CommonObject
 		$this->db->begin();
 		$error = 0;
 
+		$now = dol_now();
+
 		$sql = "INSERT INTO " . $this->db->prefix() . "element_element (";
 		$sql .= "fk_source";
 		$sql .= ", sourcetype";
 		$sql .= ", fk_target";
 		$sql .= ", targettype";
+		$sql .= ", fk_user_creat";
+		$sql .= ", date_creation";
+		$sql .= ", fk_user_modif";
+		$sql .= ", tms";
 		$sql .= ") VALUES (";
 		$sql .= ((int) $origin_id);
 		$sql .= ", '" . $this->db->escape($origin) . "'";
 		$sql .= ", " . ((int) $this->id);
 		$sql .= ", '" . $this->db->escape($targettype) . "'";
+		$sql .= ", ".($f_user->id > 0 ? ((int) $f_user->id) : "NULL");
+		$sql .= ", '".$this->db->idate($now)."'";
+		$sql .= ", ".($f_user->id > 0 ? ((int) $f_user->id) : "NULL");
+		$sql .= ", '".$this->db->idate($now)."'";
 		$sql .= ")";
 
 		dol_syslog(get_class($this) . "::add_object_linked", LOG_DEBUG);
@@ -4473,8 +4483,25 @@ abstract class CommonObject
 							continue;
 						}
 
-						$sqladd = "INSERT INTO " . $this->db->prefix() . "element_element (fk_source, sourcetype, fk_target, targettype)";
-						$sqladd .= " VALUES (".((int) $origin_id).", '".$this->db->escape($origin)."', ".((int) $srcid).", '".$this->db->escape($targettype)."')";
+						$sqladd = "INSERT INTO " . $this->db->prefix() . "element_element (";
+						$sqladd .= "fk_source";
+						$sqladd .= ", sourcetype";
+						$sqladd .= ", fk_target";
+						$sqladd .= ", targettype";
+						$sqladd .= ", fk_user_creat";
+						$sqladd .= ", date_creation";
+						$sqladd .= ", fk_user_modif";
+						$sqladd .= ", tms";
+						$sqladd .= ") VALUES (";
+						$sqladd .= ((int) $origin_id);
+						$sqladd .= ", '".$this->db->escape($origin)."'";
+						$sqladd .= ", ".((int) $srcid);
+						$sqladd .= ", '".$this->db->escape($targettype)."'";
+						$sqladd .= ", ".($f_user->id > 0 ? ((int) $f_user->id) : "NULL");
+						$sqladd .= ", '".$this->db->idate($now)."'";
+						$sqladd .= ", ".($f_user->id > 0 ? ((int) $f_user->id) : "NULL");
+						$sqladd .= ", '".$this->db->idate($now)."'";
+						$sqladd .= ")";
 						$this->db->query($sqladd); // Best-effort: do not fail original link action
 					}
 				}
@@ -4753,6 +4780,8 @@ abstract class CommonObject
 		$error = 0;
 
 		$sql = "UPDATE " . $this->db->prefix() . "element_element SET ";
+		$sql .= " fk_user_modif = ".($f_user->id > 0 ? ((int) $f_user->id) : "NULL");
+		$sql .= " tms = '".$this->db->idate(dol_now())."'";
 		if ($updatesource) {
 			$sql .= "fk_source = " . ((int) $sourceid);
 			$sql .= ", sourcetype = '" . $this->db->escape($sourcetype) . "'";

--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -611,8 +611,26 @@ class DiscountAbsolute extends CommonObject
 
 					$rescheck = $this->db->query($sqlcheck);
 					if ($rescheck && $this->db->num_rows($rescheck) === 0) {
-						$sqladd = "INSERT INTO ".$this->db->prefix()."element_element (fk_source, sourcetype, fk_target, targettype)";
-						$sqladd .= " VALUES (".((int) $sourceinvoiceid).", '".$this->db->escape($sourcetype)."', ".((int) $rowidinvoice).", '".$this->db->escape($targettype)."')";
+						$now = dol_now();
+						$sqladd = "INSERT INTO ".$this->db->prefix()."element_element (";
+						$sqladd .= " fk_source";
+						$sqladd .= ", sourcetype";
+						$sqladd .= ", fk_target";
+						$sqladd .= ", targettype";
+						$sqladd .= ", fk_user_creat";
+						$sqladd .= ", date_creation";
+						$sqladd .= ", fk_user_modif";
+						$sqladd .= ", tms";
+						$sqladd .= ") VALUES (";
+						$sqladd .= ((int) $sourceinvoiceid);
+						$sqladd .= ", '".$this->db->escape($sourcetype)."'";
+						$sqladd .= ", ".((int) $rowidinvoice);
+						$sqladd .= ", '".$this->db->escape($targettype)."'";
+						$sqladd .= ", ".((int) $user->id);
+						$sqladd .= ", '".$this->db->idate($now)."'";
+						$sqladd .= ", ".((int) $user->id);
+						$sqladd .= ", '".$this->db->idate($now)."'";
+						$sqladd .= ")";
 						$this->db->query($sqladd); // Best-effort: do not fail discount link if object link can't be created.
 					}
 				}

--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -468,16 +468,26 @@ if (empty($reshook)) {
 					$objecttmp->note_public =  $langs->transnoentities("Orders");
 				}
 
+				$now = dol_now();
+
 				$sql = "INSERT INTO ".MAIN_DB_PREFIX."element_element (";
 				$sql .= "fk_source";
 				$sql .= ", sourcetype";
 				$sql .= ", fk_target";
 				$sql .= ", targettype";
+				$sql .= ", fk_user_creat";
+				$sql .= ", date_creation";
+				$sql .= ", fk_user_modif";
+				$sql .= ", tms";
 				$sql .= ") VALUES (";
 				$sql .= ((int) $id_order);
 				$sql .= ", '".$db->escape($objecttmp->origin)."'";
 				$sql .= ", ".((int) $objecttmp->id);
 				$sql .= ", '".$db->escape($objecttmp->element)."'";
+				$sql .= ", ".((int) $user->id);
+				$sql .= ", '".$db->idate($now)."'";
+				$sql .= ", ".((int) $user->id);
+				$sql .= ", '".$db->idate($now)."'";
 				$sql .= ")";
 
 				if (!$db->query($sql)) {


### PR DESCRIPTION
# NEW element_element : manage impacts of add user & date creat/modif columns
Following #39380 : ensure queries are managing user & date of creation / update when adding/updating a record into `llx_element_element`