### PR TITLE
fix: in MO split line broken on qty of component less than 1 

### DIFF
--- a/htdocs/mrp/js/lib_dispatch.js.php
+++ b/htdocs/mrp/js/lib_dispatch.js.php
@@ -77,9 +77,8 @@ if (empty($dolibarr_nocache)) {
  * @param	index	int		index of product line. 0 = first product line
  * @param	type	string	type of dispatch (batch = batch dispatch, dispatch = non batch dispatch)
  * @param	mode	string	If mode is 'qtymissing' the split button will create a new line with qty missing, If 'lessone' it will keep 1 in old line and the rest in new one
- * @param	allowoverconsumption	int		1 to allow over comsumption (for exemple in manufacturing order)
  */
-function addDispatchLine(index, type, mode, allowoverconsumption = 0)
+function addDispatchLine(index, type, mode)
 {
 	mode = mode || 'qtymissing'
 
@@ -134,7 +133,7 @@ function addDispatchLine(index, type, mode, allowoverconsumption = 0)
 			if(count === 0){
 				$("#"+inputId+"-"+index+"-"+nbrTrs).val(qtymax);
 			} else {
-				var res = addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qtymax, mode, $row, allowoverconsumption);
+				var res = addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qtymax, mode, $row);
 				if(res === -1){
 					error = 1;
 					break;
@@ -169,18 +168,17 @@ function addDispatchLine(index, type, mode, allowoverconsumption = 0)
  * @param qty           double
  * @param mode          string
  * @param $row          object
- * @param allowoverconsumption  int
  */
-function addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row, allowoverconsumption) {
+function addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row) {
 	if (qtyOrdered <= 0) {
 		let errormsg = '<?php echo dol_escape_js($langs->trans('QtyCantBeSplit')); ?>';
 		$.jnotify(errormsg, 'error', true);
 		return -1;
-	} else if ((qtyDispatched >= qtyOrdered) && allowoverconsumption==0) {
+	} else if (qtyDispatched >= qtyOrdered) {
 		let errormsg = '<?php echo dol_escape_js($langs->trans('NoRemainQtyToDispatch')); ?>';
 		$.jnotify(errormsg, 'error', true);
 		return -1;
-	} else if ((qtyDispatched < qtyOrdered)  || allowoverconsumption) {
+	} else if (qtyDispatched < qtyOrdered) {
 		//replace tr suffix nbr
 		var re1 = new RegExp('_'+index+'_1', 'g');
 		var re2 = new RegExp('-'+index+'-1', 'g');

--- a/htdocs/mrp/js/lib_dispatch.js.php
+++ b/htdocs/mrp/js/lib_dispatch.js.php
@@ -77,8 +77,9 @@ if (empty($dolibarr_nocache)) {
  * @param	index	int		index of product line. 0 = first product line
  * @param	type	string	type of dispatch (batch = batch dispatch, dispatch = non batch dispatch)
  * @param	mode	string	If mode is 'qtymissing' the split button will create a new line with qty missing, If 'lessone' it will keep 1 in old line and the rest in new one
+ * @param	allowoverconsumption	int		1 to allow over comsumption (for exemple in manufacturing order)
  */
-function addDispatchLine(index, type, mode)
+function addDispatchLine(index, type, mode, allowoverconsumption = 0)
 {
 	mode = mode || 'qtymissing'
 
@@ -133,7 +134,7 @@ function addDispatchLine(index, type, mode)
 			if(count === 0){
 				$("#"+inputId+"-"+index+"-"+nbrTrs).val(qtymax);
 			} else {
-				var res = addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qtymax, mode, $row);
+				var res = addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qtymax, mode, $row, allowoverconsumption);
 				if(res === -1){
 					error = 1;
 					break;
@@ -146,10 +147,10 @@ function addDispatchLine(index, type, mode)
 		}
 
 		if (error === 0) {
-			addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, '', mode, $row);
+			addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, '', mode, $row, allowoverconsumption);
 		}
 	} else {
-		addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row);
+		addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row, allowoverconsumption);
 	}
 
 }
@@ -168,17 +169,18 @@ function addDispatchLine(index, type, mode)
  * @param qty           double
  * @param mode          string
  * @param $row          object
+ * @param allowoverconsumption  int
  */
-function addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row) {
-	if (qtyOrdered <= 1) {
+function addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row, allowoverconsumption) {
+	if (qtyOrdered <= 0) {
 		let errormsg = '<?php echo dol_escape_js($langs->trans('QtyCantBeSplit')); ?>';
 		$.jnotify(errormsg, 'error', true);
 		return -1;
-	} else if (qtyDispatched >= qtyOrdered) {
+	} else if ((qtyDispatched >= qtyOrdered) && allowoverconsumption==0) {
 		let errormsg = '<?php echo dol_escape_js($langs->trans('NoRemainQtyToDispatch')); ?>';
 		$.jnotify(errormsg, 'error', true);
 		return -1;
-	} else if (qtyDispatched < qtyOrdered) {
+	} else if ((qtyDispatched < qtyOrdered)  || allowoverconsumption) {
 		//replace tr suffix nbr
 		var re1 = new RegExp('_'+index+'_1', 'g');
 		var re2 = new RegExp('-'+index+'-1', 'g');

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1540,13 +1540,13 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 						// Split
 						$type = 'batch';
 						print '<td align="right" class="split">';
-						print ' '.img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" onClick="addDispatchLine('.((int) $line->id).', \''.dol_escape_js($type).'\', \'qtymissingconsume\')"');
+						print ' '.img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" onClick="addDispatchLine('.((int) $line->id).', \''.dol_escape_js($type).'\', \'qtymissingconsume\', 1)"');
 						print '</td>';
 
 						// Split All
 						print '<td align="right" class="splitall">';
 						if (($action == 'consumeorproduce' || $action == 'consumeandproduceall') && $tmpproduct->status_batch == 2) {
-							print img_picto($langs->trans('SplitAllQuantity'), 'split', 'class="splitbutton splitallbutton field-error-icon" data-max-qty="1" onClick="addDispatchLine('.$line->id.', \'batch\', \'allmissingconsume\')"');
+							print img_picto($langs->trans('SplitAllQuantity'), 'split', 'class="splitbutton splitallbutton field-error-icon" data-max-qty="1" onClick="addDispatchLine('.$line->id.', \'batch\', \'allmissingconsume\', 1)"');
 						}
 						print '</td>';
 


### PR DESCRIPTION
In a BOM/MO if I have a component required with less than 1 qty, it's not possible to use the split line
<img width="1618" height="527" alt="image" src="https://github.com/user-attachments/assets/f4e298af-30b2-4440-864d-e75b9204bf0b" />

Because of `if (qtyOrdered <= 1) {` in function addDispatchTR 





