### PR TITLE
Fix: API auth fails in multicompany transverse mode when user has sev…

### DIFF
--- a/htdocs/api/class/api_access.class.php
+++ b/htdocs/api/class/api_access.class.php
@@ -136,7 +136,7 @@ class DolibarrApiAccess implements iAuthenticate
 
 			if (!getDolGlobalString('API_IN_TOKEN_TABLE')) {
 				if (isModEnabled('multicompany') && getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && defined("DOLENTITY")) {
-					$sql = "SELECT u.login, u.datec, u.api_key as use_api, u.api_key as api_key, 0 as token_rowid,";
+					$sql = "SELECT DISTINCT u.login, u.datec, u.api_key as use_api, u.api_key as api_key, 0 as token_rowid,";
 					$sql .= " u.tms as date_modification,";
 					$sql .= " gu.entity, gu.entity as token_entity";
 					$sql .= " FROM ".$this->db->prefix()."user as u";
@@ -150,7 +150,7 @@ class DolibarrApiAccess implements iAuthenticate
 				}
 			} else {
 				if (isModEnabled('multicompany') && getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && defined("DOLENTITY")) {
-					$sql = "SELECT u.login, u.datec, u.api_key as use_api, oat.tokenstring as api_key, oat.entity as token_entity, rowid as token_rowid,";
+					$sql = "SELECT DISTINCT u.login, u.datec, u.api_key as use_api, oat.tokenstring as api_key, oat.entity as token_entity, rowid as token_rowid,";
 					$sql .= " oat.tms as date_modification,";
 					$sql .= " gu.entity";
 					$sql .= " FROM ".$this->db->prefix()."oauth_token AS oat";


### PR DESCRIPTION
In checkAccess(), when multicompany is enabled with MULTICOMPANY_TRANSVERSE_MODE
  and DOLENTITY is set, the SQL query joins llx_usergroup_user to check the user
  belongs to a group in the requested entity. This join returns one row per group
  membership, so a user belonging to 2+ groups in the entity gets several
  identical rows and the "num_rows == 1" check rejects the authentication.

  Add SELECT DISTINCT to both transverse-mode queries (api_key and oauth_token
  with API_IN_TOKEN_TABLE). Since gu.entity is constrained to the requested
  entity, duplicate rows are strictly identical and collapse into one, while an
  API key matching two different users would still return 2 rows and be rejected
  as before.