### PR TITLE
fix: remove bug introcuded in previous PR 39407 merged yesterday (JS var allowoverconsumption not declared)

### DIFF
--- a/htdocs/mrp/js/lib_dispatch.js.php
+++ b/htdocs/mrp/js/lib_dispatch.js.php
@@ -146,10 +146,10 @@ function addDispatchLine(index, type, mode)
 		}
 
 		if (error === 0) {
-			addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, '', mode, $row, allowoverconsumption);
+			addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, '', mode, $row);
 		}
 	} else {
-		addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row, allowoverconsumption);
+		addDispatchTR(qtyOrdered, qtyDispatched, index, nbrTrs, warehouseId, inputId, type, qty, mode, $row);
 	}
 
 }


### PR DESCRIPTION
I've introduced a bug in #39407.

<img width="1868" height="108" alt="image" src="https://github.com/user-attachments/assets/64f88a7b-525f-4606-bcaa-4e16c733b69d" />
