### PR TITLE
Qual: Fix CI: Index type selected payment mode in form_modes_reglement

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -7409,9 +7409,9 @@ class Form
 			$out .= '<input type="submit" class="button smallpaddingimp valignmiddle" value="' . $langs->trans("Modify") . '">';
 			$out .= '</form>';
 		} else {
-			if ($selected) {
+			if ((int) $selected) {
 				$this->load_cache_types_paiements();
-				$out .= isset($this->cache_types_paiements[$selected]['label']) ? $this->cache_types_paiements[$selected]['label'] : '';
+				$out .= $this->cache_types_paiements[(int) $selected]['label'] ?? '&nbsp;';
 			} else {
 				$out .= "&nbsp;";
 			}


### PR DESCRIPTION
# Qual: Fix CI: Index type selected payment mode in form_modes_reglement

The selected payment mode is cast to an integer when accessing the cache_types_paiements array. The string type of '$selected' resulted in phan reporting that the nature of cache_types_paiements was different from the declared type.