### PR TITLE
Renaming a product's attached file fails when PRODUCT_USE_OLD_PATH_FO…

### DIFF
--- a/htdocs/core/actions_linkedfiles.inc.php
+++ b/htdocs/core/actions_linkedfiles.inc.php
@@ -268,24 +268,31 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes' && !empty($permissionto
 		}
 
 		if (empty($error) && $filenamefrom != $filenameto) {
+			// For backward compatibility, the file to rename may be stored into an old path (see PRODUCT_USE_OLD_PATH_FOR_PHOTO).
+			// Upload and delete actions already fall back on $upload_dirold, so the rename action must do the same.
+			$dirforfile = $upload_dir;
+			if (!empty($upload_dirold) && !dol_is_file($upload_dir.'/'.$filenamefrom) && dol_is_file($upload_dirold.'/'.$filenamefrom)) {
+				$dirforfile = $upload_dirold;
+			}
+
 			// Security:
 			// Disallow file with some extensions. We rename them.
 			// Because if we put the documents directory into a directory inside web root (very bad), this allows to execute on demand arbitrary code.
 			if (isAFileWithExecutableContent($filenameto) && !getDolGlobalString('MAIN_DOCUMENT_IS_OUTSIDE_WEBROOT_SO_NOEXE_NOT_REQUIRED')) {
-				// $upload_dir ends with a slash, so be must be sure the medias dir to compare to ends with slash too.
+				// $dirforfile ends with a slash, so be must be sure the medias dir to compare to ends with slash too.
 				$publicmediasdirwithslash = $conf->medias->multidir_output[$conf->entity];
 				if (!preg_match('/\/$/', $publicmediasdirwithslash)) {
 					$publicmediasdirwithslash .= '/';
 				}
 
-				if (strpos($upload_dir, $publicmediasdirwithslash) !== 0) {	// We never add .noexe on files into media directory
+				if (strpos($dirforfile, $publicmediasdirwithslash) !== 0) {	// We never add .noexe on files into media directory
 					$filenameto .= '.noexe';
 				}
 			}
 
 			if ($filenamefrom && $filenameto) {
-				$srcpath = $upload_dir.'/'.$filenamefrom;
-				$destpath = $upload_dir.'/'.$filenameto;
+				$srcpath = $dirforfile.'/'.$filenamefrom;
+				$destpath = $dirforfile.'/'.$filenameto;
 				/* disabled. Too many bugs. All files of an object must remain into directory of object. link with event should be done in llx_ecm_files with column agenda_id.
 				if ($modulepart == "ticket" && !dol_is_file($srcpath)) {
 					$srcbis = $conf->agenda->dir_output.'/'.GETPOST('section_dir').$filenamefrom;
@@ -296,7 +303,7 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes' && !empty($permissionto
 				}*/
 
 				$reshook = $hookmanager->initHooks(array('actionlinkedfiles'));
-				$parameters = array('filenamefrom' => $filenamefrom, 'filenameto' => $filenameto, 'upload_dir' => $upload_dir);
+				$parameters = array('filenamefrom' => $filenamefrom, 'filenameto' => $filenameto, 'upload_dir' => $dirforfile);
 				$reshook = $hookmanager->executeHooks('renameUploadedFile', $parameters, $object);
 
 				if (empty($reshook)) {

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -439,7 +439,8 @@ function completeFileArrayWithDatabaseInfo(&$filearray, $relativedir, $object = 
 	$filearrayindatabase = dol_dir_list_in_database(rtrim($relativedir, "/\\"), '', null, 'name', SORT_ASC, 0, '', $object);
 
 	global $modulepart;
-	if ($modulepart == 'produit' && getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
+	// Note: $modulepart is 'product' when set by product/document.php, but 'produit' in some other contexts, so we accept both.
+	if (in_array($modulepart, array('produit', 'product')) && getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
 		// TODO Remove this when PRODUCT_USE_OLD_PATH_FOR_PHOTO will be removed
 		global $object;
 		if (!empty($object->id)) {
@@ -452,7 +453,8 @@ function completeFileArrayWithDatabaseInfo(&$filearray, $relativedir, $object = 
 			$relativedirold = preg_replace('/^'.preg_quote(DOL_DATA_ROOT, '/').'/', '', $upload_dirold);
 			$relativedirold = ltrim($relativedirold, "/\\");
 
-			$filearrayindatabase = array_merge($filearrayindatabase, dol_dir_list_in_database($relativedirold, '', null, 'name', SORT_ASC));
+			// Note: $object must be provided so the entity filter matches the one used to forge $upload_dirold (multicompany)
+			$filearrayindatabase = array_merge($filearrayindatabase, dol_dir_list_in_database($relativedirold, '', null, 'name', SORT_ASC, 0, '', $object));
 		}
 	} elseif ($modulepart == 'ticket') {
 		foreach ($filearray as $key => $val) {


### PR DESCRIPTION
# FIX - Renaming a product's attached file fails when `PRODUCT_USE_OLD_PATH_FOR_PHOTO` is enabled

When that option is on, `product/document.php:100` builds the wrong directory. It calls `get_exdir(0, 0, 0, 1, $object, 'product')` expecting the `ref`-based path, but `get_exdir()` overrides `$level = 0` to `2` (`functions.lib.php:8799`) and returns only the legacy prefix. For product id `14332`:

- `$upload_dir` -> `produit/2/3` — empty, wrong
- `$upload_dirold` -> `produit/2/3/14332/photos` — where the files really are

That one bad value breaks two things:

1. **Rename fails.** Upload (`actions_linkedfiles.inc.php:109`) and delete (line 155) already fall back to `$upload_dirold`; the rename branch (lines 244-288) never got that fallback, so it looks for a file that isn't there.
2. **`DB_ERROR_RECORD_ALREADY_EXISTS` on `uk_ecm_files`, on every page load.** The branch meant to load the legacy DB rows is dead code: `files.lib.php:442` tests `$modulepart == 'produit'`, but `product/document.php:114` sets `'product'`. Every legacy file looks unindexed, so Dolibarr tries to insert a row that already exists. Harmless, but noisy.

**Fix:** accept both spellings at `files.lib.php:442`, and add the `$upload_dirold` fallback to the rename branch.