### PR TITLE
FIX #39423 Multicurrency rate lost (comes as 1) when creating Supplier Invoice from Supplier Order

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -951,7 +951,7 @@ if (empty($reshook)) {
 				$object->fk_incoterms       = GETPOSTINT('incoterm_id');
 				$object->location_incoterms	= GETPOST('location_incoterms', 'alpha');
 				$object->multicurrency_code	= GETPOST('multicurrency_code', 'alpha');
-				$object->multicurrency_tx   = GETPOSTINT('originmulticurrency_tx');
+				$object->multicurrency_tx   = GETPOSTFLOAT('originmulticurrency_tx');
 				$object->transport_mode_id	= GETPOSTINT('transport_mode_id');
 
 				// Proprietes particulieres a facture avoir
@@ -1054,7 +1054,7 @@ if (empty($reshook)) {
 				$object->fk_incoterms       = GETPOSTINT('incoterm_id');
 				$object->location_incoterms = GETPOST('location_incoterms', 'alpha');
 				$object->multicurrency_code = GETPOST('multicurrency_code', 'alpha');
-				$object->multicurrency_tx   = GETPOSTINT('originmulticurrency_tx');
+				$object->multicurrency_tx   = GETPOSTFLOAT('originmulticurrency_tx');
 
 				// Source facture
 				$object->fac_rec = $fac_recid;
@@ -1121,7 +1121,7 @@ if (empty($reshook)) {
 				$object->fk_incoterms		= GETPOSTINT('incoterm_id');
 				$object->location_incoterms	= GETPOST('location_incoterms', 'alpha');
 				$object->multicurrency_code	= GETPOST('multicurrency_code', 'alpha');
-				$object->multicurrency_tx	= GETPOSTINT('originmulticurrency_tx');
+				$object->multicurrency_tx	= GETPOSTFLOAT('originmulticurrency_tx');
 				$object->transport_mode_id	= GETPOSTINT('transport_mode_id');
 
 				// Auto calculation of date due if not filled by user


### PR DESCRIPTION
# FIX #39423 Multicurrency rate lost (comes as 1) when creating Supplier Invoice from Supplier Order

## Problem

When creating a Supplier Invoice from a Supplier Order (or other origin), the multicurrency exchange rate did not carry over correctly. It always came out as 1, even when the multi-currency setup was configured to keep the original rate from the source object.

## Root cause

In `htdocs/fourn/facture/card.php`, the origin multicurrency rate is read with:
```php
$object->multicurrency_tx = GETPOSTINT('originmulticurrency_tx');
```
`GETPOSTINT()` truncates the value to an integer, so any fractional exchange rate (e.g. 0.83, 1.27) collapses to 0 or 1. This occurs at 3 of the 4 places in this file where the origin rate is read (the 4th, in the credit-note/replacement-invoice path, was already fixed to use `GETPOSTFLOAT()`).

This was already fixed on `develop`/`23.0` (all 4 occurrences use `GETPOSTFLOAT()` there), but the fix for the other 3 occurrences was never backported to the `22.0` maintenance branch, so it's still present as of `22.0.4`. This PR targets `22.0` per the contributing guidelines (fix the oldest affected branch).

## Fix

Change the remaining 3 occurrences of `GETPOSTINT('originmulticurrency_tx')` to `GETPOSTFLOAT('originmulticurrency_tx')` in `htdocs/fourn/facture/card.php`, matching the pattern already used for the 4th occurrence and for `develop`/`23.0`.

## Testing

- `php -l` passes on the modified file.
- Manually verified that creating a Supplier Invoice from a Supplier Order with a fractional exchange rate (e.g. instance base currency GBP, order in USD) now correctly carries over the rate instead of forcing it to 1.

Fixes #39423