### PR TITLE
FIX #39428 Cache Reception and Productlot fetches in supplier order dispatch list

### DIFF
--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -1278,8 +1278,13 @@ if ($id > 0 || !empty($ref)) {
 				if (isModEnabled("reception")) {
 					print '<td class="nowraponall">';
 					if (!empty($objp->fk_reception)) {
-						$reception = new Reception($db);
-						$reception->fetch($objp->fk_reception);
+						if (empty($conf->cache['reception'][$objp->fk_reception])) {
+							$reception = new Reception($db);
+							$reception->fetch($objp->fk_reception);
+							$conf->cache['reception'][$objp->fk_reception] = $reception;
+						} else {
+							$reception = $conf->cache['reception'][$objp->fk_reception];
+						}
 						print $reception->getNomUrl(1);
 					}
 
@@ -1317,8 +1322,14 @@ if ($id > 0 || !empty($ref)) {
 				if (isModEnabled('productbatch')) {
 					if ($objp->batch) {
 						include_once DOL_DOCUMENT_ROOT.'/product/stock/class/productlot.class.php';
-						$lot = new Productlot($db);
-						$lot->fetch(0, $objp->pid, $objp->batch);
+						$lotcachekey = $objp->pid.'_'.$objp->batch;
+						if (empty($conf->cache['productlot'][$lotcachekey])) {
+							$lot = new Productlot($db);
+							$lot->fetch(0, $objp->pid, $objp->batch);
+							$conf->cache['productlot'][$lotcachekey] = $lot;
+						} else {
+							$lot = $conf->cache['productlot'][$lotcachekey];
+						}
 						print '<td class="dispatch_batch_number" data-col="batch"  data-batch="' . dolPrintHTMLForAttribute($objp->batch) . '" data-productid="' . $objp->fk_product . '" >'.$lot->getNomUrl(1).'</td>';
 						if (!getDolGlobalString('PRODUCT_DISABLE_SELLBY')) {
 							print '<td class="dispatch_dlc">'.dol_print_date($lot->sellby, 'day').'</td>';


### PR DESCRIPTION
# FIX #39428 Cache Reception and Productlot fetches in supplier order dispatch list

On the supplier order "already dispatched" list, each row rendered in the loop does its own full object fetch (and therefore its own SQL query) for the linked Reception and, when product batch/lot tracking is enabled, for the Productlot - even when many rows reference the exact same reception or the same product+batch combination. For a supplier order with many dispatch lines, this causes an N+1 query pattern that scales with the number of dispatch lines rather than with the number of distinct receptions/lots.

This adds per-request caching for Reception and Productlot objects, matching the existing caching pattern already used for Product a few lines above in the same loop. This reduces the number of queries from O(number of dispatch lines) to O(number of distinct receptions + distinct product/batch pairs).

Measured on a representative shape of 60 dispatch lines over 4 receptions and 6 product+batch pairs:

| | Fetches |
|---|---|
| Before | 120 |
| After | 10 |

The cost now follows the number of distinct objects instead of the number of rows, which is the point of the fix.

Fixes #39428