### PR TITLE
NEW: Add Generate button for SN/Lot on supplier order dispatch and MO production

### DIFF
--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1258,10 +1258,11 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 		$numFinal = $ref;
 	} elseif ($mode == 'next') {
 		//Begin Customisation: Accellier Ltd: If Increment in SN is required more than 1
-		if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
+		$snAdvancedIncrement = getDolGlobalString('SN_ADVANCED_INCREMENT');
+		if (empty($snAdvancedIncrement)) {
 			$counter++;
 		} else {
-			$counter += (int) getDolGlobalString('SN_ADVANCED_INCREMENT');
+			$counter += (int) $snAdvancedIncrement;
 		}
 		//End Customisation
 		$maskrefclient_counter = 0;

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1261,7 +1261,7 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 		if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
 			$counter++;
 		} else {
-			$counter = $counter + getDolGlobalString('SN_ADVANCED_INCREMENT');
+			$counter += (int) getDolGlobalString('SN_ADVANCED_INCREMENT');
 		}
 		//End Customisation
 		$maskrefclient_counter = 0;

--- a/htdocs/core/lib/functions2.lib.php
+++ b/htdocs/core/lib/functions2.lib.php
@@ -1257,7 +1257,13 @@ function get_next_value($db, $mask, $table, $field, $where = '', $objsoc = '', $
 
 		$numFinal = $ref;
 	} elseif ($mode == 'next') {
-		$counter++;
+		//Begin Customisation: Accellier Ltd: If Increment in SN is required more than 1
+		if (empty(getDolGlobalString('SN_ADVANCED_INCREMENT'))) {
+			$counter++;
+		} else {
+			$counter = $counter + getDolGlobalString('SN_ADVANCED_INCREMENT');
+		}
+		//End Customisation
 		$maskrefclient_counter = 0;
 
 		// If value for $counter has a length higher than $maskcounter chars

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -954,7 +954,13 @@ if ($id > 0 || !empty($ref)) {
 							print '</td>';
 
 							print '<td>';
-							print '<input type="text" class="inputlotnumber quatrevingtquinzepercent" id="lot_number'.$suffix.'" name="lot_number'.$suffix.'" value="'.GETPOST('lot_number'.$suffix).'">';
+							print '<input type="text" class="inputlotnumber quatrevingtquinzepercent" id="lot_number'.$suffix.'" name="lot_number'.$suffix.'" value="'.dol_escape_htmltag(GETPOST('lot_number'.$suffix)).'">';
+							// Generate button: clicking the barcode icon fetches the next serial/lot from the configured addon.
+							print ' <a href="#" class="generatedispatchbatch paddingleft"';
+							print ' data-suffix="'.dol_escape_htmltag($suffix).'"';
+							print ' data-fk-product="'.((int) $objp->fk_product).'"';
+							print ' data-status-batch="'.((int) $objp->tobatch).'"';
+							print ' title="'.dol_escape_htmltag($langs->trans('Generate')).'"><span class="fas fa-barcode"></span></a>';
 							print '</td>';
 							if (!getDolGlobalString('PRODUCT_DISABLE_SELLBY')) {
 								print '<td class="nowraponall">';
@@ -1190,6 +1196,120 @@ if ($id > 0 || !empty($ref)) {
 					id = id.split("reset_");
 					console.log("Reset trigger for id = qty_"+id[1]);
 					$("#qty_"+id[1]).val("");
+				});
+
+				// Generate button: fetch next serial/lot values from the configured addon.
+				// SN (tobatch=2): clones the row for each serial and forces qty=1.
+				// LOT (tobatch=1): fills the lot_number field directly.
+				// Row suffix "_X_Y": X=split index (0 for original), Y=line index — matches server regex /product_batch_(\\d+)_(\\d+)/.
+				$(document).on("click", ".generatedispatchbatch", function(e) {
+					e.preventDefault();
+					var $btn = $(this);
+					var suffix = $btn.data("suffix");          // e.g. "_0_3"
+					var fkProduct = $btn.data("fk-product");
+					var statusBatch = parseInt($btn.data("status-batch"), 10);
+					var qty = Math.max(1, parseInt($("#qty" + suffix).val(), 10) || 1);
+
+					$btn.css("opacity", "0.4").css("pointer-events", "none");
+
+					// Suffix format "_X_Y": X is split counter, Y is line index
+					var suffixParts = suffix.split("_");           // ["", "0", "3"]
+					var lineIdx = suffixParts[suffixParts.length - 1];   // "3"
+					var baseSplitIdx = parseInt(suffixParts[1], 10);     // 0
+
+					// Identify all lot_number inputs for this product line (original + split rows).
+					// Re-used below for: existing value collection, qty count, and filling results.
+					var $lotFields = $("input[name]").filter(function() {
+						return /^lot_number_\\d+_/.test(this.name) &&
+							this.name.split("_").pop() === lineIdx;
+					});
+
+					// Collect values already in the form so the endpoint can skip them.
+					// getNextValue() only sees the committed DB state; without this, generating
+					// twice in the same session returns the same lot number.
+					var existingLots = [];
+					$lotFields.each(function() {
+						if (this.value) existingLots.push(this.value);
+					});
+
+					$.getJSON("' . DOL_URL_ROOT . '/product/ajax/get_next_batch.php", {
+						fk_product: fkProduct,
+						// SN: one serial per unit.  LOT: one lot per split row.
+						qty: (statusBatch === 2) ? qty : Math.max(1, $lotFields.length),
+						existing_lots: existingLots.join(",")
+					}, function(data) {
+						if (data.error) {
+							alert(data.error);
+							$btn.css("opacity", "").css("pointer-events", "");
+							return;
+						}
+						var batches = data.batches;
+						var type = data.type;
+
+						if (type === "lot") {
+							// Each split row gets its own unique lot number.
+							$lotFields.each(function(i) {
+								$(this).val(batches[i] !== undefined ? batches[i] : batches[batches.length - 1]);
+							});
+						} else {
+							$("#lot_number" + suffix).val(batches[0]);
+							$("#qty" + suffix).val(1);
+
+							// Clone from $originalRow each iteration so the original suffix is always present in the source.
+							var $originalRow = $("tr[name=\\"batch" + suffix + "\\"]");
+							var $currentRow = $originalRow;
+							var warehouseVal = $("select[name=\\"entrepot" + suffix + "\\"]").val();
+
+							for (var n = 1; n < batches.length; n++) {
+								var newSplitIdx = baseSplitIdx + n;
+								var newSuffix = "_" + newSplitIdx + "_" + lineIdx;
+
+								var $newRow = $originalRow.clone(false);
+								$newRow.find("[name]").each(function() {
+									$(this).attr("name", $(this).attr("name").split(suffix).join(newSuffix));
+								});
+								$newRow.find("[id]").each(function() {
+									$(this).attr("id", $(this).attr("id").split(suffix).join(newSuffix));
+								});
+								$newRow.attr("name", "batch" + newSuffix);
+
+								$newRow.find("[name=\\"lot_number" + newSuffix + "\\"]").val(batches[n]);
+								$newRow.find(".qtydispatchinput").val(1);
+								$newRow.find("[name=\\"entrepot" + newSuffix + "\\"]").val(warehouseVal);
+
+								$newRow.find(".generatedispatchbatch").remove();
+								$newRow.find("[name=\\"lot_number" + newSuffix + "\\"]").after(
+									"<a href=\\"#\\" class=\\"removedispatchbatch paddingleft\\" title=\\"Remove\\"><span class=\\"fas fa-times\\"></span></a>"
+								);
+
+								$currentRow.after($newRow);
+								$currentRow = $newRow;
+							}
+						}
+						$btn.css("opacity", "").css("pointer-events", "");
+					}).fail(function() {
+						alert("Failed to fetch batch/serial numbers");
+						$btn.css("opacity", "").css("pointer-events", "");
+					});
+				});
+
+				// Zero the qty so the server skips this row; keep the hidden product_batch field for form discovery.
+				$(document).on("click", ".removedispatchbatch", function(e) {
+					e.preventDefault();
+					var $row = $(this).closest("tr");
+					$row.find(".qtydispatchinput").val(0);
+					$row.hide();
+				});
+
+				// The native resetline handler uses direct .click() binding and only attaches to rows
+				// that exist at page-load time. Cloned SN rows miss it, leaving the button without
+				// type="button" so it submits the form. This delegated handler fixes both cases.
+				$(document).on("click", ".resetline", function(e) {
+					e.preventDefault();
+					var parts = ($(this).attr("id") || "").split("reset_");
+					if (parts[1]) {
+						$("#qty_" + parts[1]).val("");
+					}
 				});
 			});
 		</script>';

--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -1218,7 +1218,7 @@ if ($id > 0 || !empty($ref)) {
 					var baseSplitIdx = parseInt(suffixParts[1], 10);     // 0
 
 					// Identify all lot_number inputs for this product line (original + split rows).
-					// Re-used below for: existing value collection, qty count, and filling results.
+					// Reused below for: existing value collection, qty count, and filling results.
 					var $lotFields = $("input[name]").filter(function() {
 						return /^lot_number_\\d+_/.test(this.name) &&
 							this.name.split("_").pop() === lineIdx;

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1973,6 +1973,14 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 							if ($tmpproduct->status_batch) {
 								$preselected = (GETPOSTISSET('batchtoproduce-'.$line->id.'-'.$i) ? GETPOST('batchtoproduce-'.$line->id.'-'.$i) : '');
 								print '<input type="text" class="width75" name="batchtoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'">';
+								// Show generate button on the first split row only
+								if ($i == 1) {
+									print ' <a href="#" class="generatemo paddingleft"';
+									print ' data-line-id="'.$line->id.'"';
+									print ' data-fk-product="'.$line->fk_product.'"';
+									print ' data-status-batch="'.$tmpproduct->status_batch.'"';
+									print ' title="'.dol_escape_htmltag($langs->trans('Generate')).'"><span class="fas fa-barcode"></span></a>';
+								}
 							}
 							print '</td>';
 							// Batch number in same column than the stock movement picto
@@ -2145,6 +2153,63 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 					});
 				});
 			}
+
+			// Generate button: fetch next serial/lot from the configured addon, fill batchtoproduce fields.
+			// SN (status_batch=2): triggers addDispatchLine to split rows, one serial per row.
+			// LOT (status_batch=1): fills the single batchtoproduce field directly.
+			$(document).on('click', '.generatemo', function(e) {
+				e.preventDefault();
+				var $btn = $(this);
+				var lineId = $btn.data('line-id');
+				var fkProduct = $btn.data('fk-product');
+				var statusBatch = parseInt($btn.data('status-batch'), 10);
+
+				// If rows were already split, count them; otherwise use the qty input.
+				var existingRows = $('tr[name^="batch_' + lineId + '_"]').length;
+				var qty;
+				if (existingRows > 1) {
+					qty = existingRows;
+				} else {
+					qty = Math.max(1, parseInt($('#qtytoproduce-' + lineId + '-1').val(), 10) || 1);
+				}
+
+				$btn.css('opacity', '0.4').css('pointer-events', 'none');
+
+				$.getJSON('<?php echo DOL_URL_ROOT ?>/product/ajax/get_next_batch.php', {
+					fk_product: fkProduct,
+					qty: (statusBatch === 2) ? qty : 1
+				}, function(data) {
+					if (data.error) {
+						alert(data.error);
+						$btn.css('opacity', '').css('pointer-events', '');
+						return;
+					}
+					var batches = data.batches;
+					var type = data.type;
+
+					if (type === 'lot') {
+						$('input[name="batchtoproduce-' + lineId + '-1"]').val(batches[0]);
+					} else {
+						if (existingRows <= 1 && qty > 1) {
+							// addDispatchLine creates one extra empty row — remove it after splitting.
+							addDispatchLine(lineId, 'batch', 'alltoproduce');
+							var $allRows = $('tr[name^="batch_' + lineId + '_"]');
+							var $lastRow = $allRows.last();
+							if ($lastRow.find('input[id^="qtytoproduce-' + lineId + '-"]').val() === '') {
+								$lastRow.remove();
+							}
+						}
+						for (var n = 0; n < batches.length; n++) {
+							$('input[name="batchtoproduce-' + lineId + '-' + (n + 1) + '"]').val(batches[n]);
+						}
+					}
+
+					$btn.css('opacity', '').css('pointer-events', '');
+				}).fail(function() {
+					alert('Failed to fetch batch/serial numbers');
+					$btn.css('opacity', '').css('pointer-events', '');
+				});
+			});
 
 		</script>
 

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -1973,14 +1973,12 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 							if ($tmpproduct->status_batch) {
 								$preselected = (GETPOSTISSET('batchtoproduce-'.$line->id.'-'.$i) ? GETPOST('batchtoproduce-'.$line->id.'-'.$i) : '');
 								print '<input type="text" class="width75" name="batchtoproduce-'.$line->id.'-'.$i.'" value="'.$preselected.'">';
-								// Show generate button on the first split row only
-								if ($i == 1) {
-									print ' <a href="#" class="generatemo paddingleft"';
-									print ' data-line-id="'.$line->id.'"';
-									print ' data-fk-product="'.$line->fk_product.'"';
-									print ' data-status-batch="'.$tmpproduct->status_batch.'"';
-									print ' title="'.dol_escape_htmltag($langs->trans('Generate')).'"><span class="fas fa-barcode"></span></a>';
-								}
+								// $i is always 1 in this scope (this row is never split); show the Generate button unconditionally.
+								print ' <a href="#" class="generatemo paddingleft"';
+								print ' data-line-id="'.$line->id.'"';
+								print ' data-fk-product="'.$line->fk_product.'"';
+								print ' data-status-batch="'.$tmpproduct->status_batch.'"';
+								print ' title="'.dol_escape_htmltag($langs->trans('Generate')).'"><span class="fas fa-barcode"></span></a>';
 							}
 							print '</td>';
 							// Batch number in same column than the stock movement picto

--- a/htdocs/product/ajax/get_next_batch.php
+++ b/htdocs/product/ajax/get_next_batch.php
@@ -106,14 +106,13 @@ if ($isAdvanced) {
  * Both lot addons use this table as their counter source, so any value found here
  * must be skipped to avoid issuing a duplicate lot/serial number.
  *
- * @param DoliDB $db
- * @param string $value
- * @return bool
+ * @param DoliDB $db     Database handler
+ * @param string $value  Batch/serial value to look up
+ * @return bool          True if the value already exists in llx_product_lot
  */
 function batchExistsInDb($db, $value)
 {
-	$sql = "SELECT rowid FROM ".$db->prefix()."product_lot"
-		." WHERE batch = '".$db->escape($value)."'";
+	$sql = "SELECT rowid FROM ".$db->prefix()."product_lot WHERE batch = '".$db->escape($value)."'";
 	$res = $db->query($sql);
 	return ($res && $db->fetch_object($res) !== null);
 }
@@ -165,13 +164,13 @@ if (empty($firstValue) || $firstValue <= 0) {
  * Advance $value past anything in $skipList or already in llx_product_lot.
  * Returns the first candidate that is both absent from the DB and not in $skipList.
  *
- * @param string   $value
- * @param bool     $isAdvanced
- * @param string   $mask
- * @param int      $step
- * @param string[] $skipList
- * @param DoliDB   $db
- * @return string
+ * @param string   $value       Starting value to advance from
+ * @param bool     $isAdvanced  True for mod_*_advanced addons
+ * @param string   $mask        Advanced mask string (ignored for standard addon)
+ * @param int      $step        Increment step
+ * @param string[] $skipList    Values to skip even if not yet in the database
+ * @param DoliDB   $db          Database handler
+ * @return string               First candidate value that is unique
  */
 function nextUniqueBatchValue($value, $isAdvanced, $mask, $step, $skipList, $db)
 {

--- a/htdocs/product/ajax/get_next_batch.php
+++ b/htdocs/product/ajax/get_next_batch.php
@@ -1,0 +1,216 @@
+<?php
+/* Copyright (C) 2024 Accellier Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
+/**
+ * \file    htdocs/product/ajax/get_next_batch.php
+ * \brief   AJAX endpoint: return N sequential serial/lot numbers for a product.
+ *
+ * GET parameters:
+ *   fk_product     (int)    Product ID
+ *   qty            (int)    Number of values to generate. For SN: one per unit. For LOT: one per split row.
+ *   existing_lots  (string) Comma-separated lot/serial values already in the current form
+ *                           (not yet committed). The endpoint skips these to avoid duplicates
+ *                           within the same session.
+ *
+ * JSON response:
+ *   { "batches": ["SN-0001", "SN-0002", ...], "type": "sn"|"lot" }
+ *   { "error": "message" }
+ */
+if (!defined('NOTOKENRENEWAL')) {
+	define('NOTOKENRENEWAL', 1);
+}
+if (!defined('NOREQUIREMENU')) {
+	define('NOREQUIREMENU', '1');
+}
+if (!defined('NOREQUIREHTML')) {
+	define('NOREQUIREHTML', '1');
+}
+require '../../main.inc.php';
+/**
+ * @var Conf        $conf
+ * @var DoliDB      $db
+ * @var Translate   $langs
+ * @var User        $user
+ */
+require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
+header('Content-Type: application/json');
+$fk_product = GETPOSTINT('fk_product');
+$qty        = max(1, GETPOSTINT('qty'));
+// Lot/serial values already displayed in the form that have not been submitted yet.
+// The endpoint must not return any of these to avoid duplicate lot numbers within
+// the same form session (getNextValue() reads MAX from the DB and cannot see
+// values that are only in the browser).
+$existing_raw  = GETPOST('existing_lots', 'alphanohtml');
+$existing_lots = ($existing_raw !== '') ? array_filter(array_map('trim', explode(',', $existing_raw))) : array();
+// Permission check
+if (!$user->hasRight('produit', 'lire') && !$user->hasRight('service', 'lire')) {
+	echo json_encode(array('error' => 'Access denied'));
+	exit;
+}
+if ($fk_product <= 0) {
+	echo json_encode(array('error' => 'Missing fk_product'));
+	exit;
+}
+if (!isModEnabled('productbatch')) {
+	echo json_encode(array('error' => 'Product batch module not enabled'));
+	exit;
+}
+$product = new Product($db);
+if ($product->fetch($fk_product) <= 0) {
+	echo json_encode(array('error' => 'Product not found'));
+	exit;
+}
+if (empty($product->status_batch)) {
+	echo json_encode(array('error' => 'Product does not use batch/serial tracking'));
+	exit;
+}
+$isSN = ($product->status_batch == 2);
+// Resolve addon name
+if ($isSN) {
+	$addonName = getDolGlobalString('PRODUCTBATCH_SN_ADDON');
+} else {
+	$addonName = getDolGlobalString('PRODUCTBATCH_LOT_ADDON');
+}
+$supportedAddons = array('mod_sn_advanced', 'mod_sn_standard', 'mod_lot_advanced', 'mod_lot_standard');
+if (!in_array($addonName, $supportedAddons)) {
+	echo json_encode(array('error' => 'Unsupported batch addon: '.$addonName));
+	exit;
+}
+dol_include_once('/core/modules/product_batch/'.$addonName.'.php');
+$addonMod = new $addonName($db);
+// Build a lightweight object so getNextValue() can look up the product-level mask
+$batchObj             = new stdClass();
+$batchObj->fk_product = $fk_product;
+// Determine mask and step (used by incrementBatchValue() and the sequence loop)
+$isAdvanced = in_array($addonName, array('mod_sn_advanced', 'mod_lot_advanced'));
+$step       = getDolGlobalString('SN_ADVANCED_INCREMENT') ? (int) getDolGlobalString('SN_ADVANCED_INCREMENT') : 1;
+$mask       = '';
+if ($isAdvanced) {
+	if ($isSN && getDolGlobalString('PRODUCTBATCH_SN_USE_PRODUCT_MASKS') && !empty($product->batch_mask)) {
+		$mask = $product->batch_mask;
+	} elseif (!$isSN && getDolGlobalString('PRODUCTBATCH_LOT_USE_PRODUCT_MASKS') && !empty($product->batch_mask)) {
+		$mask = $product->batch_mask;
+	} elseif ($isSN) {
+		$mask = getDolGlobalString('SN_ADVANCED_MASK');
+	} else {
+		$mask = getDolGlobalString('LOT_ADVANCED_MASK');
+	}
+}
+/**
+ * Return true if $value already exists in llx_product_lot.
+ * Both lot addons use this table as their counter source, so any value found here
+ * must be skipped to avoid issuing a duplicate lot/serial number.
+ *
+ * @param DoliDB $db
+ * @param string $value
+ * @return bool
+ */
+function batchExistsInDb($db, $value)
+{
+	$sql = "SELECT rowid FROM ".$db->prefix()."product_lot"
+		." WHERE batch = '".$db->escape($value)."'";
+	$res = $db->query($sql);
+	return ($res && $db->fetch_object($res) !== null);
+}
+/**
+ * Return the next batch/serial value after $current, using the same increment
+ * logic as the configured addon.
+ *
+ * @param string $current     Current value to increment from
+ * @param bool   $isAdvanced  True for mod_*_advanced addons
+ * @param string $mask        Advanced mask string (ignored for standard addon)
+ * @param int    $step        Increment step
+ * @return string             Next value, or $current if the counter cannot be parsed
+ */
+function incrementBatchValue($current, $isAdvanced, $mask, $step)
+{
+	if ($isAdvanced) {
+		if (preg_match('/\{(0+)([@\+][0-9\-\+\=]+)?([@\+][0-9\-\+\=]+)?\}/i', $mask, $reg)) {
+			$maskcounter       = $reg[1];
+			$maskNoBraces      = str_replace(array('{', '}'), '', $mask);
+			$maskcounter_start = strpos($maskNoBraces, $maskcounter);
+			$maskcounter_len   = strlen($maskcounter);
+			$batch_pre     = substr($current, 0, $maskcounter_start);
+			$batch_suf     = substr($current, $maskcounter_start + $maskcounter_len);
+			$batch_counter = substr($current, $maskcounter_start, $maskcounter_len);
+			if (!empty($batch_counter) && $batch_pre !== $current) {
+				return $batch_pre.sprintf("%0".$maskcounter_len."d", ((int) $batch_counter + $step)).$batch_suf;
+			}
+		}
+		return $current; // mask has no counter segment
+	} else {
+		// Standard addon: PREFIX-NNNN
+		$parts = explode('-', $current);
+		if (count($parts) >= 2) {
+			$num = (int) array_pop($parts) + 1;
+			return implode('-', $parts).'-'.($num < 9999 ? sprintf('%04d', $num) : (string) $num);
+		}
+		return $current;
+	}
+}
+// Call getNextValue() ONCE — it queries MAX(batch) from the DB.
+// Subsequent values (for SN sequences or duplicate-skipping) are computed arithmetically.
+$firstValue = $addonMod->getNextValue(null, $batchObj);
+if (empty($firstValue) || $firstValue <= 0) {
+	$langs->load('errors');
+	echo json_encode(array('error' => !empty($addonMod->error) ? $addonMod->error : 'Could not generate batch number'));
+	exit;
+}
+/**
+ * Advance $value past anything in $skipList or already in llx_product_lot.
+ * Returns the first candidate that is both absent from the DB and not in $skipList.
+ *
+ * @param string   $value
+ * @param bool     $isAdvanced
+ * @param string   $mask
+ * @param int      $step
+ * @param string[] $skipList
+ * @param DoliDB   $db
+ * @return string
+ */
+function nextUniqueBatchValue($value, $isAdvanced, $mask, $step, $skipList, $db)
+{
+	$maxAttempts = 500;
+	for ($i = 0; $i < $maxAttempts; $i++) {
+		if (!in_array($value, $skipList) && !batchExistsInDb($db, $value)) {
+			return $value;
+		}
+		$next = incrementBatchValue($value, $isAdvanced, $mask, $step);
+		if ($next === $value) {
+			break; // mask has no counter — cannot advance further
+		}
+		$value = $next;
+	}
+	return $value; // best effort if loop exhausted
+}
+// Advance the first value past anything already in the form or in the DB.
+$firstValue = nextUniqueBatchValue($firstValue, $isAdvanced, $mask, $step, $existing_lots, $db);
+$batches    = array($firstValue);
+$usedValues = array_merge($existing_lots, array($firstValue));
+// SN: one serial per unit.  LOT: one per split row (caller passes row count as qty).
+$countNeeded = $qty;
+if ($countNeeded > 1) {
+	$prevValue = $firstValue;
+	for ($n = 2; $n <= $countNeeded; $n++) {
+		$candidate = incrementBatchValue($prevValue, $isAdvanced, $mask, $step);
+		if ($candidate === $prevValue) {
+			// Mask has no counter — cannot generate distinct values
+			$batches[] = $prevValue;
+		} else {
+			// Skip past DB duplicates and values already in this batch
+			$candidate  = nextUniqueBatchValue($candidate, $isAdvanced, $mask, $step, $usedValues, $db);
+			$prevValue  = $candidate;
+			$batches[]  = $candidate;
+			$usedValues[] = $candidate;
+		}
+	}
+}
+echo json_encode(array(
+	'batches' => $batches,
+	'type'    => $isSN ? 'sn' : 'lot',
+));

--- a/htdocs/product/ajax/get_next_batch.php
+++ b/htdocs/product/ajax/get_next_batch.php
@@ -38,7 +38,7 @@ require '../../main.inc.php';
  * @var User        $user
  */
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
-header('Content-Type: application/json');
+top_httphead('application/json');
 $fk_product = GETPOSTINT('fk_product');
 $qty        = max(1, GETPOSTINT('qty'));
 // Lot/serial values already displayed in the form that have not been submitted yet.

--- a/htdocs/product/ajax/get_next_batch.php
+++ b/htdocs/product/ajax/get_next_batch.php
@@ -82,9 +82,11 @@ if (!in_array($addonName, $supportedAddons)) {
 	exit;
 }
 dol_include_once('/core/modules/product_batch/'.$addonName.'.php');
-$addonMod = new $addonName($db);
-// Build a lightweight object so getNextValue() can look up the product-level mask
-$batchObj             = new stdClass();
+$addonMod = new $addonName();
+// Use a real Productlot object (not a bare stdClass) so it matches the ?Productlot
+// phpdoc type declared by getNextValue() in mod_sn_advanced/mod_lot_advanced.
+require_once DOL_DOCUMENT_ROOT.'/product/stock/class/productlot.class.php';
+$batchObj             = new Productlot($db);
 $batchObj->fk_product = $fk_product;
 // Determine mask and step (used by incrementBatchValue() and the sequence loop)
 $isAdvanced = in_array($addonName, array('mod_sn_advanced', 'mod_lot_advanced'));
@@ -138,6 +140,7 @@ function incrementBatchValue($current, $isAdvanced, $mask, $step)
 			$batch_suf     = substr($current, $maskcounter_start + $maskcounter_len);
 			$batch_counter = substr($current, $maskcounter_start, $maskcounter_len);
 			if (!empty($batch_counter) && $batch_pre !== $current) {
+				// @phan-suppress-next-line PhanPluginPrintfVariableFormatString
 				return $batch_pre.sprintf("%0".$maskcounter_len."d", ((int) $batch_counter + $step)).$batch_suf;
 			}
 		}


### PR DESCRIPTION
## NEW: Add Generate button for SN/Lot on supplier order dispatch and MO production

Fixes #35197

### What
Adds an explicit "Generate" button next to the batch/serial number field(s) on:
- the supplier order reception/dispatch page (`fourn/commande/dispatch.php`)
- the MO production page (`mrp/mo_production.php`)

Clicking the button calls a new AJAX endpoint, `product/ajax/get_next_batch.php`, which resolves the product's configured SN/Lot addon (`mod_sn_advanced`, `mod_sn_standard`, `mod_lot_advanced`, `mod_lot_standard`), calls its `getNextValue()` once, and derives any additional sequential values arithmetically (skipping values already in the database or already present, uncommitted, in the calling form). For serial numbers this splits the row into one row per unit; for lots it fills the single lot field.

Nothing is filled in automatically — the value(s) are only generated when the user clicks the button.

Also included, since both lot addons' `getNextValue()` call it in the same code path:
- `core/lib/functions2.lib.php`: `get_next_value()`'s `next` mode now honors an optional `SN_ADVANCED_INCREMENT` global to increment the counter by more than 1 per generated value, falling back to the existing `+1` behavior when unset.
- `fourn/commande/dispatch.php`: also escapes the existing `lot_number` value with `dol_escape_htmltag()` when echoed back into the input.

### Why
Generating unique serial/lot numbers by hand is tedious and error-prone for suppliers/warehouses receiving or producing in bulk. This adds an opt-in, explicit-action way to auto-populate them from the configured numbering addon.

### Relation to #35198
This supersedes #35198, which addresses the same request (#35197) with a different approach: silently auto-filling the batch field server-side when left blank at submission. This PR instead uses an explicit "Generate" button so nothing is filled without a deliberate user action, and targets `develop` rather than the outdated `20.0` branch.

### Test plan
- Configure a product with `mod_sn_advanced` or `mod_sn_standard` and batch/serial tracking enabled.
- On a supplier order reception, click "Generate" next to a lot/serial field and confirm it (or the split rows, for SN) populate with the next unique value(s).
- Repeat on an MO's production page.
- Confirm generated values do not collide with existing rows in `llx_product_lot` or with other rows already present in the form.