### PR TITLE
NEW: Add includetimespent parameter to tasks API index endpoint

### DIFF
--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -114,11 +114,12 @@ class Tasks extends DolibarrApi
 	 * @param	string			$sqlfilters			Other criteria to filter answers separated by a comma. Syntax example "(t.ref:like:'SO-%') and (t.date_creation:>:'20160101')"
 	 * @param	string			$properties			Restrict the data returned to these properties. Ignored if empty. Comma separated list of properties names
 	 * @param	bool			$pagination_data	If this parameter is set to true the response will include pagination data. Default value is false. Page starts from 0
+	 * @param	int				$includetimespent	0=Return only task. 1=Include a summary of time spent, 2=Include details of time spent lines
 	 * @return	array								Array of project objects
 	 * @phan-return Task[]
 	 * @phpstan-return Task[]
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $sqlfilters = '', $properties = '', $pagination_data = false)
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $sqlfilters = '', $properties = '', $pagination_data = false, $includetimespent = 0)
 	{
 		global $db, $conf;
 
@@ -186,6 +187,12 @@ class Tasks extends DolibarrApi
 				$obj = $this->db->fetch_object($result);
 				$task_static = new Task($this->db);
 				if ($task_static->fetch($obj->rowid)) {
+					if ($includetimespent == 1) {
+						$task_static->getSummaryOfTimeSpent(0);
+					}
+					if ($includetimespent == 2) {
+						$task_static->fetchTimeSpentOnTask();
+					}
 					$obj_ret[] = $this->_filterObjectProperties($this->_cleanObjectDatas($task_static), $properties);
 				}
 				$i++;


### PR DESCRIPTION
# NEW Add includetimespent parameter to the tasks API list endpoint

`GET /tasks` (`TaskApi::index()`) has no way to return time spent, while `GET /tasks/{id}` (`TaskApi::get()`) has had an `includetimespent` parameter for a long time. A client that needs the time spent of several tasks therefore has to issue one extra call per task.

This adds the same parameter to the list endpoint, implemented exactly as in `get()`:

- `includetimespent=1` calls `Task::getSummaryOfTimeSpent(0)`, which fills `timespent_min_date`, `timespent_max_date`, `timespent_total_duration`, `timespent_total_amount`, `timespent_nblines` and `timespent_nblinesnull`;
- `includetimespent=2` calls `Task::fetchTimeSpentOnTask()`, which fills `lines`.

Both are already preserved by `_cleanObjectDatas()` of this API class, so nothing else is needed.

The parameter is appended at the end of the signature and defaults to `0`, so existing callers are unaffected and no extra query is run unless the parameter is used.

## Credit

This takes over #30744 by @kadogo, which proposed the same feature in 2024 and stalled on a CI indentation issue.

## Tests

Checked on a local install (modules Projects + API REST enabled) with one task carrying two time spent entries (7200 s and 3600 s at 50/h):

| Request | Result |
| --- | --- |
| `GET /tasks` | `timespent_*` all `null`, `lines` `null` (unchanged behaviour) |
| `GET /tasks?includetimespent=1` | `timespent_total_duration=10800`, `timespent_nblines=2`, `timespent_nblinesnull=0`, `timespent_total_amount=150`, `timespent_min_date=1786093200`, `timespent_max_date=1786197600` |
| `GET /tasks?includetimespent=2` | `lines` contains the 2 time spent lines |
| `GET /tasks/1?includetimespent=1` | same summary values as the list call above |

So the list endpoint now returns exactly what the single object endpoint returns.
