### PR TITLE
FIX: REST API POST /tasks/{id}/addtimespent always returns 500

### DIFF
--- a/htdocs/projet/class/api_tasks.class.php
+++ b/htdocs/projet/class/api_tasks.class.php
@@ -651,7 +651,7 @@ class Tasks extends DolibarrApi
 	 * @since	5.0.0	Initial implementation
 	 *
 	 * @param   int         	$id                 Task ID
-	 * @param   datetime|string	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
+	 * @param   datetime    	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
 	 * @phan-param string $date
 	 * @param   int         	$duration           Duration in seconds (3600 = 1h)
 	 * @param   int         	$product_id         The product id that is used, default is null


### PR DESCRIPTION
# FIX REST API `POST /tasks/{id}/addtimespent` always returns 500

## Problem

On 24.0 and develop, every call to `POST /api/index.php/tasks/{id}/addtimespent` fails with an empty **HTTP 500**, so registering time spent through the REST API is impossible.

The Apache log shows:

```
PHP Fatal error:  Uncaught TypeError: Illegal offset type in isset or empty
  in /includes/restler/framework/Luracast/Restler/Data/Validator.php:427
Stack trace:
#0 .../Restler.php(1038): Luracast\Restler\Data\Validator::validate('2026-08-09 10:0...', Object(ValidationInfo))
#1 .../Restler.php(306): Luracast\Restler\Restler->validate()
#2 /api/index.php(466): Luracast\Restler\Restler->handle()
```

## Cause

The docblock of `addTimeSpent()` declares a union type:

```php
 * @param   datetime|string	$date               Date (YYYY-MM-DD HH:MI:SS in GMT)
```

Restler turns that into an **array** of types. `Validator::validate()` does, at line 427:

```php
if (isset(static::$preFilters[$info->type]) && ...)
```

which uses that array as an array offset — hence `Illegal offset type`. Restler *does* know how to handle several types, but that branch is at line 454, i.e. **after** the crash point, so it is never reached.

With a single `datetime` type there is no problem: `Validator` has a dedicated `datetime()` method (`Validator.php:302`) that is picked up by the `method_exists()` check and validates the value properly.

This is a regression of the 24.0 cycle: 20.0 → 23.0 all declare `@param datetime $date` and work. `putTimeSpent()` in the same file still declares the single `datetime` and is unaffected.

## Fix

Restore the single type on that one line (the `@phan-param string $date` just below is left untouched, so static analysis is unaffected).

## Tests

Local install of this branch, modules Projects + API REST enabled:

| Call | Before | After |
| --- | --- | --- |
| `POST /tasks/1/addtimespent` `{"date":"2026-08-09 10:00:00","duration":7200,"user_id":1}` | **500**, `Illegal offset type` in the log, nothing written | **200**, one row added in `llx_element_time` |
| `GET /tasks/1?includetimespent=1` | `timespent_total_duration` unchanged | `timespent_total_duration=7200`, `timespent_nblines=1` |
| `POST /tasks/1/addtimespent` with `"date":"not-a-date"` | 500 | **400**, nothing written (date validation works again) |
