### PR TITLE
Qual: Remove unused use statement in api_users.class.php that breaks phan CI

### DIFF
--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -22,7 +22,6 @@
  */
 
 use Luracast\Restler\RestException;
-use PhpParser\Node\Name;
 
 require_once DOL_DOCUMENT_ROOT.'/user/class/user.class.php';
 require_once DOL_DOCUMENT_ROOT.'/user/class/usergroup.class.php';


### PR DESCRIPTION
# Qual Remove an unused `use` statement that makes the phan CI fail on 24.0

`htdocs/user/class/api_users.class.php` imports `PhpParser\Node\Name`, which is never used in the file (the only occurrence is the `use` line itself). It was added by mistake in 12687f83705c ("Fix CVE-2026-71510 …"), next to the intended change.

Since then the `phan` job fails on the 24.0 branch:

```
htdocs/user/class/api_users.class.php:25
api_users.class.php: PhanUnreferencedUseNormal: Possibly zero references to use statement
for classlike/namespace Name (\PhpParser\Node\Name)
```

It is reproducible on the branch itself (not only on pull requests), for example in run 31288384659, and it makes every pull request opened against 24.0 show a red `phan` check.

This removes that single line. `use Luracast\Restler\RestException;` right above is of course kept (it is used throughout the file).

The line only exists on 24.0 — 21.0, 22.0, 23.0 and develop do not have it.
