### PR TITLE
FIX: Remove always-true error checks in mysql dump export (24.0)

### DIFF
--- a/htdocs/admin/tools/export.php
+++ b/htdocs/admin/tools/export.php
@@ -143,17 +143,15 @@ if ($what == 'mysql') {
 		}
 	}
 
-	if (!$errormsg && $cmddump) {
+	if ($cmddump) {
 		dolibarr_set_const($db, 'SYSTEMTOOLS_MYSQLDUMP', $cmddump, 'chaine', 0, '', 0);
 	}
 
-	if (!$errormsg) {
-		$result = $utils->dumpDatabase(GETPOST('compression', 'alpha'), $what, 0, $file, 0, 0, $lowmemorydump);
+	$result = $utils->dumpDatabase(GETPOST('compression', 'alpha'), $what, 0, $file, 0, 0, $lowmemorydump);
 
-		$errormsg = $utils->error;
-		$_SESSION["commandbackuplastdone"] = $utils->result['commandbackuplastdone'];
-		$_SESSION["commandbackuptorun"] = $utils->result['commandbackuptorun'];
-	}
+	$errormsg = $utils->error;
+	$_SESSION["commandbackuplastdone"] = $utils->result['commandbackuplastdone'];
+	$_SESSION["commandbackuptorun"] = $utils->result['commandbackuptorun'];
 }
 
 // MYSQL NO BIN


### PR DESCRIPTION
# FIX Remove always-true error checks in mysql dump export (24.0)

This is the same change as #39339, which was merged into develop on 2026-07-31, applied to 24.0.

## Why it is needed on 24.0

`$errormsg` is initialised to `''` at the top of the file and nothing sets it in the `mysql` branch before these two conditions, so both are always true. PHPStan reports it on the 24.0 branch:

```
htdocs/admin/tools/export.php:146  Negated boolean expression is always true.
htdocs/admin/tools/export.php:150  Negated boolean expression is always true.
```

The `phpstan` job is therefore red on 24.0 itself (for example run 31288384659), and since merges go from 24.0 up to develop, the fix already merged in develop will never come down to 24.0 on its own.

The check that used to set `$errormsg` here (`dolibarr_main_restrict_os_commands` / `CommandIsNotInsideAllowedCommands`, still present in 23.0) is now done inside `Utils::dumpDatabase()` (`htdocs/core/class/utils.class.php`), so the restriction on allowed commands is still enforced — only the leftover checks are removed. The result is byte for byte identical to what develop has today.

## Note

The same hunk was briefly present on 24.0 and was reverted by #39386 ("Revert /imports/index.php wrongly shows access refused (#39379)"), which reverted about 40 files at once (including `.agents/skills/*`, `SECURITY.md`, `install/mysql/migration/24.0.0-25.0.0.sql` and `version.inc.php`). It looks like this hunk was collateral damage of that bulk revert rather than an intentional revert of #39339 — but please tell me if the old form is wanted on 24.0 and I will close this.
