### PR TITLE
NEW: add EXPENSEREPORT_DISABLE_ALL_MAILS constant to disable expense report notification emails

### DIFF
--- a/htdocs/admin/expensereport.php
+++ b/htdocs/admin/expensereport.php
@@ -177,7 +177,10 @@ if ($action == 'updateMask') {
 	$linesblocked = GETPOSTINT('EXPENSEREPORT_BLOCK_LINE_CREATION_IF_NOT_BETWEEN_DATES');
 	$res6 = dolibarr_set_const($db, 'EXPENSEREPORT_BLOCK_LINE_CREATION_IF_NOT_BETWEEN_DATES', intval($linesblocked), 'chaine', 0, '', $conf->entity);
 
-	if (!($res1 > 0) || !($res2 > 0) || !($res3 >= 0) || !($res4 > 0) || !($res5 > 0) || !($res6 > 0)) {
+	$disablemails = GETPOSTINT('EXPENSEREPORT_DISABLE_ALL_MAILS');
+	$res7 = dolibarr_set_const($db, 'EXPENSEREPORT_DISABLE_ALL_MAILS', intval($disablemails), 'chaine', 0, '', $conf->entity);
+
+	if (!($res1 > 0) || !($res2 > 0) || !($res3 >= 0) || !($res4 > 0) || !($res5 > 0) || !($res6 > 0) || !($res7 > 0)) {
 		$error++;
 	}
 
@@ -522,6 +525,12 @@ print '<tr class="oddeven"><td>';
 print $langs->trans('BlockExpenseReportLineCreationIfNotBetweenDates');
 print '</td><td class="right">';
 print $form->selectyesno('EXPENSEREPORT_BLOCK_LINE_CREATION_IF_NOT_BETWEEN_DATES', getDolGlobalString('EXPENSEREPORT_BLOCK_LINE_CREATION_IF_NOT_BETWEEN_DATES') ? 1 : 0, 1);
+print '</td></tr>';
+
+print '<tr class="oddeven"><td>';
+print $form->textwithpicto($langs->trans('ExpenseReportDisableAllMails'), $langs->trans('ExpenseReportDisableAllMailsHelp'));
+print '</td><td class="right">';
+print $form->selectyesno('EXPENSEREPORT_DISABLE_ALL_MAILS', getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS') ? 1 : 0, 1);
 print '</td></tr>';
 
 print '</table>';

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -427,7 +427,7 @@ if (empty($reshook)) {
 			$error++;
 		}
 
-		if (!$error && $result > 0 && $object->fk_user_validator > 0) {
+		if (!$error && $result > 0 && $object->fk_user_validator > 0 && !getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS')) {
 			$langs->load("mails");
 
 			// TO
@@ -544,6 +544,12 @@ if (empty($reshook)) {
 		}
 
 		if ($result > 0) {
+			if (getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS')) {
+				setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+				exit;
+			}
+
 			// Send mail
 
 			// TO
@@ -658,6 +664,12 @@ if (empty($reshook)) {
 		}
 
 		if ($result > 0) {
+			if (getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS')) {
+				setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+				exit;
+			}
+
 			// Send mail
 
 			// TO
@@ -776,6 +788,12 @@ if (empty($reshook)) {
 		}
 
 		if ($result > 0) {
+			if (getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS')) {
+				setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+				header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+				exit;
+			}
+
 			// Send mail
 
 			// TO
@@ -894,6 +912,12 @@ if (empty($reshook)) {
 				}
 
 				if ($result > 0) {
+					if (getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS')) {
+						setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
+						header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
+						exit;
+					}
+
 					// Send mail
 
 					// TO
@@ -1088,7 +1112,7 @@ if (empty($reshook)) {
 		if ($result > 0) {
 			// TODO We must never send an email without a setup or confirm option to choose if email is
 			// sent or not. So we add a hidden constant to avoid this for the moment.
-			if (getDolGlobalString('EXPENSEREPORT_SEND_EMAIL_ON_STATUS_PAID')) {
+			if (getDolGlobalString('EXPENSEREPORT_SEND_EMAIL_ON_STATUS_PAID') && !getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS')) {
 				// Send mail
 
 				// TO

--- a/htdocs/langs/en_US/trips.lang
+++ b/htdocs/langs/en_US/trips.lang
@@ -159,3 +159,5 @@ TF_TRIP=Transportation
 FailedToSetPaid=Failed to set as paid
 FailedToSetToCancel=Failed to cancel
 NobodyHasPermissionToValidateExpenseReport=Nobody has permission to validate expensereport
+ExpenseReportDisableAllMails=Disable all automatic emails related to expense reports
+ExpenseReportDisableAllMailsHelp=If enabled, no email will be sent automatically on expense report status changes (submission, approval, refusal, cancellation, payment).


### PR DESCRIPTION
# FIX #39082 No option to disable the "expense report approved" notification email sent to the report's author

Expense report status-change emails (submission, resubmission after refusal, approval, refusal, cancellation, and optionally payment) are currently hardcoded in `expensereport/card.php` with no way to disable them. There is already a precedent for this kind of opt-in constant on this exact file (`EXPENSEREPORT_SEND_EMAIL_ON_STATUS_PAID`), including a `// TODO We must never send an email without a setup or confirm option` comment acknowledging the gap — but even that one is hidden, with no UI to toggle it.

This PR adds a new global constant, `EXPENSEREPORT_DISABLE_ALL_MAILS`, exposed as a Yes/No option on the Expense Report module setup page (`admin/expensereport.php`). When enabled, no email is sent automatically on any expense report status change. Default behavior is unchanged (option unset by default), so this is fully backward-compatible.

## Implementation notes

Four of the affected code blocks (approve, refuse, cancel, resubmission after refusal) tie the "status change succeeded" event message directly to the same condition used to trigger the mail send (`if ($result > 0) { // send mail ... } else { setEventMessages("FailedToSetTo...") }`). Simply adding the new constant check to that outer condition would incorrectly show a "Failed" message on a successful status change whenever mails are disabled. To avoid this, the constant check is placed as an early bypass inside the existing `if ($result > 0)` block, so the original success/failure branching for the status change itself is left untouched:

```php
if ($result > 0) {
    if (getDolGlobalString('EXPENSEREPORT_DISABLE_ALL_MAILS')) {
        setEventMessages($langs->trans("RecordSaved"), null, 'mesgs');
        header("Location: ".$_SERVER["PHP_SELF"]."?id=".$id);
        exit;
    }

    // Send mail
    ...
} else {
    setEventMessages($langs->trans("FailedtoSetToApprove"), null, 'warnings');
}
```

The submission block and the payment block already separate status-change success from mail-sending success, so only the mail-triggering condition needed the extra check there.

## Files changed

- `htdocs/expensereport/card.php`: constant check on the 6 mail-sending blocks
- `htdocs/admin/expensereport.php`: new Yes/No setup option
- `htdocs/langs/en_US/trips.lang`: new language keys (`ExpenseReportDisableAllMails`, `ExpenseReportDisableAllMailsHelp`)

## Testing

Manually tested on a local instance:
- With the new option set to **No** (default): submitted, approved, refused, canceled, and resubmitted an expense report. All emails sent as before, no change in behavior.
- With the option set to **Yes**: repeated the same five actions. Status changes succeed with a normal success message each time, and no email is sent in any case.

## Screenshot
<img width="1356" height="603" alt="image" src="https://github.com/user-attachments/assets/219ed967-2054-4f58-ae81-73902b1a35b9" />
