### PR TITLE
FIX|Fix mandatory field validation broken for select and textarea fields

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -12055,7 +12055,7 @@ function printCommonFooter($zone = 'private')
 
 										if (tmptypefield == 'textarea') {
 											// We must instead check the content of ckeditor
-											var tmpeditor = CKEDITOR.instances['".dol_escape_js($paramkey)."'];
+											var tmpeditor = (typeof CKEDITOR !== 'undefined') ? CKEDITOR.instances['".dol_escape_js($paramkey)."'] : null;
 										    if (tmpeditor) {
         										tmpvalue = tmpeditor.getData();
 												console.log('For textarea tmpvalue is '+tmpvalue);
@@ -12063,7 +12063,7 @@ function printCommonFooter($zone = 'private')
 										}
 
 										let tmpvalueisempty = false;
-										if (tmpvalue === null || tmpvalue === undefined || tmpvalue === '' || tmpvalue === -1) {
+										if (tmpvalue === null || tmpvalue === undefined || tmpvalue === '' || tmpvalue === -1 || tmpvalue === '-1') {
 											tmpvalueisempty = true;
 										}
 										if (tmpvalue === '0' && (tmptypefield == 'select' || tmptypefield == 'input')) {


### PR DESCRIPTION
# FIX|Fix mandatory field validation broken for select and textarea fields

Two bugs in the JavaScript mandatory field validation (`defaultvalues.php` feature):

- **Select fields**: the empty option generated by `selectarray()` has value `"-1"` (string in the DOM), but the emptiness check used strict equality `=== -1` (number). Since `'-1' !== -1` in JavaScript strict comparison, a select left on 
its empty option was never detected as empty and the form submitted without error.
                                                                                                                                                                                                                                                 
- **Textarea fields**: `CKEDITOR.instances[fieldname]` was accessed unconditionally, causing a `ReferenceError: CKEDITOR is not defined` on pages that do not load CKEditor (e.g. `societe/card.php`). This silently aborted the submit handler before `event.preventDefault()` and the alert could be reached, allowing the form to submit despite the field being empty.