### PR TITLE
NEW Add hooks to let modules add columns to the project overview lists

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1410,6 +1410,13 @@ foreach ($listofreferent as $key => $value) {
 			print '</td>';
 		}
 
+		// Additional columns from hooks
+		$parameters = array('key' => $key, 'value' => $value, 'tablename' => $tablename);
+		$reshook = $hookmanager->executeHooks('printOverviewDetailTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+		if ($reshook < 0) {
+			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+		}
+		print $hookmanager->resPrint;
 
 		// Amount HT
 		//if (empty($value['disableamount']) && ! in_array($tablename, array('projet_task'))) print '<td class="right" width="120">'.$langs->trans("AmountHT").'</td>';
@@ -1751,6 +1758,13 @@ foreach ($listofreferent as $key => $value) {
 					print '</td>';
 				}
 
+				// Additional columns from hooks
+				$parameters = array('key' => $key, 'value' => $value, 'tablename' => $tablename, 'element' => $element, 'i' => $i, 'qualifiedfortotal' => $qualifiedfortotal);
+				$reshook = $hookmanager->executeHooks('printOverviewDetailValue', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+				if ($reshook < 0) {
+					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+				}
+				print $hookmanager->resPrint;
 
 				// Amount without tax
 				$warning = '';
@@ -1977,6 +1991,13 @@ foreach ($listofreferent as $key => $value) {
 				if ($tablename == 'fichinter') {
 					print '<td class="left">'.convertSecondToTime($total_duration, 'all', $conf->global->MAIN_DURATION_OF_WORKDAY).'</td>';
 				}
+				// Additional total columns from hooks
+				$parameters = array('key' => $key, 'value' => $value, 'tablename' => $tablename, 'nbelement' => $i);
+				$reshook = $hookmanager->executeHooks('printOverviewDetailTotal', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+				if ($reshook < 0) {
+					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+				}
+				print $hookmanager->resPrint;
 				print '<td class="right">';
 				if (empty($value['disableamount'])) {
 					if ($key == 'loan') {


### PR DESCRIPTION
## Problem

The element lists of the project overview (`projet/element.php`) cannot be extended with an extra column.

The only hook available in that loop, `printOverviewDetail`, replaces the **whole block** of an element type. To display one additional column, a module has to duplicate roughly 760 lines of core rendering — including the link/unlink actions and their permission checks — and then re-validate that copy on every release. In practice this pushes module authors to patch the core file instead.

## What this PR does

It adds three output hooks, named consistently with the `printOverview*` family already present in this file:

| Hook | Position | Parameters |
|---|---|---|
| `printOverviewDetailTitle` | header row, before the amount columns | `key`, `value`, `tablename` |
| `printOverviewDetailValue` | each element row, same relative position | + `element`, `i`, `qualifiedfortotal` |
| `printOverviewDetailTotal` | total row, before the amount totals | + `nbelement` |

Three design points:

- **All three sit at the same relative position**, so a module printing N cells in each keeps every row aligned.
- **`qualifiedfortotal` is passed** to the row hook. The core already excludes some records from its own totals (replacement invoices, canceled orders). Without that flag a module computing its own total would silently disagree with the amount total displayed right next to it.
- **No existing hook name is reused.** Reusing the generic `printFieldListTitle` / `printFieldListValue` would make every context-blind implementation of those hooks inject unexpected columns into this page.

## Impact

No behaviour change when no module implements the hooks: `$hookmanager->resPrint` is empty and nothing is printed. 21 added lines, no existing line modified.

Tested with a module implementing the three hooks to add buying price and margin columns, including the total row and the exclusion of non-qualified records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)