### PR TITLE
Fix #39355 load images.lib.php before image_format_supported in API

### DIFF
--- a/htdocs/api/class/api_documents.class.php
+++ b/htdocs/api/class/api_documents.class.php
@@ -1061,6 +1061,7 @@ class Documents extends DolibarrApi
 
 		if (is_object($object) && $generateThumbs) {
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/images.lib.php';	// image_format_supported() is defined here
 			if (image_format_supported($dest_file)) {
 				$object->addThumbs($dest_file);
 			}


### PR DESCRIPTION
Calling POST /documents with generateThumbs=1 crashed with an uncaught fatal error and returned a bare HTTP 500 with no JSON body.

In api_documents.class.php the post() method required only files.lib.php before calling image_format_supported(), but that function is defined in images.lib.php, which was never included on this code path. Adding the missing require_once fixes the crash.

Bug is present on 22.0, 23.0 and develop (the code path does not exist on 18.0 to 21.0), so this targets 22.0 for forward-merge.

Verified locally: without the require, image_format_supported() is undefined and the call is fatal; with it, the function loads and returns 1 for a .png and -1 for a .pdf as expected.