### PR TITLE
Fix #38389 use instance constant for validated status in PDF merge

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -807,7 +807,7 @@ if (!$error && $massaction == "builddoc" && $permissiontoread && !GETPOST('butto
 		$filename = preg_replace('/\s/', '_', $filename);
 
 		// Save merged file
-		if (in_array($objecttmp->element, array('facture', 'facture_fournisseur')) && $search_status == Facture::STATUS_VALIDATED) {
+		if (in_array($objecttmp->element, array('facture', 'facture_fournisseur')) && $search_status == $objecttmp::STATUS_VALIDATED) {
 			if ($option == 'late') {
 				$filename .= '_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Unpaid"))).'_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Late")));
 			} else {
@@ -884,7 +884,7 @@ if (!$error && $massaction == "builddoc" && $permissiontoread && !GETPOST('butto
 		$filename = preg_replace('/\s/', '_', $filename);
 
 		// Save merged file
-		if (in_array($objecttmp->element, array('facture', 'facture_fournisseur')) && $search_status == Facture::STATUS_VALIDATED) {
+		if (in_array($objecttmp->element, array('facture', 'facture_fournisseur')) && $search_status == $objecttmp::STATUS_VALIDATED) {
 			if ($option == 'late') {
 				$filename .= '_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Unpaid"))).'_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Late")));
 			} else {


### PR DESCRIPTION
PDF Merge (builddoc mass action) on the supplier invoice list crashed with a blank 500.

In actions_massactions.inc.php the merge block tests $objecttmp->element against both 'facture' and 'facture_fournisseur', but compares $search_status to Facture::STATUS_VALIDATED. On the supplier invoice list only FactureFournisseur is loaded, never the Facture class, so the reference raised a fatal Error "Class Facture not found" and the request died.

Using $objecttmp::STATUS_VALIDATED resolves the constant on the real object class. Both Facture and FactureFournisseur define it as 1, so customer invoice merge is unaffected.

Reproduced and verified locally: before the change, merging two validated supplier invoices returns the fatal; after it, the merged PDF is produced.