### PR TITLE
FIX Holiday shown one day off in agenda for users in another timezone

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -1207,8 +1207,10 @@ if ($user->hasRight("holiday", "read")) {
 			$event->type = 'holiday';
 			$event->type_picto = 'holiday';
 
-			$event->datep                   = $db->jdate($obj->date_start) + (empty($obj->halfday) || $obj->halfday == 1 ? 0 : 12) * 60 * 60;
-			$event->datef                   = $db->jdate($obj->date_end) + (empty($obj->halfday) || $obj->halfday == -1 ? 24 : 12) * 60 * 60 - 1;
+			// date_debut and date_fin are dates without time, so they must be read and rendered in GMT to
+			// stay independent from the server and user timezones (otherwise the calendar day box is shifted).
+			$event->datep                   = $db->jdate($obj->date_start, 'gmt') + (empty($obj->halfday) || $obj->halfday == 1 ? 0 : 12) * 60 * 60;
+			$event->datef                   = $db->jdate($obj->date_end, 'gmt') + (empty($obj->halfday) || $obj->halfday == -1 ? 24 : 12) * 60 * 60 - 1;
 			$event->date_start_in_calendar  = $event->datep;
 			$event->date_end_in_calendar    = $event->datef;
 
@@ -1223,14 +1225,14 @@ if ($user->hasRight("holiday", "read")) {
 			$event->label = $langs->trans("Holiday");
 
 			$daycursor = $event->date_start_in_calendar;
-			$annee = (int) dol_print_date($daycursor, '%Y', 'tzuserrel');
-			$mois = (int) dol_print_date($daycursor, '%m', 'tzuserrel');
-			$jour = (int) dol_print_date($daycursor, '%d', 'tzuserrel');
+			$annee = (int) dol_print_date($daycursor, '%Y', 'gmt');
+			$mois = (int) dol_print_date($daycursor, '%m', 'gmt');
+			$jour = (int) dol_print_date($daycursor, '%d', 'gmt');
 
 			$daycursorend = $event->date_end_in_calendar;
-			$anneeend = (int) dol_print_date($daycursorend, '%Y', 'tzuserrel');
-			$moisend = (int) dol_print_date($daycursorend, '%m', 'tzuserrel');
-			$jourend = (int) dol_print_date($daycursorend, '%d', 'tzuserrel');
+			$anneeend = (int) dol_print_date($daycursorend, '%Y', 'gmt');
+			$moisend = (int) dol_print_date($daycursorend, '%m', 'gmt');
+			$jourend = (int) dol_print_date($daycursorend, '%d', 'gmt');
 
 			// daykey must be date that represent day box in calendar so must be a user time
 			$daykey = dol_mktime(0, 0, 0, $mois, $jour, $annee, 'gmt');

--- a/htdocs/comm/action/peruser.php
+++ b/htdocs/comm/action/peruser.php
@@ -1104,8 +1104,10 @@ if ($user->hasRight("holiday", "read")) {
 			$event->type = 'holiday';
 			$event->type_picto = 'holiday';
 
-			$event->datep                   = $db->jdate($obj->date_start) + (empty($obj->halfday) || $obj->halfday == 1 ? 0 : 12) * 60 * 60;
-			$event->datef                   = $db->jdate($obj->date_end) + (empty($obj->halfday) || $obj->halfday == -1 ? 24 : 12) * 60 * 60 - 1;
+			// date_debut and date_fin are dates without time, so they must be read and rendered in GMT to
+			// stay independent from the server and user timezones (otherwise the calendar day box is shifted).
+			$event->datep                   = $db->jdate($obj->date_start, 'gmt') + (empty($obj->halfday) || $obj->halfday == 1 ? 0 : 12) * 60 * 60;
+			$event->datef                   = $db->jdate($obj->date_end, 'gmt') + (empty($obj->halfday) || $obj->halfday == -1 ? 24 : 12) * 60 * 60 - 1;
 			$event->date_start_in_calendar  = $event->datep;
 			$event->date_end_in_calendar    = $event->datef;
 
@@ -1124,14 +1126,14 @@ if ($user->hasRight("holiday", "read")) {
 
 
 			$daycursor = $event->date_start_in_calendar;
-			$annee = (int) dol_print_date($daycursor, '%Y', 'tzuserrel');
-			$mois = (int) dol_print_date($daycursor, '%m', 'tzuserrel');
-			$jour = (int) dol_print_date($daycursor, '%d', 'tzuserrel');
+			$annee = (int) dol_print_date($daycursor, '%Y', 'gmt');
+			$mois = (int) dol_print_date($daycursor, '%m', 'gmt');
+			$jour = (int) dol_print_date($daycursor, '%d', 'gmt');
 
 			$daycursorend = $event->date_end_in_calendar;
-			$anneeend = (int) dol_print_date($daycursorend, '%Y', 'tzuserrel');
-			$moisend = (int) dol_print_date($daycursorend, '%m', 'tzuserrel');
-			$jourend = (int) dol_print_date($daycursorend, '%d', 'tzuserrel');
+			$anneeend = (int) dol_print_date($daycursorend, '%Y', 'gmt');
+			$moisend = (int) dol_print_date($daycursorend, '%m', 'gmt');
+			$jourend = (int) dol_print_date($daycursorend, '%d', 'gmt');
 
 			// daykey must be date that represent day box in calendar so must be a user time
 			$daykey = dol_mktime(0, 0, 0, $mois, $jour, $annee, 'gmt');


### PR DESCRIPTION
## Bug

`llx_holiday.date_debut` and `date_fin` are pure `DATE` columns: they hold a **calendar fact**, not an absolute instant, so they carry no time and no timezone.

The agenda read them with `jdate()` defaulting to `'tzserver'`, then projected them back with `dol_print_date(..., 'tzuserrel')` to pick the calendar day box. The resulting shift equals `TZ_user - TZ_server`, so **any user whose timezone differs from the server sees leaves on the wrong day**. Users aligned with the server see nothing wrong, which is why this went unnoticed.

It also triggers with **no user timezone configured at all**: `'tzuserrel'` falls back to UTC when `$_SESSION['dol_tz_string']` is empty, shifting leaves on any server east of UTC.

### How to reproduce

Server in UTC (or any TZ), user in a different one — e.g. `America/Cayenne` (UTC-3):

1. Create and approve a single full-day leave on `2026-07-28`.
2. Open the agenda month view as a user whose browser timezone is `America/Cayenne`.
3. The leave is rendered on **both 2026-07-27 and 2026-07-28**.

## Fix

Read and project those dates in GMT instead.

This follows the documented core convention for dates without time:

- `commonobject.class.php` — *"We suppose dates without time are always gmt (storage of course + output)"*
- `extrafields.class.php` — *"For date without hour, date is always GMT for storage and output"*

It also honors the `$daykey` contract of `$eventarray`, which must be midnight GMT of the displayed calendar day (*"We use gmt because we want the value represented by string 'YYYYMMDD'"*), and makes the half-day comparison consistent, since `dol_get_first_hour()` is already called with `'gmt'` a few lines below and only supports `gmt`/`tzserver` anyway.

### Two further defects fixed as a side effect

- The loop condition `while ($daykey <= $event->date_end_in_calendar)` compared a user-shifted `$daykey` against a server-anchored `$datef`, rendering **one extra day box**.
- `halfday = -1` happened to be correct while `halfday = 0/1` were not, because the `+12h` offset accidentally compensated the timezone shift — so the same leave could land on the right or wrong day depending on the half-day.

## No impact on regular events

`llx_actioncomm.datep` is a `DATETIME` holding a real instant, and its block still uses `'tzuserrel'` — a 9am meeting stays correctly shifted for a viewer in another timezone. Every other render path already excludes `type_code == 'HOLIDAY'`, so there is no display change elsewhere.

`peruser.php` carries a copy of the same block and is fixed identically; patching only `index.php` would make the two views of the same page contradict each other.

## Testing

Driven with a real browser (Playwright) against a server running in UTC, opening the month view as `Europe/Paris`, `America/Cayenne` and `Pacific/Auckland` users over three existing leaves:

| | Europe/Paris | America/Cayenne | Pacific/Auckland |
|---|---|---|---|
| before | 3 PASS | **3 FAIL** | 3 PASS |
| after | 3 PASS | 3 PASS | 3 PASS |

Note: `Pacific/Auckland` (UTC+12) also breaks, in the opposite direction — an "afternoon" half-day leave of `2026-08-11` was rendered on `2026-08-12`. It is not visible in the table above because the sampled leaves are full-day ones.

The day-box computation was additionally replayed through the real Dolibarr date functions over 4 timezones and 5 date/half-day combinations: 20/20 identical results after the fix, 5 mismatches before.
