### PR TITLE
QUAL Add the CSP nonce on the drag and drop script tag

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -4049,7 +4049,7 @@ function dragAndDropFileUpload($htmlname)
 	$out = "";
 	$out .= '<div id="'.$htmlname.'Message" class="dragDropAreaMessage hidden"><span>'.img_picto("", 'download').'<br>'.$langs->trans("DropFileToAddItToObject").'</span></div>';
 	$out .= "\n<!-- JS CODE TO ENABLE DRAG AND DROP OF FILE -->\n";
-	$out .= "<script>";
+	$out .= '<script nonce="'.getNonce().'">';
 	$out .= '
 		jQuery(document).ready(function() {
 			var enterTargetDragDrop = null;


### PR DESCRIPTION
## What

`dragAndDropFileUpload()` emits an inline `<script>` tag without the CSP nonce, while the ~25 other inline scripts of `main.inc.php` carry it. Under a Content Security Policy that allows inline scripts through the nonce, this one is blocked and the drag and drop is silently inert on every card that enables it.

One line.

## Notes

`getNonce()` is stable within a request (cached in `$conf->cache['nonce']`), and the attribute is simply ignored by browsers when no policy is defined, so there is no change for an instance without CSP.

This is the first of a series of small fixes on the drag and drop of a file on a card. The others are independent of this one.