### PR TITLE
Fix #39395 remove duplicate fk_user_modif in chargesociales update

### DIFF
--- a/htdocs/compta/sociales/class/chargesociales.class.php
+++ b/htdocs/compta/sociales/class/chargesociales.class.php
@@ -418,7 +418,6 @@ class ChargeSociales extends CommonObject
 		if ($this->type > 0) {
 			$sql .= ", fk_type = ".((int) $this->type);
 		}
-		$sql .= ", fk_user_modif=".((int) $user->id);
 		$sql .= " WHERE rowid=".((int) $this->id);
 
 		dol_syslog(get_class($this)."::update", LOG_DEBUG);


### PR DESCRIPTION
ChargeSociales::update() assigns fk_user_modif twice in the same UPDATE statement. PostgreSQL rejects it with "multiple assignments to the same column fk_user_modif", so editing a social contribution fails.

This removes the duplicate assignment. It is a backport of #39389, which fixed the same duplicate on develop but was not carried to the maintenance branches. The duplicate is present on 22.0 and 23.0, absent on 18.0.

Verified locally: the UPDATE built by update() contained fk_user_modif= twice before the change and once after.