### PR TITLE
Fix #39373 reload thirdparty after fetch on supplier order line add

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -675,6 +675,7 @@ if (empty($reshook)) {
 			$db->commit();
 
 			$ret = $object->fetch($object->id); // Reload to get new records
+			$object->fetch_thirdparty(); // fetch() reset thirdparty to null, reload it before reading default_lang
 
 			// Define output language
 			if (empty($conf->global->MAIN_DISABLE_PDF_AUTOUPDATE)) {


### PR DESCRIPTION
After adding a line to a draft supplier order, fourn/commande/card.php reloads the object with fetch() to get the new records, then reads $object->thirdparty->default_lang to choose the PDF output language. CommandeFournisseur::fetch() resets thirdparty to null, so this raised "Attempt to read property default_lang on null".

Call fetch_thirdparty() right after the reload, the same way comm/propal/card.php already does.

Verified locally on a real supplier order: after fetch() thirdparty is null (reading default_lang warns); after fetch_thirdparty() it is populated and read cleanly.