### PR TITLE
Fix #32605 keep decimals on supplier multicurrency payment amount

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -216,7 +216,7 @@ if (empty($reshook)) {
 					}
 				}
 
-				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => GETPOST($key, 'int'));
+				$formquestion[$i++] = array('type' => 'hidden', 'name' => $key, 'value' => price2num(GETPOST($key)));
 			}
 		}
 


### PR DESCRIPTION
When paying a supplier invoice in its own currency, the confirmation dialog re-read the multicurrency amount with GETPOST($key, 'int'). That filter does not keep a proper decimal amount: a comma-decimal value like 15,99 comes back empty, so the payment amount is wrong or lost.

Use price2num(GETPOST($key)), the same parsing already used for this amount a few lines above.

This is the 18.0 equivalent of #35354 (which used GETPOSTFLOAT on 21.0+, a function that does not exist on 18.0).

Verified locally: with the old code 15,99 becomes empty; with price2num it stays 15.99, and 15.99 / 1234.56 are preserved too.