### PR TITLE
Fix #30673 use invoice-currency remain for mass payment multicurrency amount

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -419,11 +419,15 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 					$errorpayment++;
 				} else {
 					if ($facture->type != Facture::TYPE_CREDIT_NOTE && $facture->statut == Facture::STATUS_VALIDATED && $facture->paye == 0) {
-						$paiementAmount = $facture->getSommePaiement();
+						// Get both the base-currency and invoice-currency paid amount in a single query
+						$sommePaiement = $facture->getSommePaiement(-1);
+						$paiementAmount = $sommePaiement['alreadypaid'];
 						$totalcreditnotes = $facture->getSumCreditNotesUsed();
 						$totaldeposits = $facture->getSumDepositsUsed();
 						$totalallpayments = $paiementAmount + $totalcreditnotes + $totaldeposits;
 						$remaintopay = price2num($facture->total_ttc - $totalallpayments);
+						// Remain to pay in the invoice currency (may differ from $remaintopay when multicurrency is used)
+						$multicurrency_remaintopay = price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
 						if ($remaintopay != 0) {
 							$resultBank = $facture->setBankAccount($bankid);
 							if ($resultBank < 0) {
@@ -433,7 +437,7 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 								$paiement = new Paiement($db);
 								$paiement->datepaye = $paiementdate;
 								$paiement->amounts[$facture->id] = $remaintopay; // Array with all payments dispatching with invoice id
-								$paiement->multicurrency_amounts[$facture->id] = $remaintopay;
+								$paiement->multicurrency_amounts[$facture->id] = $multicurrency_remaintopay;
 								$paiement->paiementid = $paiementid;
 								$paiement_id = $paiement->create($user, 1, $facture->thirdparty);
 								if ($paiement_id < 0) {


### PR DESCRIPTION
The mass "Record Payment" action on the customer invoice list stored a wrong payment amount for invoices in a foreign currency (the amount came out multiplied by the invoice rate).

Root cause: the code put the base-currency remaining amount ($remaintopay, from total_ttc) into both $paiement->amounts and $paiement->multicurrency_amounts. When the multicurrency module is enabled, Paiement::getWay() returns 'customer' as soon as multicurrency_amounts is non-empty, and create() then treats that value as the foreign-currency amount and re-derives the base amount by the invoice rate, producing the wrong figure.

Fix: compute the remaining amount in the invoice currency from multicurrency_total_ttc and getSommePaiement(1) - the same way the single-invoice payment page (compta/paiement.php) does - and use it for multicurrency_amounts.

No regression: for a base-currency invoice the two remains are equal, and with the module disabled getWay() is 'dolibarr' so multicurrency_amounts is recomputed from amounts and the input is ignored. Verified deterministically for the foreign-currency, base-currency and module-off cases.