### PR TITLE
FIX webportal shared documents controller page

### DIFF
--- a/htdocs/webportal/class/context.class.php
+++ b/htdocs/webportal/class/context.class.php
@@ -260,7 +260,7 @@ class Context
 		//** below the addition of DocumentListController adding files by third party attached documents
 		$this->addControllerDefinition('documentlist', $defaultControllersPath . 'documentlist.controller.class.php', 'DocumentListController');
 		//** Below is the addition to the menu of the DocumentUtileController.class.php controller in order to share via the GED (documents) "Documentscomptes"
-		$this->addControllerDefinition('documentutile', $defaultControllersPath . 'documentutile.controller.class.php', 'DocumentUtileController');
+		$this->addControllerDefinition('shareddocuments', $defaultControllersPath . 'shareddocuments.controller.class.php', 'SharedDocumentsController');
 		$this->addControllerDefinition('viewimage', $defaultControllersPath . 'viewimage.controller.class.php', 'ViewImageController');
 
 		// Hooks for init controller


### PR DESCRIPTION
FIX webportal shared documents controller page

The "documentutile" controller page was renamed with "shareddocuments".
Otherwise the page in not found in Webprtal.