### PR TITLE
Qual: Fix phpstan notices on 24.0 (wrong case and always-false comparison)

### DIFF
--- a/htdocs/admin/remotestore/class/externalModules.class.php
+++ b/htdocs/admin/remotestore/class/externalModules.class.php
@@ -591,7 +591,7 @@ class ExternalModules
 
 						// For community modules, we download from community repo.
 						// But we can force to download from dolistore if MAIN_DOWNLOAD_FROM_DOLISTORE_IN_PRIORITY is set (less reliable, less up to date)
-						if ($product["direct-download"] == 'dolistore' || $product['source'] === 'dolistore' || getDolGlobalString("MAIN_DOWNLOAD_FROM_DOLISTORE_IN_PRIORITY")) {
+						if ($product["direct-download"] == 'dolistore' || getDolGlobalString("MAIN_DOWNLOAD_FROM_DOLISTORE_IN_PRIORITY")) {
 							if (preg_match('/https:.*\?id=(\d+)$/', $urlview, $reg)) {
 								$urldownload = 'https://www.dolistore.com/_service_download.php?t=free&p='.$reg[1];
 							}

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1623,7 +1623,7 @@ if ($action == 'create') {
 		print '<td class="right">'.($close['total_qty'] ? price2num($close['total_qty']) : '<span class="opacitymedium">0</span>').'</td>';
 		print '</tr>';
 
-		if (getDolglobalString("CONTRACT_SHOW_SUMMARY_Of_AMOUNTS")) {
+		if (getDolGlobalString("CONTRACT_SHOW_SUMMARY_Of_AMOUNTS")) {
 			print '<tr><td class="titlefield">'.$langs->trans("TotalHT").'</td>';
 			print '<td class="nowraponall amountcard right">'.($all['total_ht'] ? price($all['total_ht']) : '<span class="opacitymedium">0</span>').'</td>';
 			print '<td class="nowraponall amountcard right">'.($draft['total_ht'] ? price($draft['total_ht']) : '<span class="opacitymedium">0</span>').'</td>';


### PR DESCRIPTION
# Qual Fix the two phpstan notices that keep the 24.0 branch red

The `phpstan` job currently fails on the 24.0 branch itself. It reports two things:

```
htdocs/contrat/card.php:1626
  Call to function getDolGlobalString() with incorrect case: getDolglobalString

htdocs/admin/remotestore/class/externalModules.class.php:594
  Strict comparison using === between 'githubcommunity' and 'dolistore' will always evaluate to false
```

## 1. `contrat/card.php`

`getDolglobalString(...)` with a lowercase `g`. PHP resolves function names case-insensitively so the page works, only the case is wrong. develop does not have the typo.

## 2. `externalModules.class.php`

The test is inside the `if ($product['source'] === 'githubcommunity') { … }` block, so `$product['source'] === 'dolistore'` can never be true there:

```php
if ($product['source'] === 'githubcommunity') {
    …
    if ($product["direct-download"] == 'dolistore' || $product['source'] === 'dolistore' || getDolGlobalString("MAIN_DOWNLOAD_FROM_DOLISTORE_IN_PRIORITY")) {
```

Only that impossible clause is removed. The two remaining conditions — `direct-download` set to `dolistore`, or `MAIN_DOWNLOAD_FROM_DOLISTORE_IN_PRIORITY` — are untouched, so the behaviour of "force the download from Dolistore for a community module" is unchanged. (I did not align the block on develop here, because 24.0 is the newer one on this part: the `MAIN_DOWNLOAD_FROM_DOLISTORE_IN_PRIORITY` option does not exist in develop yet.)

Neither file is part of the revert in #39386, so these are not related to it — they are simply two spots that were fixed in develop and never on 24.0.

With this and #39443 (phan), the 24.0 branch should be green again.
