### PR TITLE
FIX #30801 Filter a dependent select list of extrafields when the field is edited alone

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1186,9 +1186,10 @@ class ExtraFields
 	 * @param  int|CommonObject     $object       			Current object or object ID. Preferably, pass the object itself.
 	 * @param  string        		$extrafieldsobjectkey	The key to use to store retrieved data (commonly $object->table_element)
 	 * @param  int	         		$mode                  	1=Used for search filters
+	 * @param  int	         		$filteronparentvalue	1=Filter the values of a dependent list on the value currently saved for its parent list. Used when the field is edited alone (the parent list is not on the form, so the javascript that filters the list can't work).
 	 * @return string
 	 */
-	public function showInputField($key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = '', $object = 0, $extrafieldsobjectkey = '', $mode = 0)
+	public function showInputField($key, $value, $moreparam = '', $keysuffix = '', $keyprefix = '', $morecss = '', $object = 0, $extrafieldsobjectkey = '', $mode = 0, $filteronparentvalue = 0)
 	{
 		global $conf, $langs, $form, $hookmanager;
 
@@ -1470,6 +1471,19 @@ class ExtraFields
 					$parent = '';
 					if (!empty($valarray[1])) {
 						$parent = $valarray[1];
+					}
+					// When the field is edited alone (not into the whole form), the parent list is not on the page, so the
+					// javascript that filters a dependent list can't do its job. In this case, we filter the values here, on
+					// the value currently saved for the parent list. Note that the selected value is always kept, whatever the
+					// parent value is, so editing the field does not silently clear it.
+					if ($filteronparentvalue && !empty($parent) && (string) $value != (string) $key2) {
+						$tmpparent = explode(':', $parent, 2);
+						if (!empty($tmpparent[1]) && is_object($object)) {
+							$parentvalue = isset($object->array_options['options_'.$tmpparent[0]]) ? $object->array_options['options_'.$tmpparent[0]] : '';
+							if ((string) $parentvalue !== '' && (string) $parentvalue !== (string) $tmpparent[1]) {
+								continue;
+							}
+						}
 					}
 					$out .= '<option value="'.$key2.'"';
 					$out .= (((string) $value == (string) $key2) ? ' selected' : '');

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -311,7 +311,9 @@ if (empty($reshook) && !empty($object->table_element) && isset($extrafields->att
 				print '<input type="hidden" name="token" value="'.newToken().'">';
 				print '<input type="hidden" name="'.$fieldid.'" value="'.$object->id.'">';
 				print '<input type="hidden" name="page_y" value="">';
-				print $extrafields->showInputField($tmpkeyextra, $value, '', '', '', '', $object, $object->table_element);
+				// Last parameter is 1 because the field is edited alone: a dependent list can't be filtered by javascript
+				// here (its parent list is not on this form), so it must be filtered on the saved value of its parent.
+				print $extrafields->showInputField($tmpkeyextra, $value, '', '', '', '', $object, $object->table_element, 0, 1);
 
 				print '<input type="submit" class="button reposition" value="'.dolPrintHTMLForAttribute($langs->trans('Modify')).'">';
 

--- a/test/phpunit/AllTests.php
+++ b/test/phpunit/AllTests.php
@@ -173,6 +173,9 @@ class AllTests
 		require_once dirname(__FILE__).'/CommonObjectTest.php';
 		$suite->addTestSuite('CommonObjectTest');
 
+		require_once dirname(__FILE__).'/ExtraFieldsTest.php';
+		$suite->addTestSuite('ExtraFieldsTest');
+
 		require_once dirname(__FILE__).'/ActionCommTest.php';
 		$suite->addTestSuite('ActionCommTest');
 		require_once dirname(__FILE__).'/SocieteTest.php';

--- a/test/phpunit/ExtraFieldsTest.php
+++ b/test/phpunit/ExtraFieldsTest.php
@@ -1,0 +1,183 @@
+<?php
+/* Copyright (C) 2026 Jam <jambalaya.pyoncafe@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/ExtraFieldsTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test
+ *      \remarks    To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db;
+//define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
+//require_once 'PHPUnit/Autoload.php';
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/class/extrafields.class.php';
+require_once dirname(__FILE__).'/../../htdocs/societe/class/societe.class.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->loadRights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class ExtraFieldsTest extends CommonClassTest
+{
+	/**
+	 * Build an ExtraFields object with a "select" list depending on another "select" list.
+	 * The child list has one value for the parent value 'a', one for the parent value 'b',
+	 * and one value with no dependency at all.
+	 *
+	 * @return	ExtraFields		Object with the definitions loaded in memory (nothing is written in database)
+	 */
+	private function getExtraFieldsWithDependentList()
+	{
+		global $db;
+
+		$extrafields = new ExtraFields($db);
+
+		$elementtype = 'societe';
+		foreach (array('parentlist', 'childlist') as $code) {
+			$extrafields->attributes[$elementtype]['type'][$code] = 'select';
+			$extrafields->attributes[$elementtype]['label'][$code] = $code;
+			$extrafields->attributes[$elementtype]['size'][$code] = '';
+			$extrafields->attributes[$elementtype]['default'][$code] = '';
+			$extrafields->attributes[$elementtype]['computed'][$code] = '';
+			$extrafields->attributes[$elementtype]['unique'][$code] = 0;
+			$extrafields->attributes[$elementtype]['required'][$code] = 0;
+			$extrafields->attributes[$elementtype]['perms'][$code] = '';
+			$extrafields->attributes[$elementtype]['langfile'][$code] = '';
+			$extrafields->attributes[$elementtype]['list'][$code] = '1';
+			$extrafields->attributes[$elementtype]['totalizable'][$code] = 0;
+			$extrafields->attributes[$elementtype]['help'][$code] = '';
+			$extrafields->attributes[$elementtype]['alwayseditable'][$code] = 0;
+		}
+
+		$extrafields->attributes[$elementtype]['param']['parentlist'] = array('options' => array('a' => 'Value A', 'b' => 'Value B'));
+		$extrafields->attributes[$elementtype]['param']['childlist'] = array('options' => array(
+			'childofa' => 'Child of A|parentlist:a',
+			'childofb' => 'Child of B|parentlist:b',
+			'nodepend' => 'No dependency',
+		));
+
+		return $extrafields;
+	}
+
+	/**
+	 * Build a thirdparty holding a value for the parent list
+	 *
+	 * @param	string		$parentvalue	Value saved for the parent list
+	 * @param	string		$childvalue		Value saved for the dependent list
+	 * @return	Societe						Object not saved in database
+	 */
+	private function getObjectWithParentValue($parentvalue, $childvalue = '')
+	{
+		global $db;
+
+		$object = new Societe($db);
+		$object->array_options['options_parentlist'] = $parentvalue;
+		$object->array_options['options_childlist'] = $childvalue;
+
+		return $object;
+	}
+
+	/**
+	 * When the whole form is shown, all the values must be output, whatever the parent value is:
+	 * the filtering is done by javascript, on the value chosen in the parent list of the same form.
+	 *
+	 * @return void
+	 */
+	public function testShowInputFieldKeepsAllValuesOfADependentListByDefault()
+	{
+		$extrafields = $this->getExtraFieldsWithDependentList();
+		$object = $this->getObjectWithParentValue('a');
+
+		$out = $extrafields->showInputField('childlist', '', '', '', '', '', $object, 'societe');
+
+		print __METHOD__." out=".$out."\n";
+		$this->assertStringContainsString('value="childofa"', $out);
+		$this->assertStringContainsString('value="childofb"', $out);
+		$this->assertStringContainsString('parent="parentlist:a"', $out);
+	}
+
+	/**
+	 * When the field is edited alone, the parent list is not on the form, so the values must be
+	 * filtered on the value already saved for the parent list.
+	 *
+	 * @return void
+	 */
+	public function testShowInputFieldFiltersADependentListOnTheSavedParentValue()
+	{
+		$extrafields = $this->getExtraFieldsWithDependentList();
+		$object = $this->getObjectWithParentValue('a');
+
+		$out = $extrafields->showInputField('childlist', '', '', '', '', '', $object, 'societe', 0, 1);
+
+		print __METHOD__." out=".$out."\n";
+		$this->assertStringContainsString('value="childofa"', $out);
+		$this->assertStringNotContainsString('value="childofb"', $out);
+		// A value that does not depend on the parent list is always kept
+		$this->assertStringContainsString('value="nodepend"', $out);
+	}
+
+	/**
+	 * If nothing is saved for the parent list, we can't filter, so all the values must be kept.
+	 *
+	 * @return void
+	 */
+	public function testShowInputFieldKeepsAllValuesWhenParentValueIsEmpty()
+	{
+		$extrafields = $this->getExtraFieldsWithDependentList();
+		$object = $this->getObjectWithParentValue('');
+
+		$out = $extrafields->showInputField('childlist', '', '', '', '', '', $object, 'societe', 0, 1);
+
+		print __METHOD__." out=".$out."\n";
+		$this->assertStringContainsString('value="childofa"', $out);
+		$this->assertStringContainsString('value="childofb"', $out);
+	}
+
+	/**
+	 * The value currently saved must always be output, even when it does not match the parent value,
+	 * otherwise editing the field would silently clear it.
+	 *
+	 * @return void
+	 */
+	public function testShowInputFieldKeepsTheSelectedValueNotMatchingTheParentValue()
+	{
+		$extrafields = $this->getExtraFieldsWithDependentList();
+		$object = $this->getObjectWithParentValue('a', 'childofb');
+
+		$out = $extrafields->showInputField('childlist', 'childofb', '', '', '', '', $object, 'societe', 0, 1);
+
+		print __METHOD__." out=".$out."\n";
+		$this->assertStringContainsString('value="childofb"', $out);
+		$this->assertStringContainsString('selected', $out);
+		$this->assertStringContainsString('value="childofa"', $out);
+	}
+}


### PR DESCRIPTION
# FIX Filter a dependent "Select list" extrafield when the field is edited alone

Fix #30801 (also reported in 2020 as #14736).

## Problem

An extrafield of type *Select list* whose values depend on another list is filtered correctly on the creation form and on the edit form of the whole object, but **not when the field is edited alone with the pencil on the card**: the whole list is offered, including the values belonging to another parent value.

## Cause

`ExtraFields::showInputField()` only marks each value with a `parent="parentcode:parentvalue"` attribute. The filtering itself is done by the javascript `setListDependencies()`, which is emitted by `CommonObject::showOptionals()` and reads the value chosen in the **parent `<select>` of the same form**.

The pencil goes to `action=edit_extras&attribute=…`, and `core/tpl/extrafields_view.tpl.php` then renders **only that one field**, in its own form. The parent list is not on that form and the javascript is not emitted, so nothing can filter the values.

## Fix

`showInputField()` gets a new last optional parameter `$filteronparentvalue` (default `0`, so nothing changes for the existing callers). When it is set and a value depends on a parent list, the value is filtered server side on the parent value already saved on the object — the object is already passed to the method.

Only `core/tpl/extrafields_view.tpl.php` (the single field edit) passes `1`. `showOptionals()` is untouched, so the create/edit forms keep the dynamic javascript filtering.

Two cases are deliberately not filtered:

- if nothing is saved for the parent list, all values are kept (otherwise the list would be empty and unusable);
- **the value currently saved is always kept**, even when it does not match the parent value, otherwise opening the field and saving would silently clear it.

The same weakness exists for the `sellist` type; it is not addressed here to keep this change small.

## Tests

`test/phpunit/ExtraFieldsTest.php` (new, registered in `AllTests.php`) covers the 4 cases: default behaviour unchanged, filtering on the saved parent value, empty parent value, and the selected value not matching the parent.

Checked on a local install with two thirdparty extrafields (`parentlist` = `a`/`b`, `childlist` with `Child of A|parentlist:a`, `Child of B|parentlist:b`, `No dependency`):

| Page | Result |
| --- | --- |
| Card, pencil on the child field, parent saved as `a` | `childofa` + `nodepend` only — `childofb` is gone (was shown before the fix) |
| Same after changing the parent to `b` | `childofb` + `nodepend` only |
| Edit form of the whole object | all values, each with its `parent="…"` attribute, and `setListDependencies()` emitted — unchanged |
| Creation form | idem, unchanged |

## Credit

This takes over #31875 by @IC-Mathieu, which reported and attacked the same problem. The implementation is rewritten because that patch filtered unconditionally (it would also have frozen the create/edit forms, where the parent list can still be changed) and because it was written against an older signature of `showInputField()`.

## Note about the branch

Opened against develop because it adds a parameter to a public method. Tell me if you prefer it on a maintenance branch and I will redo it there.
