### PR TITLE
Fix #39020 use universal-search filter for MoLine lookup on V21+

### DIFF
--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -174,7 +174,8 @@ if (empty($reshook)) {
 			// The lookup must be scoped to the parent MO and use an exact match on origin_id/origin_type,
 			// otherwise the default 'origin_id LIKE %..%' filter can return an unrelated line (or none),
 			// which would let the child MO be created from the leftover parent POST data (duplicate MO).
-			$TMoLines = $moline->fetchAll('DESC', 'rowid', '1', '', array('fk_mo' => $mo_parent->id, 'origin_id' => $id_bom_line, 'origin_type' => 'bomline'));
+			$filter = '(fk_mo:=:'.((int) $mo_parent->id).') AND (origin_id:=:'.((int) $id_bom_line).") AND (origin_type:=:'bomline')";
+			$TMoLines = $moline->fetchAll('DESC', 'rowid', '1', '', $filter);
 
 			if (empty($TMoLines)) {
 				continue;


### PR DESCRIPTION
Follow-up to #39163 (merged on 18.0), as requested by @fappels during that review.

On 21.0 and later, MoLine::fetchAll no longer treats fk_mo/origin_id/origin_type as exact matches in the array-filter path - every non-rowid key falls back to LIKE '%value%'. So the array filter that was correct on 18.0/19.0/20.0 becomes origin_id LIKE '%..%' here, which can match an unrelated MO line and reintroduce the duplicate MO that #39020 was meant to prevent.

This switches mo_card.php to the universal-search string filter (fk_mo:=:.. AND origin_id:=:.. AND origin_type:=:'bomline'), which the class turns into exact equality.

Verified locally on 21.0: the universal filter produces `(fk_mo = 42) AND (origin_id = 5) AND (origin_type = 'bomline')`, while the old array path produced `origin_id LIKE '%5%'` (matching 5, 15, 25, ...).