### PR TITLE
Fix #39245 set TRIGGER_PREFIX to BILL on Facture

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -65,6 +65,11 @@ class Facture extends CommonInvoice
 	public $element = 'facture';
 
 	/**
+	 * @var string Prefix used to build trigger event names in generic CommonObject methods (BILL_MODIFY, ...)
+	 */
+	public $TRIGGER_PREFIX = 'BILL';
+
+	/**
 	 * @var string Name of table without prefix where object is stored
 	 */
 	public $table_element = 'facture';


### PR DESCRIPTION
Facture does not declare $TRIGGER_PREFIX, so the generic CommonObject methods that build the trigger name from get_class()/element (setPaymentMethods, setBankAccount, setShippingMethod, add_contact, delete_contact) fire FACTURE_MODIFY / FACTURE_ADD_CONTACT instead of the BILL_* events the class uses everywhere else (BILL_CREATE, BILL_MODIFY, ...). Modules listening on BILL_MODIFY miss those changes (reported for setPaymentMethods in #39245).

This declares `public $TRIGGER_PREFIX = 'BILL'`, the same pattern other objects use (Holiday='HOLIDAY', Workstation='WORKSTATION', BOM='BOM').

Verified locally: after the change setPaymentMethods/setBankAccount/setShippingMethod emit BILL_MODIFY and add_contact/delete_contact emit BILL_ADD_CONTACT/BILL_DELETE_CONTACT. No core trigger listener uses the old FACTURE_* names, so nothing in core breaks; third-party modules should already be listening on the documented BILL_* events.

Note: FactureFournisseur has the same gap (it emits FACTUREFOURNISSEUR_MODIFY instead of BILL_SUPPLIER_MODIFY). I can send a separate PR for it if you agree with this approach.