### PR TITLE
Fix #39457 keep payment type Customer (0) selected when editing dict

### DIFF
--- a/htdocs/admin/dict.php
+++ b/htdocs/admin/dict.php
@@ -2855,7 +2855,8 @@ function dictFieldList($fieldlist, $obj = null, $tabname = '', $context = '')
 		} elseif ($value == 'type' && $tabname == 'c_paiement') {
 			print '<td>';
 			$select_list = array(0 => $langs->trans('PaymentTypeCustomer'), 1 => $langs->trans('PaymentTypeSupplier'), 2 => $langs->trans('PaymentTypeBoth'));
-			print $form->selectarray($value, $select_list, (!empty($obj->{$value}) ? $obj->{$value} : '2'));
+			// Use isset(), not !empty(), because 0 (Customer) is a valid value that empty() would treat as unset
+			print $form->selectarray($value, $select_list, (isset($obj->{$value}) && $obj->{$value} !== '' ? $obj->{$value} : '2'));
 			print '</td>';
 		} elseif ($value == 'recuperableonly' || $value == 'type_cdr' || $value == 'deductible' || $value == 'category_type') {
 			if ($value == 'type_cdr') {


### PR DESCRIPTION
In Setup > Dictionaries > Payment types, editing a payment type whose Type is "Customer" reset the dropdown to "Customer and Vendor".

The Customer type is stored as 0, and the edit row selected the dropdown value with !empty($obj->type). Since empty(0) is true, the valid value 0 fell through to the '2' default. Switch to isset() with an empty-string guard so 0 is preserved.

Verified: with the old code type 0 resolves to 2; with the fix it resolves to 0, while 1, 2 and empty are unchanged. The read-only display path already indexed the list directly and was correct, so this only touches the edit select.

Present on 21.0 to develop (the c_paiement type select does not exist in this form on 18.0), so targeting 21.0.