### PR TITLE
Fix #39304 roll back transaction on exception in set_infocredit

### DIFF
--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -454,6 +454,7 @@ class BonPrelevement extends CommonObject
 
 			$this->db->begin();
 
+			try {
 			$sql = " UPDATE ".MAIN_DB_PREFIX."prelevement_bons";
 			$sql .= " SET fk_user_credit = ".$user->id;
 			$sql .= ", statut = ".self::STATUS_CREDITED;
@@ -585,6 +586,14 @@ class BonPrelevement extends CommonObject
 				return 0;
 			} else {
 				$this->db->rollback();
+				return -1;
+			}
+			} catch (Exception $e) {
+				// Never leave the transaction open on an uncaught exception (would give a blank page and a "closing a connection with an opened transaction" error)
+				$this->db->rollback();
+				$this->error = $e->getMessage();
+				$this->errors[] = $this->error;
+				dol_syslog("bon-prelevment::set_infocredit exception ".$this->error, LOG_ERR);
 				return -1;
 			}
 		} else {


### PR DESCRIPTION
Classifying a direct debit / bank transfer order as credited could return a blank white page, with "Closing a connection with an opened transaction depth=2" in the log.

BonPrelevement::set_infocredit() opens a transaction and then creates the payments (Paiement::create, addPaymentToBank, setPaid). If any of those throws (e.g. a mysqli error in strict mode on a specific dataset), the exception escaped the method before reaching the rollback, leaving the transaction open and killing the page with no message.

This wraps the transactional body in try/catch: on an uncaught exception it rolls back, stores the message in $this->error and returns -1, so card.php shows the error instead of a blank screen.

Scope note: I could reproduce the nominal path (which works and is unchanged - order credited, payment created, invoice paid, transaction closed) but not the specific exception the reporter hits, so this is a robustness guard that turns the blank page + dangling transaction into a handled error and will make the underlying trigger visible. Verified locally that the nominal path still returns 0 with depth back to 0, and that an exception inside the block now rolls back to depth 0 instead of leaving it open.