### PR TITLE
Fix #39297 keep decimals on Dynamic Prices global variable value

### DIFF
--- a/htdocs/product/admin/dynamic_prices.php
+++ b/htdocs/product/admin/dynamic_prices.php
@@ -69,7 +69,7 @@ if (!empty($action) && empty($cancel)) {
 	if ($action == 'create_variable' || $action == 'edit_variable') {
 		$price_globals->code = GETPOSTISSET('code') ? GETPOST('code', 'alpha') : $price_globals->code;
 		$price_globals->description = GETPOSTISSET('description') ? GETPOST('description', 'restricthtml') : $price_globals->description;
-		$price_globals->value = GETPOSTISSET('value') ? GETPOSTINT('value') : $price_globals->value;
+		$price_globals->value = GETPOSTISSET('value') ? GETPOSTFLOAT('value') : $price_globals->value;
 		//Check if record already exists only when saving
 		if (!empty($save)) {
 			foreach ($price_globals->listGlobalVariables() as $entry) {


### PR DESCRIPTION
In the Dynamic Prices module configuration, saving a global variable with a decimal Value (e.g. 1.5) stored 1, because the field was read with GETPOSTINT.

The column c_price_global_variable.value is a double(24,8), so the value should keep its decimals. Switch to GETPOSTFLOAT.

Verified: GETPOSTINT('1.5') returns 1 while GETPOSTFLOAT('1.5') returns 1.5 (and a comma-decimal 1,5 returns 0 with the old cast, 1.5 with the fix). Present from 20.0 to develop; 18.0/19.0 use GETPOST(,'int') which has the same effect but GETPOSTFLOAT does not exist there, so this targets 20.0 for forward-merge.