### PR TITLE
Fix #39494 keep decimals on asset disposal amount

### DIFF
--- a/htdocs/asset/card.php
+++ b/htdocs/asset/card.php
@@ -124,7 +124,7 @@ if (empty($reshook)) {
 	// Action dispose object
 	if ($action == 'confirm_disposal' && $confirm == 'yes' && $permissiontoadd) {
 		$object->disposal_date = dol_mktime(12, 0, 0, GETPOSTINT('disposal_datemonth'), GETPOSTINT('disposal_dateday'), GETPOSTINT('disposal_dateyear')); // for date without hour, we use gmt
-		$object->disposal_amount_ht = GETPOSTINT('disposal_amount');
+		$object->disposal_amount_ht = GETPOSTFLOAT('disposal_amount');
 		$object->fk_disposal_type = GETPOSTINT('fk_disposal_type');
 		$disposal_invoice_id = GETPOSTINT('disposal_invoice_id');
 		$object->disposal_depreciated = ((GETPOST('disposal_depreciated') == '1' || GETPOST('disposal_depreciated') == 'on') ? 1 : 0);
@@ -265,7 +265,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		$langs->load('bills');
 
 		$disposal_date = dol_mktime(12, 0, 0, GETPOSTINT('disposal_datemonth'), GETPOSTINT('disposal_dateday'), GETPOSTINT('disposal_dateyear')); // for date without hour, we use gmt
-		$disposal_amount = GETPOSTINT('disposal_amount');
+		$disposal_amount = GETPOSTFLOAT('disposal_amount');
 		$fk_disposal_type = GETPOSTINT('fk_disposal_type');
 		$disposal_invoice_id = GETPOSTINT('disposal_invoice_id');
 		$disposal_depreciated = GETPOSTISSET('disposal_depreciated') ? GETPOST('disposal_depreciated') : 1;


### PR DESCRIPTION
When disposing of an asset, the disposal amount was read with GETPOSTINT and truncated to an integer, so 1500.50 was stored as 1500.

htdocs/asset/card.php reads disposal_amount with GETPOSTINT in the confirm_disposal action and again when building the disposal confirmation form. Asset::disposal_amount_ht is a 'price' field, so switch both to GETPOSTFLOAT to keep the decimals.

Present from 20.0 (the module does not exist on 18.0). Verified that GETPOSTINT('1500.50') returns 1500 while GETPOSTFLOAT keeps 1500.5.