### PR TITLE
Fix keep decimals when redisplaying deposit value on invoice create

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -3639,7 +3639,7 @@ if ($action == 'create') {
 						'variablealllines' => $langs->transnoentitiesnoconv('VarAmountAllLines')
 					);
 					$typedeposit = GETPOST('typedeposit', 'aZ09');
-					$valuedeposit = GETPOSTINT('valuedeposit');
+					$valuedeposit = GETPOSTFLOAT('valuedeposit');
 					if (empty($typedeposit) && !empty($objectsrc->deposit_percent)) {
 						$origin_payment_conditions_deposit_percent = getDictionaryValue('c_payment_term', 'deposit_percent', $objectsrc->cond_reglement_id);
 						if (!empty($origin_payment_conditions_deposit_percent)) {


### PR DESCRIPTION
Minor fix. On the deposit-invoice creation form, the deposit value field (amount or percent, e.g. 33.33) was reread for redisplay with GETPOSTINT, so on a form re-render the input showed the value truncated to an integer.

The actual processing already uses price2num (the stored deposit is correct), so this only affected the value shown back in the field. Switched the redisplay read to GETPOSTFLOAT so it keeps its decimals, consistent with how the value is processed.

Present 20.0 to develop.