### PR TITLE
Fix #39245 set TRIGGER_PREFIX to BILL on Facture

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -73,6 +73,11 @@ class Facture extends CommonInvoice
 	public $element = 'facture';
 
 	/**
+	 * @var string Prefix used to build trigger event names in generic CommonObject methods (BILL_MODIFY, ...)
+	 */
+	public $TRIGGER_PREFIX = 'BILL';
+
+	/**
 	 * @var string Name of table without prefix where object is stored
 	 */
 	public $table_element = 'facture';


### PR DESCRIPTION
Rework of #39490 targeting 23.0 instead of 18.0, after @lvessiller-opendsi correctly pointed out that CommonObject does not use TRIGGER_PREFIX on the older branches.

On 23.0, CommonObject::setPaymentMethods() (and setBankAccount/setShippingMethod) build the trigger name as `$triggerName = (empty($this->TRIGGER_PREFIX) ? strtoupper(get_class($this)) : $this->TRIGGER_PREFIX)`. Facture does not declare TRIGGER_PREFIX, so it fires FACTURE_MODIFY instead of the BILL_* events the class uses everywhere else (BILL_CREATE, BILL_MODIFY, ...). Modules listening on BILL_MODIFY miss those changes (reported for setPaymentMethods in #39245).

This declares `public $TRIGGER_PREFIX = 'BILL'`, matching Holiday='HOLIDAY', Workstation='WORKSTATION', BOM='BOM'.

Verified on the real 23.0 code: without the change Facture->setPaymentMethods emits FACTURE_MODIFY, with it BILL_MODIFY.

Note: on 18.0-22.0 setPaymentMethods still calls `call_trigger(strtoupper(get_class($this)).'_MODIFY')` directly and ignores TRIGGER_PREFIX, so this fix only applies from 23.0. FactureFournisseur has the same gap on 23.0+ (FACTUREFOURNISSEUR_MODIFY vs BILL_SUPPLIER_MODIFY) and can follow up.