### PR TITLE
NEW Add llx_socpeople.use_thirdparty_address column (data structure of #38118)

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -78,4 +78,9 @@ UPDATE llx_commande_fournisseurdet SET subprice_ttc = 0 WHERE subprice_ttc <> 0 
 UPDATE llx_facture_fourn_det SET pu_ttc = 0 WHERE pu_ttc <> 0 AND EXISTS (SELECT c.rowid FROM llx_const as c WHERE c.name = 'MAIN_VERSION_LAST_UPGRADE' AND c.value < '25.0.0');
 UPDATE llx_supplier_proposaldet SET subprice_ttc = 0 WHERE subprice_ttc <> 0 AND EXISTS (SELECT c.rowid FROM llx_const as c WHERE c.name = 'MAIN_VERSION_LAST_UPGRADE' AND c.value < '25.0.0');
 
+-- Explicit contact address mode flag. NULL keeps the legacy resolution for existing records,
+-- so an existing alternative contact address stays independent from its thirdparty address.
+-- VMYSQL4.1 ALTER TABLE llx_socpeople ADD COLUMN use_thirdparty_address smallint DEFAULT NULL AFTER fk_soc;
+-- VPGSQL8.2 ALTER TABLE llx_socpeople ADD COLUMN use_thirdparty_address smallint DEFAULT NULL;
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_socpeople.sql
+++ b/htdocs/install/mysql/tables/llx_socpeople.sql
@@ -25,6 +25,7 @@ create table llx_socpeople
   datec				datetime,
   tms				timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   fk_soc			integer,									-- lien vers la societe
+  use_thirdparty_address	smallint DEFAULT NULL,					-- 1=use linked thirdparty address, 0=use contact address, null=legacy resolution
   entity			integer DEFAULT 1 NOT NULL,					-- multi company id
   ref_ext           varchar(255),                               -- reference into an external system (not used by dolibarr)
   name_alias        varchar(255),


### PR DESCRIPTION
# NEW Add llx_socpeople.use_thirdparty_address column

Data structure only, extracted from #38118 and submitted standalone as `CONTRIBUTING.md` asks, so it can be reviewed and accepted before the code that uses it. Nothing but `htdocs/install/` in the diff.

A contact can either carry its own address or reuse the address of its thirdparty. Today that choice is guessed from the content of the address fields, which cannot tell an empty address from a deliberate "use the thirdparty address": as soon as a contact has no street, the display falls back to the thirdparty, and filling one field later silently changes the meaning of the record.

The column stores the choice explicitly:

| value | meaning |
|---|---|
| `0` | use the address of the contact |
| `1` | use the address of the linked thirdparty |
| `NULL` | legacy resolution |

`NULL` is the value of every existing record, so nothing changes on an upgraded base: an existing alternative address stays independent from its thirdparty address, and the current guess keeps being applied until the user makes the choice explicit.

`smallint DEFAULT NULL`, placed after `fk_soc` on a fresh install since that is the column it qualifies. `AFTER` is not portable, hence the `-- VMYSQL4.1` / `-- VPGSQL8.2` pair in the migration.

Code side, blocked by this one: #38118.
