### PR TITLE
NEW Add a date_sent column on the documents that can be emailed (data structure of #38349)

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -78,4 +78,18 @@ UPDATE llx_commande_fournisseurdet SET subprice_ttc = 0 WHERE subprice_ttc <> 0 
 UPDATE llx_facture_fourn_det SET pu_ttc = 0 WHERE pu_ttc <> 0 AND EXISTS (SELECT c.rowid FROM llx_const as c WHERE c.name = 'MAIN_VERSION_LAST_UPGRADE' AND c.value < '25.0.0');
 UPDATE llx_supplier_proposaldet SET subprice_ttc = 0 WHERE subprice_ttc <> 0 AND EXISTS (SELECT c.rowid FROM llx_const as c WHERE c.name = 'MAIN_VERSION_LAST_UPGRADE' AND c.value < '25.0.0');
 
+-- Feature date_sent - Timestamp of the last successful email send on commercial document objects
+ALTER TABLE llx_propal ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_commande ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_facture ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_supplier_proposal ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_commande_fournisseur ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_facture_fourn ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_contrat ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_expedition ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_delivery ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_reception ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_fichinter ADD COLUMN date_sent datetime DEFAULT NULL;
+ALTER TABLE llx_projet ADD COLUMN date_sent datetime DEFAULT NULL;
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_commande.sql
+++ b/htdocs/install/mysql/tables/llx_commande.sql
@@ -72,6 +72,7 @@ create table llx_commande
   fk_mode_reglement			integer,						-- mode de reglement
 
   date_livraison			datetime DEFAULT NULL,
+  date_sent                 datetime DEFAULT NULL,           -- date of last email send
   fk_shipping_method		integer,						-- shipping method id
   fk_warehouse				integer DEFAULT NULL,
   fk_availability			integer NULL,

--- a/htdocs/install/mysql/tables/llx_commande_fournisseur.sql
+++ b/htdocs/install/mysql/tables/llx_commande_fournisseur.sql
@@ -61,6 +61,7 @@ create table llx_commande_fournisseur
 
   date_livraison			datetime default NULL,			-- date planned of delivery (expected shipment date)
   date_reception        	datetime default NULL,			-- date of real final reception (when everything is received)
+  date_sent					datetime DEFAULT NULL,			-- date of last email send
   fk_account				integer,                        -- bank account
   fk_cond_reglement			integer,                        -- condition de reglement
   deposit_percent			varchar(63) DEFAULT NULL,		-- default deposit % if payment term needs it

--- a/htdocs/install/mysql/tables/llx_contrat.sql
+++ b/htdocs/install/mysql/tables/llx_contrat.sql
@@ -33,6 +33,7 @@ create table llx_contrat
 
   fin_validite				datetime,	-- not used
   date_cloture				datetime,	-- not used
+  date_sent					datetime DEFAULT NULL,	-- date of last email send
 
   fk_soc					integer NOT NULL,
   fk_projet					integer,

--- a/htdocs/install/mysql/tables/llx_delivery.sql
+++ b/htdocs/install/mysql/tables/llx_delivery.sql
@@ -33,6 +33,7 @@ create table llx_delivery
   date_valid            datetime,						-- date de validation
   fk_user_valid         integer,						-- valideur du bon de livraison
   date_delivery 	    datetime		DEFAULT NULL,	-- delivery date
+  date_sent             datetime		DEFAULT NULL,	-- date of last email send
   fk_address  			integer,						-- delivery address (deprecated)
   fk_statut             smallint     DEFAULT 0,
   total_ht              double(24,8) DEFAULT 0,

--- a/htdocs/install/mysql/tables/llx_expedition.sql
+++ b/htdocs/install/mysql/tables/llx_expedition.sql
@@ -38,6 +38,7 @@ create table llx_expedition
   fk_user_valid         integer,						-- user that validate
   date_delivery			datetime	DEFAULT NULL,		-- date planned of delivery
   date_expedition       datetime,						-- date real shipment (to implement)
+  date_sent             datetime DEFAULT NULL,				-- date of last email send
   fk_address  			integer		DEFAULT NULL, 		-- delivery address (deprecated)
   fk_shipping_method    integer,
   tracking_number       varchar(50),

--- a/htdocs/install/mysql/tables/llx_facture.sql
+++ b/htdocs/install/mysql/tables/llx_facture.sql
@@ -82,6 +82,7 @@ create table llx_facture
   fk_cond_reglement		integer  DEFAULT 1 NOT NULL,			-- default payment term (30 days, end of month...)
   fk_mode_reglement		integer,								-- default payment mode (cash, card, cheque, ...)
   date_lim_reglement	date,									-- due date
+  date_sent             datetime DEFAULT NULL,               -- date of last email send
 
   payment_reference     varchar(25),                            -- SEPA and any other national or custom payment id (use case for this field is not clear)
   fk_thirdparty_rib_id	integer NULL,							-- ID of thirdparty payment mode in llx_societe_rib

--- a/htdocs/install/mysql/tables/llx_facture_fourn.sql
+++ b/htdocs/install/mysql/tables/llx_facture_fourn.sql
@@ -74,6 +74,7 @@ create table llx_facture_fourn
   fk_cond_reglement		integer,   	                   -- condition de reglement (30 jours, fin de mois ...)
   fk_mode_reglement		integer,                	   -- mode de reglement (CHQ, VIR, ...)
   date_lim_reglement 	date,                          -- date limite de reglement
+  date_sent             datetime DEFAULT NULL,          -- date of last email send
 
   payment_reference     varchar(25),                    -- SEPA and any other national or custom payment id (use case for this field is not clear)
   fk_thirdparty_rib_id	integer NULL,					-- ID of thirdparty payment mode in llx_societe_rib

--- a/htdocs/install/mysql/tables/llx_fichinter.sql
+++ b/htdocs/install/mysql/tables/llx_fichinter.sql
@@ -38,6 +38,7 @@ create table llx_fichinter
   dateo				date,						-- date start intervention
   datee				date,						-- date end intervention
   datet				date,						-- date end intervention
+  date_sent			datetime DEFAULT NULL,       -- date of last email send
   duree				real,                       -- duration total of  intervention
   description		text,
 

--- a/htdocs/install/mysql/tables/llx_projet.sql
+++ b/htdocs/install/mysql/tables/llx_projet.sql
@@ -53,6 +53,7 @@ create table llx_projet
   usage_organize_event integer DEFAULT 0,		-- Set to 1 if you want to use project to organize an event or receive attendees registration
   date_start_event 	datetime,					-- date start event
   date_end_event   	datetime,					-- date end event
+  date_sent        	datetime DEFAULT NULL,				-- date of last email send
   location         	varchar(255),				-- location
   accept_conference_suggestions integer DEFAULT 0,		-- Set to 1 if you want to allow unknown people to suggest conferences
   accept_booth_suggestions integer DEFAULT 0,			-- Set to 1 if you want to Allow unknown people to suggest booth

--- a/htdocs/install/mysql/tables/llx_propal.sql
+++ b/htdocs/install/mysql/tables/llx_propal.sql
@@ -73,6 +73,7 @@ create table llx_propal
   last_main_doc			varchar(255),					-- relative filepath+filename of the last main generated document
 
   date_livraison		date DEFAULT NULL,				-- delivery date
+  date_sent             datetime DEFAULT NULL,           -- date of last email send
   fk_shipping_method    integer,                        -- shipping method id
   fk_warehouse		    integer DEFAULT NULL,           -- warehouse id
   fk_availability		integer NULL,

--- a/htdocs/install/mysql/tables/llx_reception.sql
+++ b/htdocs/install/mysql/tables/llx_reception.sql
@@ -39,6 +39,7 @@ create table llx_reception
   fk_user_valid         integer,						-- valideur
   date_delivery			datetime	DEFAULT NULL,		-- date planned of delivery
   date_reception        datetime,
+  date_sent             datetime DEFAULT NULL,				-- date of last email send
   fk_shipping_method    integer,
   tracking_number       varchar(50),
   fk_statut             smallint	DEFAULT 0,			-- 0 = draft, 1 = validated, 2 = billed or closed depending on WORKFLOW_BILL_ON_SHIPMENT option

--- a/htdocs/install/mysql/tables/llx_supplier_proposal.sql
+++ b/htdocs/install/mysql/tables/llx_supplier_proposal.sql
@@ -53,6 +53,7 @@ CREATE TABLE llx_supplier_proposal (
   last_main_doc			varchar(255),					-- relative filepath+filename of last main generated document
 
   date_livraison date DEFAULT NULL,
+  date_sent datetime DEFAULT NULL,                    -- date of last email send
   fk_shipping_method integer DEFAULT NULL,
   import_key varchar(14) DEFAULT NULL,
   extraparams varchar(255) DEFAULT NULL,


### PR DESCRIPTION
# NEW Add a date_sent column on the documents that can be emailed

Data structure only, extracted from #38349 and submitted standalone as `CONTRIBUTING.md` asks, so it can be reviewed and accepted before the code that uses it. Nothing but `htdocs/install/` in the diff.

Knowing whether a document was already sent to the customer, and when, currently means scanning the event log of the object. That works for a single record on screen, it does not work for a list: the information cannot be shown as a column, sorted, filtered, or used by a mass action, and every list line would need its own query on `llx_actioncomm`.

The column stores the date of the last successful email send on the object itself, so it becomes an ordinary date field of the object.

`datetime DEFAULT NULL`, `NULL` meaning never sent — the value of every existing record. The past sends are deliberately **not** backfilled: the event log stays the history of every send, this column is only the last one. So on an upgraded base the column fills up as documents are sent from then on.

Added on the twelve objects that own a "send by email" action, and nowhere else:

`llx_propal`, `llx_commande`, `llx_facture`, `llx_supplier_proposal`, `llx_commande_fournisseur`, `llx_facture_fourn`, `llx_contrat`, `llx_expedition`, `llx_delivery`, `llx_reception`, `llx_fichinter`, `llx_projet`

Code side, blocked by this one: #38349.
