### PR TITLE
FIX Agenda "per user" view does not fire printFieldListFrom hook

### DIFF
--- a/htdocs/comm/action/peruser.php
+++ b/htdocs/comm/action/peruser.php
@@ -752,6 +752,11 @@ if (($filtert != '-1' && $filtert != '-2') || $usergroup > 0) {
 	}
 }
 
+// Add table from hooks
+$parameters = array();
+$reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+$sql .= $hookmanager->resPrint;
+
 $sql .= " WHERE a.fk_action = ca.id";
 $sql .= " AND a.entity IN (".getEntity('agenda').")";	// bookcal is a "virtual view" of agenda
 


### PR DESCRIPTION
## Summary

`comm/action/index.php` (agenda month/week/day view) fires the `printFieldListFrom` hook right before the `WHERE` clause of the event query, letting external modules add extra `JOIN` conditions to the agenda SQL query.

`comm/action/peruser.php` (agenda "per user" view) builds a structurally identical query but never calls this hook — it only fires `printFieldListSelect`, whose output lands before `FROM` and can't be used to add a `WHERE`-equivalent join condition. `printFieldListWhere` isn't fired in either file, so `printFieldListFrom` is the only hook point available before `WHERE`.

This adds the same hook call already present in `index.php`, at the same relative position (after the `FROM`/`JOIN` clauses, right before `WHERE`), so modules can extend the agenda query the same way in both views.

Trivial, additive change: 5 lines added, no existing line modified.

Fixes #39506

## Test plan

- [x] `php -l` on the changed file
- [x] PHPStan level 10 (same config/bootstrap as CI `phpstan.yml`) run against the changed file: no errors
- [x] Manually verified in a downstream module (implements `printFieldListFrom` for hook context `agenda` to filter out events with an unrealistically long duration): the hook now fires in the "per user" view exactly like it already did in the month/week/day view, confirmed against a real dataset