### PR TITLE
FIX Project::loadTimeSpentMonth() drops last day of month in some timezones

### DIFF
--- a/htdocs/projet/class/project.class.php
+++ b/htdocs/projet/class/project.class.php
@@ -2229,8 +2229,16 @@ class Project extends CommonObject
 		$sql .= " WHERE ptt.fk_element = pt.rowid";
 		$sql .= " AND ptt.elementtype = 'task'";
 		$sql .= " AND pt.fk_projet = ".((int) $this->id);
+		// Note: we must not compute the month end with dol_time_plus_duree($datestart, 1, 'm') - 1.
+		// dol_time_plus_duree() forces UTC before adding the month, which shifts the "start of month"
+		// instant backward by the server TZ offset (e.g. -2h for CEST). For a month directly following
+		// a shorter one (May, July, October), that shift lands the +1 month calendar arithmetic one
+		// calendar day short (e.g. Jul 1 00:00 Europe/Berlin = Jun 30 22:00 UTC; +1 month from June 30
+		// is July 30, not July 31/Aug 1), silently excluding the last day of the month from this query.
+		$tmpdatestart = dol_getdate($datestart);
+		$tmpmonthend = dol_mktime(23, 59, 59, $tmpdatestart['mon'], (int) cal_days_in_month(CAL_GREGORIAN, $tmpdatestart['mon'], $tmpdatestart['year']), $tmpdatestart['year']);
 		$sql .= " AND (ptt.element_date >= '".$this->db->idate($datestart)."' ";
-		$sql .= " AND ptt.element_date <= '".$this->db->idate(dol_time_plus_duree($datestart, 1, 'm') - 1)."')";
+		$sql .= " AND ptt.element_date <= '".$this->db->idate($tmpmonthend)."')";
 		if ($taskid) {
 			$sql .= " AND ptt.fk_element=".((int) $taskid);
 		}


### PR DESCRIPTION
## Bug

`Project::loadTimeSpentMonth()` computes the month's upper date bound as:

```php
$sql .= " AND ptt.element_date <= '".$this->db->idate(dol_time_plus_duree($datestart, 1, 'm') - 1)."')";
```

`dol_time_plus_duree()` forces its internal `DateTime` to UTC before adding the interval. This shifts the "start of month" instant backward by the server's UTC offset (e.g. -2h for `Europe/Berlin` in CEST). For a month directly following a shorter one, that shift lands the "+1 month" calendar arithmetic exactly one calendar day short.

**Example**: with server TZ `Europe/Berlin` (CEST, UTC+2), `$datestart` for July is `2026-07-01 00:00:00` local = `2026-06-30 22:00:00` UTC. Adding 1 month to June 30 (in UTC) gives July 30, not July 31/Aug 1, because June only has 30 days. The resulting upper bound becomes `2026-07-30 23:59:59` instead of `2026-07-31 23:59:59`, so every `element_time` row on July 31 is silently excluded from the query — both from `Project::$monthWorkLoad` / `$monthWorkLoadPerTask` and therefore from the "Month" timesheet view (`projet/activity/permonth.php`), even though the underlying time entries are untouched and correct.

This affects any month immediately following a shorter month while DST is active for the server timezone (e.g. May, July and October for a CEST server in 2026). A month following an equal-or-longer month is unaffected; a month following a longer month overflows into the next month instead (a separate, pre-existing issue not addressed here).

## Fix

Compute the month end directly (last day of `$datestart`'s own month, `23:59:59`) via `dol_getdate()` / `dol_mktime()` / `cal_days_in_month()`, instead of deriving it from UTC-forced interval arithmetic.

## Reproduction / verification

Reproduced and verified against Dolibarr 23.0.2 with server TZ `Europe/Berlin`:
- Before the fix: a user's July timesheet in the Month view undercounted the last week by exactly the July 31 entries (e.g. week total off by 7:40), while the Week/Day views and the raw database rows were correct throughout the month.
- After the fix: the Month view total matches the database and the manually-summed weekly totals.

Confirmed the root cause by directly executing Dolibarr's own `dol_mktime()`/`dol_time_plus_duree()`/`idate()` logic under `Europe/Berlin`, which reproduces the exact wrong upper bound (`2026-07-30 23:59:59`) described above.

## Test plan

- [x] `php -l` on the modified file
- [x] Reproduced the bug live (server TZ forced to `Europe/Berlin`) on a test Dolibarr 23.0.2 instance: Month view for July showed a missing week-31 total
- [x] Applied the fix on the same instance: Month view for July now matches the database
- [x] Confirmed months not adjacent to a shorter/longer neighbor (e.g. August, since July and August both have 31 days) are unaffected before and after the fix