### PR TITLE
FIX Phan warnings introduced by the 24.0 merges of 2026-08-13

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -201,7 +201,7 @@ class Asset extends CommonObject
 	 */
 	public $disposal_date;
 	/**
-	 * @var null|string|int  Is string, but asset/Card.php assigns int.
+	 * @var null|string|int|float  Is string in database, but asset/card.php assigns a float.
 	 */
 	public $disposal_amount_ht;
 	/**

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3465,7 +3465,7 @@ class Commande extends CommonOrder
 		$sql .= " fk_user_valid=".((isset($this->user_validation_id) && $this->user_validation_id > 0) ? ((int) $this->user_validation_id) : "null").",";
 		$sql .= " fk_projet=".(isset($this->fk_project) ? ((int) $this->fk_project) : "null").",";
 		$sql .= " fk_cond_reglement=".(isset($this->cond_reglement_id) ? ((int) $this->cond_reglement_id) : "null").",";
-		$sql .= " deposit_percent=".(!empty($this->deposit_percent) ? "'".$this->db->escape($this->deposit_percent)."'" : "null").",";
+		$sql .= " deposit_percent=".(!empty($this->deposit_percent) ? "'".$this->db->escape((string) $this->deposit_percent)."'" : "null").",";
 		$sql .= " fk_mode_reglement=".(isset($this->mode_reglement_id) ? ((int) $this->mode_reglement_id) : "null").",";
 		$sql .= " date_livraison=".(strval($this->delivery_date) != '' ? "'".$this->db->idate($this->delivery_date)."'" : 'null').",";
 		$sql .= " fk_shipping_method=".(isset($this->shipping_method_id) ? ((int) $this->shipping_method_id) : "null").",";

--- a/htdocs/core/modules/dons/html_cerfafr.modules.php
+++ b/htdocs/core/modules/dons/html_cerfafr.modules.php
@@ -133,7 +133,7 @@ class html_cerfafr extends ModeleDon
 				} else {
 					$paymentmode = '';
 				}
-				$modepaymentcode = !empty($formclass->cache_types_paiements[$modepaymentid]['code']) ? $formclass->cache_types_paiements[$modepaymentid]['code'] : "";
+				$modepaymentcode = !empty($formclass->cache_types_paiements[(int) $modepaymentid]['code']) ? $formclass->cache_types_paiements[(int) $modepaymentid]['code'] : "";
 				if ($modepaymentcode == 'CHQ') {
 					$ModePaiement = '<td width="25%"><input type="checkbox"> Remise d\'espèces</td><td width="25%"><input type="checkbox" disabled="true" checked="checked"> Chèque</td><td width="50%"><input type="checkbox"> Virement, prélèvement, carte bancaire</td>';
 				} elseif ($modepaymentcode == 'LIQ') {

--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -173,7 +173,7 @@ if (empty($reshook)) {
 			// otherwise the default 'origin_id LIKE %..%' filter can return an unrelated line (or none),
 			// which would let the child MO be created from the leftover parent POST data (duplicate MO).
 			$filter = '(fk_mo:=:'.((int) $mo_parent->id).') AND (origin_id:=:'.((int) $id_bom_line).") AND (origin_type:=:'bomline')";
-			$TMoLines = $moline->fetchAll('DESC', 'rowid', '1', '', $filter);
+			$TMoLines = $moline->fetchAll('DESC', 'rowid', 1, 0, $filter);
 
 			if (empty($TMoLines)) {
 				continue;


### PR DESCRIPTION
Phan currently fails on **every** open pull request, with the same six warnings, in files the contributors never touched. Same eight annotations on #39512, #39513, #39514, #39515, #39516 and #39507 — including a pull request that only changes three lines of a label.

The four files carrying them were all modified on 2026-08-13 by the automated merges from `24.0` into `develop`:

```
htdocs/mrp/mo_card.php                             2026-08-13  Merge branch '24.0'
htdocs/core/modules/dons/html_cerfafr.modules.php  2026-08-13  Merge branch '24.0'
htdocs/commande/class/commande.class.php           2026-08-13  Automated merge from 24.0
htdocs/asset/card.php                              2026-08-13  Merge branch '24.0'
```

On a pull request the workflow analyses a file list that includes those recent changes of `develop`, which is why the warnings follow everybody around.

## The six warnings

- **`mrp/mo_card.php:176`** — `MoLine::fetchAll()` takes `int` for `$limit` and `$offset`, and receives `1` and ``. Two warnings on that single line.
- **`commande/class/commande.class.php:3468`** — `escape()` takes a string, `deposit_percent` is `float|int`. The insert path of the same class already writes `escape((string) $this->deposit_percent)` at line 1061; only the update path was missing the cast.
- **`asset/class/asset.class.php:206`** — the note on `$disposal_amount_ht` reads *"Is string, but asset/Card.php assigns int"*, but `asset/card.php:137` now assigns `GETPOSTFLOAT()`. The only other assignment in the codebase is `null`, and the consumers read the column from the database rather than the property, so widening the annotation is enough.
- **`core/modules/dons/html_cerfafr.modules.php:136`** — `$modepaymentid` is used as an array index outside of the `if ($modepaymentid)` that guarantees it is not null. Two warnings, the index appearing twice on the line.

## No functional change

The four values were already being used as `int`, `string`, `float` and `int` by PHP itself; the casts only state it. One of the four changes is a PHPDoc line.

I ran into this while opening #39512 and spent a while making sure it was not my own doing, so it seemed worth fixing for everyone rather than working around it.