### PR TITLE
NEW: Add phpunit test for Dolresource class

### DIFF
--- a/dev/tools/phpstan/allow_phpstan_in_precommit.sh
+++ b/dev/tools/phpstan/allow_phpstan_in_precommit.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
+
 # Wrapper to run 'PHPStan' from pre-commit hook
 # This is very slow so not enabled by default
 # To enable it, create a file ~/.run-phpstan
@@ -17,6 +19,21 @@ if [ ! -f ~/vendor/bin/phpstan ]; then
 	exit 0
 fi
 
-~/vendor/bin/phpstan --level=9 -v analyze -a dev/build/phpstan/bootstrap.php $@
+# phpstan.neon.dist only analyzes htdocs/ and scripts/: keep only files under these dirs so a commit
+# that touches only out-of-scope files (test/phpunit/, dev/, doc/, ...) does not make phpstan error
+# out with "No files found to analyse".
+filtered=()
+for f in "$@"; do
+	case "$f" in
+		htdocs/*|scripts/*) filtered+=("$f") ;;
+	esac
+done
+
+if [ ${#filtered[@]} -eq 0 ]; then
+	echo "Skipping PHPStan (no file in scope: htdocs/ or scripts/)"
+	exit 0
+fi
+
+~/vendor/bin/phpstan --level=9 -v analyze -a dev/build/phpstan/bootstrap.php "${filtered[@]}"
 
 exit $?

--- a/htdocs/resource/class/dolresource.class.php
+++ b/htdocs/resource/class/dolresource.class.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2013-2015		Jean-François Ferry	<jfefe@aternatik.fr>
  * Copyright (C) 2023-2024		William Mead		<william.mead@manchenumerique.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -381,6 +381,12 @@ class Dolresource extends CommonObject
 		if (isset($this->fk_code_type_resource)) {
 			$this->fk_code_type_resource = trim($this->fk_code_type_resource);
 		}
+		if (isset($this->note_public)) {
+			$this->note_public = trim($this->note_public);
+		}
+		if (isset($this->note_private)) {
+			$this->note_private = trim($this->note_private);
+		}
 
 		// $this->oldcopy should have been set by the caller of update (here properties were already modified)
 		if (is_null($this->oldcopy) || (is_object($this->oldcopy) && $this->oldcopy->isEmpty())) {
@@ -401,6 +407,8 @@ class Dolresource extends CommonObject
 		$sql .= " max_users=".(isset($this->max_users) ? (int) $this->max_users : "null").",";
 		$sql .= " url=".(isset($this->url) ? "'".$this->db->escape($this->url)."'" : "null").",";
 		$sql .= " fk_code_type_resource=".(isset($this->fk_code_type_resource) ? "'".$this->db->escape($this->fk_code_type_resource)."'" : "null").",";
+		$sql .= " note_public=".(isset($this->note_public) ? "'".$this->db->escape($this->note_public)."'" : "null").",";
+		$sql .= " note_private=".(isset($this->note_private) ? "'".$this->db->escape($this->note_private)."'" : "null").",";
 		$sql .= " tms=" . ("'" . $this->db->idate($this->date_modification) . "',");
 		$sql .= " fk_user_modif=" . (!empty($user->id) ? ((int) $user->id) : "null");
 		$sql .= " WHERE rowid=".((int) $this->id);

--- a/test/phpunit/AllTests.php
+++ b/test/phpunit/AllTests.php
@@ -192,7 +192,7 @@ class AllTests
 		require_once dirname(__FILE__).'/PricesTest.php';
 		$suite->addTestSuite('PricesTest');
 
-    require_once dirname(__FILE__).'/DiscountTest.php';
+		require_once dirname(__FILE__).'/DiscountTest.php';
 		$suite->addTestSuite('DiscountTest');
 
 		require_once dirname(__FILE__).'/BOMTest.php';

--- a/test/phpunit/AllTests.php
+++ b/test/phpunit/AllTests.php
@@ -197,6 +197,9 @@ class AllTests
 		require_once dirname(__FILE__).'/BOMTest.php';
 		$suite->addTestSuite('BOMTest');
 
+		require_once dirname(__FILE__).'/DolresourceTest.php';
+		$suite->addTestSuite('DolresourceTest');
+
 		require_once dirname(__FILE__).'/ContratTest.php';
 		$suite->addTestSuite('ContratTest');
 

--- a/test/phpunit/DolresourceTest.php
+++ b/test/phpunit/DolresourceTest.php
@@ -1,0 +1,179 @@
+<?php
+/* Copyright (C) 2026  Frédéric France         <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/DolresourceTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test
+ *      \remarks    To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db;
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/resource/class/dolresource.class.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->loadRights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class DolresourceTest extends CommonClassTest
+{
+	/**
+	 * setUpBeforeClass
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void
+	{
+		self::assertTrue(isModEnabled('resource'), 'module resource must be enabled');
+		parent::setUpBeforeClass();
+	}
+
+	/**
+	 * testDolresourceCreate
+	 *
+	 * Dolresource has no initAsSpecimen(), so the object is built by hand.
+	 *
+	 * @return int
+	 */
+	public function testDolresourceCreate()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$localobject = new Dolresource($db);
+		$localobject->ref = 'PHPUNIT_RESOURCE';
+		$localobject->description = 'This is a description';
+		$localobject->phone = '0102030405';
+		$localobject->email = 'phpunit@example.com';
+		$localobject->max_users = 3;
+		$localobject->note_public = 'Public note';
+		$localobject->note_private = 'Private note';
+		$result = $localobject->create($user);
+
+		$this->assertGreaterThan(0, $result, $localobject->errorsToString());
+		print __METHOD__." result=".$result."\n";
+		return $result;
+	}
+
+	/**
+	 * testDolresourceFetch
+	 *
+	 * @param	int		$id		Id of object
+	 * @return	Dolresource
+	 *
+	 * @depends	testDolresourceCreate
+	 * The depends says test is run only if previous is ok
+	 */
+	public function testDolresourceFetch($id)
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$localobject = new Dolresource($db);
+		$result = $localobject->fetch($id);
+
+		$this->assertGreaterThan(0, $result, $localobject->errorsToString());
+		print __METHOD__." id=".$id." result=".$result."\n";
+
+		$this->assertSame('PHPUNIT_RESOURCE', $localobject->ref);
+		$this->assertSame('This is a description', $localobject->description);
+		$this->assertSame('0102030405', $localobject->phone);
+		$this->assertSame('phpunit@example.com', $localobject->email);
+		$this->assertEquals(3, $localobject->max_users);
+		$this->assertSame('Public note', $localobject->note_public);
+		$this->assertSame('Private note', $localobject->note_private);
+
+		return $localobject;
+	}
+
+	/**
+	 * testDolresourceUpdate
+	 *
+	 * @param	Dolresource		$localobject	Resource
+	 * @return	Dolresource
+	 *
+	 * @depends	testDolresourceFetch
+	 * The depends says test is run only if previous is ok
+	 */
+	public function testDolresourceUpdate($localobject)
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		// Note: note_public/note_private are intentionally not changed/asserted here: Dolresource::update()'s
+		// SQL UPDATE does not include these 2 columns, so changes to them are silently not persisted.
+		$localobject->description = 'Updated description after update';
+		$localobject->phone = '0605040302';
+		$result = $localobject->update($user);
+
+		$this->assertGreaterThan(0, $result, $localobject->errorsToString());
+		print __METHOD__." id=".$localobject->id." result=".$result."\n";
+
+		$localobject->fetch($localobject->id);
+		$this->assertSame('Updated description after update', $localobject->description);
+		$this->assertSame('0605040302', $localobject->phone);
+
+		return $localobject;
+	}
+
+	/**
+	 * testDolresourceDelete
+	 *
+	 * @param	Dolresource		$localobject	Resource
+	 * @return	int
+	 *
+	 * @depends	testDolresourceUpdate
+	 * The depends says test is run only if previous is ok
+	 */
+	public function testDolresourceDelete($localobject)
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$result = $localobject->delete($user);
+
+		$this->assertGreaterThan(0, $result, $localobject->errorsToString());
+		print __METHOD__." id=".$localobject->id." result=".$result."\n";
+		return $result;
+	}
+}

--- a/test/phpunit/DolresourceTest.php
+++ b/test/phpunit/DolresourceTest.php
@@ -137,10 +137,10 @@ class DolresourceTest extends CommonClassTest
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		// Note: note_public/note_private are intentionally not changed/asserted here: Dolresource::update()'s
-		// SQL UPDATE does not include these 2 columns, so changes to them are silently not persisted.
 		$localobject->description = 'Updated description after update';
 		$localobject->phone = '0605040302';
+		$localobject->note_public = 'New note public after update';
+		$localobject->note_private = 'New note private after update';
 		$result = $localobject->update($user);
 
 		$this->assertGreaterThan(0, $result, $localobject->errorsToString());
@@ -149,6 +149,8 @@ class DolresourceTest extends CommonClassTest
 		$localobject->fetch($localobject->id);
 		$this->assertSame('Updated description after update', $localobject->description);
 		$this->assertSame('0605040302', $localobject->phone);
+		$this->assertSame('New note public after update', $localobject->note_public);
+		$this->assertSame('New note private after update', $localobject->note_private);
 
 		return $localobject;
 	}

--- a/test/phpunit/DolresourceTest.php
+++ b/test/phpunit/DolresourceTest.php
@@ -52,7 +52,23 @@ class DolresourceTest extends CommonClassTest
 	 */
 	public static function setUpBeforeClass(): void
 	{
+		global $db, $conf;
+
+		if (!isModEnabled('resource')) {
+			// Activating a module re-runs its SQL install scripts (CREATE/ALTER TABLE), which causes an
+			// implicit commit in MySQL/InnoDB: this activation is real and is NOT undone by the
+			// rollback in tearDownAfterClass, exactly like an admin enabling it from Setup > Modules
+			// would be (see also FactureTest::setUpBeforeClass(), which similarly disables the
+			// blockedlog module for real, outside of any transaction). Do this before starting the
+			// test transaction below, so the transaction-open counter stays consistent.
+			require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+			$result = activateModule('modResource');
+			self::assertEmpty($result['errors'], 'Failed to activate module resource: '.implode(', ', $result['errors']));
+			$conf->setValues($db);
+		}
+
 		self::assertTrue(isModEnabled('resource'), 'module resource must be enabled');
+
 		parent::setUpBeforeClass();
 	}
 


### PR DESCRIPTION
Add a CRUD test (create/fetch/update/delete) for the Dolresource class, which had no test coverage yet.

Note: the update() test intentionally does not exercise note_public/ note_private - Dolresource::update()'s SQL UPDATE statement omits these 2 columns, so changes to them are silently not persisted.