### PR TITLE
FIX: CommonObject::updateExtraField() method

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -898,7 +898,7 @@ if (empty($reshook)) {
 
 		if (!$error) {
 			// Actions on extra fields
-			$result = $object->updateExtraField($attribute_name, 'INTERVENTION_MODIFY');
+			$result = $object->updateExtraField($attribute_name, 'FICHINTER_MODIFY');
 			if ($result < 0) {
 				setEventMessages($object->error, $object->errors, 'errors');
 				$error++;


### PR DESCRIPTION
should call the corresponding object update trigger

# FIX: CommonObject::updateExtraField() method should call the corresponding object update trigger

`Fichinter::update()` method calls the `FICHINTER_MODIFY` trigger, while the `$object->updateExtrafield()` used in the card calls a trigger called `INTERVENTION_MODIFY`. It creates an error in the dolibarr log (on line 70 of `htdocs/core/class/commontrigger.class.php`) and should not work this way
