### PR TITLE
FIX: Exclude title lines from the quantities expected by the shipment and reception workflow

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -455,6 +455,11 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 							if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) {
 								continue;
 							}
+							// Title and separator lines can never be shipped, so they must never be counted into the expected
+							// quantities (same rule as into ExpeditionLigne::checkQtyVsOrderLine())
+							if ($orderline->product_type == 9) {
+								continue;
+							}
 							if (isset($qtyordred[$orderline->fk_product])) {
 								$qtyordred[$orderline->fk_product] += $orderline->qty;
 							} else {
@@ -532,6 +537,11 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 						foreach ($order->lines as $orderline) {
 							// Exclude lines not qualified for shipment, similar code is found into calcAndSetStatusDispatch() for vendors
 							if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) {
+								continue;
+							}
+							// Title and separator lines can never be received, so they must never be counted into the expected
+							// quantities (same rule as into ExpeditionLigne::checkQtyVsOrderLine())
+							if ($orderline->product_type == 9) {
 								continue;
 							}
 							$qtyordred[$orderline->fk_product] += $orderline->qty;


### PR DESCRIPTION
# FIX Exclude title lines from the quantities expected by the shipment and reception workflow

## Problem

Reported by @jyhere in #33749:

> - set the increase stock on reception validate
> - set STOCK_SUPPORTS_SERVICES = 1
> - Activate the Workflow module, with WORKFLOW_ORDER_CLASSIFY_RECEIVED_RECEPTION = 1
> - use a free text line module like Subtotal
> - Create a supplier order with a product line and a title line
> - Create the reception from the order, validate the reception. The order won't be classified.

## Cause

When it builds the quantities expected on the order, the workflow trigger only skips the service lines, and only when `STOCK_SUPPORTS_SERVICES` is off:

```php
// Exclude lines not qualified for shipment, similar code is found into calcAndSetStatusDispatch() for vendors
if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) {
	continue;
}
$qtyordred[$orderline->fk_product] += $orderline->qty;
```

So with `STOCK_SUPPORTS_SERVICES = 1`, a title line (`product_type = 9`, as created by a subtotal/free text module) is counted too. Such a line has no product, so it adds an entry `$qtyordred['']` that can never be matched by any shipped/received quantity: `array_diff_assoc()` is never empty and the order is never classified.

It is visible in the PHP log, the empty key comes from the title line:

```
PHP Warning: Undefined array key "" in .../interface_20_modWorkflow_WorkflowManager.class.php on line 537
```

Title lines are already skipped elsewhere for the very same reason, e.g. `ExpeditionLigne::checkQtyVsOrderLine()`:

```php
if ($orderline->product_type == 9) {
	return true; // Skip check for title/separator lines, they have no deliverable quantity
}
```

## Fix

Skip `product_type == 9` lines in the two places that build the expected quantities (customer order → shipment, and supplier order → reception). The existing condition is left untouched, the guard is added next to it.

## Tests

Local install with the settings of the report (`STOCK_SUPPORTS_SERVICES = 1`, `WORKFLOW_ORDER_CLASSIFY_RECEIVED_RECEPTION = 1`, stock increase on reception), a supplier order with one product line (qty 2) and one title line, then a reception of the whole quantity of the product line:

| Case | Order status after validating the reception |
| --- | --- |
| Before, order with a title line | **1** — not classified (bug), with the `Undefined array key ""` warning |
| After, order with a title line | **5** — received completely, no more warning |
| After, order without any title line | **5** — received completely (unchanged) |

## Credit

This takes over #33749 by @jyhere, same diagnosis and same repro. The implementation adds a separate guard instead of extending the existing condition, and it does not touch `CommandeFournisseur::calcAndSetStatusDispatch()`: that method already ignores those lines on 24.0 and develop (it tests `empty($line->stockable_product)` there), and touching it on this branch would conflict when merging forward.

## Note about the branch

Opened against 22.0 (N-2). The two spots are identical from at least 21.0 up to develop, so this merges forward cleanly. Tell me if you prefer another branch.
