### PR TITLE
FIX: Remove a block duplicated by a merge into Expedition::delete()

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -455,6 +455,11 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 							if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) {
 								continue;
 							}
+							// Title and separator lines can never be shipped, so they must never be counted into the expected
+							// quantities (same rule as into ExpeditionLigne::checkQtyVsOrderLine())
+							if ($orderline->product_type == 9) {
+								continue;
+							}
 							if (isset($qtyordred[$orderline->fk_product])) {
 								$qtyordred[$orderline->fk_product] += $orderline->qty;
 							} else {
@@ -532,6 +537,11 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 						foreach ($order->lines as $orderline) {
 							// Exclude lines not qualified for shipment, similar code is found into calcAndSetStatusDispatch() for vendors
 							if (!getDolGlobalString('STOCK_SUPPORTS_SERVICES') && $orderline->product_type > 0) {
+								continue;
+							}
+							// Title and separator lines can never be received, so they must never be counted into the expected
+							// quantities (same rule as into ExpeditionLigne::checkQtyVsOrderLine())
+							if ($orderline->product_type == 9) {
 								continue;
 							}
 							$qtyordred[$orderline->fk_product] += $orderline->qty;

--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -1886,9 +1886,9 @@ class Expedition extends CommonObject
 
 						// We delete PDFs
 						$ref = dol_sanitizeFileName($this->ref);
-						if (!empty($conf->expedition->dir_output)) {
-							$dir = $conf->expedition->dir_output . '/sending/' . $ref;
-							$file = $dir . '/' . $ref . '.pdf';
+						if (!empty($conf->expedition->dir_output) && !empty($ref)) {
+							$dir = $conf->expedition->dir_output.'/sending/'.$ref;
+							$file = $dir.'/'.$ref.'.pdf';
 							if (file_exists($file)) {
 								if (!dol_delete_file($file)) {
 									return 0;
@@ -1902,36 +1902,7 @@ class Expedition extends CommonObject
 							}
 						}
 
-						if (!$error) {
-							$this->db->commit();
-
-							// Delete record into ECM index (Note that delete is also done when deleting files with the dol_delete_dir_recursive
-							$this->deleteEcmFiles(0);	 // Deleting files physically is done later with the dol_delete_dir_recursive
-							$this->deleteEcmFiles(1);	 // Deleting files physically is done later with the dol_delete_dir_recursive
-
-							// We delete PDFs
-							$ref = dol_sanitizeFileName($this->ref);
-							if (!empty($conf->expedition->dir_output) && !empty($ref)) {
-								$dir = $conf->expedition->dir_output.'/sending/'.$ref;
-								$file = $dir.'/'.$ref.'.pdf';
-								if (file_exists($file)) {
-									if (!dol_delete_file($file)) {
-										return 0;
-									}
-								}
-								if (file_exists($dir)) {
-									if (!dol_delete_dir_recursive($dir)) {
-										$this->error = $langs->trans("ErrorCanNotDeleteDir", $dir);
-										return 0;
-									}
-								}
-							}
-
-							return 1;
-						} else {
-							$this->db->rollback();
-							return -1;
-						}
+						return 1;
 					} else {
 						$this->db->rollback();
 						return -1;


### PR DESCRIPTION
# FIX Remove a block duplicated by a merge into Expedition::delete()

## What happens

The `phpstan` job is red on the 22.0 branch itself since 2026-08-13 (it was green until 2026-08-13 01:24, and fails from 15:25 on, for example run 31806741185):

```
htdocs/expedition/class/expedition.class.php:2924
  Negated boolean expression is always true.

htdocs/core/class/commonsignedobject.class.php (in context of class Expedition):143
  Ignored error pattern #^Negated boolean expression is always true\.$# (booleanNot.alwaysTrue)
  in path .../htdocs/expedition/class/expedition.class.php is expected to occur 7 times, but occurred 8 times.
```

## Cause

The automated merge d119dd688e ("Automated merge from 21.0 to 22.0 by tool pullmerge.sh", 2026-08-13 15:18) did not replace the end of `Expedition::delete()`, it **nested the incoming version inside the existing one**. As a result the same block was present twice:

- `$this->db->commit()` was called twice,
- `deleteEcmFiles(0)` / `deleteEcmFiles(1)` were called twice,
- the deletion of the PDF and of its directory was done twice,

and the duplicated `if (!$error)` is the 8th "negated boolean expression is always true" of the file, one more than the baseline expects.

22.0 was the only branch in this state: 21.0, 23.0, 24.0 and develop all have that block once.

## Fix

Keep a single block. The one kept is the incoming version, i.e. the one with the `&& !empty($ref)` guard from "avoid to delete directory if ref is empty" (#38877), so that fix is preserved. The surrounding `if (!$error) { … } else { $this->db->rollback(); return -1; }` of 22.0 is left as it is.

So `delete()` now commits once, cleans the ECM index once and deletes the PDF once, and the file is back to 7 occurrences of the ignored pattern, which is what the baseline expects.

No other change: `reOpen()` and `setClosed()` are untouched.
