### PR TITLE
FIX WorkstationTest crash in the full test suite (stale $db)

### DIFF
--- a/test/phpunit/CommonClassTest.class.php
+++ b/test/phpunit/CommonClassTest.class.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2018 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -131,6 +131,42 @@ abstract class CommonClassTest extends TestCase
 		if ((int) getenv('PHPUNIT_DEBUG') > 0) {
 			print get_called_class()."::".__FUNCTION__.PHP_EOL;
 		}
+	}
+
+	/**
+	 * Defensive: in the full test suite (all classes run in one continuous process, processIsolation=false),
+	 * the global $db, $mysoc and $user can end up with a stale/closed underlying DB connection by the time a
+	 * given test class's setUpBeforeClass() runs, for reasons outside that test's control (see
+	 * https://github.com/Dolibarr/dolibarr/issues/38068 and https://github.com/Dolibarr/dolibarr/pull/39010
+	 * for related "mysqli object is already closed" reports elsewhere in this codebase, on stricter PHP
+	 * versions). Call this before doing anything that needs a working DB connection outside of the test
+	 * transaction itself - typically before activateModule() for a module whose dependency chain reaches
+	 * modProduct, whose constructor queries the DB via Societe::useNPR().
+	 *
+	 * @return void
+	 */
+	protected static function ensureDbIsConnected(): void
+	{
+		global $db, $conf, $dolibarr_main_db_pass, $mysoc, $user;
+
+		$stillconnected = false;
+		try {
+			$stillconnected = (bool) $db->query('SELECT 1');
+		} catch (Throwable $e) {
+			$stillconnected = false;
+		}
+		if (!$stillconnected) {
+			// $conf->db->pass is deliberately unset by master.inc.php right after the initial connection (to
+			// avoid the password lingering in memory) - $dolibarr_main_db_pass is the one global left
+			// available for this exact kind of reconnect.
+			$db = getDoliDBInstance($conf->db->type, $conf->db->host, $conf->db->user, $dolibarr_main_db_pass, $conf->db->name, (int) $conf->db->port);
+		}
+		// Always resync, even if $db itself did not need reconnecting above: $mysoc and $user were built once
+		// at bootstrap (master.inc.php) and each stashed their own reference to $db in their ->db property,
+		// which can go stale independently of the global $db variable (for example if an earlier test class
+		// in the same continuous run already reconnected $db without going through this same code).
+		$mysoc->db = $db;
+		$user->db = $db;
 	}
 
 	/**

--- a/test/phpunit/WorkstationTest.php
+++ b/test/phpunit/WorkstationTest.php
@@ -52,9 +52,37 @@ class WorkstationTest extends CommonClassTest
 	 */
 	public static function setUpBeforeClass(): void
 	{
-		global $db, $conf;
+		global $db, $conf, $dolibarr_main_db_pass, $mysoc, $user;
 
 		if (!isModEnabled('workstation')) {
+			// Defensive: in the full test suite (all classes run in one continuous process,
+			// processIsolation=false), $db can become stale/closed by the time this class runs, for
+			// reasons outside this test's control. modWorkstation depends on modMrp, which depends on
+			// modBom, which itself depends on modProduct, whose constructor queries the DB via
+			// Societe::useNPR() - and would crash on a dead connection (see
+			// https://github.com/Dolibarr/dolibarr/issues/38068 and
+			// https://github.com/Dolibarr/dolibarr/pull/39010 for related "mysqli object is already
+			// closed" reports elsewhere in this codebase, on stricter PHP versions). Reconnect first.
+			$stillconnected = false;
+			try {
+				$stillconnected = (bool) $db->query('SELECT 1');
+			} catch (Throwable $e) {
+				$stillconnected = false;
+			}
+			if (!$stillconnected) {
+				// $conf->db->pass is deliberately unset by master.inc.php right after the initial
+				// connection (to avoid the password lingering in memory) - $dolibarr_main_db_pass is
+				// the one global left available for this exact kind of reconnect.
+				$db = getDoliDBInstance($conf->db->type, $conf->db->host, $conf->db->user, $dolibarr_main_db_pass, $conf->db->name, (int) $conf->db->port);
+				// Reassigning the global $db is not enough: $mysoc (and $user) were built once at
+				// bootstrap (master.inc.php) and each stashed their own reference to the old, now dead,
+				// connection object in their ->db property - Societe::useNPR(), called from
+				// modProduct::__construct() during the dependency activation below, uses $mysoc->db, not
+				// the global $db, and would still crash on the stale reference otherwise.
+				$mysoc->db = $db;
+				$user->db = $db;
+			}
+
 			// Activating a module re-runs its SQL install scripts (CREATE/ALTER TABLE), which causes an
 			// implicit commit in MySQL/InnoDB: this activation is real and is NOT undone by the
 			// rollback in tearDownAfterClass, exactly like an admin enabling it from Setup > Modules

--- a/test/phpunit/WorkstationTest.php
+++ b/test/phpunit/WorkstationTest.php
@@ -74,14 +74,16 @@ class WorkstationTest extends CommonClassTest
 				// connection (to avoid the password lingering in memory) - $dolibarr_main_db_pass is
 				// the one global left available for this exact kind of reconnect.
 				$db = getDoliDBInstance($conf->db->type, $conf->db->host, $conf->db->user, $dolibarr_main_db_pass, $conf->db->name, (int) $conf->db->port);
-				// Reassigning the global $db is not enough: $mysoc (and $user) were built once at
-				// bootstrap (master.inc.php) and each stashed their own reference to the old, now dead,
-				// connection object in their ->db property - Societe::useNPR(), called from
-				// modProduct::__construct() during the dependency activation below, uses $mysoc->db, not
-				// the global $db, and would still crash on the stale reference otherwise.
-				$mysoc->db = $db;
-				$user->db = $db;
 			}
+			// Always resync, even if $db itself did not need reconnecting above: $mysoc and $user were
+			// built once at bootstrap (master.inc.php) and each stashed their own reference to $db in
+			// their ->db property, which can go stale independently of the global $db variable (for
+			// example if an earlier test class in the same continuous run already reconnected $db
+			// without going through this same code) - Societe::useNPR(), called from
+			// modProduct::__construct() during the dependency activation below, uses $mysoc->db, not the
+			// global $db, and would still crash on a stale reference otherwise.
+			$mysoc->db = $db;
+			$user->db = $db;
 
 			// Activating a module re-runs its SQL install scripts (CREATE/ALTER TABLE), which causes an
 			// implicit commit in MySQL/InnoDB: this activation is real and is NOT undone by the

--- a/test/phpunit/WorkstationTest.php
+++ b/test/phpunit/WorkstationTest.php
@@ -52,38 +52,14 @@ class WorkstationTest extends CommonClassTest
 	 */
 	public static function setUpBeforeClass(): void
 	{
-		global $db, $conf, $dolibarr_main_db_pass, $mysoc, $user;
+		global $db, $conf;
 
 		if (!isModEnabled('workstation')) {
-			// Defensive: in the full test suite (all classes run in one continuous process,
-			// processIsolation=false), $db can become stale/closed by the time this class runs, for
-			// reasons outside this test's control. modWorkstation depends on modMrp, which depends on
-			// modBom, which itself depends on modProduct, whose constructor queries the DB via
-			// Societe::useNPR() - and would crash on a dead connection (see
-			// https://github.com/Dolibarr/dolibarr/issues/38068 and
-			// https://github.com/Dolibarr/dolibarr/pull/39010 for related "mysqli object is already
-			// closed" reports elsewhere in this codebase, on stricter PHP versions). Reconnect first.
-			$stillconnected = false;
-			try {
-				$stillconnected = (bool) $db->query('SELECT 1');
-			} catch (Throwable $e) {
-				$stillconnected = false;
-			}
-			if (!$stillconnected) {
-				// $conf->db->pass is deliberately unset by master.inc.php right after the initial
-				// connection (to avoid the password lingering in memory) - $dolibarr_main_db_pass is
-				// the one global left available for this exact kind of reconnect.
-				$db = getDoliDBInstance($conf->db->type, $conf->db->host, $conf->db->user, $dolibarr_main_db_pass, $conf->db->name, (int) $conf->db->port);
-			}
-			// Always resync, even if $db itself did not need reconnecting above: $mysoc and $user were
-			// built once at bootstrap (master.inc.php) and each stashed their own reference to $db in
-			// their ->db property, which can go stale independently of the global $db variable (for
-			// example if an earlier test class in the same continuous run already reconnected $db
-			// without going through this same code) - Societe::useNPR(), called from
-			// modProduct::__construct() during the dependency activation below, uses $mysoc->db, not the
-			// global $db, and would still crash on a stale reference otherwise.
-			$mysoc->db = $db;
-			$user->db = $db;
+			// activateModule() below transitively instantiates modProduct (modWorkstation depends on modMrp,
+			// which depends on modBom, which depends on modProduct), whose constructor queries the DB via
+			// Societe::useNPR() - make sure $db/$mysoc/$user are not stale before that (see
+			// CommonClassTest::ensureDbIsConnected() for why this is needed).
+			self::ensureDbIsConnected();
 
 			// Activating a module re-runs its SQL install scripts (CREATE/ALTER TABLE), which causes an
 			// implicit commit in MySQL/InnoDB: this activation is real and is NOT undone by the


### PR DESCRIPTION
## Summary
- Same class of bug already fixed in StockTransferTest and MoTest: `modWorkstation` depends on `modMrp` → `modBom` → `modProduct`, and `modProduct::__construct()` does DB I/O via `Societe::useNPR()`.
- When the full PHPUnit suite runs all test classes in one continuous process (`processIsolation=false`), `$db` can be stale/closed by the time `WorkstationTest::setUpBeforeClass()` runs and tries to activate the module, crashing on the dead connection (`mysqli object is already closed`).
- Reconnect `$db` defensively before calling `activateModule('modWorkstation')`, and refresh `$mysoc->db`/`$user->db` too, since those globals stashed their own reference to the old connection at bootstrap and are not updated by simply reassigning the global `$db`.

## Test plan
- [x] `php vendor/bin/phpunit test/phpunit/WorkstationTest.php` passes with the module already enabled (repeated runs).
- [x] Genuinely disabled `modWorkstation` (`unActivateModule`) and re-ran `php vendor/bin/phpunit test/phpunit/WorkstationTest.php` — passes through the activation path.
- [x] Reproduced the crash directly by closing `$db` and calling `WorkstationTest::setUpBeforeClass()` in isolation: fails without this fix, succeeds with it.
- [x] `php -l` and phpcs clean.