### PR TITLE
FIX flaky testIsValidMXRecord (usace.army.mil DNS filtering)

### DIFF
--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2015	   	Juanjo Menent			<jmenent@2byte.es>
  * Copyright (C) 2023 		Alexandre Janniaux   	<alexandre.janniaux@gmail.com>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -429,7 +429,9 @@ class FunctionsLibTest extends CommonClassTest
 		print __METHOD__." ".$input." result=".$result."\n";
 		$this->assertEquals(0, $result);
 
-		$input = "usace.army.mil";
+		// Note: intentionally not a .mil domain (some CI network environments filter/block .mil DNS
+		// resolution intermittently, which made this assertion flaky without any actual code issue).
+		$input = "microsoft.com";
 		$result = isValidMXRecord($input);
 		print __METHOD__." ".$input." result=".$result."\n";
 		$this->assertEquals(1, $result);


### PR DESCRIPTION
## Summary
- `FunctionsLibTest::testIsValidMXRecord` does a real live DNS lookup via `isValidMXRecord()` for several real domains.
- In a recent CI run, only the `usace.army.mil` assertion failed (expected 1, got 0) while `yahoo.com`, `yhaoo.com`, and `dolibarr.fr` all resolved correctly in the same run — pointing to that specific `.mil` zone being filtered/unreachable from the CI network rather than any bug in `isValidMXRecord()`. `.mil` DNS is a known target for network filtering on shared CI infrastructure.
- Swap `usace.army.mil` for `microsoft.com`: same "domain with a valid MX record" semantics for the assertion, but a far more globally reachable and stable DNS setup, much less likely to be blocked by CI network policies.

## Test plan
- [x] `php vendor/bin/phpunit test/phpunit/FunctionsLibTest.php` — 56 tests / 454 assertions, all pass.
- [x] `php -l` and phpcs clean.