### PR TITLE
FIX Stale example in get_exdir() docblock

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -8841,7 +8841,7 @@ function yn($yesno, $format = 1, $color = 0)
  *         or:  $conf->module->dir_output.'/'.get_exdir(0, 0, 0, 0, $object, '')
  *
  *  Example of output with new usage:       $object is invoice -> 'INYYMM-ABCD'
- *  Example of output with old usage:       '015' with level 3->"0/1/5/", '015' with level 1->"5/", 'ABC-1' with level 3 ->"0/0/1/"
+ *  Example of output with old usage:       '015' with level 3->"5/1/0/", '015' with level 1->"5/", 'ABC-1' with level 3 ->"1/0/0/"
  *
  *	@param	string|int		$num            Id of object (deprecated, $object->id will be used in future)
  *	@param  int				$level		    Level of subdirs to return (1, 2 or 3 levels). (deprecated, global setup will be used in future)


### PR DESCRIPTION
## Summary
- The docblock's example of the legacy numeric path split was wrong: `'015'` with level 3 was documented as producing `"0/1/5/"` and `'ABC-1'` with level 3 as `"0/0/1/"`.
- The actual code (`substr($num, 2, 1).'/'.substr($num, 1, 1).'/'.substr($num, 0, 1)`) reads the digits in the opposite order, producing `"5/1/0/"` and `"1/0/0/"` respectively.
- Found and verified empirically (calling `get_exdir()` directly with these exact inputs) while adding PHPUnit coverage for this function in #39551.
- The level 1 example (`"5/"`) was already correct and is unchanged.

## Test plan
- [x] `php -l` and phpcs clean.
- [x] Manually re-verified `get_exdir('015', 3, 0, 0, null, 'mailing')` returns `'5/1/0/'` and `get_exdir('ABC-1', 3, 1, 0, null, 'mailing')` returns `'1/0/0/'` against current code.