### PR TITLE
FIX: Broken feature 'Generate Child Mo'

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -273,6 +273,14 @@ class Mo extends CommonObject
 	 */
 	public $tpl = array();
 
+	/**
+	 * @var int[] Ids of BOM lines (with a sub-BOM) that must not be flattened into their raw materials
+	 *            when generating the consume/produce lines, because the user asked to generate a child MO
+	 *            for them instead (see mo_card.php "Generate Child MO"). A single MoLine anchored on the
+	 *            sub-assembly product is created for these lines instead of recursing into the sub-BOM.
+	 */
+	public $noFlattenBomLineIds = array();
+
 
 	/**
 	 * Constructor
@@ -815,7 +823,7 @@ class Mo extends CommonObject
 
 			$tmpproduct = new Product($this->db);
 			$tmpproduct->fetch($line->fk_product);
-			if ($line->fk_bom_child > 0) {
+			if ($line->fk_bom_child > 0 && !in_array($line->id, $this->noFlattenBomLineIds)) {
 				$bom = new BOM($this->db);
 				$bom->fetch((int) $line->fk_bom_child);
 				$error += $this->processBOM($user, $role, $bom, $quantity_line);

--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -161,7 +161,7 @@ if (empty($reshook)) {
 		// Sub-BOM lines the user checked "Generate Child MO" for must not be flattened into their
 		// raw materials on the parent MO: keep a single consume line anchored on the sub-assembly
 		// product instead, so it can be found below to create the child MO.
-		$object->noFlattenBomLineIds = $TBomLineId;
+		$object->noFlattenBomLineIds = array_map('intval', $TBomLineId);
 		include DOL_DOCUMENT_ROOT.'/core/actions_addupdatedelete.inc.php';
 
 		$mo_parent = $object;

--- a/htdocs/mrp/mo_card.php
+++ b/htdocs/mrp/mo_card.php
@@ -158,6 +158,10 @@ if (empty($reshook)) {
 	// Create MO with Children
 	if ($action == 'add' && empty($id) && !empty($TBomLineId) && $permissiontoadd) {
 		$noback = 1;
+		// Sub-BOM lines the user checked "Generate Child MO" for must not be flattened into their
+		// raw materials on the parent MO: keep a single consume line anchored on the sub-assembly
+		// product instead, so it can be found below to create the child MO.
+		$object->noFlattenBomLineIds = $TBomLineId;
 		include DOL_DOCUMENT_ROOT.'/core/actions_addupdatedelete.inc.php';
 
 		$mo_parent = $object;


### PR DESCRIPTION
Root cause: commit 6c8b4da4456 (#35424, merged 2025-09-22, in your v23 branch) rewrote MO line generation to flatten sub-BOMs into raw materials via processBOM(). As a side effect, it stopped creating a MoLine for any BOM line that has a sub-BOM (fk_bom_child > 0) — but "Generate Child MO" depends on finding exactly that line to anchor the child MO. Since it never existed anymore, the lookup was always empty and (after the more recent #39020 duplicate-MO fix added continue) the feature just silently did nothing.

Fix (2 files):

mo.class.php: added $noFlattenBomLineIds property; processBOM() now only recurses/flattens a sub-BOM line when it's not in that list — otherwise it creates the anchor MoLine for the sub-assembly product (the pre-#35424 behavior), preserving origin_id/origin_type for the lookup.
mo_card.php: sets $object->noFlattenBomLineIds = $TBomLineId (the checked BOM lines) before creating the parent MO.
Default behavior (no checkboxes checked) is untouched — flattening still happens exactly as before, so there's no regression to #35424's fix. Only BOM lines explicitly checked for "Generate Child MO" skip flattening and get an anchor line instead, avoiding double stock consumption between parent and child MO.