### PR TITLE
Fix #39533 do not credit years of holiday accrual when lastUpdate is empty

### DIFF
--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -1683,6 +1683,12 @@ class Holiday extends CommonObject
 
 			// Get month of last update
 			$stringInDBForLastUpdate = $this->getConfCP('lastUpdate', dol_print_date($now, '%Y%m%d%H%M%S'));	// Example '20200101120000'
+			// The lastUpdate config row is created empty (value NULL) at install, so getConfCP() returns an empty value
+			// the first time. Treat an empty value as "start from now" (like define_holiday.php does) instead of a very
+			// old date, otherwise the catch-up loop below would credit every user with years of monthly accrual at once.
+			if (empty($stringInDBForLastUpdate)) {
+				$stringInDBForLastUpdate = dol_print_date($now, '%Y%m%d%H%M%S');
+			}
 			// Protection when $lastUpdate has a not valid value
 			if ($stringInDBForLastUpdate < '20000101000000') {
 				$stringInDBForLastUpdate = '20000101000000';


### PR DESCRIPTION
Opening the leave-request list credited every user with a huge number of days when a leave type has a monthly accrual set.

Root cause: the holiday_config 'lastUpdate' row is created with a NULL value at install (data/llx_holiday_config.sql). getConfCP('lastUpdate', now) only applies its default when the row is absent, not when the row exists with a NULL value, so it returns an empty value the first time updateSoldeCP() runs. The guard then treated that empty value as older than 2000-01-01, and the monthly catch-up loop credited ~25 years of monthly accrual at once.

Fix: treat an empty lastUpdate as 'start from now' (consistent with define_holiday.php, which initialises it to now).

Verified locally on 21.0 with a paid-leave type at 2.08334/month and lastUpdate=NULL: before the fix updateSoldeCP() set the user balance to 664.58 days; after the fix it stays 0. Present 21.0 to develop.