### PR TITLE
NEW Track how many times a proposal or an order was sent by email

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -335,6 +335,11 @@ class Propal extends CommonObject
 	 */
 	public $line;
 
+	/**
+	 * @var int			counter used to track how many times the document was sent by email
+	 */
+	public $email_sent_counter = 0;
+
 	public $labelStatus = array();
 	public $labelStatusShort = array();
 
@@ -1690,6 +1695,7 @@ class Propal extends CommonObject
 		$sql .= ", p.fk_warehouse";
 		$sql .= ", p.fk_incoterms, p.location_incoterms";
 		$sql .= ", p.fk_multicurrency, p.multicurrency_code, p.multicurrency_tx, p.multicurrency_total_ht, p.multicurrency_total_tva, p.multicurrency_total_ttc";
+		$sql .= ", p.email_sent_counter";
 		$sql .= ", p.tms as date_modification";
 		$sql .= ", i.libelle as label_incoterms";
 		$sql .= ", c.label as statut_label";
@@ -1745,6 +1751,7 @@ class Propal extends CommonObject
 				$this->project = null; // Clear if another value was already set by fetchProject
 
 				$this->model_pdf = $obj->model_pdf;
+				$this->email_sent_counter = (int) $obj->email_sent_counter;
 				$this->last_main_doc = $obj->last_main_doc;
 				$this->note                 = $obj->note_private; // TODO deprecated
 				$this->note_private         = $obj->note_private;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -289,6 +289,11 @@ class Commande extends CommonOrder
 	/**
 	 * @var array<int,float>	Array with lines of all shipments (qty)
 	 */
+	/**
+	 * @var int			counter used to track how many times the document was sent by email
+	 */
+	public $email_sent_counter = 0;
+
 	public $expeditions;
 
 	/**
@@ -2020,6 +2025,7 @@ class Commande extends CommonOrder
 		$sql .= ', c.fk_warehouse';
 		$sql .= ', c.fk_projet as fk_project, c.source, c.facture as billed';
 		$sql .= ', c.note_private, c.note_public, c.ref_client, c.ref_ext, c.model_pdf, c.last_main_doc, c.fk_delivery_address, c.extraparams';
+		$sql .= ', c.email_sent_counter';
 		$sql .= ', c.fk_incoterms, c.location_incoterms';
 		$sql .= ", c.fk_multicurrency, c.multicurrency_code, c.multicurrency_tx, c.multicurrency_total_ht, c.multicurrency_total_tva, c.multicurrency_total_ttc";
 		$sql .= ", c.module_source, c.pos_source";
@@ -2090,6 +2096,7 @@ class Commande extends CommonOrder
 				$this->note_private = $obj->note_private;
 				$this->note_public = $obj->note_public;
 				$this->model_pdf = $obj->model_pdf;
+				$this->email_sent_counter = (int) $obj->email_sent_counter;
 				$this->last_main_doc = $obj->last_main_doc;
 				$this->mode_reglement_id	= $obj->fk_mode_reglement;
 				$this->mode_reglement_code	= $obj->mode_reglement_code;

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -289,12 +289,12 @@ class Commande extends CommonOrder
 	/**
 	 * @var array<int,float>	Array with lines of all shipments (qty)
 	 */
+	public $expeditions;
+
 	/**
 	 * @var int			counter used to track how many times the document was sent by email
 	 */
 	public $email_sent_counter = 0;
-
-	public $expeditions;
 
 	/**
 	 * @var string payment url

--- a/htdocs/core/actions_sendmails.inc.php
+++ b/htdocs/core/actions_sendmails.inc.php
@@ -487,16 +487,18 @@ if (($action == 'send' || $action == 'relance') && !GETPOST('addfile') && !GETPO
 
 						// Call of triggers (you should have set $triggersendname to execute trigger.
 						if (!empty($triggersendname)) {
-							if ($triggersendname == 'BILL_SENTBYMAIL' && $object instanceof Facture) {
-								/* @var Facture $object */
-
-								// If sending email for invoice, we increase the counter of invoices sent by email
-								$sql = "UPDATE ".MAIN_DB_PREFIX."facture SET email_sent_counter = email_sent_counter + 1";
+							// An object that declares email_sent_counter keeps a denormalized count of the
+							// emails it was sent with. Drive it from the property, so adding the counter to
+							// another object is a column plus a property, with nothing to change here.
+							if (property_exists($object, 'email_sent_counter') && !empty($object->table_element) && $object->id > 0) {
+								$sql = "UPDATE ".$db->prefix().$object->table_element." SET email_sent_counter = email_sent_counter + 1";
 								$sql .= " WHERE rowid = ".((int) $object->id);
 
 								$resql = $db->query($sql);
 								if ($resql) {
 									$object->email_sent_counter += 1;
+								} else {
+									dol_syslog("Failed to increase email_sent_counter for ".$object->element." id ".$object->id.": ".$db->lasterror(), LOG_ERR);
 								}
 							}
 

--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -149,6 +149,10 @@ ALTER TABLE llx_contrat ADD COLUMN fk_contract_type tinyint DEFAULT 0 AFTER ref_
 ALTER TABLE llx_user ADD COLUMN country_job_id integer DEFAULT NULL;
 ALTER TABLE llx_user ADD COLUMN state_job_id integer DEFAULT NULL;
 
+-- Track how many times a proposal or an order was sent by email, like llx_facture already does
+ALTER TABLE llx_propal ADD COLUMN email_sent_counter integer DEFAULT 0;
+ALTER TABLE llx_commande ADD COLUMN email_sent_counter integer DEFAULT 0;
+
 -- end of migration - nothing after this line
 
 -- Variants: allow standard import/export of variants (attributes, values, combinations,

--- a/htdocs/install/mysql/tables/llx_commande.sql
+++ b/htdocs/install/mysql/tables/llx_commande.sql
@@ -59,6 +59,7 @@ create table llx_commande
 
   note_private				text,
   note_public				text,
+  email_sent_counter	integer DEFAULT 0,				-- counter used to track how many times the document was sent by email
   model_pdf					varchar(255),
   last_main_doc				varchar(255),					-- relative filepath+filename of last main generated document
 

--- a/htdocs/install/mysql/tables/llx_propal.sql
+++ b/htdocs/install/mysql/tables/llx_propal.sql
@@ -68,6 +68,7 @@ create table llx_propal
   note_private			text,
   note_public			text,
 
+  email_sent_counter	integer DEFAULT 0,				-- counter used to track how many times the document was sent by email
   model_pdf				varchar(255),					-- last template used to generate main document (exemple: azur, generic_invoice_odt:/pathto/template_invoice.odt)
   model_pdf_pos_sign 	varchar(32),					-- last position used to include the signature (example: posX:posY:Height:Width)
   last_main_doc			varchar(255),					-- relative filepath+filename of the last main generated document


### PR DESCRIPTION
This replaces #38349 and #39500, which added a `date_sent` column on 12 objects. @eldy was right to refuse them: a single column cannot represent a document sent several times, and `llx_actioncomm` is the right place for the full history.

What is actually missing is the fast filter, and Dolibarr already has the pattern for it — `email_sent_counter` on `llx_facture`. It just does not exist anywhere else, so "sent / not sent" cannot be filtered on any other document type.

So this PR uses your own pattern instead of inventing one:

- `email_sent_counter` added on `llx_propal` and `llx_commande`.
- The increment in `actions_sendmails.inc.php` stops being hardcoded on `Facture` / `BILL_SENTBYMAIL`. It now fires for any object that declares an `email_sent_counter` property and targets `$object->table_element`, so adding the counter to a third object is a column plus a property, with nothing to change in the send code.
- A failed update is logged instead of being silently ignored, which the invoice path did not do.

6 files, 27 added lines. The send history stays in `llx_actioncomm`; this column answers "how many times", not "when".