### PR TITLE
NEW or FIX : Show thirdparty (supplier) in FactureFournisseur and SupplierProposal tooltips

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -17,6 +17,7 @@
  * Copyright (C) 2023		Nick Fragoulis
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Vincent de Grandpré		<vincent@de-grandpre.quebec>
+ * Copyright (C) 2026		Jose Martinez				<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2868,6 +2869,15 @@ class FactureFournisseur extends CommonInvoice
 		}
 		if (!empty($this->ref_supplier)) {
 			$datas['refsupplier'] = '<br><b>'.$langs->trans('RefSupplier').':</b> '.$this->ref_supplier;
+		}
+		if (empty($params['nofetch'])) {
+			$langs->load('companies');
+			if (empty($this->thirdparty)) {
+				$this->fetch_thirdparty();
+			}
+			if (is_object($this->thirdparty)) {
+				$datas['supplier'] = '<br><b>'.$langs->trans('Supplier').':</b> '.$this->thirdparty->getNomUrl(1, '', 0, 1);
+			}
 		}
 		if (!empty($this->label)) {
 			$datas['label'] = '<br><b>'.$langs->trans('Label').':</b> '.$this->label;

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -19,6 +19,7 @@
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Vincent de Grandpré		<vincent@de-grandpre.quebec>
  * Copyright (C) 2026		Lionel Vessiller		<lvessiller@open-dsi.fr>
+ * Copyright (C) 2026		Jose Martinez				<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2546,6 +2547,15 @@ class SupplierProposal extends CommonObject
 		}
 		if (!empty($this->ref_fourn)) {
 			$datas['ref_supplier'] = '<br><b>'.$langs->trans('RefSupplier').':</b> '.$this->ref_fourn;
+		}
+		if (empty($params['nofetch'])) {
+			$langs->load('companies');
+			if (empty($this->thirdparty)) {
+				$this->fetch_thirdparty();
+			}
+			if (is_object($this->thirdparty)) {
+				$datas['supplier'] = '<br><b>'.$langs->trans('Supplier').':</b> '.$this->thirdparty->getNomUrl(1, '', 0, 1);
+			}
 		}
 		if (!empty($this->total_ht)) {
 			$datas['amount_ht'] = '<br><b>'.$langs->trans('AmountHT').':</b> '.price($this->total_ht, 0, $langs, 0, -1, -1, getDolCurrency());


### PR DESCRIPTION
CommonObject `getNomUrl()` tooltips are built by each class `getTooltipContentArray()`. `CommandeFournisseur::getTooltipContentArray()` already adds a **Supplier** line (the thirdparty `getNomUrl()`), but `FactureFournisseur` and `SupplierProposal` do not.

As a result, hovering a **supplier invoice** or **supplier proposal** link never reveals which thirdparty it concerns, while hovering a **supplier order** link does — an inconsistency between three otherwise-similar supplier objects.

### Change

Add the same `$datas['supplier']` entry to both methods, right after `RefSupplier`, mirroring `CommandeFournisseur`:

```php
if (empty($params['nofetch'])) {
    $langs->load('companies');
    if (empty($this->thirdparty)) {
        $this->fetch_thirdparty();
    }
    if (is_object($this->thirdparty)) {
        $datas['supplier'] = '<br><b>'.$langs->trans('Supplier').':</b> '.$this->thirdparty->getNomUrl(1, '', 0, 1);
    }
}
```

- Honors the `nofetch` param (no extra DB fetch when the caller asked to skip it).
- Adds an `is_object()` guard before dereferencing (slightly more defensive than the existing supplier-order code).
- No schema change, no behavior change beyond the tooltip content.

Verified on a real instance: `FactureFournisseur::getTooltipContentArray()` and `SupplierProposal::getTooltipContentArray()` now return a `supplier` entry (`Fournisseur: <name>`), and return none when called with `nofetch=1`.

Draft for maintainer review (also a candidate for backport to maintained branches).
