### PR TITLE
Fix #39572 add missing comma before u.lastname in time list query

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1597,7 +1597,7 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 
 		$sql = "SELECT t.rowid, t.fk_element, t.element_date, t.element_datehour, t.element_date_withhour, t.element_duration, t.fk_user, t.note, t.thm,";
 		$sql .= " t.fk_product, t.invoice_line_id,";
-		$sql .= " pt.ref, pt.label, pt.fk_projet, pt.billable";
+		$sql .= " pt.ref, pt.label, pt.fk_projet, pt.billable,";
 		$sql .= " u.lastname, u.firstname, u.login, u.photo, u.gender, u.statut as user_status,";
 		$sql .= " il.fk_facture as invoice_id, inv.fk_statut,";
 		$sql .= " p.fk_soc,s.name_alias,";


### PR DESCRIPTION
The time spent list built its SELECT with pt.billable at the end of one concatenated line and u.lastname at the start of the next, with no comma between them:

```php
$sql .= " pt.ref, pt.label, pt.fk_projet, pt.billable";
$sql .= " u.lastname, u.firstname, ...";
```

This produces `pt.billable u.lastname` and a MariaDB syntax error 1064 near `.lastname`, exactly as in the report. The trailing-comma cleanup (`preg_replace('/,\s*$/', ...)`) cannot fix a comma missing inside the field list.

Present on 21.0, 22.0 and 23.0 (billable was added there without the comma); 18.0-20.0 do not have the billable column and are unaffected; develop already orders the fields correctly. Fix adds the missing comma. Base is 21.0 so it forward-merges up.

Verified in a local MariaDB: the comma-less field list returns ERROR 1064 near '.lastname', the fixed one runs cleanly.
