### PR TITLE
Fix #39276 keep the entered start time when updating time spent

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1635,9 +1635,10 @@ class Task extends CommonObjectLine
 		if (isset($this->timespent_note)) {
 			$this->timespent_note = trim($this->timespent_note);
 		}
-		if (empty($this->timespent_datehour)) {
-			// Only fall back to the day-level date when no accurate start time was provided.
-			// Copying it unconditionally when the two differ would discard the hour set by the caller (#39276).
+		if (empty($this->timespent_datehour) || empty($this->timespent_withhour)) {
+			// Sync datehour from the day-level date when no start hour was provided (withhour = 0), or when
+			// datehour is empty. When a start hour was entered (withhour = 1), keep datehour untouched so the
+			// hour is not discarded (#39276). This still resynchronizes datehour when only the day changes.
 			$this->timespent_datehour = $this->timespent_date;
 		}
 
@@ -2091,9 +2092,10 @@ class Task extends CommonObjectLine
 		}
 
 		// Clean parameters
-		if (empty($this->timespent_datehour)) {
-			// Only fall back to the day-level date when no accurate start time was provided.
-			// Copying it unconditionally when the two differ would discard the hour set by the caller (#39276).
+		if (empty($this->timespent_datehour) || empty($this->timespent_withhour)) {
+			// Sync datehour from the day-level date when no start hour was provided (withhour = 0), or when
+			// datehour is empty. When a start hour was entered (withhour = 1), keep datehour untouched so the
+			// hour is not discarded (#39276). This still resynchronizes datehour when only the day changes.
 			$this->timespent_datehour = $this->timespent_date;
 		}
 		if (isset($this->timespent_note)) {

--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1635,7 +1635,9 @@ class Task extends CommonObjectLine
 		if (isset($this->timespent_note)) {
 			$this->timespent_note = trim($this->timespent_note);
 		}
-		if (empty($this->timespent_datehour) || ($this->timespent_date != $this->timespent_datehour)) {
+		if (empty($this->timespent_datehour)) {
+			// Only fall back to the day-level date when no accurate start time was provided.
+			// Copying it unconditionally when the two differ would discard the hour set by the caller (#39276).
 			$this->timespent_datehour = $this->timespent_date;
 		}
 
@@ -2089,7 +2091,9 @@ class Task extends CommonObjectLine
 		}
 
 		// Clean parameters
-		if (empty($this->timespent_datehour) || ($this->timespent_date != $this->timespent_datehour)) {
+		if (empty($this->timespent_datehour)) {
+			// Only fall back to the day-level date when no accurate start time was provided.
+			// Copying it unconditionally when the two differ would discard the hour set by the caller (#39276).
 			$this->timespent_datehour = $this->timespent_date;
 		}
 		if (isset($this->timespent_note)) {


### PR DESCRIPTION
Editing an existing time spent line reset its start time to 12:00.

time.php updateline sets timespent_date to the day at noon and timespent_datehour to the accurate start time entered by the user. But Task::addTimeSpent() and Task::updateTimeSpent() did:

```php
if (empty($this->timespent_datehour) || ($this->timespent_date != $this->timespent_datehour)) {
    $this->timespent_datehour = $this->timespent_date;
}
```

Since date (noon) and datehour (real hour) legitimately differ here, the second clause overwrote datehour with the noon date, discarding the hour - stored and displayed as 12:00.

Fix: only fall back to the day-level date when no datehour was provided. I checked all eight callers (time.php x3, perday/permonth/perweek, api_tasks x2): every other one sets timespent_date == timespent_datehour, so none relied on the removed clause. Applied to both addTimeSpent and updateTimeSpent.

Note: on 21.0 updateTimeSpent was already correct; the edit-path regression is on 22.0+, so base is 22.0.

Verified in Docker against a real MariaDB: calling updateTimeSpent with date=noon / datehour=09:30 now stores element_datehour=09:30 (before the fix the same call stored 12:00).
