### PR TITLE
Fix #39435 report a clear error when intl is missing for receipt printing

### DIFF
--- a/htdocs/core/class/dolreceiptprinter.class.php
+++ b/htdocs/core/class/dolreceiptprinter.class.php
@@ -1030,6 +1030,15 @@ class dolReceiptPrinter extends Printer
 	 */
 	public function initPrinter($printerid)
 	{
+		// The escpos-php library requires the PHP intl extension (IntlBreakIterator). Without it, the first
+		// call to Printer::text() raises a fatal "Class IntlBreakIterator not found" error that the catch
+		// blocks below cannot handle. Report a clear error (return > 0 so callers skip the print) instead of
+		// letting the print crash.
+		if (!extension_loaded('intl')) {
+			$this->errors[] = 'The receipt printer requires the PHP intl extension, which is not loaded on this server.';
+			return 1;
+		}
+
 		if (getDolGlobalString('TAKEPOS_PRINT_METHOD') == "takeposconnector") {
 			$this->connector = new DummyPrintConnector();
 			$this->printer = new Printer($this->connector, $this->profile);


### PR DESCRIPTION
The receipt printer crashes with a fatal "Class IntlBreakIterator not found" when the PHP intl extension is not loaded.

escpos-php uses IntlBreakIterator in EscposPrintBuffer, so the first Printer::text() raises the error. It is a \Error (not \Exception), so the existing catch (Exception $e) blocks in initPrinter() do not catch it and the whole print request dies.

Guard initPrinter(): if extension_loaded('intl') is false, push a clear message into $this->errors and return a non-zero value. Callers already do `if ($ret > 0) { setEventMessages(...) } else { ...print... }`, so they now show the message and skip the print instead of dereferencing a null printer.

Verified in a container without intl (php -n): Printer::text() indeed throws `Error: Class "IntlBreakIterator" not found`; with the guard, initPrinter returns 1 and fills errors, so no print call and no fatal. With intl present, behaviour is unchanged. Base 21.0 so it forward-merges up.
