### PR TITLE
Fix #39561 test the cleanup delete in MouvementStock::_create

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -654,11 +654,13 @@ class MouvementStock extends CommonObject
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sql = "DELETE FROM ".$this->db->prefix()."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".$this->db->prefix()."product_batch as pb)";
 				$resql = $this->db->query($sql);
-				// We tolerate a failure here when there are child rows in batch details, but a deadlock (1213)
-				// rolls back the whole transaction (including the movement just inserted). If we swallowed it,
-				// _create() would commit an empty transaction and return the movement id as a success, so the
-				// caller (and the REST API) would think the movement was saved while it was lost.
-				if (!$resql && $this->db->lasterrno() == 'DB_ERROR_1213') {
+				// The NOT IN clause already excludes rows still referenced by product_batch (the only child FK on
+				// product_stock), so this DELETE cannot fail on a child constraint. Any failure is therefore a real
+				// error, in particular a deadlock (1213) that rolls back the whole transaction including the movement
+				// just inserted; if we swallowed it, _create() would commit an empty transaction and return the
+				// movement id as a success, so the caller (and the REST API) would think the movement was saved while
+				// it was lost.
+				if (!$resql) {
 					$this->errors[] = $this->db->lasterror();
 					$error++;
 				}

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -654,7 +654,14 @@ class MouvementStock extends CommonObject
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sql = "DELETE FROM ".$this->db->prefix()."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".$this->db->prefix()."product_batch as pb)";
 				$resql = $this->db->query($sql);
-				// We do not test error, it can fails if there is child in batch details
+				// We tolerate a failure here when there are child rows in batch details, but a deadlock (1213)
+				// rolls back the whole transaction (including the movement just inserted). If we swallowed it,
+				// _create() would commit an empty transaction and return the movement id as a success, so the
+				// caller (and the REST API) would think the movement was saved while it was lost.
+				if (!$resql && $this->db->lasterrno() == 'DB_ERROR_1213') {
+					$this->errors[] = $this->db->lasterror();
+					$error++;
+				}
 			}
 		}
 


### PR DESCRIPTION
MouvementStock::_create() runs a cleanup DELETE on product_stock after inserting the movement and deliberately ignores its result:

```php
$resql = $this->db->query($sql);
// We do not test error, it can fails if there is child in batch details
```

The comment no longer matches the query: the NOT IN clause already excludes the rows still referenced by product_batch, which is the only child FK on product_stock, so this DELETE cannot fail on a child constraint. Any failure is a real error.

It matters on an InnoDB deadlock (1213), where MariaDB rolls back the whole transaction including the movement, product_stock, batch and lot rows just inserted. As the error was swallowed, $error stayed 0, _create() reached commit() on an empty transaction and returned the movement id as a success, so POST /stockmovements answered HTTP 200 with a rowid that does not exist and the movement was silently lost. Reported and reproduced twice in production with concurrent movement creation, with an auto_increment gap for the rolled back row.

The delete is now tested and any failure raises $error, so _create() rolls back and returns -6 instead of a phantom success. Verified against a real InnoDB deadlock in a container.