### PR TITLE
Fix #39435 update `icu*.dll` versions in exe/doliwamp inno-setup build

### DIFF
--- a/dev/build/exe/doliwamp/doliwamp.iss
+++ b/dev/build/exe/doliwamp/doliwamp.iss
@@ -394,13 +394,13 @@ begin
 
     phpDllCopy := 'libssh2.dll';
     filecopy (pathWithSlashes+'/bin/php/php'+phpVersion+'/'+phpDllCopy, pathWithSlashes+'/bin/apache/apache'+apacheVersion+'/bin/'+phpDllCopy, False);
-    phpDllCopy := 'icuuc64.dll';
+    phpDllCopy := 'icuuc66.dll';
     filecopy (pathWithSlashes+'/bin/php/php'+phpVersion+'/'+phpDllCopy, pathWithSlashes+'/bin/apache/apache'+apacheVersion+'/bin/'+phpDllCopy, False);
-    phpDllCopy := 'icuin64.dll';
+    phpDllCopy := 'icuin66.dll';
     filecopy (pathWithSlashes+'/bin/php/php'+phpVersion+'/'+phpDllCopy, pathWithSlashes+'/bin/apache/apache'+apacheVersion+'/bin/'+phpDllCopy, False);
-    phpDllCopy := 'icuio64.dll';
+    phpDllCopy := 'icuio66.dll';
     filecopy (pathWithSlashes+'/bin/php/php'+phpVersion+'/'+phpDllCopy, pathWithSlashes+'/bin/apache/apache'+apacheVersion+'/bin/'+phpDllCopy, False);
-    phpDllCopy := 'icudt64.dll';
+    phpDllCopy := 'icudt66.dll';
     filecopy (pathWithSlashes+'/bin/php/php'+phpVersion+'/'+phpDllCopy, pathWithSlashes+'/bin/apache/apache'+apacheVersion+'/bin/'+phpDllCopy, False);
     phpDllCopy := 'libsasl.dll';
     filecopy (pathWithSlashes+'/bin/php/php'+phpVersion+'/'+phpDllCopy, pathWithSlashes+'/bin/apache/apache'+apacheVersion+'/bin/'+phpDllCopy, False);


### PR DESCRIPTION
### Root Cause

PHP internationalization extension is enabled but fails to load because Apache is using incompatible/outdated ICU DLL versions (`v63`). 

This fix ensures that the ICU DLLs in `APACHE_DIR` match the versions required by `php_intl.dll` during build time.

### Change

Update the ICU DLLs bundled with DoliWamp to the versions required by `PHP 7.4.6` (`exe/doliwamp` `v19.0` → `v23.0`) in inno-setup build.