### PR TITLE
FIX Unknown column 'efpt.search_options_*' on the project task list

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1268,7 +1268,13 @@ class Task extends CommonObjectLine
 		// Add where from extra fields
 		$extrafieldsobjectkey = 'projet_task';
 		$extrafieldsobjectprefix = 'efpt.';
-		$search_options_pattern = 'search_task_options_'; // Aligned with perweek.php/perday.php that build $search_array_options with this prefix (via extrafields->getOptionalsFromPost('projet_task', '', 'search_task_')). Without it, the SQL template falls back to 'search_options_' and the preg_replace fails to strip the actual prefix, generating phantom column names like efpt.search_task_options_<field>.
+		$search_options_pattern = 'search_options_';
+		if (is_array($search_array_options) && !empty($search_array_options)) {
+			$firstsearchkey = (string) array_keys($search_array_options)[0];
+			if (strpos($firstsearchkey, 'search_task_options_') === 0) {
+				$search_options_pattern = 'search_task_options_';
+			}
+		}
 		global $db, $conf; // needed for extrafields_list_search_sql.tpl
 		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 


### PR DESCRIPTION
# FIX Unknown column 'efpt.search_options_*' on the project task list

`Task::getTasksArray()` hardcoded the extrafield search prefix to `search_task_options_`,
but its callers do not agree on that prefix:

- `perweek.php` / `perday.php` build `$search_array_options` with `search_task_options_`
  (via `getOptionalsFromPost('projet_task', '', 'search_task_')`)
- `tasks.php` builds it with the default `search_options_`

Since the pattern was fixed, `extrafields_list_search_sql.tpl.php` could not strip the
actual prefix from the keys coming from `tasks.php`, and built a phantom column name:

```
Unknown column 'efpt.search_options_<field>' in 'WHERE'
```

The prefix is now deduced from the keys actually present in `$search_array_options`,
so both call paths work.

## How to reproduce

1. Add an extrafield of type `link` on the object `projet_task`
2. Display it as a column on a project's task list (`projet/tasks.php`)
3. Submit the list form (search button or any mass action)

The page ends with the SQL error above. The filter's default value of `-1` is no longer
excluded, so the empty filter is enough to reach the faulty code.