### PR TITLE
FIX Skip usergroup query when no group is selected

### DIFF
--- a/htdocs/holiday/card_group.php
+++ b/htdocs/holiday/card_group.php
@@ -271,14 +271,16 @@ if (empty($reshook)) {
 			// usergroup  select
 			// better perf on single sql
 			/** GROUPS */
-			$sql = ' SELECT DISTINCT u.rowid,u.lastname,u.firstname from ' . MAIN_DB_PREFIX . 'user as  u';
-			$sql .= ' LEFT JOIN  ' . MAIN_DB_PREFIX . 'usergroup_user as ug on ug.fk_user = u.rowid  ';
-			$sql .= ' WHERE  fk_usergroup in (' .$db->sanitize(implode(',', $groups)) . ')';
-			$resql = $db->query($sql);
+			if (is_array($groups) && count($groups) > 0) {
+				$sql = ' SELECT DISTINCT u.rowid,u.lastname,u.firstname from ' . MAIN_DB_PREFIX . 'user as  u';
+				$sql .= ' LEFT JOIN  ' . MAIN_DB_PREFIX . 'usergroup_user as ug on ug.fk_user = u.rowid  ';
+				$sql .= ' WHERE  fk_usergroup in (' .$db->sanitize(implode(',', $groups)) . ')';
+				$resql = $db->query($sql);
 
-			if ($resql) {
-				while ($obj = $db->fetch_object($resql)) {
-					$TusersToProcess[$obj->rowid] = $obj->rowid;
+				if ($resql) {
+					while ($obj = $db->fetch_object($resql)) {
+						$TusersToProcess[$obj->rowid] = $obj->rowid;
+					}
 				}
 			}
 			/** USERS  */


### PR DESCRIPTION
# FIX Skip usergroup query when no group is selected

`htdocs/holiday/card_group.php` resolves the members of the selected user groups with an unconditional query:

```php
$sql .= ' WHERE  fk_usergroup in (' .$db->sanitize(implode(',', $groups)) . ')';
```

When a group leave request is submitted with **users only**, `$groups` is empty, `implode()` returns an empty string and the query becomes `WHERE fk_usergroup in ()`, which the database rejects:

```
DB_ERROR_SYNTAX You have an error in your SQL syntax; check the manual that corresponds
to your MariaDB server version for the right syntax to use near ')'
```

Selecting users without any group is a valid input: the form validation raises an error only when **both** `$groups` and `$users` are empty. The group query must therefore not run in that case.

The leave request is still created, because the failed query returns `false` and the selected users are added right after. The only effect is an SQL error logged on every such submission.

**Fix:** run the group query only when at least one group is selected, consistent with the `/** USERS */` block right below it.

**To reproduce:** Leave requests > New group request, leave *Groups* empty, select one or more users, fill type, dates and approver, then submit. The error above is written to the log.


