### PR TITLE
Fix #39364 honor partial amount on supplier invoice payment with multicurrency

### DIFF
--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -494,7 +494,15 @@ class SupplierInvoices extends DolibarrApi
 		$amounts[$id] = $paymentamount;
 
 		// Multicurrency
-		$newvalue = (float) price2num($this->invoice->multicurrency_total_ttc, 'MT');
+		// getWay() switches the payment to the invoice currency as soon as a multicurrency amount is set, so
+		// this value must match the partial amount, not always the full invoice TTC. When a partial amount was
+		// requested, convert it at the invoice rate (multicurrency_total_ttc / total_ttc); otherwise use the
+		// full multicurrency TTC (full payment).
+		if (null !== $amount && $amount > 0 && !empty($this->invoice->total_ttc)) {
+			$newvalue = (float) price2num($paymentamount * $this->invoice->multicurrency_total_ttc / $this->invoice->total_ttc, 'MT');
+		} else {
+			$newvalue = (float) price2num($this->invoice->multicurrency_total_ttc, 'MT');
+		}
 		$multicurrency_amounts[$id] = $newvalue;
 
 		// Creation of payment line


### PR DESCRIPTION
POST /supplierinvoices/{id}/payments accepts an optional partial `amount`, but with MultiCurrency enabled the recorded payment used the full invoice multicurrency TTC instead of the partial amount.

In api_supplier_invoices.class.php addPayment(), $amounts[$id] got the correct partial amount, but multicurrency_amounts[$id] was always set to the full multicurrency_total_ttc. PaiementFourn::getWay() switches the payment to the invoice currency as soon as a multicurrency amount is non-empty, so PaiementFourn::create() used multicurrency_amounts (full TTC) and ignored $amounts. This mis-recorded the payment even for invoices in the company currency, where multicurrency_total_ttc equals total_ttc.

Fix: when a partial amount is requested, set the multicurrency amount to that amount converted at the invoice rate (multicurrency_total_ttc / total_ttc), guarding total_ttc = 0. Full payments keep the full multicurrency TTC (unchanged).

Verified the computed value: same-currency partial 30 of 100 -> 30 (was 100); foreign 30 with ttc 100 / mc 120 -> 36; full payment -> 120; total_ttc = 0 -> falls back to full TTC, no division by zero. Present on 21.0-24.0/develop; base 21.0 so it forward-merges up.
