### PR TITLE
Fix #39596 remap parent of cloned tasks in the clone mass action

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1897,6 +1897,8 @@ if (!$error && ($massaction == 'clonetasks' || ($action == 'clonetasks' && $conf
 	}
 
 	if ($permisstiontoadd) {
+		$taskidsmapping = array();		// old task id => new cloned task id
+		$clonedtaskoldparent = array();	// new cloned task id => old parent task id
 		foreach (GETPOST('selected') as $task) {
 			$origin_task->fetch($task, '', 0);
 
@@ -1928,6 +1930,8 @@ if (!$error && ($massaction == 'clonetasks' || ($action == 'clonetasks' && $conf
 
 				if ($taskid > 0) {
 					$result = $clone_task->add_contact(GETPOSTINT("userid"), 'TASKEXECUTIVE', 'internal');
+					$taskidsmapping[$task] = $taskid;						// remember old id => new id
+					$clonedtaskoldparent[$taskid] = $origin_task->fk_task_parent;	// remember new id => old parent id
 					$num++;
 				} else {
 					if ($db->lasterrno() == 'DB_ERROR_RECORD_ALREADY_EXISTS') {
@@ -1939,6 +1943,26 @@ if (!$error && ($massaction == 'clonetasks' || ($action == 'clonetasks' && $conf
 					}
 					$action = 'list';
 					$error++;
+				}
+			}
+		}
+
+		// Remap the parent of cloned tasks: if a cloned task's original parent was also cloned, point it to the
+		// new parent instead of the old id, otherwise the cloned sub-task would reference a task from the source
+		// project and end up orphaned (#39596). If the old parent was not cloned, detach it (set to 0).
+		if (!$error) {
+			foreach ($clonedtaskoldparent as $newtaskid => $oldparentid) {
+				if (empty($oldparentid)) {
+					continue;
+				}
+				$newparentid = isset($taskidsmapping[$oldparentid]) ? $taskidsmapping[$oldparentid] : 0;
+				$remaptask = new Task($db);
+				if ($remaptask->fetch($newtaskid) > 0 && $remaptask->fk_task_parent != $newparentid) {
+					$remaptask->fk_task_parent = $newparentid;
+					if ($remaptask->update($user) < 0) {
+						setEventMessages($remaptask->error, $remaptask->errors, 'errors');
+						$error++;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The "Clone" mass action on the task list (clonetasks in core/actions_massactions.inc.php) copied each selected task's fk_task_parent verbatim:

```php
$clone_task->fk_task_parent = $origin_task->fk_task_parent;
```

So when a task and its sub-task are both selected and cloned into another project, the cloned sub-task keeps the parent id from the source project. That id does not exist in the destination project, so the sub-task is orphaned and the tree cleaner then reports "orphelins were found ..." (as in #39596).

Fix: build an old-id to new-id map while cloning, then in a second pass remap each cloned task's parent to the newly cloned parent when the parent was also part of the selection, or detach it (set to 0) when it was not - so a cloned task never points at a task from the source project.

Verified in DB: cloning parent T + sub-task S into another project. Before, cloned S kept fk_task_parent = old T id (orphan in the destination project). After, cloned S points to the cloned T, no orphan. Present on 21.0-23.0/develop; base 21.0.
