### PR TITLE
FIX : Repair broken SELECT of the time spent list

### DIFF
--- a/htdocs/projet/tasks/time.php
+++ b/htdocs/projet/tasks/time.php
@@ -1626,10 +1626,10 @@ if (($id > 0 || !empty($ref)) || $projectidforalltimes > 0 || $allprojectforuser
 
 		$sql = "SELECT t.rowid, t.fk_element, t.element_date, t.element_datehour, t.element_date_withhour, t.element_duration, t.fk_user, t.note, t.thm,";
 		$sql .= " t.fk_product, t.invoice_line_id,";
-		$sql .= " pt.rowid as taskid, pt.ref, pt.label, pt.fk_projet, pt.billable";
+		$sql .= " pt.rowid as taskid, pt.ref, pt.label, pt.fk_projet, pt.billable,";
 		$sql .= " u.lastname, u.firstname, u.login, u.photo, u.gender, u.statut as user_status,";
 		$sql .= " il.fk_facture as invoice_id, inv.fk_statut,";
-		$sql .= " p.fk_soc,s.name_alias,";
+		$sql .= " p.fk_soc,s.name_alias";
 		if (!empty($extrafields->attributes['projet_task']['label'])) {
 			foreach ($extrafields->attributes['projet_task']['label'] as $key => $val) {
 				$sql .= ($extrafields->attributes['projet_task']['type'][$key] != 'separate' ? ",efpt.".$key." as options_".$key : '');


### PR DESCRIPTION
# FIX Repair broken SELECT of the time spent list

The list of time spent (`htdocs/projet/tasks/time.php`) fails with a SQL syntax error, so the page is entirely unusable:

```
DB_ERROR_SYNTAX You have an error in your SQL syntax; check the manual that corresponds
to your MariaDB server version for the right syntax to use near '.lastname, u.firstname,
u.login, u.photo, u.gender, u.statut as user_status, ...'
```

Two changes merged after 23.0.3 each left a broken separator in the field list:

- `pt.billable` has no trailing comma while the next line starts with `" u.lastname"`, producing `pt.billable u.lastname`.
- `p.fk_soc,s.name_alias,` ends with a comma while the extrafield loop right below prepends one, producing `s.name_alias,,efpt.<field>`.

The generated field list:

```
... pt.fk_projet, pt.billable u.lastname, ... p.fk_soc,s.name_alias,,efpt.soldprice as options_soldprice ...
```

**Fix:** add the missing separator after `pt.billable` and drop the extra one after `s.name_alias`, so the leading commas of the extrafield loop stay consistent. The existing `preg_replace('/,\s*$/', '', $sql)` still covers the case with no extrafield and no hook output.

**To reproduce:** open the time spent list (`projet/tasks/time.php`). The technical error is displayed and no line is listed.

Both faulty separators are absent from 23.0.3, so no released version is affected — but the 23.0 branch currently preparing 23.0.4 is.
