### PR TITLE
FIX cron list keep search filters after launching a job

### DIFF
--- a/htdocs/cron/list.php
+++ b/htdocs/cron/list.php
@@ -121,6 +121,7 @@ if (empty($reshook)) {
 	if (GETPOST('button_removefilter_x', 'alpha') || GETPOST('button_removefilter.x', 'alpha') || GETPOST('button_removefilter', 'alpha')) { // All tests are required to be compatible with all browsers
 		$search_label = '';
 		$search_status = -1;
+		$search_module_name = '';
 		$search_lastresult = '';
 		$toselect = array();
 		$search_array_options = array();
@@ -188,6 +189,15 @@ if (empty($reshook)) {
 			}
 			if ($search_label) {
 				$param .= '&search_label='.urlencode($search_label);
+			}
+			if ($search_module_name) {
+				$param .= '&search_module_name='.urlencode($search_module_name);
+			}
+			if ($search_lastresult) {
+				$param .= '&search_lastresult='.urlencode($search_lastresult);
+			}
+			if ($mode) {
+				$param .= '&mode='.urlencode($mode);
 			}
 			if ($optioncss != '') {
 				$param .= '&optioncss='.urlencode($optioncss);


### PR DESCRIPTION
FIX cron list keep search filters after launching a job

In cron list when you filter (ex : filter on module)
<img width="1680" height="543" alt="image" src="https://github.com/user-attachments/assets/79f13722-2d41-4f1e-869b-284fb42bdbba" />

After launching a job you loose this previous filter : 
<img width="1676" height="626" alt="image" src="https://github.com/user-attachments/assets/5ca0dbcc-1811-498b-a8ea-0376e64c0115" />

With this fix, you keep the previous filter after launching cron : 
<img width="1670" height="366" alt="image" src="https://github.com/user-attachments/assets/9453a54c-9d0f-456c-8d6c-0c3984bc45d3" />

And the filter is removed when you clear filter when you click on "x" at the top of this list.