### PR TITLE
Fix #38389 use instance constant for validated status in PDF merge

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -916,7 +916,7 @@ if (!$error && $massaction == "builddoc" && $permissiontoread && !GETPOST('butto
 		$filename = preg_replace('/\s/', '_', $filename);
 
 		// Save merged file
-		if (in_array($objecttmp->element, array('facture', 'invoice_supplier')) && $search_status == Facture::STATUS_VALIDATED) {
+		if (in_array($objecttmp->element, array('facture', 'invoice_supplier')) && $search_status == $objecttmp::STATUS_VALIDATED) {
 			if ($option == 'late') {
 				$filename .= '_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Unpaid"))).'_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Late")));
 			} else {
@@ -995,7 +995,7 @@ if (!$error && $massaction == "builddoc" && $permissiontoread && !GETPOST('butto
 
 
 		// Save merged file
-		if (in_array($objecttmp->element, array('facture', 'invoice_supplier')) && $search_status == Facture::STATUS_VALIDATED) {
+		if (in_array($objecttmp->element, array('facture', 'invoice_supplier')) && $search_status == $objecttmp::STATUS_VALIDATED) {
 			if ($option == 'late') {
 				$filename .= '_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Unpaid"))).'_'.strtolower(dol_sanitizeFileName($langs->transnoentities("Late")));
 			} else {


### PR DESCRIPTION
Re-targets the #38389 fix to develop, where the crash is actually reachable (see the review on #39463).

On develop the builddoc (PDF Merge) mass action is enabled on the supplier invoice list, and the merge block guard is `in_array($objecttmp->element, array('facture', 'invoice_supplier'))`, which matches FactureFournisseur ($element = 'invoice_supplier'). But it then compares $search_status to `Facture::STATUS_VALIDATED`. On the supplier list only FactureFournisseur is loaded, never Facture, so the reference raises a fatal "Class Facture not found" and the merge returns a blank 500.

Fix: use `$objecttmp::STATUS_VALIDATED` so the constant resolves on the real object class. Both Facture and FactureFournisseur define it as 1, so customer invoice merge is unaffected.

Verified on develop code: FactureFournisseur->element = 'invoice_supplier' (matches the guard), `$objecttmp::STATUS_VALIDATED` = 1, and `Facture::STATUS_VALIDATED` without the class loaded throws Error "Class Facture not found" (class_exists('Facture', false) is false in that path).

Note: this supersedes #39463 (base 18.0). As @lvessiller-opendsi correctly pointed out, the bug is not reachable on 18.0 there (builddoc is commented out on the supplier list and the guard uses 'facture_fournisseur' while $element is 'invoice_supplier', so the STATUS_VALIDATED reference is short-circuited). I will close #39463.
