### PR TITLE
Fix phan false positive on $object type in affecttag mass action

### DIFF
--- a/htdocs/core/actions_massactions.inc.php
+++ b/htdocs/core/actions_massactions.inc.php
@@ -1373,6 +1373,9 @@ if (!$error && ($action == 'affecttag' && $confirm == 'yes') && $permissiontoadd
 
 		// For each valid categ type set common categ
 		if (!empty($to_affecttag_type_array)) {
+			// The CommonSocialNetworks trait forces $object to its own type on the global $object for phan, which
+			// makes phan lose the CommonObject methods here (fetch, setCategoriesCommon). Restore the real type.
+			'@phan-var-force CommonObject $object';
 			foreach ($to_affecttag_type_array as $categ_type) {
 				$contcats = GETPOST('contcats_' . $categ_type, 'array');
 				foreach ($toselect as $toselectid) {


### PR DESCRIPTION
phan reports two false positives on htdocs/core/actions_massactions.inc.php that block any PR touching this file (the file-list phan run flags them, and the baseline only covers PhanUndeclaredProperty for this file):

```
PhanUndeclaredMethod: Call to undeclared method \CommonSocialNetworks::fetch
PhanUndeclaredMethod: Call to undeclared method \CommonSocialNetworks::setCategoriesCommon
```

Root cause: the CommonSocialNetworks trait (core/class/commonsocialnetworks.class.php) does `global $object;` then `'@phan-var-force CommonSocialNetworks $object';` inside showSocialNetwork(). That force-type on the global $object leaks into phan's analysis of actions_massactions.inc.php, where the affecttag mass action uses the global $object and calls $object->fetch() / $object->setCategoriesCommon() (lines ~1379/1381). phan then resolves $object to the trait type, which has neither method.

Fix: restore the real type with a local `'@phan-var-force CommonObject $object';` just before the affecttag loop. Runtime behaviour is unchanged (it's a phan annotation string). Verified locally: `Run local Phan ... Passed` after the change.

This unblocks phan for PRs on this file (e.g. #39612).
