### PR TITLE
FIX: Societe::fetch() returns integer not array

### DIFF
--- a/htdocs/societe/class/api_thirdparties.class.php
+++ b/htdocs/societe/class/api_thirdparties.class.php
@@ -9,6 +9,7 @@
  * Copyright (C) 2025		William Mead			<william@m34d.com>
  * Copyright (C) 2025		Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2026		Benjamin Falière		<benjamin@faliere.com>
+ * Copyright (C) 2026		Noé Cendrier			<noe.cendrier@altairis.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1061,7 +1062,7 @@ class Thirdparties extends DolibarrApi
 		}
 
 		$result = $this->company->fetch($id);
-		if (!is_array($result)) {
+		if ($result < 1) {
 			throw new RestException(404, 'Thirdparty not found');
 		}
 


### PR DESCRIPTION
# FIX: Societe::fetch() returns integer not array
in PR #33311 `!$result` was replaced by `!is_array($result)` as test for Thirdparty existence in Thirdparties::getSalesReprensatives() method.
But `Societe::fetch()` returns an integer, thus we must check if we do have a valid thirparty ID instead