### PR TITLE
FIX Add missing CSRF token check on core/ajax/objectonoff.php

### DIFF
--- a/htdocs/core/ajax/objectonoff.php
+++ b/htdocs/core/ajax/objectonoff.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2015-2023 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,6 +38,9 @@ if (!defined('NOREQUIREAJAX')) {
 }
 if (!defined('NOREQUIRESOC')) {
 	define('NOREQUIRESOC', '1');
+}
+if (!defined('CSRFCHECK_WITH_TOKEN')) {
+	define('CSRFCHECK_WITH_TOKEN', '1'); // Token is required even in GET mode
 }
 
 // Load Dolibarr environment


### PR DESCRIPTION
## Summary
- `core/ajax/objectonoff.php` toggles object status (product `tosell`/`tobuy`, third-party status, etc.) and can be called via GET when `MAIN_DIRECT_STATUS_UPDATE` is enabled.
- Unlike its sibling endpoints `core/ajax/constantonoff.php` and `core/ajax/changepositionfields.php`, which both force `CSRFCHECK_WITH_TOKEN`, this file only relied on `restrictedArea()` permission checks and did not require a CSRF token, making the status change reachable via a crafted link (CSRF) against a logged-in user with rights on the object.
- Adds the same `CSRFCHECK_WITH_TOKEN` guard used by the sibling ajax endpoints.
- No JS/behavior change needed: the caller `ajax_object_onoff()` (`core/lib/ajax.lib.php`) already sends `token: currentToken()` with the GET request, this PR only enables the server-side check that was missing.

## Test plan
- [x] `php -l` on the modified file
- [x] Pre-commit hooks (PHPStan, Phan, Codesniffer) pass
- [x] Manual check: toggling a product's `tosell` status via the ajax endpoint with a valid session token still works (200, DB updated)
- [x] Manual check: replaying the same GET request without the `token` param is now rejected (403, "Access to a page that needs a token ... is refused by CSRF protection", DB unchanged)