### PR TITLE
FIX: Correct broken SQL concatenations (missing space/comma/AND)

### DIFF
--- a/htdocs/compta/accounting-files.php
+++ b/htdocs/compta/accounting-files.php
@@ -191,7 +191,7 @@ if ($action == 'searchfiles' || $action == 'dl') {	// Test on permission not req
 			if (!empty($sql)) {
 				$sql .= " UNION ALL";
 			}
-			$sql .= "SELECT t.rowid as id, t.entity, t.ref, t.paye as paid, t.total_ht, t.total_ttc, t.total_tva as total_vat,";
+			$sql .= " SELECT t.rowid as id, t.entity, t.ref, t.paye as paid, t.total_ht, t.total_ttc, t.total_tva as total_vat,";
 			$sql .= " t.localtax1, t.localtax2, t.revenuestamp,";
 			$sql .= " t.multicurrency_code as currency, t.fk_soc, t.datef as date, t.date_lim_reglement as date_due, 'Invoice' as item, s.nom as thirdparty_name, s.code_client as thirdparty_code, c.code as country_code, s.tva_intra as vatnum, ".PAY_CREDIT." as sens";
 			$sql .= " FROM ".MAIN_DB_PREFIX."facture as t LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON s.rowid = t.fk_soc LEFT JOIN ".MAIN_DB_PREFIX."c_country as c ON c.rowid = s.fk_pays";

--- a/htdocs/core/ajax/ziptown.php
+++ b/htdocs/core/ajax/ziptown.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2010      Regis Houssin       <regis.houssin@inodbox.com>
  * Copyright (C) 2011-2023 Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -102,12 +102,12 @@ if (GETPOST('zipcode') || GETPOST('town')) {
 		$sql .= " FROM ".MAIN_DB_PREFIX.'societe as s';
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_departements as d ON s.fk_departement = d.rowid";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX.'c_country as c ON s.fk_pays = c.rowid';
-		$sql .= " WHERE";
+		$sql .= " WHERE 1 = 1";
 		if ($zipcode) {
-			$sql .= " s.zip LIKE '".$db->escape($db->escapeforlike($zipcode))."%'";
+			$sql .= " AND s.zip LIKE '".$db->escape($db->escapeforlike($zipcode))."%'";
 		}
 		if ($town) {
-			$sql .= " s.town LIKE '%".$db->escape($db->escapeforlike($town))."%'";
+			$sql .= " AND s.town LIKE '%".$db->escape($db->escapeforlike($town))."%'";
 		}
 		$sql .= " ORDER BY s.fk_pays, s.zip, s.town";
 		$sql .= $db->plimit(100); // Avoid pb with bad criteria

--- a/htdocs/core/class/ctyperesource.class.php
+++ b/htdocs/core/class/ctyperesource.class.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2014-2016  Juanjo Menent       <jmenent@2byte.es>
  * Copyright (C) 2016       Florian Henry       <florian.henry@atm-consulting.fr>
  * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -88,7 +88,7 @@ class Ctyperesource extends CommonDict
 		// Insert request
 		$sql = 'INSERT INTO '.$this->db->prefix().$this->table_element.'(';
 		$sql .= 'code,';
-		$sql .= 'label';
+		$sql .= 'label,';
 		$sql .= 'active';
 		$sql .= ') VALUES (';
 		$sql .= ' '.(!isset($this->code) ? 'NULL' : "'".$this->db->escape($this->code)."'").',';

--- a/htdocs/product/stock/class/productlot.class.php
+++ b/htdocs/product/stock/class/productlot.class.php
@@ -1081,7 +1081,7 @@ class Productlot extends CommonObject
 			$sql .= " FROM ".$this->db->prefix()."mrp_mo as c";
 			$sql .= " INNER JOIN ".$this->db->prefix()."mrp_production as mp ON mp.fk_mo=c.rowid";
 			if (!$user->hasRight('societe', 'client', 'voir')) {
-				$sql .= "INNER JOIN ".$this->db->prefix()."societe_commerciaux as sc ON sc.fk_soc=c.fk_soc AND sc.fk_user = ".((int) $user->id);
+				$sql .= " INNER JOIN ".$this->db->prefix()."societe_commerciaux as sc ON sc.fk_soc=c.fk_soc AND sc.fk_user = ".((int) $user->id);
 			}
 			$sql .= " WHERE ";
 			$sql .= " c.entity IN (".getEntity('mo').")";


### PR DESCRIPTION
## Summary

Found by static analysis while auditing `$sql .=` concatenation patterns across the codebase. All 4 fixes were verified by actually running the affected SQL against the dev database (see test plan below); one of them turned out to be non-reachable in practice on closer inspection, but is kept as a harmless consistency fix.

- `htdocs/core/class/ctyperesource.class.php`: **confirmed reachable bug.** `Ctyperesource::create()` was missing a comma between the `label` and `active` column names (`labelactive`), so the column list no longer matched the 3 values in `VALUES (...)`. Reproduced: `Column count doesn't match value count at row 1`. Fixed and re-verified: insert now succeeds.
- `htdocs/product/stock/class/productlot.class.php`: **confirmed reachable bug.** `Productlot::loadStatsMo()` was missing a leading space before an `INNER JOIN`, merging it with the previous `c.rowid` token, for any user without the `societe/client/voir` permission. Reproduced: `Unknown column 'c.rowidINNER' in 'on clause'`. Fixed and re-verified: query now succeeds.
- `htdocs/core/ajax/ziptown.php`: **confirmed reachable bug, and the default code path** (triggers whenever `MAIN_USE_ZIPTOWN_DICTIONNARY` is off, which is the default). The third-party search branch appended the optional zip/town `LIKE` filters without `AND`, so submitting both a zipcode and a town (as the address autocomplete widget can do) produced two conditions glued with no boolean operator. Reproduced the exact SQL syntax error with both filters set. Fixed by adding a `WHERE 1 = 1` anchor (matching the pattern already used a few lines above, in the dictionary branch) and prefixing each optional filter with `AND`; re-verified both the combined-filters case and the single-filter case work correctly.
- `htdocs/compta/accounting-files.php`: **not actually reachable — kept as a style/consistency fix only.** The first `UNION`'d `SELECT` (customer invoices block) was missing its leading space. On closer inspection, this block is unconditionally the *first* sequential `if` in the function, right after `$sql` is reset to `''`, with no loop reordering it — so `$sql` is always empty when this line executes and the `UNION ALL` prefix can never precede it. Verified this with an isolated harness reproducing the exact control flow: the query is well-formed with or without the leading space in every combination tested. Kept the fix anyway since it makes the line consistent with every other `UNION`'d block in the same function (lines with `" SELECT ..."`), and the leading space is harmless SQL either way.

## Test plan

- [x] `php -l` on all 4 changed files
- [x] `Ctyperesource::create()`: reproduced `Column count doesn't match value count` with the bug reintroduced, confirmed clean insert with the fix
- [x] `Productlot::loadStatsMo()` as a user without `societe/client/voir`: reproduced `Unknown column 'c.rowidINNER'` with the bug reintroduced, confirmed successful query with the fix
- [x] `core/ajax/ziptown.php` search logic with both a zipcode and a town, `MAIN_USE_ZIPTOWN_DICTIONNARY` off (the default): reproduced the SQL syntax error with the bug reintroduced, confirmed successful query with the fix (and confirmed the single-filter case still works)
- [x] `compta/accounting-files.php`: isolated harness confirmed the block order makes the original code unreachable in practice; no functional regression from the fix