### PR TITLE
Fix #20876 compute local taxes on replenishment order lines

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -255,6 +255,10 @@ if ($action == 'order' && GETPOST('valid')) {
 					if (empty($line->remise_percent)) {
 						$line->remise_percent = $order->thirdparty->remise_supplier_percent;
 					}
+					// Compute local taxes for the line (purchase: buyer is mysoc, seller is the supplier),
+					// otherwise localtax1/localtax2 stay empty and Tax 2 is missing on replenishment lines (#20876).
+					$line->localtax1_tx = get_localtax($line->tva_tx, 1, $mysoc, $order->thirdparty);
+					$line->localtax2_tx = get_localtax($line->tva_tx, 2, $mysoc, $order->thirdparty);
 					$result = $order->addline(
 						$line->desc,
 						$line->subprice,
@@ -299,6 +303,10 @@ if ($action == 'order' && GETPOST('valid')) {
 					if (empty($line->remise_percent)) {
 						$line->remise_percent = $order->thirdparty->remise_supplier_percent;
 					}
+					// Compute local taxes for the line (purchase: buyer is mysoc, seller is the supplier),
+					// otherwise localtax1/localtax2 stay empty and Tax 2 is missing on replenishment lines (#20876).
+					$line->localtax1_tx = get_localtax($line->tva_tx, 1, $mysoc, $order->thirdparty);
+					$line->localtax2_tx = get_localtax($line->tva_tx, 2, $mysoc, $order->thirdparty);
 					$order->lines[] = $line;
 				}
 				$order->cond_reglement_id = $order->thirdparty->cond_reglement_supplier_id;


### PR DESCRIPTION
When creating a supplier order from the replenishment screen (product/stock/replenish.php), the order lines are built and passed to addline() / $order->lines[] with `$line->localtax1_tx` and `$line->localtax2_tx` never set. They stay empty, so local taxes (for example Spanish IRPF, which is Tax 2) are missing on the lines - whereas a supplier order created via "new invoice"/order card computes them. Editing a line then shows the wrong value because the rate was never stored.

Fix: compute the rates with get_localtax() before adding each line, using the purchase party order (buyer = $mysoc, seller = $order->thirdparty), matching how fourn/commande/card.php does it. Applied to both loops (add to an existing order, and create a new order).

Verified with get_localtax on Spanish parties (tva=21): localtax1_tx='5.2', localtax2_tx='-19:-15:-9' (IRPF) are now returned and stored, while a non-localtax country (FR) returns 0, so there is no impact where local taxes do not apply. Present since at least 18.0; base 18.0 so it forward-merges up.
