### PR TITLE
Clean code: suppress Phan false positive on imagecreatefromavif()/imageavif()

### DIFF
--- a/htdocs/core/lib/images.lib.php
+++ b/htdocs/core/lib/images.lib.php
@@ -671,7 +671,7 @@ function vignette($file, $maxWidth = 160, $maxHeight = 120, $extName = '_small',
 			$extImg = '.webp';
 			break;
 		case 19:	// 19 TYPEIMAGE_AVIF constant don't exists with php < 8.1
-			$img = imagecreatefromavif($filetoread);
+			$img = imagecreatefromavif($filetoread); // @phan-suppress-current-line PhanParamTooManyInternal -- Phan's internal signature for imagecreatefromavif() is missing its $filename param, see https://github.com/phan/phan/issues/5562
 			$extImg = '.avif';
 			break;
 	}
@@ -850,7 +850,7 @@ function vignette($file, $maxWidth = 160, $maxHeight = 120, $extName = '_small',
 			imagewebp($imgThumb, $imgThumbName, $newquality); // @phan-suppress-current-line PhanTypeMismatchArgumentNullableInternal,PhanPossiblyUndeclaredVariable
 			break;
 		case 19:    // 19 TYPEIMAGE_AVIF constant don't exists with php < 8.1
-			imageavif($imgThumb, $imgThumbName, $newquality); // @phan-suppress-current-line PhanTypeMismatchArgumentNullableInternal,PhanPossiblyUndeclaredVariable
+			imageavif($imgThumb, $imgThumbName, $newquality); // @phan-suppress-current-line PhanTypeMismatchArgumentNullableInternal,PhanPossiblyUndeclaredVariable,PhanParamTooManyInternal -- Phan's internal signature for imageavif() is missing its params, see https://github.com/phan/phan/issues/5562
 			break;
 	}
 


### PR DESCRIPTION
## Summary
- `htdocs/core/lib/images.lib.php` calls `imagecreatefromavif($filetoread)` and `imageavif($imgThumb, $imgThumbName, $newquality)`, both correct per the documented PHP signatures (confirmed with `ReflectionFunction` on PHP 8.2/8.5).
- Phan's bundled internal function signature map is missing the parameters for these two GD functions (every sibling `imagecreatefrom*`/`image{jpeg,png,webp}` entry declares them correctly), so Phan predicts a false `PhanParamTooManyInternal` ("would throw an ArgumentCountError").
- The project's own `dev/tools/phan/stubs/gd.phan_php` already declares the correct signatures, but it never gets consulted for this — Phan's bundled signature map takes priority for function names it already recognizes, confirmed even with `ext-gd` fully unloaded.
- Reported upstream: https://github.com/phan/phan/issues/5562
- Adds `@phan-suppress-current-line PhanParamTooManyInternal` (with a link to the upstream issue) on both call sites, following the file's existing suppression convention.

## Test plan
- [x] `php -l htdocs/core/lib/images.lib.php`
- [x] `vendor/bin/phan` (Phan 6.0.7, project config) on this file: exit 0, no findings, before had 2x `PhanParamTooManyInternal`
- [x] Local pre-commit hooks passed (PHPStan, Phan, PHP Codesniffer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)