### PR TITLE
FIX: Skip local PHPStan pre-commit hook for non-PHP files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,6 +139,7 @@ repos:
         language: script
         entry: ./dev/tools/phpstan/allow_phpstan_in_precommit.sh
         pass_filenames: true
+        files: \.(php)$
         stages: [pre-commit]
       - id: phan
         name: Run local Phan


### PR DESCRIPTION
## Summary
- The local `php-stan` pre-commit hook (repo: local) had no `files:` filter, unlike its `manual`-stage duplicate further down in the same config.
- Any commit touching only non-PHP files (e.g. SQL migrations under `htdocs/install/mysql/`) made PHPStan fail with `No files found to analyse`, blocking the commit.
- Added `files: \.(php)$` to match the existing manual-stage definition.