### PR TITLE
NEW: Add fk_user_creat and fk_user_modif to llx_const (SQL only)

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -81,4 +81,8 @@ ALTER TABLE llx_c_action_trigger ADD COLUMN enabled varchar(255);
 -- VMYSQL4.1 ALTER TABLE llx_socpeople ADD COLUMN use_thirdparty_address smallint DEFAULT NULL AFTER fk_soc;
 -- VPGSQL8.2 ALTER TABLE llx_socpeople ADD COLUMN use_thirdparty_address smallint DEFAULT NULL;
 
+-- Add user information to const
+ALTER TABLE llx_const ADD COLUMN fk_user_creat integer;
+ALTER TABLE llx_const ADD COLUMN fk_user_modif integer;
+
 -- end of migration

--- a/htdocs/install/mysql/tables/llx_const.sql
+++ b/htdocs/install/mysql/tables/llx_const.sql
@@ -32,7 +32,9 @@ create table llx_const
   type        varchar(64) DEFAULT 'string', -- null or 'encrypted' if param has been encrypted
   visible     tinyint DEFAULT 1 NOT NULL,
   note        text,
-  tms         timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+  tms         timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  fk_user_creat integer,		-- user who created the constant
+  fk_user_modif integer		-- user who last modified the constant
 ) ENGINE=innodb;
 
 --


### PR DESCRIPTION
## Summary
- Add `fk_user_creat` and `fk_user_modif` columns to `llx_const`, so we can track which user created or last modified a setup constant.
- SQL only in this PR (table definition + migration in `24.0.0-25.0.0.sql`); the PHP side (`dolibarr_set_const()` / `dolibarr_get_const()`) to populate these columns will follow in a separate PR.