### PR TITLE
Fix #32312 email attachments copied in wrong agenda directory

### DIFF
--- a/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
+++ b/htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php
@@ -1682,9 +1682,7 @@ class InterfaceActionsAuto extends DolibarrTriggers
 			// @phan-suppress-next-line PhanUndeclaredProperty
 			if (property_exists($object, 'attachedfiles') && is_array($object->attachedfiles) && array_key_exists('paths', $object->attachedfiles) && count($object->attachedfiles['paths']) > 0) {
 				// Note: None of the dolibarr classes seem to have an attachedfiles property
-				// Get directory of object
-				$tmpelems = getElementProperties($object->element.($object->module ? '@'.$object->module : ''));
-				$destdir = $tmpelems['dir_output'].'/'.$ret;
+				$destdir = $conf->agenda->dir_output.'/'.dol_sanitizeFileName($actioncomm->ref);
 
 				// @phan-suppress-next-line PhanUndeclaredProperty
 				foreach ($object->attachedfiles['paths'] as $key => $filespath) {


### PR DESCRIPTION
# FIX #32312

Fix destination directory for attached files in modAgenda. `MAIN_COPY_FILE_IN_EVENT_AUTO` copies email attachments into the wrong directory.

### Bug

`MAIN_COPY_FILE_IN_EVENT_AUTO` copies email attachments into the wrong directory, so they never appear in the agenda event's Documents tab.

### Root cause

In `htdocs/core/triggers/interface_50_modAgenda_ActionsAuto.class.php`, the destination directory is computed from the **source object** (proposal, order, invoice...) instead of the **agenda module**:

```php
$tmpelems = getElementProperties($object->element.($object->module ? '@'.$object->module : ''));
$destdir = $tmpelems['dir_output'].'/'.$ret;
```

This copies the file to `documents/{source_object_type}/{event_id}/`, e.g. `documents/propale/1234/quote.pdf`.

But `htdocs/comm/action/document.php` (the event's Documents tab) reads from:

```php
$upload_dir = $conf->agenda->dir_output.'/'.dol_sanitizeFileName($object->ref);
```

i.e. `documents/agenda/{ref}/`. The file is copied successfully (`dol_copy()` doesn't fail) but to a path nothing ever reads, so it silently appears "not attached."
