### PR TITLE
FIX: validated order deletion condition should consider stock options

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -3694,7 +3694,8 @@ if ($action == 'create' && $usercancreate) {
 
 				// Delete order
 				if ($usercandelete) {
-					if ($numshipping == 0) {
+					$stocksent = getDolGlobalString('STOCK_CALCULATE_ON_VALIDATE_ORDER') && $object->status > Commande::STATUS_DRAFT;
+					if ($numshipping == 0 && !$stocksent) {
 						print dolGetButtonAction('', $langs->trans('Delete'), 'delete', $_SERVER["PHP_SELF"] . '?action=delete&token=' . newToken() . '&id=' . $object->id, '');
 					} else {
 						print dolGetButtonAction($langs->trans('ShippingExist'), $langs->trans('Delete'), 'default', $_SERVER['PHP_SELF'] . '#', '', false);


### PR DESCRIPTION
# FIX: validated order deletion condition should consider stock options
If we use STOCK_CALCULATE_ON_VALIDATE_ORDER, we can delete a validated order, which decreased stock, and stock won’t be restored.

With this additional condition, we can ensure that this doesn’t happen.

