### PR TITLE
 Fix supplier reference display and copy icon behavior

### DIFF
--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -705,9 +705,11 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							// Ref
 							print '<td data-col="object-name" class="nowraponall">';
 							print '<div class="inline-block lineheightsmall">';
+							print '<span data-field="ref">';
 							print $invoicesupplierstatic->getNomUrl(1);
-							print '<br><span class="opacitymedium small" title="'.$langs->trans("RefSupplier").'">';
-							print dolPrintHTML($objp->ref_supplier);
+							print '</span> ';
+							print '<br class="paiement-line-break-for-ref" /><span class="opacitymedium small" data-field="ref-supplier" title="'.$langs->trans("RefSupplier").'">';
+							print showValueWithClipboardCPButton($objp->ref_supplier);
 							print '</span>';
 							print '</div>';
 							print '</td>';

--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -9037,10 +9037,19 @@ div.clipboardCPValue.hidewithsize {
 
 .clipboardCPShowOnHover{
 	cursor: copy;
+	position: relative;
 }
 
 .clipboardCPShowOnHover .clipboardCPButton {
 	display: none;
+}
+
+.clipboardCPShowOnHover .clipboardCPButton,
+.clipboardCPShowOnHover .clipboardCPTick {
+	position: absolute;
+	right: 0;
+	top: 50%;
+	transform: translate(100%, -50%);
 }
 
 /* To make a div popup, we must use a position absolute inside a position relative */


### PR DESCRIPTION
# Fix display of supplier reference in supplier invoice payments

The **Supplier Reference** column, which had previously been added to the supplier invoice payments table, had been removed. This created an inconsistency with the customer-side display.

The reference and supplier reference are now displayed across two lines, which made it less convenient to use. In particular, when users try to click or copy the supplier reference, they may accidentally click on the invoice `getNomUrl()` link because the two elements are positioned very close to each other.

This PR keeps the existing display while introducing a few improvements:

* added dedicated CSS classes for better styling and positioning control;
* added the ability to **copy the supplier reference with a single click**;

# Fix copy icon flash effect

When using the `hover` state, the copy icon caused the surrounding elements to shift slightly when it appeared because it occupied space in the layout.

This issue is fixed by changing the copy icons to use **absolute positioning (`position: absolute`)** instead of relative positioning.

As a result, displaying the icon no longer affects the layout or causes nearby elements to move.
