### PR TITLE
Fix #35207 keep page limit when saving inventory lines

### DIFF
--- a/htdocs/product/inventory/inventory.php
+++ b/htdocs/product/inventory/inventory.php
@@ -607,6 +607,9 @@ print '<input type="hidden" name="action" value="updateinventorylines">';
 print '<input type="hidden" name="id" value="'.$object->id.'">';
 print '<input type="hidden" name="sortfield" value="' . $sortfield . '">';
 print '<input type="hidden" name="sortorder" value="' . $sortorder . '">';
+// Keep the same limit as the displayed page, otherwise the save reads a different page slice
+// (plimit($limit, $offset)) than the one shown and quantities of the extra rows are lost (#35207).
+print '<input type="hidden" name="limit" value="' . ((int) $limit) . '">';
 if ($backtopage) {
 	print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
 }


### PR DESCRIPTION
When saving inventory lines with more products than the default page limit, the entered quantities of the rows beyond the first page-slice are lost.

The save action (updateinventorylines in product/inventory/inventory.php) reads the rows to update with `plimit($limit, $offset)`, and `$limit` comes from `GETPOST('limit')`. But the formrecord form only submitted page/sortfield/sortorder, not limit. So when the displayed limit differed from $conf->liste_limit (e.g. the user raised it to show all products on one page), the save fell back to the default limit and iterated a smaller/different slice than the one shown: the id_X inputs of the extra rows were never in that slice, so their quantities were not saved (and, in the fetched slice, missing inputs are treated as a reset to null).

Fix: add a hidden `limit` field to the form so the save uses the same slice as the display.

Verified the offset logic: display limit=50 page=0 shows rows [0..49]; without the fix the save runs plimit(20,0) and only saves [0..19] (rows 20..49 lost); with the fix it runs plimit(50,0) and saves [0..49]. The default-limit case (limit=20) is unchanged. Present on 21.0/22.0; base 21.0 so it forward-merges up.
