### PR TITLE
Translate remaining French comments in core code to English

### DIFF
--- a/htdocs/comm/remise.php
+++ b/htdocs/comm/remise.php
@@ -108,7 +108,7 @@ if (! ($socid > 0)) {
 	accessforbidden('Record not found');
 }
 
-// On recupere les donnees societes par l'objet
+// Retrieve third-party data via the object
 $object = new Societe($db);
 $object->fetch($socid);
 

--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -281,7 +281,7 @@ $tmpuser = new User($db);
 llxHeader('', $langs->trans("GlobalDiscount"));
 
 if ($socid > 0) {
-	// On recupere les donnees societes par l'objet
+	// Retrieve third-party data via the object
 	$object = new Societe($db);
 	$object->fetch($socid);
 

--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -158,7 +158,7 @@ if (empty($reshook)) {
 
 	// Create user from contact
 	if ($action == 'confirm_create_user' && $confirm == 'yes' && $user->hasRight('user', 'user', 'creer')) {
-		// Recuperation contact actuel
+		// Retrieve current contact
 		$result = $object->fetch($id);
 
 		if ($result > 0) {

--- a/htdocs/core/boxes/box_external_rss.php
+++ b/htdocs/core/boxes/box_external_rss.php
@@ -72,7 +72,7 @@ class box_external_rss extends ModeleBoxes
 
 		$this->max = $max;
 
-		// On recupere numero de param de la boite
+		// Retrieve box param number
 		$reg = array();
 		preg_match('/^([0-9]+) /', $this->paramdef, $reg);
 		$site = $reg[1];

--- a/htdocs/core/modules/expedition/doc/pdf_merou.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_merou.modules.php
@@ -516,7 +516,7 @@ class pdf_merou extends ModelePdfExpedition
 
 		pdf_pagehead($pdf, $outputlangs, $this->page_hauteur);
 
-		//Affiche le filigrane brouillon - Print Draft Watermark
+		// Print Draft Watermark
 		if ($object->statut == 0 && (getDolGlobalString('SENDING_DRAFT_WATERMARK'))) {
 			pdf_watermark($pdf, $outputlangs, $this->page_hauteur, $this->page_largeur, 'mm', $conf->global->SENDING_DRAFT_WATERMARK);
 		}

--- a/htdocs/core/modules/member/doc/pdf_standard_member.class.php
+++ b/htdocs/core/modules/member/doc/pdf_standard_member.class.php
@@ -454,7 +454,7 @@ class pdf_standard_member extends CommonStickerGenerator
 		$pdf->setAutoPageBreak(false);
 
 		$this->_Metric_Doc = $this->Tformat['metric'];
-		// Permet de commencer l'impression de l'etiquette desiree dans le cas ou la page a deja service
+		// Allows starting the print of the desired label in case the page has already been used
 		$posX = 1;
 		$posY = 1;
 		if ($posX > 0) {

--- a/htdocs/core/modules/mrp/doc/pdf_vinci.modules.php
+++ b/htdocs/core/modules/mrp/doc/pdf_vinci.modules.php
@@ -1014,7 +1014,7 @@ class pdf_vinci extends ModelePDFMo
 		// Do not add the BACKGROUND as this is for suppliers
 		//pdf_pagehead($pdf,$outputlangs,$this->page_hauteur);
 
-		//Affiche le filigrane brouillon - Print Draft Watermark
+		// Print Draft Watermark
 		/*if($object->statut==0 && getDolGlobalString('COMMANDE_DRAFT_WATERMARK'))
 		{
 			pdf_watermark($pdf,$outputlangs,$this->page_hauteur,$this->page_largeur,'mm',getDolGlobalString('COMMANDE_DRAFT_WATERMARK'));

--- a/htdocs/core/modules/printsheet/doc/pdf_tcpdflabel.class.php
+++ b/htdocs/core/modules/printsheet/doc/pdf_tcpdflabel.class.php
@@ -338,7 +338,7 @@ class pdf_tcpdflabel extends CommonStickerGenerator
 		$pdf->setAutoPageBreak(false);
 
 		$this->_Metric_Doc = $this->Tformat['metric'];
-		// Permet de commencer l'impression de l'etiquette desiree dans le cas ou la page a deja service
+		// Allows starting the print of the desired label in case the page has already been used
 		$posX = 1;
 		$posY = 1;
 		if ($posX > 0) {

--- a/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_cornas.modules.php
@@ -1247,7 +1247,7 @@ class pdf_cornas extends ModelePDFSuppliersOrders
 		// Do not add the BACKGROUND as this is for suppliers
 		//pdf_pagehead($pdf,$outputlangs,$this->page_hauteur);
 
-		//Affiche le filigrane brouillon - Print Draft Watermark
+		// Print Draft Watermark
 		/*if($object->statut==0 && getDolGlobalString('COMMANDE_DRAFT_WATERMARK'))
 		{
 			pdf_watermark($pdf,$outputlangs,$this->page_hauteur,$this->page_largeur,'mm',getDolGlobalString('COMMANDE_DRAFT_WATERMARK'));

--- a/htdocs/core/modules/supplier_order/doc/pdf_muscadet.modules.php
+++ b/htdocs/core/modules/supplier_order/doc/pdf_muscadet.modules.php
@@ -1115,7 +1115,7 @@ class pdf_muscadet extends ModelePDFSuppliersOrders
 		// Do not add the BACKGROUND as this is for suppliers
 		//pdf_pagehead($pdf,$outputlangs,$this->page_hauteur);
 
-		//Affiche le filigrane brouillon - Print Draft Watermark
+		// Print Draft Watermark
 		/*if($object->statut==0 && getDolGlobalString('COMMANDE_DRAFT_WATERMARK'))
 		{
 			pdf_watermark($pdf,$outputlangs,$this->page_hauteur,$this->page_largeur,'mm',getDolGlobalString('COMMANDE_DRAFT_WATERMARK'));

--- a/htdocs/core/modules/supplier_proposal/doc/pdf_zenith.modules.php
+++ b/htdocs/core/modules/supplier_proposal/doc/pdf_zenith.modules.php
@@ -1228,7 +1228,7 @@ class pdf_zenith extends ModelePDFSupplierProposal
 		// Do not add the BACKGROUND as this is for suppliers
 		//pdf_pagehead($pdf,$outputlangs,$this->page_hauteur);
 
-		//Affiche le filigrane brouillon - Print Draft Watermark
+		// Print Draft Watermark
 		/*if($object->statut==0 && getDolGlobalString('COMMANDE_DRAFT_WATERMARK'))
 		{
 			pdf_watermark($pdf,$outputlangs,$this->page_hauteur,$this->page_largeur,'mm',getDolGlobalString('COMMANDE_DRAFT_WATERMARK'));

--- a/htdocs/expedition/dispatch.php
+++ b/htdocs/expedition/dispatch.php
@@ -80,7 +80,7 @@ if ($user->socid) {
 
 $hookmanager->initHooks(array('expeditiondispatch'));
 
-// Recuperation de l'id de projet
+// Retrieve the project id
 $projectid = 0;
 if (GETPOSTISSET("projectid")) {
 	$projectid = GETPOSTINT("projectid");

--- a/htdocs/projet/tasks/contact.php
+++ b/htdocs/projet/tasks/contact.php
@@ -433,7 +433,7 @@ if ($id > 0 || !empty($ref)) {
 			print '</td>';
 
 			print '<td>';
-			// On recupere les id des users deja selectionnes
+			// Retrieve ids of already selected users
 			if ($object->project->public) {
 				$contactsofproject = ''; // Everybody
 			} else {

--- a/htdocs/reception/dispatch.php
+++ b/htdocs/reception/dispatch.php
@@ -76,7 +76,7 @@ if ($user->socid) {
 
 $hookmanager->initHooks(array('ordersupplierdispatch'));
 
-// Recuperation de l'id de projet
+// Retrieve the project id
 $projectid = 0;
 if (GETPOSTISSET("projectid")) {
 	$projectid = GETPOSTINT("projectid");

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1131,7 +1131,7 @@ function WeighingScale(callback) {
 				}
 			});
 		<?php } else { ?>
-			// Protocole par défaut de takeposconnector: réception continue du poids/stabilité
+			// Default takeposconnector protocol: continuous reception of weight/stability
 			editnumber = globalWeight;
 			$("#poslines").load("invoice.php?token=<?php echo newToken(); ?>&action=updateqty&place="+place+"&idline="+selectedline+"&number="+editnumber, function() {
 				editnumber="";


### PR DESCRIPTION
## Summary
- Found and translated the last plain-French comments (non-copyright, non-vendored) still present in `htdocs/core` and a few module files, replacing them with English equivalents.
- Left untouched: license/copyright headers with accented author names, `langs/` translation files, and vendored third-party libraries under `includes/` (Sabre, TCPDF, Symfony, etc.) which are out of scope.

## Test plan
- [x] `php -l` on all 15 modified files
- [x] Local pre-commit hooks (PHPStan, Phan, PHPCS, syntax check) passed on commit