### PR TITLE
Translate remaining French comments in admin setup pages to English

### DIFF
--- a/htdocs/accountancy/admin/journals_list.php
+++ b/htdocs/accountancy/admin/journals_list.php
@@ -117,15 +117,15 @@ $tabsql[35] = "SELECT a.rowid as rowid, a.code as code, a.label, a.nature, a.act
 $tabsqlsort = array();
 $tabsqlsort[35] = "code ASC";
 
-// Nom des champs en resultat de select pour affichage du dictionnaire
+// Name of the fields in the result of select to display the dictionary
 $tabfield = array();
 $tabfield[35] = "code,label,nature";
 
-// Nom des champs d'edition pour modification d'un enregistrement
+// Name of editing fields for record modification
 $tabfieldvalue = array();
 $tabfieldvalue[35] = "code,label,nature";
 
-// Nom des champs dans la table pour insertion d'un enregistrement
+// Name of the fields in the table for inserting a record
 $tabfieldinsert = array();
 $tabfieldinsert[35] = "code,label,nature";
 

--- a/htdocs/admin/contract.php
+++ b/htdocs/admin/contract.php
@@ -134,8 +134,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "CONTRACT_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->CONTRACT_ADDON_PDF = $value;
 	}
 
@@ -336,7 +336,7 @@ print '</table></div><br>';
 
 print load_fiche_titre($langs->trans("TemplatePDFContracts"), '', '');
 
-// Defini tableau def des modeles
+// Define array def of models
 $def = array();
 $sql = "SELECT nom";
 $sql .= " FROM ".MAIN_DB_PREFIX."document_model";

--- a/htdocs/admin/delivery.php
+++ b/htdocs/admin/delivery.php
@@ -175,8 +175,8 @@ if ($action == 'del') {
 
 if ($action == 'setdoc') {
 	if (dolibarr_set_const($db, "DELIVERY_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->DELIVERY_ADDON_PDF = $value;
 	}
 
@@ -336,7 +336,7 @@ if (getDolGlobalString('MAIN_SUBMODULE_DELIVERY')) {
 	print '<br>';
 	print load_fiche_titre($langs->trans("DeliveryOrderModel"), '', '');
 
-	// Defini tableau def de modele
+	// Define array def of model
 	$type = "delivery";
 	$def = array();
 

--- a/htdocs/admin/expedition.php
+++ b/htdocs/admin/expedition.php
@@ -153,8 +153,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "EXPEDITION_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->EXPEDITION_ADDON_PDF = $value;
 	}
 
@@ -293,7 +293,7 @@ print '</table><br>';
  */
 print load_fiche_titre($langs->trans("SendingsReceiptModel"), '', '');
 
-// Defini tableau def de modele invoice
+// Define array def of model invoice
 $type = "shipping";
 $def = array();
 

--- a/htdocs/admin/expensereport.php
+++ b/htdocs/admin/expensereport.php
@@ -138,8 +138,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "EXPENSEREPORT_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->EXPENSEREPORT_ADDON_PDF = $value;
 	}
 
@@ -318,7 +318,7 @@ print "</table></div><br>\n";
 
 print load_fiche_titre($langs->trans("TemplatePDFExpenseReports"), '', '');
 
-// Defini tableau def des modeles
+// Define array def of models
 $type = 'expensereport';
 $def = array();
 $sql = "SELECT nom";

--- a/htdocs/admin/external_rss.php
+++ b/htdocs/admin/external_rss.php
@@ -136,7 +136,7 @@ if (GETPOST("delete")) {
 	if (GETPOSTINT("norss")) {
 		$db->begin();
 
-		// Supprime boite box_external_rss de definition des boites
+		// Remove box box_external_rss from box definitions
 		$sql = "SELECT rowid FROM ".MAIN_DB_PREFIX."boxes_def";
 		$sql .= " WHERE file = 'box_external_rss.php' AND note LIKE '".$db->escape((string) GETPOSTINT("norss"))." %'";
 

--- a/htdocs/admin/fichinter.php
+++ b/htdocs/admin/fichinter.php
@@ -136,8 +136,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "FICHEINTER_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->FICHEINTER_ADDON_PDF = $value;
 	}
 
@@ -383,7 +383,7 @@ print '<br>';
 
 print load_fiche_titre($langs->trans("TemplatePDFInterventions"), '', '');
 
-// Defini tableau def des modeles
+// Define array def of models
 $type = 'ficheinter';
 $def = array();
 $sql = "SELECT nom";

--- a/htdocs/admin/holiday.php
+++ b/htdocs/admin/holiday.php
@@ -132,8 +132,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "HOLIDAY_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->HOLIDAY_ADDON_PDF = $value;
 	}
 

--- a/htdocs/admin/invoice.php
+++ b/htdocs/admin/invoice.php
@@ -152,8 +152,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "FACTURE_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->FACTURE_ADDON_PDF = $value;
 	}
 

--- a/htdocs/admin/ldap_contacts.php
+++ b/htdocs/admin/ldap_contacts.php
@@ -162,7 +162,7 @@ print '<tr class="liste_titre">';
 print '<td colspan="4">'.$langs->trans("LDAPSynchronizeContacts").'</td>';
 print "</tr>\n";
 
-// DN Pour les contacts
+// DN For the contacts
 print '<!-- LDAP_CONTACT_DN -->';
 print '<tr class="oddeven"><td><span class="fieldrequired">'.$langs->trans("LDAPContactDn").'</span></td><td>';
 print '<input size="48" type="text" name="contactdn" value="' . getDolGlobalString('LDAP_CONTACT_DN').'">';

--- a/htdocs/admin/ldap_members.php
+++ b/htdocs/admin/ldap_members.php
@@ -207,7 +207,7 @@ print '<tr class="liste_titre">';
 print '<td colspan="4">'.$langs->trans("LDAPSynchronizeMembers").'</td>';
 print "</tr>\n";
 
-// DN Pour les adherents
+// DN For the members
 print '<!-- LDAP_MEMBER_DN -->';
 print '<tr class="oddeven"><td><span class="fieldrequired">'.$langs->trans("LDAPMemberDn").'</span></td><td>';
 print '<input size="48" type="text" name="user" value="' . getDolGlobalString('LDAP_MEMBER_DN').'">';

--- a/htdocs/admin/ldap_members_types.php
+++ b/htdocs/admin/ldap_members_types.php
@@ -134,7 +134,7 @@ print '<tr class="liste_titre">';
 print '<td colspan="4">'.$langs->trans("LDAPSynchronizeMembersTypes").'</td>';
 print "</tr>\n";
 
-// DN pour les types de membres
+// DN for the member types
 print '<!-- LDAP_MEMBER_TYPE_DN -->';
 print '<tr class="oddeven"><td><span class="fieldrequired">'.$langs->trans("LDAPMemberTypeDn").'</span></td><td>';
 print '<input size="48" type="text" name="membertype" value="' . getDolGlobalString('LDAP_MEMBER_TYPE_DN').'">';

--- a/htdocs/admin/mails_emailing.php
+++ b/htdocs/admin/mails_emailing.php
@@ -822,9 +822,9 @@ if ($action == 'edit') {
 		$formmail->withdeliveryreceipt = 1;
 		$formmail->withfckeditor = ($action == 'testhtml' ? 1 : 0);
 		$formmail->ckeditortoolbar = 'dolibarr_mailings';
-		// Tableau des substitutions
+		// Array of substitutions
 		$formmail->substit = $substitutionarrayfortest;
-		// Tableau des parameters complementaires du post
+		// Array of additional post parameters
 		$formmail->param["action"] = "send";
 		$formmail->param["models"] = "body";
 		$formmail->param["mailid"] = 0;

--- a/htdocs/admin/mails_passwordreset.php
+++ b/htdocs/admin/mails_passwordreset.php
@@ -873,9 +873,9 @@ if ($action == 'edit') {
 		$formmail->withdeliveryreceipt = 1;
 		$formmail->withfckeditor = ($action == 'testhtml' ? 1 : 0);
 		$formmail->ckeditortoolbar = 'dolibarr_mailings';
-		// Tableau des substitutions
+		// Array of substitutions
 		$formmail->substit = $substitutionarrayfortest;
-		// Tableau des parameters complementaires du post
+		// Array of additional post parameters
 		$formmail->param["action"] = "send";
 		$formmail->param["models"] = "body";
 		$formmail->param["mailid"] = 0;

--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -154,7 +154,7 @@ if ($rowid > 0) {
 $tabname = array();
 $tabname[25] = MAIN_DB_PREFIX."c_email_templates";
 
-// Nom des champs en resultat de select pour affichage du dictionnaire
+// Name of the fields in the result of select to display the dictionary
 // Names of fields in select results for dictionary display (AI translated)
 $tabfield = array();
 $tabfield[25] = "label,lang,type_template,fk_user,position,module,topic,joinfiles,defaultfortype,content";
@@ -162,7 +162,7 @@ if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfield[25] .= ',content_lines';
 }
 
-// Nom des champs d'edition pour modification d'un enregistrement
+// Name of editing fields for record modification
 // Names of edit fields for modifying a record (AI translated)
 $tabfieldvalue = array();
 $tabfieldvalue[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content";
@@ -170,7 +170,7 @@ if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfieldvalue[25] .= ',content_lines';
 }
 
-// Nom des champs dans la table pour insertion d'un enregistrement
+// Name of the fields in the table for inserting a record
 // Field names in the table for inserting a record (AI translated)
 $tabfieldinsert = array();
 $tabfieldinsert[25] = "label,lang,type_template,fk_user,private,position,topic,email_from,joinfiles,defaultfortype,content,datec";

--- a/htdocs/admin/mails_ticket.php
+++ b/htdocs/admin/mails_ticket.php
@@ -818,9 +818,9 @@ if ($action == 'edit') {
 		$formmail->withdeliveryreceipt = 1;
 		$formmail->withfckeditor = ($action == 'testhtml' ? 1 : 0);
 		$formmail->ckeditortoolbar = 'dolibarr_mailings';
-		// Tableau des substitutions
+		// Array of substitutions
 		$formmail->substit = $substitutionarrayfortest;
-		// Tableau des parameters complementaires du post
+		// Array of additional post parameters
 		$formmail->param["action"] = "send";
 		$formmail->param["models"] = "body";
 		$formmail->param["mailid"] = 0;

--- a/htdocs/admin/reception_setup.php
+++ b/htdocs/admin/reception_setup.php
@@ -157,8 +157,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "RECEPTION_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->RECEPTION_ADDON_PDF = $value;
 	}
 
@@ -303,7 +303,7 @@ print '<br>';
  */
 print load_fiche_titre($langs->trans("ReceptionsReceiptModel"), '', '');
 
-// Defini tableau def de modele invoice
+// Define array def of model invoice
 $type = "reception";
 $def = array();
 

--- a/htdocs/admin/security.php
+++ b/htdocs/admin/security.php
@@ -433,7 +433,6 @@ if (!getDolGlobalString('DATABASE_PWD_ENCRYPTED')) {
 } else {
 	print '<td class="center" width="100">';
 	if ($allow_disable_encryption) {
-		//On n'autorise pas l'annulation de l'encryption car les mots de passe ne peuvent pas etre decodes
 		//Do not allow "disable encryption" as passwords cannot be decrypted
 		print '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?action=disable_encrypt&token='.newToken().'">'.$langs->trans("Disable").'</a>';
 	} else {

--- a/htdocs/admin/sms.php
+++ b/htdocs/admin/sms.php
@@ -286,9 +286,9 @@ if ($action == 'edit') {
 		$formsms->withbody = (GETPOSTISSET('message') ? (!GETPOST('message') ? 1 : GETPOST('message')) : $langs->trans("ThisIsATestMessage"));
 		$formsms->withbodyreadonly = 0;
 		$formsms->withcancel = 1;
-		// Tableau des substitutions
+		// Array of substitutions
 		$formsms->substit = $substitutionarrayfortest;
-		// Tableau des parameters complementaires du post
+		// Array of additional post parameters
 		$formsms->param["action"] = "send";
 		$formsms->param["models"] = "body";
 		$formsms->param["smsid"] = 0;

--- a/htdocs/admin/spip.php
+++ b/htdocs/admin/spip.php
@@ -59,13 +59,13 @@ $action = GETPOST('action', 'aZ09');
  */
 $error = 0;
 
-// Action mise a jour ou ajout d'une constante
+// Action update or add a constant
 if ($action == 'update' || $action == 'add') {
 	$constnamearray = GETPOST("constname", 'array');
 	$constvaluearray = GETPOST("constvalue", 'array');
 	$constnotearray = GETPOST("constnote", 'array');
 
-	// Action mise a jour ou ajout d'une constante
+	// Action update or add a constant
 	if ($action == 'update' || $action == 'add') {
 		foreach ($constnamearray as $key => $val) {
 			$constname = dol_escape_htmltag($constnamearray[$key]);
@@ -87,7 +87,7 @@ if ($action == 'update' || $action == 'add') {
 	}
 }
 
-// Action activation d'un sous module du module adherent
+// Action activate a sub-module of the member module
 if ($action == 'set') {
 	$result = dolibarr_set_const($db, GETPOST("name", 'aZ09'), GETPOST("value"), '', 0, '', $conf->entity);
 	if ($result < 0) {
@@ -95,7 +95,7 @@ if ($action == 'set') {
 	}
 }
 
-// Action deactivation d'un sous module du module adherent
+// Action deactivate a sub-module of the member module
 if ($action == 'unset') {
 	$result = dolibarr_del_const($db, GETPOST("name", 'aZ09'), $conf->entity);
 	if ($result < 0) {
@@ -137,7 +137,7 @@ if (getDolGlobalString('ADHERENT_USE_SPIP')) {
 	//$link.=$langs->trans("Disable");
 	$link .= img_picto($langs->trans("Activated"), 'switch_on');
 	$link .= '</a>';
-	// Edition des variables globales
+	// Edit global variables
 	$constantes = array(
 		'ADHERENT_SPIP_SERVEUR',
 		'ADHERENT_SPIP_DB',

--- a/htdocs/admin/user.php
+++ b/htdocs/admin/user.php
@@ -83,8 +83,8 @@ if ($action == 'set_default') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "USER_ADDON_PDF_ODT", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->USER_ADDON_PDF_ODT = $value;
 	}
 
@@ -203,7 +203,7 @@ print '<br>';
 
 $dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
 
-// Defini tableau def des modeles
+// Define array def of models
 $def = array();
 $sql = "SELECT nom";
 $sql .= " FROM ".MAIN_DB_PREFIX."document_model";

--- a/htdocs/admin/usergroup.php
+++ b/htdocs/admin/usergroup.php
@@ -78,8 +78,8 @@ if ($action == 'set_default') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "USERGROUP_ADDON_PDF_ODT", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->USERGROUP_ADDON_PDF_ODT = $value;
 	}
 
@@ -127,7 +127,7 @@ $dirmodels = array_merge(array('/'), (array) $conf->modules_parts['models']);
 
 $form = new Form($db);
 
-// Defini tableau def des modeles
+// Define array def of models
 $def = array();
 $sql = "SELECT nom";
 $sql .= " FROM ".MAIN_DB_PREFIX."document_model";

--- a/htdocs/admin/website.php
+++ b/htdocs/admin/website.php
@@ -98,15 +98,15 @@ $tabsql[1] = "SELECT f.rowid as rowid, f.entity, f.ref, f.description, f.virtual
 $tabsqlsort = array();
 $tabsqlsort[1] = "ref ASC";
 
-// Nom des champs en resultat de select pour affichage du dictionnaire
+// Name of the fields in the result of select to display the dictionary
 $tabfield = array();
 $tabfield[1] = "ref,description,virtualhost,position,date_creation,lastaccess,pageviews_previous_month,pageviews_total";
 
-// Nom des champs d'edition pour modification d'un enregistrement
+// Name of editing fields for record modification
 $tabfieldvalue = array();
 $tabfieldvalue[1] = "ref,description,virtualhost,position,entity";
 
-// Nom des champs dans la table pour insertion d'un enregistrement
+// Name of the fields in the table for inserting a record
 $tabfieldinsert = array();
 $tabfieldinsert[1] = "ref,description,virtualhost,position,entity";
 

--- a/htdocs/core/tpl/massactions_pre.tpl.php
+++ b/htdocs/core/tpl/massactions_pre.tpl.php
@@ -356,7 +356,7 @@ if ($massaction == 'presend') {
 	// Array of substitutions
 	$formmail->substit = $substitutionarray;
 
-	// Tableau des parameters complementaires du post
+	// Array of additional post parameters
 	$formmail->param['action'] = $action;
 	$formmail->param['models'] = $modelmail;	// the filter to know which kind of template emails to show. 'none' means no template suggested.
 	$formmail->param['models_id'] = GETPOSTINT('modelmailselected') ? GETPOSTINT('modelmailselected') : '';

--- a/htdocs/product/admin/product.php
+++ b/htdocs/product/admin/product.php
@@ -237,8 +237,8 @@ if ($action == 'del') {
 // Set default model
 if ($action == 'setdoc') {
 	if (dolibarr_set_const($db, "PRODUCT_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->PRODUCT_ADDON_PDF = $value;
 	}
 

--- a/htdocs/product/admin/product_lot.php
+++ b/htdocs/product/admin/product_lot.php
@@ -155,8 +155,8 @@ if ($action == 'updateMaskLot') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "PRODUCT_BATCH_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->PRODUCT_BATCH_ADDON_PDF = $value;
 	}
 

--- a/htdocs/projet/admin/project.php
+++ b/htdocs/projet/admin/project.php
@@ -210,8 +210,8 @@ if ($action == 'updateMaskTask') {
 	dolibarr_del_const($db, "PROJECT_ADDON_PDF", $conf->entity);
 } elseif ($action == 'setdoctask') {
 	if (dolibarr_set_const($db, "PROJECT_TASK_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->PROJECT_TASK_ADDON_PDF = $value;
 	}
 
@@ -520,7 +520,7 @@ if (!getDolGlobalString('PROJECT_HIDE_TASKS')) {
 
 print load_fiche_titre($langs->trans("ProjectsModelModule"), '', '');
 
-// Defini tableau def de modele
+// Define array def of model
 $type = 'project';
 $def = array();
 // TODO Replace with $def = getListOfModels($db, $type);
@@ -670,7 +670,7 @@ if (!getDolGlobalString('PROJECT_HIDE_TASKS')) {
 
 	print load_fiche_titre($langs->trans("TaskModelModule"), '', '');
 
-	// Defini tableau def de modele
+	// Define array def of model
 	$type = 'project_task';
 	$def = array();
 

--- a/htdocs/supplier_invoice/admin/supplier_invoice.php
+++ b/htdocs/supplier_invoice/admin/supplier_invoice.php
@@ -160,8 +160,8 @@ if ($action == 'specimen') {  // For invoices
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "INVOICE_SUPPLIER_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->INVOICE_SUPPLIER_ADDON_PDF = $value;
 	}
 
@@ -338,7 +338,7 @@ print '</table></div><br>';
 
 print load_fiche_titre($langs->trans("BillsPDFModules"), '', '');
 
-// Defini tableau def de modele
+// Define array def of model
 $def = array();
 
 $sql = "SELECT nom";

--- a/htdocs/supplier_invoice/admin/supplier_payment.php
+++ b/htdocs/supplier_invoice/admin/supplier_payment.php
@@ -102,8 +102,8 @@ if ($action == 'updateMask') {
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "SUPPLIER_PAYMENT_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->FACTURE_ADDON_PDF = $value;
 	}
 

--- a/htdocs/supplier_order/admin/supplier_order.php
+++ b/htdocs/supplier_order/admin/supplier_order.php
@@ -152,8 +152,8 @@ if ($action == 'specimen') {  // For orders
 } elseif ($action == 'setdoc') {
 	// Set default model
 	if (dolibarr_set_const($db, "COMMANDE_SUPPLIER_ADDON_PDF", $value, 'chaine', 0, '', $conf->entity)) {
-		// La constante qui a ete lue en avant du nouveau set
-		// on passe donc par une variable pour avoir un affichage coherent
+		// The constant that was read before the new set
+		// so we go through a variable to get a consistent display
 		$conf->global->COMMANDE_SUPPLIER_ADDON_PDF = $value;
 	}
 
@@ -354,7 +354,7 @@ print '</table></div><br>';
 
 print load_fiche_titre($langs->trans("OrdersModelModule"), '', '');
 
-// Defini tableau def de modele
+// Define array def of model
 $def = array();
 
 $sql = "SELECT nom";


### PR DESCRIPTION
## Summary
- Translated a set of French comments repeated across ~16 module admin setup pages (`admin/*.php`, `*/admin/*.php`): the "constant read before new set" pair, the "define model array" line, the dictionary field-name triplet (aligned with the English wording already used identically in `accountancy/admin/categories_list.php` / `report_list.php`), the mail template substitutions array pair, the LDAP "DN for..." comments, plus a few one-off items in `admin/spip.php`, `admin/security.php` (removed a stray duplicate French line that already had a correct English translation right below it) and `admin/external_rss.php`.

## Test plan
- [x] `php -l` on all 30 modified files
- [x] Local pre-commit hooks (PHPStan, Phan, PHPCS, syntax check) passed on commit