### PR TITLE
Translate remaining French comments in payment/banking/accounting classes to English

### DIFF
--- a/htdocs/compta/bank/annuel.php
+++ b/htdocs/compta/bank/annuel.php
@@ -94,8 +94,8 @@ $title = $object->ref.' - '.$langs->trans("IOMonthlyReporting");
 $helpurl = "";
 llxHeader('', $title, $helpurl);
 
-// Ce rapport de tresorerie est base sur llx_bank (car doit inclure les transactions sans facture)
-// plutot que sur llx_paiement + llx_paiementfourn
+// This treasury report is based on llx_bank (because it must include transactions without invoice)
+// rather than on llx_paiement + llx_paiementfourn
 
 $sql = "SELECT SUM(b.amount)";
 $sql .= ", date_format(b.dateo,'%Y-%m') as dm";
@@ -185,7 +185,7 @@ print dol_get_fiche_end();
 $head = bank_report_prepare_head($object);
 print dol_get_fiche_head($head, 'annual', $langs->trans("FinancialAccount"), -1);
 
-// Affiche tableau
+// Display array
 print load_fiche_titre('', $link, '');
 
 print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you don't need reserved height for your table
@@ -362,7 +362,7 @@ if ($result < 0) {
 		$datamin[$i] = 0;
 	}
 
-	// Fabrication tableau 4b
+	// Build array 4b
 	$file = $conf->bank->dir_temp."/credmovement".$id."-".$year.".png";
 	$fileurl = DOL_URL_ROOT.'/viewimage.php?modulepart=banque_temp&file='."/credmovement".$id."-".$year.".png";
 	$title = $langs->transnoentities("Credit").' - '.$langs->transnoentities("Year").': '.($year - 2).' - '.($year - 1)." - ".$year;

--- a/htdocs/compta/bank/bankentries_list.php
+++ b/htdocs/compta/bank/bankentries_list.php
@@ -1608,7 +1608,7 @@ if ($resql) {
 					// Show link with label $links[$key]['label']
 					print '<a href="'.$links[$key]['url'].$links[$key]['url_id'].'">';
 					if (preg_match('/^\((.*)\)$/i', $links[$key]['label'], $reg)) {
-						// Label generique car entre parentheses. On l'affiche en le traduisant
+						// Generic label because it is in parentheses. We display it translated.
 						if ($reg[1] == 'paiement') {
 							$reg[1] = 'Payment';
 						}

--- a/htdocs/compta/bank/graph.php
+++ b/htdocs/compta/bank/graph.php
@@ -249,7 +249,7 @@ if ($result < 0) {
 		//var_dump($datas);
 		//exit;
 
-		// Fabrication tableau 1
+		// Build array 1
 		$file = $conf->bank->dir_temp."/balance".$account."-".$year.$month.".png";
 		$fileurl = DOL_URL_ROOT.'/viewimage.php?modulepart=banque_temp&file='."/balance".$account."-".$year.$month.".png";
 		$title = $langs->transnoentities("Balance").' - '.$langs->transnoentities("Month").': '.$month.' '.$langs->transnoentities("Year").': '.$year;
@@ -647,7 +647,7 @@ if ($result < 0) {
 			$datamin[$i] = $object->min_desired;
 		}
 
-		// Fabrication tableau 4a
+		// Build array 4a
 		$file = $conf->bank->dir_temp."/movement".$account."-".$year.$month.".png";
 		$fileurl = DOL_URL_ROOT.'/viewimage.php?modulepart=banque_temp&file='."/movement".$account."-".$year.$month.".png";
 		$title = $langs->transnoentities("BankMovements").' - '.$langs->transnoentities("Month").': '.$month.' '.$langs->transnoentities("Year").': '.$year;
@@ -748,7 +748,7 @@ if ($result < 0) {
 			$datamin[$i] = $object->min_desired;
 		}
 
-		// Fabrication tableau 4b
+		// Build array 4b
 		$file = $conf->bank->dir_temp."/movement".$account."-".$year.".png";
 		$fileurl = DOL_URL_ROOT.'/viewimage.php?modulepart=banque_temp&file='."/movement".$account."-".$year.".png";
 		$title = $langs->transnoentities("BankMovements").' - '.$langs->transnoentities("Year").': '.$year;

--- a/htdocs/compta/bank/line.php
+++ b/htdocs/compta/bank/line.php
@@ -613,7 +613,7 @@ if ($result) {
 			print '<td>';
 			print '<input name="label" class="flat minwidth300" '.($objp->rappro ? ' disabled' : '').' value="';
 			if (preg_match('/^\((.*)\)$/i', $objp->label, $reg)) {
-				// Label generique car entre parentheses. On l'affiche en le traduisant
+				// Generic label because it is in parentheses. We display it translated.
 				print $langs->trans($reg[1]);
 			} else {
 				print dol_escape_htmltag($objp->label);
@@ -623,7 +623,7 @@ if ($result) {
 		} else {
 			print '<td>';
 			if (preg_match('/^\((.*)\)$/i', $objp->label, $reg)) {
-				// Label generique car entre parentheses. On l'affiche en le traduisant
+				// Generic label because it is in parentheses. We display it translated.
 				print $langs->trans($reg[1]);
 			} else {
 				print dol_escape_htmltag($objp->label);

--- a/htdocs/compta/bank/releve.php
+++ b/htdocs/compta/bank/releve.php
@@ -499,7 +499,7 @@ if (empty($numref)) {
 
 	$totalc = $totald = 0;
 
-	// Recherche les ecritures pour le releve
+	// Search entries for the statement
 	$sql = $sqlrequestforbankline;
 
 	$resql = $db->query($sql);
@@ -522,7 +522,7 @@ if (empty($numref)) {
 			// Date operation
 			print '<td class="nowrap center">'.dol_print_date($db->jdate($objp->do), "day").'</td>';
 
-			// Date de valeur
+			// Value date
 			print '<td valign="center" class="center nowrap">';
 			print '<span class="spanforajaxedit">'.dol_print_date($db->jdate($objp->dv), "day").'</span>';
 			print '&nbsp;';

--- a/htdocs/compta/journal/purchasesjournal.php
+++ b/htdocs/compta/journal/purchasesjournal.php
@@ -158,7 +158,7 @@ $tablocaltax2 = array();
 $result = $db->query($sql);
 if ($result) {
 	$num = $db->num_rows($result);
-	// les variables
+	// the variables
 	$cptfour = getDolGlobalString('ACCOUNTING_ACCOUNT_SUPPLIER', $langs->trans("CodeNotDef"));
 	$cpttva = getDolGlobalString('ACCOUNTING_VAT_BUY_ACCOUNT', $langs->trans("CodeNotDef"));
 

--- a/htdocs/compta/journal/sellsjournal.php
+++ b/htdocs/compta/journal/sellsjournal.php
@@ -179,7 +179,7 @@ if ($result) {
 	$resligne = array();
 	while ($i < $num) {
 		$obj = $db->fetch_object($result);
-		// les variables
+		// the variables
 		$cptcli = getDolGlobalString('ACCOUNTING_ACCOUNT_CUSTOMER', $langs->trans("CodeNotDef"));
 		$compta_soc = (!empty($obj->code_compta_client) ? $obj->code_compta_client : $cptcli);
 		$compta_prod = $obj->accountancy_code_sell;

--- a/htdocs/compta/localtax/class/localtax.class.php
+++ b/htdocs/compta/localtax/class/localtax.class.php
@@ -513,7 +513,7 @@ class Localtax extends CommonObject
 			return -5;
 		}
 
-		// Insertion dans table des paiement localtax
+		// Insert into localtax payment table
 		$sql = "INSERT INTO ".MAIN_DB_PREFIX."localtax(localtaxtype, datep, datev, amount";
 		if ($this->note) {
 			$sql .= ", note";
@@ -541,7 +541,7 @@ class Localtax extends CommonObject
 			if ($this->id > 0) {
 				$ok = 1;
 				if (isModEnabled("bank")) {
-					// Insertion dans llx_bank
+					// Insert into llx_bank
 					require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 
 					$acc = new Account($this->db);

--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -207,8 +207,8 @@ class Paiement extends CommonObject
 	 */
 	public $bank_line;
 
-	// fk_paiement dans llx_paiement est l'id du type de paiement (7 pour CHQ, ...)
-	// fk_paiement dans llx_paiement_facture est le rowid du paiement
+	// fk_paiement in llx_paiement is the id of the payment type (7 for CHQ, ...)
+	// fk_paiement in llx_paiement_facture is rowid of payment
 	/**
 	 * @var int payment id
 	 */
@@ -659,7 +659,7 @@ class Paiement extends CommonObject
 			dol_syslog(get_class($this).'::create Now we call the triggers if no error (error = '.$error.')', LOG_DEBUG);
 
 			if (!$error) {    // All payments into $this->amounts were recorded without errors
-				// Appel des triggers
+				// Call triggers
 				$result = $this->call_trigger('PAYMENT_CUSTOMER_CREATE', $user);
 				if ($result < 0) {
 					$error++;
@@ -875,8 +875,8 @@ class Paiement extends CommonObject
 				(float) $totalamount_main_currency
 			);
 
-			// Mise a jour fk_bank dans llx_paiement
-			// On connait ainsi le paiement qui a genere l'ecriture bancaire
+			// Update fk_bank in llx_paiement
+			// This way we know the payment that generated the bank entry
 			if ($bank_line_id > 0) {
 				$result = $this->update_fk_bank($bank_line_id);
 				if ($result <= 0) {
@@ -970,7 +970,7 @@ class Paiement extends CommonObject
 				}
 
 				if (!$error && !$notrigger) {
-					// Appel des triggers
+					// Call triggers
 					$result = $this->call_trigger('PAYMENT_ADD_TO_BANK', $user);
 					if ($result < 0) {
 						$error++;

--- a/htdocs/compta/recap-compta.php
+++ b/htdocs/compta/recap-compta.php
@@ -170,7 +170,7 @@ if ($id > 0) {
 		if ($resql) {
 			$num = $db->num_rows($resql);
 
-			// Boucle sur chaque facture
+			// Loop over each invoice
 			for ($i = 0; $i < $num; $i++) {
 				$objf = $db->fetch_object($resql);
 

--- a/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
+++ b/htdocs/compta/sociales/class/paymentsocialcontribution.class.php
@@ -611,8 +611,8 @@ class PaymentSocialContribution extends CommonObject
 				$emetteur_banque
 			);
 
-			// Mise a jour fk_bank dans llx_paiement.
-			// On connait ainsi le paiement qui a genere l'ecriture bancaire
+			// Update fk_bank in llx_paiement.
+			// This way we know the payment that generated the bank entry
 			if ($bank_line_id > 0) {
 				$result = $this->update_fk_bank($bank_line_id);
 				if ($result <= 0) {
@@ -787,7 +787,7 @@ class PaymentSocialContribution extends CommonObject
 			$labeltoshow = $this->label;
 			$reg = array();
 			if (preg_match('/^\((.*)\)$/i', $this->label, $reg)) {
-				// Label generique car entre parentheses. On l'affiche en le traduisant
+				// Generic label because it is in parentheses. We display it translated.
 				if ($reg[1] == 'paiement') {
 					$reg[1] = 'Payment';
 				}

--- a/htdocs/compta/tva/class/paymentvat.class.php
+++ b/htdocs/compta/tva/class/paymentvat.class.php
@@ -769,7 +769,7 @@ class PaymentVAT extends CommonObject
 			$labeltoshow = $this->label;
 			$reg = array();
 			if (preg_match('/^\((.*)\)$/i', $this->label, $reg)) {
-				// Label generique car entre parentheses. On l'affiche en le traduisant
+				// Generic label because it is in parentheses. We display it translated.
 				if ($reg[1] == 'paiement') {
 					$reg[1] = 'Payment';
 				}

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -1592,7 +1592,7 @@ class Contrat extends CommonObject
 				}
 			}
 
-			// Insertion dans la base
+			// Insert into database
 			$sql = "INSERT INTO ".MAIN_DB_PREFIX."contratdet";
 			$sql .= " (fk_contrat, label, description, fk_product, qty, tva_tx, vat_src_code,";
 			$sql .= " localtax1_tx, localtax2_tx, localtax1_type, localtax2_type, remise_percent, subprice, subprice_ttc,";

--- a/htdocs/contrat/class/contratligne.class.php
+++ b/htdocs/contrat/class/contratligne.class.php
@@ -827,7 +827,7 @@ class ContratLigne extends CommonObjectLine
 
 		$error = 0;
 
-		// Insertion dans la base
+		// Insert into database
 		$sql = "INSERT INTO ".MAIN_DB_PREFIX."contratdet";
 		$sql .= " (fk_contrat, label, description, fk_product, qty, vat_src_code, tva_tx,";
 		$sql .= " localtax1_tx, localtax2_tx, localtax1_type, localtax2_type, remise_percent, subprice, subprice_ttc,";

--- a/htdocs/don/class/don.class.php
+++ b/htdocs/don/class/don.class.php
@@ -252,7 +252,7 @@ class Don extends CommonObject
 
 		$now = dol_now();
 
-		// Charge tableau des id de societe socids
+		// Load array of company ids socids
 		$socids = array();
 
 		$sql = "SELECT rowid";

--- a/htdocs/don/class/paymentdonation.class.php
+++ b/htdocs/don/class/paymentdonation.class.php
@@ -639,7 +639,7 @@ class PaymentDonation extends CommonObject
 			);
 
 			// Update fk_bank in llx_paiement.
-			// On connait ainsi le paiement qui a genere l'ecriture bancaire
+			// This way we know the payment that generated the bank entry
 			if ($bank_line_id > 0) {
 				$result = $this->update_fk_bank($bank_line_id);
 				if ($result <= 0) {

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -59,7 +59,7 @@ class PaiementFourn extends Paiement
 	 * @var int	Status of payment. 0 = unvalidated; 1 = validated
 	 */
 	public $statut;
-	// fk_paiement dans llx_paiement est l'id du type de paiement (7 pour CHQ, ...)
+	// fk_paiement in llx_paiement is the id of the payment type (7 for CHQ, ...)
 	// fk_paiement dans llx_paiement_facture is rowid of payment
 
 	/**
@@ -285,7 +285,7 @@ class PaiementFourn extends Paiement
 			if ($resql) {
 				$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX.'paiementfourn');
 
-				// Insere tableau des montants / factures
+				// Insert array of amounts / invoices
 				foreach ($this->amounts as $key => $amount) {
 					$facid = $key;
 					if (is_numeric($amount) && $amount != 0) {
@@ -549,7 +549,7 @@ class PaiementFourn extends Paiement
 			}
 
 			if (!$notrigger) {
-				// Appel des triggers
+				// Call triggers
 				$result = $this->call_trigger('PAYMENT_SUPPLIER_DELETE', $user);
 				if ($result < 0) {
 					$this->db->rollback();
@@ -719,7 +719,7 @@ class PaiementFourn extends Paiement
 		$text = $this->ref; // Sometimes ref contains label
 		$reg = array();
 		if (preg_match('/^\((.*)\)$/i', $text, $reg)) {
-			// Label generique car entre parentheses. On l'affiche en le traduisant
+			// Generic label because it is in parentheses. We display it translated.
 			if ($reg[1] == 'paiement') {
 				$reg[1] = 'Payment';
 			}

--- a/htdocs/fourn/recap-fourn.php
+++ b/htdocs/fourn/recap-fourn.php
@@ -129,7 +129,7 @@ if ($socid > 0) {
 		if ($resql) {
 			$num = $db->num_rows($resql);
 
-			// Boucle sur chaque facture
+			// Loop over each invoice
 			for ($i = 0; $i < $num; $i++) {
 				$objf = $db->fetch_object($resql);
 


### PR DESCRIPTION
## Summary
- Translated French comments repeated across payment, banking and accounting classes: trigger-call comments (`paiement.class.php`, `paiementfourn.class.php`), the "generic label in parentheses" comment (bank/payment classes and `compta/bank/line.php`, `bankentries_list.php`), the "this way we know the payment that generated the bank entry" / "update fk_bank" pair (`paiement.class.php`, `paymentsocialcontribution.class.php`, `paymentdonation.class.php`), the `fk_paiement` column doc comments, the "Build array N" pattern in `compta/bank/graph.php` / `annuel.php`, and the "Insert into database" comment in the contract classes plus a handful of one-off lines in `compta/bank/annuel.php`, `releve.php`, the sell/purchase journals, `recap-compta.php`, `fourn/recap-fourn.php`, `don/class/don.class.php` and `compta/localtax/class/localtax.class.php`.

## Test plan
- [x] `php -l` on all 18 modified files
- [x] Local pre-commit hooks (PHPStan, Phan, PHPCS, syntax check) passed on commit