### PR TITLE
Translate duplicated French boilerplate comments (IE cache fix, path traversal guard) to English

### DIFF
--- a/htdocs/accountancy/bookkeeping/export.php
+++ b/htdocs/accountancy/bookkeeping/export.php
@@ -726,7 +726,7 @@ if ($action == 'export_fileconfirm' && $user->hasRight('accounting', 'mouvements
 		} else {
 			header('Content-Disposition: inline; filename="'.$downloadFileFullName.'"');
 		}
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		header('Cache-Control: Public, must-revalidate');
 		header('Pragma: public');
 		header('Content-Length: ' . dol_filesize($downloadFilePath));

--- a/htdocs/core/ajax/ajaxdirpreview.php
+++ b/htdocs/core/ajax/ajaxdirpreview.php
@@ -166,7 +166,7 @@ if (empty($modulepart)) {
 if ($user->socid > 0) {
 	$socid = $user->socid;
 }
-// On interdit les remontees de repertoire ainsi que les pipe dans les noms de fichiers.
+// We forbid directory traversal as well as pipes in file names.
 if (preg_match('/\.\./', $upload_dir) || preg_match('/[<>|]/', $upload_dir)) {
 	dol_syslog("Refused to deliver file ".$upload_dir);
 	// Do no show plain path in shown error message
@@ -198,7 +198,7 @@ if ($modulepart == 'ecm') {
  */
 
 if (!isset($mode) || $mode != 'noajax') {
-	// Ajout directives pour resoudre bug IE
+	// Add directives to fix IE bug
 	header('Cache-Control: Public, must-revalidate');
 	header('Pragma: public');
 

--- a/htdocs/core/ajax/ajaxdirtree.php
+++ b/htdocs/core/ajax/ajaxdirtree.php
@@ -114,7 +114,7 @@ if ($modulepart == 'ecm') {
 
 
 // Security:
-// On interdit les remontees de repertoire ainsi que les pipe dans les noms de fichiers.
+// We forbid directory traversal as well as pipes in file names.
 if (preg_match('/\.\./', $fullpathselecteddir) || preg_match('/[<>|]/', $fullpathselecteddir)) {
 	dol_syslog("Refused to deliver file ".$original_file);
 	// Do no show plain path in shown error message

--- a/htdocs/core/ajax/locationincoterms.php
+++ b/htdocs/core/ajax/locationincoterms.php
@@ -64,7 +64,7 @@ if (!isModEnabled('incoterm')) {
  * View
  */
 
-// Ajout directives pour resoudre bug IE
+// Add directives to fix IE bug
 //header('Cache-Control: Public, must-revalidate');
 //header('Pragma: public');
 

--- a/htdocs/document.php
+++ b/htdocs/document.php
@@ -454,7 +454,7 @@ if ($attachment > 0) {
 } elseif (empty($attachment)) {
 	header('Content-Disposition: inline; filename="'.$filename.'"');
 }
-// Ajout directives pour resoudre bug IE
+// Add directives to fix IE bug
 header('Cache-Control: Public, must-revalidate');
 header('Pragma: public');
 $readfile = true;

--- a/htdocs/ftp/index.php
+++ b/htdocs/ftp/index.php
@@ -320,7 +320,7 @@ if ($action == 'download' && $user->hasRight('ftp', 'read')) {
 				header('Content-Disposition: inline; filename="'.$file.'"');
 			}
 
-			// Ajout directives pour resoudre bug IE
+			// Add directives to fix IE bug
 			header('Cache-Control: Public, must-revalidate');
 			header('Pragma: public');
 

--- a/htdocs/install/doctemplates/websites/website_template-association_exp/containers/wrapper.php
+++ b/htdocs/install/doctemplates/websites/website_template-association_exp/containers/wrapper.php
@@ -257,7 +257,7 @@ if ($rss) {
 		header('Content-Disposition: attachment; filename="'.$filename.'"');
 	}
 
-	// Ajout directives pour resoudre bug IE
+	// Add directives to fix IE bug
 	//header('Cache-Control: Public, must-revalidate');
 	//header('Pragma: public');
 	if ($cachedelay) {

--- a/htdocs/install/doctemplates/websites/website_template-corporate/containers/wrapper.php
+++ b/htdocs/install/doctemplates/websites/website_template-corporate/containers/wrapper.php
@@ -204,7 +204,7 @@ if ($rss) {
 			header('Content-Disposition: attachment; filename="'.$filename.'"');
 		}
 
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		//header('Cache-Control: Public, must-revalidate');
 		//header('Pragma: public');
 		if ($cachedelay) {

--- a/htdocs/install/doctemplates/websites/website_template-homesubmenu_dev/containers/wrapper.php
+++ b/htdocs/install/doctemplates/websites/website_template-homesubmenu_dev/containers/wrapper.php
@@ -204,7 +204,7 @@ if ($rss) {
 			header('Content-Disposition: attachment; filename="'.$filename.'"');
 		}
 
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		//header('Cache-Control: Public, must-revalidate');
 		//header('Pragma: public');
 		if ($cachedelay) {

--- a/htdocs/install/doctemplates/websites/website_template-noimg_dev/containers/wrapper.php
+++ b/htdocs/install/doctemplates/websites/website_template-noimg_dev/containers/wrapper.php
@@ -204,7 +204,7 @@ if ($rss) {
 			header('Content-Disposition: attachment; filename="'.$filename.'"');
 		}
 
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		//header('Cache-Control: Public, must-revalidate');
 		//header('Pragma: public');
 		if ($cachedelay) {

--- a/htdocs/install/doctemplates/websites/website_template-restaurant_dev/containers/wrapper.php
+++ b/htdocs/install/doctemplates/websites/website_template-restaurant_dev/containers/wrapper.php
@@ -204,7 +204,7 @@ if ($rss) {
 			header('Content-Disposition: attachment; filename="'.$filename.'"');
 		}
 
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		//header('Cache-Control: Public, must-revalidate');
 		//header('Pragma: public');
 		if ($cachedelay) {

--- a/htdocs/install/doctemplates/websites/website_template-stellar/containers/wrapper.php
+++ b/htdocs/install/doctemplates/websites/website_template-stellar/containers/wrapper.php
@@ -201,7 +201,7 @@ if ($rss) {
 			header('Content-Disposition: attachment; filename="'.$filename.'"');
 		}
 
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		//header('Cache-Control: Public, must-revalidate');
 		//header('Pragma: public');
 		if ($cachedelay) {

--- a/htdocs/public/agenda/agendaexport.php
+++ b/htdocs/public/agenda/agendaexport.php
@@ -377,7 +377,7 @@ if ($format == 'rss') {
 			header('Content-Disposition: inline; filename="'.$filename.'"');
 		}
 
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		//header('Cache-Control: Public, must-revalidate');
 		//header('Pragma: public');
 		if ($cachedelay) {

--- a/htdocs/public/fichinter/agendaexport.php
+++ b/htdocs/public/fichinter/agendaexport.php
@@ -328,7 +328,7 @@ if ($format == 'rss') {
 			header('Content-Disposition: inline; filename="'.$filename.'"');
 		}
 
-		// Ajout directives pour resoudre bug IE
+		// Add directives to fix IE bug
 		//header('Cache-Control: Public, must-revalidate');
 		//header('Pragma: public');
 		if ($cachedelay) {

--- a/htdocs/public/ticket/document.php
+++ b/htdocs/public/ticket/document.php
@@ -279,7 +279,7 @@ if ($attachment > 0) {
 } elseif (empty($attachment)) {
 	header('Content-Disposition: inline; filename="'.$filename.'"');
 }
-// Ajout directives pour resoudre bug IE
+// Add directives to fix IE bug
 header('Cache-Control: Public, must-revalidate');
 header('Pragma: public');
 $readfile = true;

--- a/htdocs/public/website/index.php
+++ b/htdocs/public/website/index.php
@@ -228,8 +228,8 @@ if (!$accessallowed) {
 }
 
 // Security:
-// On interdit les remontees de repertoire ainsi que les pipe dans
-// les noms de fichiers.
+// We forbid directory traversal as well as pipes in
+// file names.
 if (preg_match('/\.\./', $original_file) || preg_match('/[<>|]/', $original_file)) {
 	dol_syslog("Refused to deliver file ".$original_file);
 	$file = basename($original_file); // Do no show plain path of original_file in shown error message

--- a/htdocs/public/website/javascript.js.php
+++ b/htdocs/public/website/javascript.js.php
@@ -162,8 +162,8 @@ if (!$accessallowed) {
 }
 
 // Security:
-// On interdit les remontees de repertoire ainsi que les pipe dans
-// les noms de fichiers.
+// We forbid directory traversal as well as pipes in
+// file names.
 if (preg_match('/\.\./', $original_file) || preg_match('/[<>|]/', $original_file)) {
 	dol_syslog("Refused to deliver file ".$original_file);
 	$file = basename($original_file); // Do no show plain path of original_file in shown error message

--- a/htdocs/public/website/styles.css.php
+++ b/htdocs/public/website/styles.css.php
@@ -162,8 +162,8 @@ if (!$accessallowed) {
 }
 
 // Security:
-// On interdit les remontees de repertoire ainsi que les pipe dans
-// les noms de fichiers.
+// We forbid directory traversal as well as pipes in
+// file names.
 if (preg_match('/\.\./', $original_file) || preg_match('/[<>|]/', $original_file)) {
 	dol_syslog("Refused to deliver file ".$original_file);
 	$file = basename($original_file); // Do no show plain path of original_file in shown error message

--- a/htdocs/viewimage.php
+++ b/htdocs/viewimage.php
@@ -331,7 +331,7 @@ if (!$accessallowed) {
 }
 
 // Security:
-// On interdit les remontees de repertoire ainsi que les pipe dans les noms de fichiers.
+// We forbid directory traversal as well as pipes in file names.
 if (preg_match('/\.\./', $fullpath_original_file) || preg_match('/[<>|]/', $fullpath_original_file)) {
 	dol_syslog("Refused to deliver file ".$fullpath_original_file);
 	print "ErrorFileNameInvalid: ".dol_escape_htmltag($original_file);

--- a/htdocs/webportal/controllers/viewimage.controller.class.php
+++ b/htdocs/webportal/controllers/viewimage.controller.class.php
@@ -244,7 +244,7 @@ class ViewImageController extends Controller
 		}
 
 		// Security:
-		// On interdit les remontees de repertoire ainsi que les pipe dans les noms de fichiers.
+		// We forbid directory traversal as well as pipes in file names.
 		if (preg_match('/\.\./', $fullpath_original_file) || preg_match('/[<>|]/', $fullpath_original_file)) {
 			dol_syslog("Refused to deliver file " . $fullpath_original_file);
 			print "ErrorFileNameInvalid: " . dol_escape_htmltag($original_file);

--- a/htdocs/webservices/server_other.php
+++ b/htdocs/webservices/server_other.php
@@ -297,8 +297,8 @@ function getDocument($authentication, $modulepart, $file, $refname = '')
 		}
 
 		// Security:
-		// On interdit les remontees de repertoire ainsi que les pipe dans
-		// les noms de fichiers.
+		// We forbid directory traversal as well as pipes in
+		// file names.
 		if (preg_match('/\.\./', $original_file) || preg_match('/[<>|]/', $original_file)) {
 			dol_syslog("Refused to deliver file ".$original_file);
 			$errorcode = 'REFUSED';

--- a/htdocs/website/samples/wrapper.php
+++ b/htdocs/website/samples/wrapper.php
@@ -262,7 +262,7 @@ if ($rss) {
 		header('Content-Disposition: attachment; filename="'.$filename.'"');
 	}
 
-	// Ajout directives pour resoudre bug IE
+	// Add directives to fix IE bug
 	//header('Cache-Control: Public, must-revalidate');
 	//header('Pragma: public');
 	if ($cachedelay) {


### PR DESCRIPTION
## Summary
- Translated two French comments that are copy-pasted verbatim across many otherwise-unrelated files: the "Add directives to fix IE bug" cache-header comment (document download/export pages and website templates), and the "We forbid directory traversal as well as pipes in file names" security comment (image/document viewers, website asset servers, webservices).
- Two occurrences of the same two comments (`core/modules/printsheet/modules_labels.php`, `core/modules/member/doc/pdf_standard_member.class.php`) are intentionally left out here — they were already translated in #39639.

## Test plan
- [x] `php -l` on all 22 modified files
- [x] Local pre-commit hooks (PHPStan, Phan, PHPCS, syntax check) passed on commit