### PR TITLE
FIX: Cache composer vendor-dir between Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ cache:
   apt: true
   directories:
     - ~/.cache
+    # Composer vendor-dir is redirected here (see `install` step below); caching it
+    # avoids re-downloading/re-extracting phpunit, phpcs, parallel-lint, etc. on every build.
+    - htdocs/includes
 
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ cache:
     - ~/.cache
     # Composer vendor-dir is redirected here (see `install` step below); caching it
     # avoids re-downloading/re-extracting phpunit, phpcs, parallel-lint, etc. on every build.
+    # Each stage below sets its own CACHE_NAME so they don't share/overwrite one cache slot.
     - htdocs/includes
 
 
@@ -47,6 +48,7 @@ jobs:
       if: type = push and commit_message !~ /latest php/
       php: '7.2'
       env:
+      - CACHE_NAME=php-min
       - DB=postgresql
       - TRAVIS_PHP_VERSION=7.2
       - TRAVIS_TYPE=push
@@ -54,6 +56,7 @@ jobs:
       if: type = push and commit_message !~ /latest php/
       php: '8.4'
       env:
+      - CACHE_NAME=php-max-push
       - DB=mysql
       - TRAVIS_PHP_VERSION=8.4
       - TRAVIS_TYPE=push
@@ -62,6 +65,7 @@ jobs:
       php: 'latest'
       language: php
       env:
+      - CACHE_NAME=php-latest
       - DB=mysql
       - TRAVIS_PHP_VERSION=latest
       - TRAVIS_TYPE=push
@@ -69,6 +73,7 @@ jobs:
       if: type = pull_request
       php: '8.4'
       env:
+      - CACHE_NAME=php-max-pr
       - DB=mysql
       - TRAVIS_PHP_VERSION=8.4
       - TRAVIS_TYPE=pull_request


### PR DESCRIPTION
## Summary
- Composer's `vendor-dir` is redirected to `htdocs/includes` (`sudo composer -n config -g vendor-dir htdocs/includes`), but that directory was never listed under `cache.directories` — only `~/.cache` was.
- As a result, phpunit, php-parallel-lint, php-codesniffer and php-var-dump-check were downloaded and re-extracted into `htdocs/includes` from scratch on every single Travis build, even when the resolved package versions hadn't changed.
- `htdocs/includes/` is already build/vendor output excluded from git (see `.gitignore`), so caching it across builds is safe and consistent with how it's already treated elsewhere in the script (excluded from phpcs/parallel-lint/var-dump-check scans).

## Test plan
- [x] Validated `.travis.yml` still parses as valid YAML (PyYAML)
- [x] Confirmed `htdocs/includes` is already git-ignored, so nothing new gets tracked
- [x] Travis CI run on this PR — first run populates the cache (no speedup yet), a follow-up push on the same branch should show a faster `install` stage