### PR TITLE
fix #33642 set user name from company for corporation member

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -1734,8 +1734,15 @@ class User extends CommonObject
 		// Set properties on new user
 		$this->admin = 0;
 		$this->civility_code = $member->civility_id;
-		$this->lastname     = $member->lastname;
-		$this->firstname    = $member->firstname;
+		// A corporation member has no lastname/firstname (the name is in the company field), so use it as the
+		// user lastname, otherwise the created user would have an empty name (#33642).
+		if ($member->morphy == 'mor' && empty($member->lastname) && !empty($member->company)) {
+			$this->lastname = $member->company;
+			$this->firstname = '';
+		} else {
+			$this->lastname     = $member->lastname;
+			$this->firstname    = $member->firstname;
+		}
 		$this->gender		= $member->gender;
 		$this->email        = $member->email;
 		$this->fk_member    = $member->id;
@@ -1752,7 +1759,8 @@ class User extends CommonObject
 
 		if (empty($login)) {
 			include_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
-			$login = dol_buildlogin($member->lastname, $member->firstname);
+			// Use the resolved name so a corporation member (name in company field) still gets a login.
+			$login = dol_buildlogin($this->lastname, $this->firstname);
 		}
 		$this->login = $login;
 


### PR DESCRIPTION
Creating a user from a member of type corporation produced a user with a blank name and an empty built login.

User::create_from_member copied lastname and firstname from the member, but a corporation member (morphy 'mor') has neither set: its name is stored in the company field. This uses the company field as the lastname in that case, so the user name and the auto-built login are populated. Individual members are unchanged, and a corporation member that already has a lastname is not overridden.