### PR TITLE
FIX: [Holiday] "Blocked when balance is negative" setting has no effect: leav...

### DIFF
--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -779,7 +779,7 @@ class Holiday extends CommonObject
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
 			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1, 0, '', $this->fk_user);
 
-			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
+			if (($balance - $daysAsked) < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -903,7 +903,7 @@ class Holiday extends CommonObject
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
 			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1, 0, '', $this->fk_user);
 
-			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
+			if (($balance - $daysAsked) < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}
@@ -1031,7 +1031,7 @@ class Holiday extends CommonObject
 			$balance = $this->getCPforUser($this->fk_user, $this->fk_type);
 			$daysAsked = num_open_day($this->date_debut, $this->date_fin, 0, 1, 0, '', $this->fk_user);
 
-			if (($balance - $daysAsked) < 0 && getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')) {
+			if (($balance - $daysAsked) < 0) {
 				$this->error = 'LeaveRequestCreationBlockedBecauseBalanceIsNegative';
 				return -1;
 			}


### PR DESCRIPTION
Fixes #39605

## Root cause

Per-type 'block_if_negative' check neutralized by undocumented global HOLIDAY_DISALLOW_NEGATIVE_BALANCE

## Changes

- Removed the extra `&& getDolGlobalString('HOLIDAY_DISALLOW_NEGATIVE_BALANCE')` requirement from the three balance guards in Holiday::validate(), Holiday::approve() and Holiday::update(), so the per-type dictionary field alone governs blocking. Default behaviour is unchanged because llx_c_holiday_types.block_if_negative defaults to 0 and no shipped leave type enables it, which preserves the intent of commit 88bc1ea3281 ('Keep same behaviour by default') while making the dictionary field effective when an admin enables it.