### PR TITLE
Fix DB_ERROR_1059 on long DB prefix: shorten transaction template FK constraint name

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -93,7 +93,7 @@ CREATE TABLE llx_accounting_transaction_template_det (
 ) ENGINE=innodb;
 
 ALTER TABLE llx_accounting_transaction_template_det ADD INDEX idx_accounting_transaction_template_det_rowid (rowid);
-ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT llx_accounting_transaction_template_det_fk_transaction_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
+ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT fk_accounting_transaction_template_det_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
 
 create table llx_categorie_mo
 (

--- a/htdocs/install/mysql/tables/llx_accounting_transaction_template_det-accounting.key.sql
+++ b/htdocs/install/mysql/tables/llx_accounting_transaction_template_det-accounting.key.sql
@@ -19,4 +19,4 @@
 -- ============================================================================
 
 ALTER TABLE llx_accounting_transaction_template_det ADD INDEX idx_accounting_transaction_template_det_rowid (rowid);
-ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT llx_accounting_transaction_template_det_fk_transaction_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
+ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT fk_accounting_transaction_template_det_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);


### PR DESCRIPTION
Fixes #39658.

## Problem

The foreign-key constraint name `llx_accounting_transaction_template_det_fk_transaction_template` is **63 characters** with the default 3-character `llx_` prefix — one below MySQL's 64-character identifier limit. Any custom `MAIN_DB_PREFIX` longer than three characters (the issue reports `llxzz_`) makes the v23→v24 migration fail at request 22:

```
DB_ERROR_1059: Identifier name 'llxzz_accounting_transaction_template_det_fk_transaction_template' is too long
```

forcing users to change their database prefix before upgrading (with a backup dance, per the report).

## Fix

Rename the constraint to **`fk_accounting_transaction_template_det_template`** — 51 characters with `llx_`, 58 even with a 10-character prefix. This matches the naming style the rest of the accounting module already uses for foreign keys (`fk_accounting_account_fk_pcg_version`, `fk_accounting_analytic_distribution_fk_analytic_account`, …), which all omit the `llx_` prefix from the constraint name.

Both creation sites are updated:

- `htdocs/install/mysql/tables/llx_accounting_transaction_template_det-accounting.key.sql` (fresh installs),
- `htdocs/install/mysql/migration/23.0.0-24.0.0.sql` (the failing upgrade).

The constraint is only *created* by these statements — nothing references it by name afterwards (MySQL FK enforcement is by definition, not by name lookup), so the rename is safe for existing databases created with the old name.
