### PR TITLE
NEW Option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS: enter the real amounts on multicurrency payments

### DIFF
--- a/htdocs/compta/paiement.php
+++ b/htdocs/compta/paiement.php
@@ -14,6 +14,7 @@
  * Copyright (C) 2023		William Mead			<william.mead@manchenumerique.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025       Josep Lluís Amador      <joseplluis@lliuretic.cat>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -206,8 +207,8 @@ if (empty($reshook)) {
 			$error++;
 		}
 
-		// Check if payments in both currency
-		if ($totalpayment > 0 && $multicurrency_totalpayment > 0) {
+		// Check if payments in both currency (allowed when entering the real amounts in both currencies, option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if ($totalpayment > 0 && $multicurrency_totalpayment > 0 && !getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS')) {
 			$langs->load("errors");
 			setEventMessages($langs->transnoentities('ErrorPaymentInBothCurrency'), null, 'errors');
 			$error++;
@@ -501,6 +502,27 @@ if ($result >= 0) {
 							$("input[name="+$(this).data(\'rowname\')+"]").val($(this).data("value")).trigger("change");
 						});';
 		print '	});'."\n";
+
+		// Live display of the derived exchange rate when the real amounts may be entered in both currencies (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS')) {
+			print ' $(document).ready(function () {
+				var derivedratelabel = "'.dol_escape_js($langs->trans('Rate')).'";
+				function updateDerivedRates() {
+					jQuery("span[id^=\'derivedrate_\']").each(function () {
+						var facid = this.id.substring(12);
+						var comp = parseFloat((jQuery("input[name=\'amount_" + facid + "\']").val() || "").replace(",", "."));
+						var forc = parseFloat((jQuery("input[name=\'multicurrency_amount_" + facid + "\']").val() || "").replace(",", "."));
+						if (!isNaN(comp) && comp != 0 && !isNaN(forc) && forc != 0) {
+							jQuery(this).html("<br>" + derivedratelabel + " : " + (Math.abs(forc) / Math.abs(comp)).toFixed(8).replace(/0+$/, "").replace(/\.$/, ""));
+						} else {
+							jQuery(this).html("");
+						}
+					});
+				}
+				jQuery("#payment_form").find("input.amount, input.multicurrency_amount").on("keyup change", updateDerivedRates);
+				updateDerivedRates();
+			});'."\n";
+		}
 
 		print '	</script>'."\n";
 	}
@@ -931,6 +953,10 @@ if ($result >= 0) {
 				} else {
 					print '<input type="text" class="maxwidth75" name="'.$namef.'_disabled" value="'.dol_escape_htmltag(GETPOST($namef)).'" disabled>';
 					print '<input type="hidden" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">';
+				}
+				// Read-only derived exchange rate, shown when the real amounts may be entered in both currencies (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+				if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($objp->multicurrency_code) && $objp->multicurrency_code != $conf->currency) {
+					print '<span class="opacitymedium small" id="derivedrate_'.$objp->facid.'"></span>';
 				}
 				print "</td>";
 

--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -14,6 +14,7 @@
  * Copyright (C) 2023       Joachim Kueter			<git-jk@bloxera.com>
  * Copyright (C) 2023       Sylvain Legrand			<technique@infras.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -341,8 +342,40 @@ class Paiement extends CommonObject
 			$invoice_multicurrency_tx = $tmparray['invoice_multicurrency_tx'];
 			$invoice_multicurrency_code = $tmparray['invoice_multicurrency_code'];
 
+			// Option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS: if both the amount in the invoice currency and the real
+			// amount in the company currency have been provided for this invoice, we keep both amounts as entered (no
+			// derivation at the invoice rate) and we derive the exchange rate from them.
+			$userealamounts = false;
+			if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS')
+				&& (float) price2num(isset($this->amounts[$key]) ? $this->amounts[$key] : 0) != 0
+				&& (float) price2num(isset($this->multicurrency_amounts[$key]) ? $this->multicurrency_amounts[$key] : 0) != 0) {
+				$userealamounts = true;
+			}
+			$invoiceidfortrans = $key; // intermediate name: phan flags a variable named key passed to trans()
+
 			// $key is id of invoice, $value is amount, $way is 'dolibarr' if amount is in main currency, 'customer' if in foreign currency
-			if ($invoice_multicurrency_tx) {
+			if ($userealamounts) {
+				$realcompanyamount = (float) price2num($this->amounts[$key], 'MU');
+				$realforeignamount = (float) price2num($this->multicurrency_amounts[$key], 'MU');
+				// Both real amounts must share the same sign
+				if (($realcompanyamount > 0) != ($realforeignamount > 0)) {
+					$this->error = $langs->trans('ErrorPaymentRealAmountsMustHaveSameSign', (string) $invoiceidfortrans);
+					return -1;
+				}
+				// The counterpart amount is the real amount entered by the user, not a value derived at the invoice rate
+				$value_converted = ($way == 'dolibarr') ? $realforeignamount : $realcompanyamount;
+				// Derived exchange rate, Dolibarr convention: multicurrency_tx = amount in invoice currency / amount in company currency
+				$derived_tx = (float) price2num(abs($realforeignamount) / abs($realcompanyamount), 'MU');
+				if ($derived_tx <= 0) {
+					$this->error = $langs->trans('FailedToFoundTheConversionRateForInvoice');
+					return -1;
+				}
+				$this->multicurrency_tx[$key] = $derived_tx;
+				// Non-blocking warning if the derived rate is far (> 50%) from the invoice rate (probable swap of the two amounts)
+				if ($invoice_multicurrency_tx && abs($derived_tx - $invoice_multicurrency_tx) > (0.5 * $invoice_multicurrency_tx)) {
+					setEventMessages($langs->trans('WarningPaymentDerivedRateFarFromInvoiceRate', (string) $invoiceidfortrans, price2num($derived_tx, 'MU'), price2num($invoice_multicurrency_tx, 'MU')), null, 'warnings');
+				}
+			} elseif ($invoice_multicurrency_tx) {
 				if ($way == 'dolibarr') {
 					$value_converted = (float) price2num($value * $invoice_multicurrency_tx, 'MU');
 				} else {
@@ -472,8 +505,13 @@ class Paiement extends CommonObject
 				$facid = $key;
 				if (is_numeric($amount) && $amount != 0) {
 					$amount = price2num($amount);
+					// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, store the per-invoice exchange rate derived from the real amounts instead of the single payment rate
+					$multicurrencytxtostore = $currencytxofpayment;
+					if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && !empty($this->multicurrency_tx[$key])) {
+						$multicurrencytxtostore = $this->multicurrency_tx[$key];
+					}
 					$sql = "INSERT INTO ".MAIN_DB_PREFIX."paiement_facture (fk_facture, fk_paiement, amount, multicurrency_amount, multicurrency_code, multicurrency_tx)";
-					$sql .= " VALUES (".((int) $facid).", ".((int) $this->id).", ".((float) $amount).", ".((float) $this->multicurrency_amounts[$key]).", ".($currencyofpayment ? "'".$this->db->escape($currencyofpayment)."'" : 'NULL').", ".(!empty($this->multicurrency_tx) ? (float) $currencytxofpayment : 1).")";
+					$sql .= " VALUES (".((int) $facid).", ".((int) $this->id).", ".((float) $amount).", ".((float) $this->multicurrency_amounts[$key]).", ".($currencyofpayment ? "'".$this->db->escape($currencyofpayment)."'" : 'NULL').", ".(!empty($multicurrencytxtostore) ? (float) $multicurrencytxtostore : 1).")";
 
 					dol_syslog(get_class($this).'::create Amount line '.$key.' insert paiement_facture', LOG_DEBUG);
 					$resql = $this->db->query($sql);
@@ -488,6 +526,17 @@ class Paiement extends CommonObject
 							$deposits = $invoice->getSumDepositsUsed();
 							$alreadypayed = price2num($paiement + $creditnotes + $deposits, 'MT');
 							$remaintopay = price2num($invoice->total_ttc - $paiement - $creditnotes - $deposits, 'MT');
+							// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, a multicurrency invoice paid at the real amounts keeps a
+							// residual amount in company currency (the exchange-rate difference), so the "paid" status must be decided
+							// on the balance in the invoice currency and not on the balance in the company currency.
+							$remaintopayforclosure = $remaintopay;
+							if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+								&& !empty($invoice->multicurrency_code) && $invoice->multicurrency_code != $conf->currency) {
+								$multicurrency_paiement = $invoice->getSommePaiement(1);
+								$multicurrency_creditnotes = $invoice->getSumCreditNotesUsed(1);
+								$multicurrency_deposits = $invoice->getSumDepositsUsed(1);
+								$remaintopayforclosure = price2num($invoice->multicurrency_total_ttc - $multicurrency_paiement - $multicurrency_creditnotes - $multicurrency_deposits, 'MT');
+							}
 
 							//var_dump($invoice->total_ttc.' - '.$paiement.' -'.$creditnotes.' - '.$deposits.' - '.$remaintopay);exit;
 
@@ -502,7 +551,7 @@ class Paiement extends CommonObject
 
 							if (!in_array($invoice->type, $affected_types)) {
 								dol_syslog("Invoice ".$facid." is not a standard, nor replacement invoice, nor credit note, nor deposit invoice, nor situation invoice. We do nothing more.");
-							} elseif ($remaintopay) {
+							} elseif ($remaintopayforclosure) {
 								// hook to have an option to automatically close a closable invoice with less payment than the total amount (e.g. agreed cash discount terms)
 								global $hookmanager;
 								$hookmanager->initHooks(array('paymentdao'));
@@ -566,22 +615,46 @@ class Paiement extends CommonObject
 											}
 										}
 
+										// Option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS: carry the invoice currency and the real exchange
+										// rate onto the discount, and scale its company-currency value to the real amount paid, so the real
+										// cost propagates when the deposit is later consumed in a final invoice. Without the option, nothing changes.
+										$discountmccode = '';
+										$discountmctx = null;
+										$discountrealratio = 1;
+										if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+											&& !empty($invoice->multicurrency_code) && $invoice->multicurrency_code != $conf->currency) {
+											$discountmccode = $invoice->multicurrency_code;
+											$discountmctx = $invoice->multicurrency_tx;
+											$realeurpaid = (float) price2num($invoice->getSommePaiement(0), 'MT');
+											$realfxpaid = (float) price2num($invoice->getSommePaiement(1), 'MT');
+											if ($realeurpaid != 0 && $realfxpaid != 0) {
+												$discountmctx = (float) price2num($realfxpaid / $realeurpaid, 'MU');
+												if ((float) $invoice->total_ttc != 0) {
+													$discountrealratio = $realeurpaid / (float) $invoice->total_ttc;
+												}
+											}
+										}
+
 										foreach ($amount_ht as $keyfordiscount => $xxx) {
 											$parts = explode('|', (string) $keyfordiscount, 2);
 											$tva_tx = $parts[0];
 											$vat_src_code = isset($parts[1]) ? $parts[1] : '';
-											$discount->amount_ht = abs($amount_ht[$keyfordiscount]);
-											$discount->total_ht = abs($amount_ht[$keyfordiscount]);
-											$discount->amount_tva = abs($amount_tva[$keyfordiscount]);
-											$discount->total_tva = abs($amount_tva[$keyfordiscount]);
-											$discount->amount_ttc = abs($amount_ttc[$keyfordiscount]);
-											$discount->total_ttc = abs($amount_ttc[$keyfordiscount]);
+											$discount->amount_ht = abs($amount_ht[$keyfordiscount] * $discountrealratio);
+											$discount->total_ht = abs($amount_ht[$keyfordiscount] * $discountrealratio);
+											$discount->amount_tva = abs($amount_tva[$keyfordiscount] * $discountrealratio);
+											$discount->total_tva = abs($amount_tva[$keyfordiscount] * $discountrealratio);
+											$discount->amount_ttc = abs($amount_ttc[$keyfordiscount] * $discountrealratio);
+											$discount->total_ttc = abs($amount_ttc[$keyfordiscount] * $discountrealratio);
 											$discount->multicurrency_amount_ht = abs($multicurrency_amount_ht[$keyfordiscount]);
 											$discount->multicurrency_total_ht = abs($multicurrency_amount_ht[$keyfordiscount]);
 											$discount->multicurrency_amount_tva = abs($multicurrency_amount_tva[$keyfordiscount]);
 											$discount->multicurrency_total_tva = abs($multicurrency_amount_tva[$keyfordiscount]);
 											$discount->multicurrency_amount_ttc = abs($multicurrency_amount_ttc[$keyfordiscount]);
 											$discount->multicurrency_total_ttc = abs($multicurrency_amount_ttc[$keyfordiscount]);
+											if ($discountmccode !== '') {
+												$discount->multicurrency_code = $discountmccode;
+												$discount->multicurrency_tx = $discountmctx;
+											}
 											$discount->tva_tx = abs((float) $tva_tx);
 											$discount->vat_src_code = $vat_src_code;
 
@@ -1411,6 +1484,12 @@ class Paiement extends CommonObject
 		}
 		if ($this->amount) {
 			$datas['amount'] = '<br><strong>'.$langs->trans("Amount").':</strong> '.price($this->amount, 0, $langs, 1, -1, -1, $conf->currency);
+		}
+		// Amount in the invoice currency and derived rate (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($this->multicurrency_amount) && (float) $this->amount != 0 && abs((float) $this->multicurrency_amount - (float) $this->amount) > 0.0001) {
+			$langs->load("multicurrency");
+			$datas['multicurrencyamount'] = '<br><strong>'.$langs->trans("MulticurrencyPaymentAmount").':</strong> '.price($this->multicurrency_amount, 0, $langs, 1);
+			$datas['multicurrencyrate'] = '<br><strong>'.$langs->trans("Rate").':</strong> '.price2num((float) $this->multicurrency_amount / (float) $this->amount, 'MU');
 		}
 
 		return $datas;

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -18,6 +18,7 @@
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Vincent de Grandpré		<vincent@de-grandpre.quebec>
  * Copyright (C) 2026		Jose Martinez				<jose.martinez@pichinov.com>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2906,6 +2907,17 @@ class FactureFournisseur extends CommonInvoice
 		}
 		if (!empty($this->total_ttc)) {
 			$datas['totalttc'] = '<br><b>'.$langs->trans('AmountTTC').':</b> '.price($this->total_ttc, 0, $langs, 0, -1, -1, $conf->currency);
+		}
+		// Multicurrency rate and total in the invoice currency (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($this->multicurrency_code) && $this->multicurrency_code != $conf->currency) {
+			$datas['multicurrencyrate'] = '<br><b>'.$langs->trans('CurrencyRate').':</b> '.price2num($this->multicurrency_tx, 'MU');
+			if (!empty($this->multicurrency_total_ht)) {
+				$datas['multicurrencytotalht'] = '<br><b>'.$langs->trans('MulticurrencyAmountHT').':</b> '.price($this->multicurrency_total_ht, 0, $langs, 0, -1, -1, $this->multicurrency_code);
+			}
+			if (!empty($this->multicurrency_total_tva)) {
+				$datas['multicurrencytotaltva'] = '<br><b>'.$langs->trans('MulticurrencyAmountVAT').':</b> '.price($this->multicurrency_total_tva, 0, $langs, 0, -1, -1, $this->multicurrency_code);
+			}
+			$datas['multicurrencytotalttc'] = '<br><b>'.$langs->trans('MulticurrencyAmountTTC').':</b> '.price($this->multicurrency_total_ttc, 0, $langs, 0, -1, -1, $this->multicurrency_code);
 		}
 		return $datas;
 	}

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2023       Sylvain Legrand		    <technique@infras.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026       Lionel Vessiller		<lvessiller@open-dsi.fr>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -197,8 +198,44 @@ class PaiementFourn extends Paiement
 			if (empty($value)) {
 				continue;
 			}
+			// Option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS: if both the amount in the invoice currency and the real
+			// amount in the company currency have been provided for this invoice, we keep both amounts as entered (no
+			// derivation at the invoice rate) and we derive the exchange rate from them.
+			$userealamounts = false;
+			if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS')
+				&& (float) price2num(isset($this->amounts[$key]) ? $this->amounts[$key] : 0) != 0
+				&& (float) price2num(isset($this->multicurrency_amounts[$key]) ? $this->multicurrency_amounts[$key] : 0) != 0) {
+				$userealamounts = true;
+			}
+			$invoiceidfortrans = $key; // intermediate name: phan flags a variable named key passed to trans()
+
 			// $key is id of invoice, $value is amount, $way is a 'dolibarr' if amount is in main currency, 'customer' if in foreign currency
-			$value_converted = MultiCurrency::getAmountConversionFromInvoiceRate((int) $key, $value ? $value : 0, $way, 'facture_fourn');
+			if ($userealamounts) {
+				$realcompanyamount = (float) price2num($this->amounts[$key], 'MU');
+				$realforeignamount = (float) price2num($this->multicurrency_amounts[$key], 'MU');
+				// Both real amounts must share the same sign
+				if (($realcompanyamount > 0) != ($realforeignamount > 0)) {
+					$this->error = $langs->trans('ErrorPaymentRealAmountsMustHaveSameSign', (string) $invoiceidfortrans);
+					return -1;
+				}
+				// The counterpart amount is the real amount entered by the user, not a value derived at the invoice rate
+				$value_converted = ($way == 'dolibarr') ? $realforeignamount : $realcompanyamount;
+				// Derived exchange rate, Dolibarr convention: multicurrency_tx = amount in invoice currency / amount in company currency
+				$derived_tx = (float) price2num(abs($realforeignamount) / abs($realcompanyamount), 'MU');
+				if ($derived_tx <= 0) {
+					$this->error = $langs->trans('FailedToFoundTheConversionRateForInvoice');
+					return -1;
+				}
+				$this->multicurrency_tx[$key] = $derived_tx;
+				// Non-blocking warning if the derived rate is far (> 50%) from the invoice rate (probable swap of the two amounts)
+				$tmprate = MultiCurrency::getInvoiceRate((int) $key, 'facture_fourn');
+				$invoice_multicurrency_tx = is_array($tmprate) ? $tmprate['invoice_multicurrency_tx'] : 0;
+				if ($invoice_multicurrency_tx && abs($derived_tx - $invoice_multicurrency_tx) > (0.5 * $invoice_multicurrency_tx)) {
+					setEventMessages($langs->trans('WarningPaymentDerivedRateFarFromInvoiceRate', (string) $invoiceidfortrans, price2num($derived_tx, 'MU'), price2num($invoice_multicurrency_tx, 'MU')), null, 'warnings');
+				}
+			} else {
+				$value_converted = MultiCurrency::getAmountConversionFromInvoiceRate((int) $key, $value ? $value : 0, $way, 'facture_fourn');
+			}
 			// Add controls of input validity
 			if ($value_converted === false) {
 				// We failed to find the conversion for one invoice
@@ -290,8 +327,13 @@ class PaiementFourn extends Paiement
 					$facid = $key;
 					if (is_numeric($amount) && $amount != 0) {
 						$amount = price2num($amount);
+						// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, store the per-invoice exchange rate derived from the real amounts instead of the single payment rate
+						$multicurrencytxtostore = $currencytxofpayment;
+						if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && !empty($this->multicurrency_tx[$key])) {
+							$multicurrencytxtostore = $this->multicurrency_tx[$key];
+						}
 						$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'paiementfourn_facturefourn (fk_facturefourn, fk_paiementfourn, amount, multicurrency_amount, multicurrency_code, multicurrency_tx)';
-						$sql .= " VALUES (".((int) $facid).", ".((int) $this->id).", ".((float) $amount).', '.((float) $this->multicurrency_amounts[$key]).', '.($currencyofpayment ? "'".$this->db->escape($currencyofpayment)."'" : 'NULL').', '.(!empty($currencytxofpayment) ? (float) $currencytxofpayment : 1).')';
+						$sql .= " VALUES (".((int) $facid).", ".((int) $this->id).", ".((float) $amount).', '.((float) $this->multicurrency_amounts[$key]).', '.($currencyofpayment ? "'".$this->db->escape($currencyofpayment)."'" : 'NULL').', '.(!empty($multicurrencytxtostore) ? (float) $multicurrencytxtostore : 1).')';
 						$resql = $this->db->query($sql);
 						if ($resql) {
 							$invoice = new FactureFournisseur($this->db);
@@ -306,7 +348,19 @@ class PaiementFourn extends Paiement
 								// $deposits = 0;
 								$alreadypayed = price2num($paiement + $creditnotes + $deposits, 'MT');
 								$remaintopay = price2num($invoice->total_ttc - $paiement - $creditnotes - $deposits, 'MT');
-								if ($remaintopay == 0) {
+
+								// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, a multicurrency invoice paid at the real amounts keeps a
+								// residual amount in company currency (the exchange-rate difference), so the "paid" status must be decided
+								// on the balance in the invoice currency and not on the balance in the company currency.
+								$remaintopayforclosure = $remaintopay;
+								if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+									&& !empty($invoice->multicurrency_code) && $invoice->multicurrency_code != $conf->currency) {
+									$multicurrency_paiement = $invoice->getSommePaiement(1);
+									$multicurrency_creditnotes = $invoice->getSumCreditNotesUsed(1);
+									$multicurrency_deposits = $invoice->getSumDepositsUsed(1);
+									$remaintopayforclosure = price2num($invoice->multicurrency_total_ttc - $multicurrency_paiement - $multicurrency_creditnotes - $multicurrency_deposits, 'MT');
+								}
+								if ($remaintopayforclosure == 0) {
 									// If invoice is a down payment, we also convert down payment to discount
 									if ($invoice->type == FactureFournisseur::TYPE_DEPOSIT) {
 										$amount_ht = $amount_tva = $amount_ttc = array();
@@ -355,10 +409,30 @@ class PaiementFourn extends Paiement
 												}
 											}
 
+											// Option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS: carry the invoice currency and the real exchange
+											// rate onto the discount, and scale its company-currency value to the real amount paid, so the real
+											// cost propagates when the deposit is later consumed in a final invoice. Without the option, nothing changes.
+											$discountmccode = '';
+											$discountmctx = null;
+											$discountrealratio = 1;
+											if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+												&& !empty($invoice->multicurrency_code) && $invoice->multicurrency_code != $conf->currency) {
+												$discountmccode = $invoice->multicurrency_code;
+												$discountmctx = $invoice->multicurrency_tx;
+												$realeurpaid = (float) price2num($invoice->getSommePaiement(0), 'MT');
+												$realfxpaid = (float) price2num($invoice->getSommePaiement(1), 'MT');
+												if ($realeurpaid != 0 && $realfxpaid != 0) {
+													$discountmctx = (float) price2num($realfxpaid / $realeurpaid, 'MU');
+													if ((float) $invoice->total_ttc != 0) {
+														$discountrealratio = $realeurpaid / (float) $invoice->total_ttc;
+													}
+												}
+											}
+
 											foreach ($amount_ht as $tva_tx => $xxx) {
-												$discount->total_ht = abs($amount_ht[$tva_tx]);
-												$discount->total_tva = abs($amount_tva[$tva_tx]);
-												$discount->total_ttc = abs($amount_ttc[$tva_tx]);
+												$discount->total_ht = abs($amount_ht[$tva_tx] * $discountrealratio);
+												$discount->total_tva = abs($amount_tva[$tva_tx] * $discountrealratio);
+												$discount->total_ttc = abs($amount_ttc[$tva_tx] * $discountrealratio);
 
 												// keep compatibility
 												$discount->amount_ht = $discount->total_ht;
@@ -374,6 +448,11 @@ class PaiementFourn extends Paiement
 												$discount->multicurrency_amount_ht = $discount->multicurrency_total_ht;
 												$discount->multicurrency_amount_tva = $discount->multicurrency_total_tva;
 												$discount->multicurrency_amount_ttc = $discount->multicurrency_total_ttc;
+
+												if ($discountmccode !== '') {
+													$discount->multicurrency_code = $discountmccode;
+													$discount->multicurrency_tx = $discountmctx;
+												}
 
 												$discount->tva_tx = abs((float) $tva_tx);
 
@@ -728,6 +807,12 @@ class PaiementFourn extends Paiement
 		}
 		if ($this->amount) {
 			$datas['amount'] = '<br><strong>'.$langs->trans("Amount").':</strong> '.price($this->amount, 0, $langs, 1, -1, -1, $conf->currency);
+		}
+		// Amount in the invoice currency and derived rate (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($this->multicurrency_amount) && (float) $this->amount != 0 && abs((float) $this->multicurrency_amount - (float) $this->amount) > 0.0001) {
+			$langs->load("multicurrency");
+			$datas['multicurrencyamount'] = '<br><strong>'.$langs->trans("MulticurrencyPaymentAmount").':</strong> '.price($this->multicurrency_amount, 0, $langs, 1);
+			$datas['multicurrencyrate'] = '<br><strong>'.$langs->trans("Rate").':</strong> '.price2num((float) $this->multicurrency_amount / (float) $this->amount, 'MU');
 		}
 
 		return $datas;

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -4025,7 +4025,7 @@ if ($action == 'create') {
 
 			$sql = 'SELECT p.datep as dp, p.ref, p.num_paiement as num_payment, p.rowid, p.fk_bank,';
 			$sql .= ' c.id as payment_type, c.code as payment_code,';
-			$sql .= ' pf.amount,';
+			$sql .= ' pf.amount, pf.multicurrency_amount, pf.multicurrency_code,';
 			$sql .= ' ba.rowid as baid, ba.ref as baref, ba.label, ba.number as banumber, ba.account_number, ba.fk_accountancy_journal';
 			$sql .= ' FROM '.MAIN_DB_PREFIX.'paiementfourn as p';
 			$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bank as b ON p.fk_bank = b.rowid';
@@ -4063,6 +4063,8 @@ if ($action == 'create') {
 						$paymentstatic->datepaye = $db->jdate($objp->dp);
 						$paymentstatic->ref = ($objp->ref ? $objp->ref : $objp->rowid);
 						$paymentstatic->num_payment = $objp->num_payment;
+						$paymentstatic->amount = $objp->amount;
+						$paymentstatic->multicurrency_amount = $objp->multicurrency_amount;
 
 						$paymentstatic->paiementcode = $objp->payment_code;
 						$paymentstatic->type_code = $objp->payment_code;
@@ -4106,7 +4108,14 @@ if ($action == 'create') {
 						}
 						print '</td>';
 						// Amount
-						print '<td class="right">'.price($sign * $objp->amount).'</td>';
+						print '<td class="right">'.price($sign * $objp->amount);
+						// Amount in the invoice currency and derived rate as a sub-line (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+						if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($object->multicurrency_code) && $object->multicurrency_code != $conf->currency && (float) $objp->amount != 0 && abs((float) $objp->multicurrency_amount - (float) $objp->amount) > 0.0001) {
+							print '<br><span class="opacitymedium small">'.price($objp->multicurrency_amount, 0, $langs, 1, -1, -1, $object->multicurrency_code);
+							print '<br>'.$langs->trans('Rate').' : '.price2num((float) $objp->multicurrency_amount / (float) $objp->amount, 'MU');
+							print '</span>';
+						}
+						print '</td>';
 						print '</tr>';
 						$totalpaid += $objp->amount;
 						$i++;

--- a/htdocs/fourn/facture/paiement.php
+++ b/htdocs/fourn/facture/paiement.php
@@ -14,6 +14,7 @@
  * Copyright (C) 2022       Udo Tamm				<dev@dolibit.de>
  * Copyright (C) 2023       Sylvain Legrand			<technique@infras.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -261,8 +262,8 @@ if (empty($reshook)) {
 			$error++;
 		}
 
-		// Check if payments in both currency
-		if ($totalpayment > 0 && $multicurrency_totalpayment > 0) {
+		// Check if payments in both currency (allowed when entering the real amounts in both currencies, option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if ($totalpayment > 0 && $multicurrency_totalpayment > 0 && !getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS')) {
 			setEventMessages($langs->transnoentities('ErrorPaymentInBothCurrency'), null, 'errors');
 			$error++;
 		}
@@ -498,6 +499,27 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							$("input[name="+$(this).data(\'rowname\')+"]").val($(this).data("value")).trigger("change");
 						});';
 				print '	});'."\n";
+
+				// Live display of the derived exchange rate when the real amounts may be entered in both currencies (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+				if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS')) {
+					print ' $(document).ready(function () {
+						var derivedratelabel = "'.dol_escape_js($langs->trans('Rate')).'";
+						function updateDerivedRates() {
+							jQuery("span[id^=\'derivedrate_\']").each(function () {
+								var facid = this.id.substring(12);
+								var comp = parseFloat((jQuery("input[name=\'amount_" + facid + "\']").val() || "").replace(",", "."));
+								var forc = parseFloat((jQuery("input[name=\'multicurrency_amount_" + facid + "\']").val() || "").replace(",", "."));
+								if (!isNaN(comp) && comp != 0 && !isNaN(forc) && forc != 0) {
+									jQuery(this).html("<br>" + derivedratelabel + " : " + (Math.abs(forc) / Math.abs(comp)).toFixed(8).replace(/0+$/, "").replace(/\.$/, ""));
+								} else {
+									jQuery(this).html("");
+								}
+							});
+						}
+						jQuery("#payment_form").find("input.amount, input.multicurrency_amount").on("keyup change", updateDerivedRates);
+						updateDerivedRates();
+					});'."\n";
+				}
 
 				print '	</script>'."\n";
 			}
@@ -874,6 +896,10 @@ if ($action == 'create' || $action == 'confirm_paiement' || $action == 'add_paie
 							} else {
 								print '<input type="text" class="width100" name="'.$namef.'_disabled" value="'.dol_escape_htmltag(GETPOST($namef)).'" disabled>';
 								print '<input type="hidden" class="amount" name="'.$namef.'" value="'.dol_escape_htmltag(GETPOST($namef)).'">'; // class is required to be used by javascript callForResult();
+							}
+							// Read-only derived exchange rate, shown when the real amounts may be entered in both currencies (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+							if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($objp->multicurrency_code) && $objp->multicurrency_code != $conf->currency) {
+								print '<span class="opacitymedium small" id="derivedrate_'.$objp->facid.'"></span>';
 							}
 							print "</td>";
 

--- a/htdocs/fourn/paiement/card.php
+++ b/htdocs/fourn/paiement/card.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025		Vincent Maury				<vmaury@timgroup.fr>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -79,6 +80,8 @@ if ($socid && $socid != $object->thirdparty->id) {
 $permissiontoadd = ($user->hasRight("fournisseur", "facture", "creer") || $user->hasRight("supplier_invoice", "write"));
 $permissiontovalidate = ((!getDolGlobalString('MAIN_USE_ADVANCED_PERMS') && ($user->hasRight("fournisseur", "facture", "creer") || $user->hasRight("supplier_invoice", "write"))) || (getDolGlobalString('MAIN_USE_ADVANCED_PERMS') && $user->hasRight("fournisseur", "supplier_invoice_advance", "validate")));
 $permissiontodelete = ($user->hasRight("fournisseur", "facture", "supprimer") || $user->hasRight("supplier_invoice", "delete"));
+// Editing the foreign-currency amount of a payment afterwards is gated behind a hidden constant (off by default) and restricted to admins
+$caneditmcamount = (getDolGlobalInt('MULTICURRENCY_PAYMENT_ALLOW_EDIT_REAL_AMOUNT') && !empty($user->admin));
 
 
 /*
@@ -147,6 +150,37 @@ if ($action == 'setdatep' && GETPOST('datepday') && $permissiontoadd) {
 	} else {
 		setEventMessages($langs->trans('PaymentDateUpdateFailed'), null, 'errors');
 	}
+}
+
+// Set the foreign-currency amount that was forgotten at entry (e.g. payment imported from bank / Banking4Dolibarr), option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS
+if ($action == 'setmulticurrencyamount' && $caneditmcamount && getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')) {
+	$object->fetch($id);
+	$newmcamount = (float) price2num(GETPOST('multicurrency_amount', 'alpha'));
+	// Only for a payment that settles a single foreign-currency supplier invoice
+	$sql = "SELECT pf.amount, ff.multicurrency_code FROM ".MAIN_DB_PREFIX."paiementfourn_facturefourn as pf";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."facture_fourn as ff ON ff.rowid = pf.fk_facturefourn";
+	$sql .= " WHERE pf.fk_paiementfourn = ".((int) $object->id);
+	$resql = $db->query($sql);
+	$nblink = $resql ? $db->num_rows($resql) : 0;
+	if ($nblink == 1) {
+		$objp = $db->fetch_object($resql);
+		$mccode = $objp->multicurrency_code;
+		$pfamount = (float) $objp->amount;
+		$newtx = ($pfamount != 0) ? (float) price2num($newmcamount / $pfamount, 'MU') : 1;
+		$db->begin();
+		$ok = $db->query("UPDATE ".MAIN_DB_PREFIX."paiementfourn SET multicurrency_amount = ".((float) $newmcamount)." WHERE rowid = ".((int) $object->id));
+		$ok = $ok && $db->query("UPDATE ".MAIN_DB_PREFIX."paiementfourn_facturefourn SET multicurrency_amount = ".((float) $newmcamount).", multicurrency_code = ".($mccode ? "'".$db->escape($mccode)."'" : "null").", multicurrency_tx = ".((float) $newtx)." WHERE fk_paiementfourn = ".((int) $object->id));
+		if ($ok) {
+			$db->commit();
+			setEventMessages($langs->trans('RecordSaved'), null, 'mesgs');
+		} else {
+			$db->rollback();
+			setEventMessages($langs->trans('Error'), null, 'errors');
+		}
+	} else {
+		setEventMessages($langs->trans('NotAvailable'), null, 'warnings');
+	}
+	$action = '';
 }
 
 // Build document
@@ -233,6 +267,52 @@ if ($result > 0) {
 	// Amount
 	print '<tr><td>'.$langs->trans('Amount').'</td>';
 	print '<td><span class="amount">'.price($object->amount, 0, $langs, 0, 0, -1, $conf->currency).'</span></td></tr>';
+
+	// Amount in the invoice currency and derived rate (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+	// Foreign-currency amount of the payment, editable to fill a value forgotten at entry (e.g. payment imported from bank / Banking4Dolibarr), option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS
+	if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')) {
+		$mccodepay = '';
+		$mctxpay = 0;
+		$nblinkpay = 0;
+		$sqlmc = "SELECT ff.multicurrency_code, ff.multicurrency_tx FROM ".MAIN_DB_PREFIX."paiementfourn_facturefourn as pf";
+		$sqlmc .= " INNER JOIN ".MAIN_DB_PREFIX."facture_fourn as ff ON ff.rowid = pf.fk_facturefourn";
+		$sqlmc .= " WHERE pf.fk_paiementfourn = ".((int) $object->id);
+		$resmc = $db->query($sqlmc);
+		if ($resmc) {
+			$nblinkpay = $db->num_rows($resmc);
+			if ($nblinkpay == 1) {
+				$objmc = $db->fetch_object($resmc);
+				$mccodepay = $objmc->multicurrency_code;
+				$mctxpay = (float) $objmc->multicurrency_tx;
+			}
+		}
+		if ($nblinkpay == 1 && !empty($mccodepay) && $mccodepay != $conf->currency) {
+			$langs->load("multicurrency");
+			print '<tr><td>'.$langs->trans('MulticurrencyPaymentAmount').'</td><td>';
+			if ($action == 'editmulticurrencyamount' && $caneditmcamount) {
+				print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'">';
+				print '<input type="hidden" name="token" value="'.newToken().'">';
+				print '<input type="hidden" name="action" value="setmulticurrencyamount">';
+				print '<input type="text" class="flat right maxwidth100" name="multicurrency_amount" value="'.((float) $object->multicurrency_amount != 0 ? price2num($object->multicurrency_amount, 'MT') : ($mctxpay > 0 ? price2num((float) $object->amount * $mctxpay, 'MT') : '')).'"> '.dol_escape_htmltag($mccodepay);
+				print ' <input type="submit" class="button smallpaddingimp" value="'.dol_escape_htmltag($langs->trans('Save')).'">';
+				print '</form>';
+			} else {
+				if ((float) $object->multicurrency_amount != 0) {
+					print '<span class="amount">'.price($object->multicurrency_amount, 0, $langs, 1, -1, 2).'</span> '.dol_escape_htmltag($mccodepay);
+				} else {
+					print '<span class="opacitymedium">'.$langs->trans('NotDefined').'</span>';
+				}
+				if ($caneditmcamount) {
+					print ' <a class="editfielda paddingleft" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=editmulticurrencyamount&token='.newToken().'">'.img_edit().'</a>';
+				}
+			}
+			print '</td></tr>';
+			if ((float) $object->multicurrency_amount != 0 && (float) $object->amount != 0) {
+				print '<tr><td>'.$langs->trans('CurrencyRate').'</td>';
+				print '<td>'.price2num((float) $object->multicurrency_amount / (float) $object->amount, 'MU').'</td></tr>';
+			}
+		}
+	}
 
 	// Status of validation of payment
 	if (getDolGlobalString('BILL_ADD_PAYMENT_VALIDATION')) {

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -753,3 +753,7 @@ CreditNoteNotCreatedErrorOnDiscount=Credit note for <b>%s</b> not created: error
 CreditNoteNotCreatedAlreadyConverted=Credit note for <b>%s</b> not created: invoice already converted
 CreditNotesCreated=%s credit note(s) created
 ThisMassActionIsOnlyForInvoices=This mass action is only available for invoices
+
+# Multicurrency payment entered with real amounts (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+WarningPaymentDerivedRateFarFromInvoiceRate=For invoice %s, the exchange rate %s derived from the amounts entered differs by more than 50%% from the invoice rate %s. Please check that the two amounts have not been swapped.
+ErrorPaymentRealAmountsMustHaveSameSign=For invoice %s, the amount in the invoice currency and the real amount in the company currency must have the same sign.


### PR DESCRIPTION
## What this solves

On a payment for an invoice in a foreign currency, Dolibarr derives one of the two amounts (company currency / invoice currency) from the other **at the invoice rate**. The amount really paid in the company currency almost always differs from that derivation — the bank applies its own rate on the day of the transfer — so the recorded payment does not match the bank statement, and the reconciliation carries a phantom difference.

## What it adds

Everything is gated by a new option **`MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS`** (off by default — behaviour is strictly unchanged without it).

1. **Payment pages (customer and supplier)**: both the amount in the invoice currency and the real amount in the company currency can be entered; a read-only exchange rate derived live from the two amounts is displayed.
2. **`Paiement::create()` / `PaiementFourn::create()`**: when both amounts are provided for an invoice, keep them as entered (no derivation), derive the per-invoice exchange rate and store it on the dispatch line. An error is raised when the two amounts have opposite signs, a non-blocking warning when the derived rate differs by more than 50% from the invoice rate (probable swap of the two fields).
3. **Paid status decided on the balance in the invoice currency**: settled at the real amounts, a multicurrency invoice keeps a residual amount in company currency — that residual *is* the exchange-rate difference, it must not keep the invoice open.
4. **Display**: in the payments table of the invoice card, each payment shows a sub-line with the amount in the invoice currency and the **real rate of that payment** (`multicurrency_amount / amount`), so a rate different from the invoice rate is visible at a glance. The payment tooltip (customer and supplier) and the supplier invoice tooltip show the same information (amount in the invoice currency, rate).
5. **A posteriori fix**: a payment whose foreign amount is missing (recorded before the option, or by an import) can be completed from the payment card — gated by the hidden option `MULTICURRENCY_PAYMENT_ALLOW_EDIT_REAL_AMOUNT` plus admin rights.

## Relationship with #38972 (@lvessiller)

The merged fix #38972 stores the invoice currency code/rate on the dispatch line when the caller does not fill the arrays. This PR integrates with it: in real-amounts mode the per-invoice derived rate is set into `$this->multicurrency_tx[$key]`, which that fallback then naturally respects; without the option, the fallback behaviour is unchanged.

## Compatibility

- Option unset ⇒ every code path falls back to the current behaviour (derivation at the invoice rate).
- No schema change: the payment dispatch tables already carry `multicurrency_amount` / `multicurrency_tx`.
- Follow-up PRs (deposits/credit notes carrying the invoice currency #39666, exchange-difference display #39667) build on this option and are submitted separately to keep reviews small. The accounting **booking** of the exchange difference (666/766, timing, lettering) is a further step we want to design with the accountancy maintainers — see the dedicated section in #39667.

## Tested

Supplier and customer flows on real USD/TWD invoices: payment recorded with the real amounts, per-invoice derived rate stored, paid status set from the foreign balance, residual company-currency amount visible as the exchange difference.
 Here is a screenshot:
 
<img width="2300" height="420" alt="pr39665_paiement_montants_reels" src="https://github.com/user-attachments/assets/e73727cf-f2e5-4358-89dd-85b94e71f105" />

Here are the tooltip and sublines orders screenshots:

<img width="1500" height="900" alt="pr39665_tooltip_facture" src="https://github.com/user-attachments/assets/c0f7f378-b776-4d4c-a9a7-03de23c32889" />
<img width="1200" height="560" alt="pr39665_tooltip_paiement" src="https://github.com/user-attachments/assets/38cdf147-9870-4cd8-87be-12028ce5465d" />