### PR TITLE
NEW Deposits and credit notes carry the invoice currency (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)

### DIFF
--- a/htdocs/comm/remx.php
+++ b/htdocs/comm/remx.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2024-2026	MDW				            <mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		    Anthony Damhet				      <a.damhet@progiseize.fr>
  * Copyright (C) 2026		Vincent de Grandpré	<vincent@de-grandpre.quebec>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -173,6 +174,8 @@ if ($action == 'confirm_split' && GETPOST("confirm", "alpha") == 'yes' && $permi
 	$amount_ttc_1 = price2num($amount_ttc_1);
 	$amount_ttc_2 = GETPOST('amount_ttc_2', 'alpha');
 	$amount_ttc_2 = price2num($amount_ttc_2);
+	$mc_amount_ttc_1 = price2num(GETPOST('mc_amount_ttc_1', 'alpha'));
+	$mc_amount_ttc_2 = price2num(GETPOST('mc_amount_ttc_2', 'alpha'));
 
 	$error = 0;
 	$remid = (GETPOSTINT("remid") ? GETPOSTINT("remid") : 0);
@@ -186,6 +189,11 @@ if ($action == 'confirm_split' && GETPOST("confirm", "alpha") == 'yes' && $permi
 		$error++;
 		setEventMessages($langs->trans("TotalOfTwoDiscountMustEqualsOriginal"), null, 'errors');
 	}
+	if (!$error && ((float) $mc_amount_ttc_1 + (float) $mc_amount_ttc_2) != 0
+		&& price2num((float) $mc_amount_ttc_1 + (float) $mc_amount_ttc_2, 'MT') != price2num($discount->multicurrency_amount_ttc, 'MT')) {
+		$error++;
+		setEventMessages($langs->trans("TotalOfTwoDiscountMustEqualsOriginal"), null, 'errors');
+	}
 	if (!$error && $discount->fk_facture_line) {
 		$error++;
 		setEventMessages($langs->trans("ErrorCantSplitAUsedDiscount"), null, 'errors');
@@ -195,6 +203,16 @@ if ($action == 'confirm_split' && GETPOST("confirm", "alpha") == 'yes' && $permi
 		$newDiscounts = $discount->splitAmount((float) $amount_ttc_1, (float) $amount_ttc_2);	// Note: splitting this way will result of a total ttc similar to original but total ht and total taxes may differ.
 		$newdiscount1 = $newDiscounts[0];
 		$newdiscount2 = $newDiscounts[1];
+
+		// Foreign-currency discount: honour the foreign amounts entered (the user may split directly in that currency) rather than the rate-derived ones
+		if (((float) $mc_amount_ttc_1 + (float) $mc_amount_ttc_2) != 0) {
+			$newdiscount1->multicurrency_amount_ttc = (float) $mc_amount_ttc_1;
+			$newdiscount1->multicurrency_amount_ht = price2num((float) $mc_amount_ttc_1 / (1 + (float) $newdiscount1->tva_tx / 100), 'MT');
+			$newdiscount1->multicurrency_amount_tva = price2num((float) $mc_amount_ttc_1 - (float) $newdiscount1->multicurrency_amount_ht);
+			$newdiscount2->multicurrency_amount_ttc = (float) $mc_amount_ttc_2;
+			$newdiscount2->multicurrency_amount_ht = price2num((float) $mc_amount_ttc_2 / (1 + (float) $newdiscount2->tva_tx / 100), 'MT');
+			$newdiscount2->multicurrency_amount_tva = price2num((float) $mc_amount_ttc_2 - (float) $newdiscount2->multicurrency_amount_ht);
+		}
 
 		$db->begin();
 
@@ -546,21 +564,21 @@ if ($socid > 0) {
 					print '<td>'.dol_print_date($db->jdate($obj->dc), 'dayhour', 'tzuserrel').'</td>';
 
 					if (preg_match('/\(CREDIT_NOTE\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturestatic->id = $obj->fk_facture_source;
 						$facturestatic->ref = $obj->ref;
 						$facturestatic->type = $obj->type;
 						print preg_replace('/\(CREDIT_NOTE\)/', $langs->trans("CreditNote"), $obj->description).'<br>'.$facturestatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(DEPOSIT\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturestatic->id = $obj->fk_facture_source;
 						$facturestatic->ref = $obj->ref;
 						$facturestatic->type = $obj->type;
 						print preg_replace('/\(DEPOSIT\)/', $langs->trans("InvoiceDeposit"), $obj->description).'<br>'.$facturestatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(EXCESS RECEIVED\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturestatic->id = $obj->fk_facture_source;
 						$facturestatic->ref = $obj->ref;
 						$facturestatic->type = $obj->type;
@@ -584,7 +602,7 @@ if ($socid > 0) {
 					if (isModEnabled('multicurrency')) {
 						print '<td class="right nowraponall amount">'.price($obj->multicurrency_amount_ttc).'</td>';
 					}
-					print '<td class="tdoverflowmax100">';
+					print '<td class="tdoverflowmax300">';
 					//print '<a href="'.DOL_URL_ROOT.'/user/card.php?id='.$obj->user_id.'">'.img_object($langs->trans("ShowUser"), 'user').' '.$obj->login.'</a>';
 					print $tmpuser->getNomUrl(-1);
 					print '</td>';
@@ -771,7 +789,31 @@ if ($socid > 0) {
 						1 => array('type' => 'text', 'name' => 'amount_ttc_2', 'label' => $langs->trans("AmountTTC").' 2', 'value' => $amount2, 'size' => '5')
 					);
 					$langs->load("dict");
-					print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&remid='.$showconfirminfo['rowid'].($backtopage ? '&backtopage='.urlencode($backtopage) : ''), $langs->trans('SplitDiscount'), $langs->trans('ConfirmSplitDiscount', price($showconfirminfo['amount_ttc']), $langs->transnoentities("Currency".$conf->currency)), 'confirm_split', $formquestion, '', 0);
+						$discountforsplit = new DiscountAbsolute($db);
+						$discountforsplit->fetch($showconfirminfo['rowid']);
+						$ismcsplit = (isModEnabled('multicurrency') && (float) $discountforsplit->multicurrency_amount_ttc != 0 && abs((float) $discountforsplit->multicurrency_amount_ttc - (float) $discountforsplit->amount_ttc) > 0.01 && $discountforsplit->multicurrency_code != $conf->currency);
+						$mcsplitcode = !empty($discountforsplit->multicurrency_code) ? $discountforsplit->multicurrency_code : $langs->trans("Currency");
+						$splitamount1 = price2num($showconfirminfo['amount_ttc'] / 2, 'MT');
+						$splitamount2 = price2num((float) $showconfirminfo['amount_ttc'] - (float) $splitamount1, 'MT');
+						$splitmc1 = price2num($discountforsplit->multicurrency_amount_ttc / 2, 'MT');
+						$splitmc2 = price2num((float) $discountforsplit->multicurrency_amount_ttc - (float) $splitmc1, 'MT');
+						print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&remid='.$showconfirminfo['rowid'].($backtopage ? '&backtopage='.urlencode($backtopage) : '').'" id="formsplit2">';
+						print '<input type="hidden" name="token" value="'.newToken().'">';
+						print '<input type="hidden" name="action" value="confirm_split">';
+						print '<div class="div-table-responsive-no-min"><table class="noborder centpercent">';
+						print '<tr class="liste_titre"><td>'.img_picto('', 'split', 'class="pictofixedwidth"').$langs->trans('SplitDiscount').'</td>';
+					if ($ismcsplit) { print '<td class="right">'.$langs->trans('AmountTTC').' ('.dol_escape_htmltag($mcsplitcode).')</td>'; }
+						print '<td class="right">'.$langs->trans('AmountTTC').' ('.$langs->trans("Currency".$conf->currency).')</td></tr>';
+						print '<tr class="oddeven"><td class="nowraponall">'.$langs->trans('Part').' 1</td>';
+					if ($ismcsplit) { print '<td class="right"><input type="text" class="flat right maxwidth100" name="mc_amount_ttc_1" value="'.$splitmc1.'"></td>'; }
+						print '<td class="right"><input type="text" class="flat right maxwidth100" name="amount_ttc_1" value="'.$splitamount1.'"></td></tr>';
+						print '<tr class="oddeven"><td class="nowraponall">'.$langs->trans('Part').' 2</td>';
+					if ($ismcsplit) { print '<td class="right"><input type="text" class="flat right maxwidth100" name="mc_amount_ttc_2" value="'.$splitmc2.'"></td>'; }
+						print '<td class="right"><input type="text" class="flat right maxwidth100" name="amount_ttc_2" value="'.$splitamount2.'"></td></tr>';
+						print '</table></div>';
+						print '<div class="center paddingtop">'.$langs->trans('ConfirmSplitDiscount', price($showconfirminfo['amount_ttc']), $langs->transnoentities("Currency".$conf->currency)).' '.$form->selectyesno('confirm', 'no', 0).' &nbsp; <input type="submit" class="button" id="splitsubmit" value="'.dol_escape_htmltag($langs->trans('Validate')).'"></div>';
+						print '</form>';
+						print '<script>(function(){function g(n){return document.querySelector(\'[name="\'+n+\'"]\');}var ismc='.($ismcsplit ? 'true' : 'false').';var totEur='.((float) $showconfirminfo['amount_ttc']).',totDev='.((float) $discountforsplit->multicurrency_amount_ttc).';var e1=g("amount_ttc_1"),e2=g("amount_ttc_2"),d1=g("mc_amount_ttc_1"),d2=g("mc_amount_ttc_2"),sub=document.getElementById("splitsubmit"),reu=document.getElementById("splitremaineur"),rdv=document.getElementById("splitremaindev");if(!e1||!e2)return;function num(v){return parseFloat((""+v).replace(/\s/g,"").replace(",","."))||0;}function r2(x){return Math.round(x*100)/100;}function recalc(){var re=r2(totEur-num(e1.value)-num(e2.value));if(reu)reu.innerHTML=re.toFixed(2).replace(".",",");var ok=Math.abs(re)<0.005;if(ismc&&d1&&d2){var rd=r2(totDev-num(d1.value)-num(d2.value));if(rdv)rdv.innerHTML=rd.toFixed(2).replace(".",",");ok=ok&&Math.abs(rd)<0.005;}if(sub)sub.disabled=!ok;}function fe(s){var v=num(s.value);(s===e1?e2:e1).value=r2(totEur-v);if(ismc&&d1&&d2){var w=r2(v/totEur*totDev);(s===e1?d1:d2).value=w;(s===e1?d2:d1).value=r2(totDev-w);}recalc();}function fd(s){var v=num(s.value);(s===d1?d2:d1).value=r2(totDev-v);var w=r2(v/totDev*totEur);(s===d1?e1:e2).value=w;(s===d1?e2:e1).value=r2(totEur-w);recalc();}e1.addEventListener("input",function(){fe(e1);});e2.addEventListener("input",function(){fe(e2);});if(ismc&&d1&&d2){d1.addEventListener("input",function(){fd(d1);});d2.addEventListener("input",function(){fd(d2);});}recalc();})();</script>';
 				}
 			}
 		} else {
@@ -844,21 +886,21 @@ if ($socid > 0) {
 					print '<tr class="oddeven">';
 					print '<td>'.dol_print_date($db->jdate($obj->dc), 'dayhour', 'tzuserrel').'</td>';
 					if (preg_match('/\(CREDIT_NOTE\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturefournstatic->id = $obj->fk_invoice_supplier_source;
 						$facturefournstatic->ref = $obj->ref;
 						$facturefournstatic->type = $obj->type;
 						print preg_replace('/\(CREDIT_NOTE\)/', $langs->trans("CreditNote"), $obj->description).'<br>'.$facturefournstatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(DEPOSIT\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturefournstatic->id = $obj->fk_invoice_supplier_source;
 						$facturefournstatic->ref = $obj->ref;
 						$facturefournstatic->type = $obj->type;
 						print preg_replace('/\(DEPOSIT\)/', $langs->trans("InvoiceDeposit"), $obj->description).'<br>'.$facturefournstatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(EXCESS PAID\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturefournstatic->id = $obj->fk_invoice_supplier_source;
 						$facturefournstatic->ref = $obj->ref;
 						$facturefournstatic->type = $obj->type;
@@ -879,7 +921,7 @@ if ($socid > 0) {
 					if (isModEnabled('multicurrency')) {
 						print '<td class="right nowraponall amount">'.price($obj->multicurrency_amount_ttc).'</td>';
 					}
-					print '<td class="tdoverflowmax100">';
+					print '<td class="tdoverflowmax300">';
 					print $tmpuser->getNomUrl(-1);
 					print '</td>';
 
@@ -1065,7 +1107,41 @@ if ($socid > 0) {
 						1 => array('type' => 'text', 'name' => 'amount_ttc_2', 'label' => $langs->trans("AmountTTC").' 2', 'value' => $amount2, 'size' => '5')
 					);
 					$langs->load("dict");
-					print $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&remid='.$showconfirminfo['rowid'].($backtopage ? '&backtopage='.urlencode($backtopage) : ''), $langs->trans('SplitDiscount'), $langs->trans('ConfirmSplitDiscount', price($showconfirminfo['amount_ttc']), $langs->transnoentities("Currency".$conf->currency)), 'confirm_split', $formquestion, 0, 0);
+					$discountforsplit = new DiscountAbsolute($db);
+					$discountforsplit->fetch($showconfirminfo['rowid']);
+					$ismcsplit = (isModEnabled('multicurrency') && (float) $discountforsplit->multicurrency_amount_ttc != 0 && abs((float) $discountforsplit->multicurrency_amount_ttc - (float) $discountforsplit->amount_ttc) > 0.01 && $discountforsplit->multicurrency_code != $conf->currency);
+					if ($ismcsplit) {
+						$mcsplitcode = !empty($discountforsplit->multicurrency_code) ? $discountforsplit->multicurrency_code : $langs->trans("Currency");
+						$mcamount1 = price2num($discountforsplit->multicurrency_amount_ttc / 2, 'MT');
+						$mcamount2 = ($discountforsplit->multicurrency_amount_ttc - (float) $mcamount1);
+						$formquestion[2] = array('type' => 'text', 'name' => 'mc_amount_ttc_1', 'label' => $langs->trans("AmountTTC").' 1 ('.$mcsplitcode.')', 'value' => $mcamount1, 'size' => '5');
+						$formquestion[3] = array('type' => 'text', 'name' => 'mc_amount_ttc_2', 'label' => $langs->trans("AmountTTC").' 2 ('.$mcsplitcode.')', 'value' => $mcamount2, 'size' => '5');
+					}
+						$discountforsplit = new DiscountAbsolute($db);
+						$discountforsplit->fetch($showconfirminfo['rowid']);
+						$ismcsplit = (isModEnabled('multicurrency') && (float) $discountforsplit->multicurrency_amount_ttc != 0 && abs((float) $discountforsplit->multicurrency_amount_ttc - (float) $discountforsplit->amount_ttc) > 0.01 && $discountforsplit->multicurrency_code != $conf->currency);
+						$mcsplitcode = !empty($discountforsplit->multicurrency_code) ? $discountforsplit->multicurrency_code : $langs->trans("Currency");
+						$splitamount1 = price2num($showconfirminfo['amount_ttc'] / 2, 'MT');
+						$splitamount2 = price2num((float) $showconfirminfo['amount_ttc'] - (float) $splitamount1, 'MT');
+						$splitmc1 = price2num($discountforsplit->multicurrency_amount_ttc / 2, 'MT');
+						$splitmc2 = price2num((float) $discountforsplit->multicurrency_amount_ttc - (float) $splitmc1, 'MT');
+						print '<form method="POST" action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&remid='.$showconfirminfo['rowid'].($backtopage ? '&backtopage='.urlencode($backtopage) : '').'" id="formsplit2">';
+						print '<input type="hidden" name="token" value="'.newToken().'">';
+						print '<input type="hidden" name="action" value="confirm_split">';
+						print '<div class="div-table-responsive-no-min"><table class="noborder centpercent">';
+						print '<tr class="liste_titre"><td>'.img_picto('', 'split', 'class="pictofixedwidth"').$langs->trans('SplitDiscount').'</td>';
+					if ($ismcsplit) { print '<td class="right">'.$langs->trans('AmountTTC').' ('.dol_escape_htmltag($mcsplitcode).')</td>'; }
+						print '<td class="right">'.$langs->trans('AmountTTC').' ('.$langs->trans("Currency".$conf->currency).')</td></tr>';
+						print '<tr class="oddeven"><td class="nowraponall">'.$langs->trans('Part').' 1</td>';
+					if ($ismcsplit) { print '<td class="right"><input type="text" class="flat right maxwidth100" name="mc_amount_ttc_1" value="'.$splitmc1.'"></td>'; }
+						print '<td class="right"><input type="text" class="flat right maxwidth100" name="amount_ttc_1" value="'.$splitamount1.'"></td></tr>';
+						print '<tr class="oddeven"><td class="nowraponall">'.$langs->trans('Part').' 2</td>';
+					if ($ismcsplit) { print '<td class="right"><input type="text" class="flat right maxwidth100" name="mc_amount_ttc_2" value="'.$splitmc2.'"></td>'; }
+						print '<td class="right"><input type="text" class="flat right maxwidth100" name="amount_ttc_2" value="'.$splitamount2.'"></td></tr>';
+						print '</table></div>';
+						print '<div class="center paddingtop">'.$langs->trans('ConfirmSplitDiscount', price($showconfirminfo['amount_ttc']), $langs->transnoentities("Currency".$conf->currency)).' '.$form->selectyesno('confirm', 'no', 0).' &nbsp; <input type="submit" class="button" id="splitsubmit" value="'.dol_escape_htmltag($langs->trans('Validate')).'"></div>';
+						print '</form>';
+						print '<script>(function(){function g(n){return document.querySelector(\'[name="\'+n+\'"]\');}var ismc='.($ismcsplit ? 'true' : 'false').';var totEur='.((float) $showconfirminfo['amount_ttc']).',totDev='.((float) $discountforsplit->multicurrency_amount_ttc).';var e1=g("amount_ttc_1"),e2=g("amount_ttc_2"),d1=g("mc_amount_ttc_1"),d2=g("mc_amount_ttc_2"),sub=document.getElementById("splitsubmit"),reu=document.getElementById("splitremaineur"),rdv=document.getElementById("splitremaindev");if(!e1||!e2)return;function num(v){return parseFloat((""+v).replace(/\s/g,"").replace(",","."))||0;}function r2(x){return Math.round(x*100)/100;}function recalc(){var re=r2(totEur-num(e1.value)-num(e2.value));if(reu)reu.innerHTML=re.toFixed(2).replace(".",",");var ok=Math.abs(re)<0.005;if(ismc&&d1&&d2){var rd=r2(totDev-num(d1.value)-num(d2.value));if(rdv)rdv.innerHTML=rd.toFixed(2).replace(".",",");ok=ok&&Math.abs(rd)<0.005;}if(sub)sub.disabled=!ok;}function fe(s){var v=num(s.value);(s===e1?e2:e1).value=r2(totEur-v);if(ismc&&d1&&d2){var w=r2(v/totEur*totDev);(s===e1?d1:d2).value=w;(s===e1?d2:d1).value=r2(totDev-w);}recalc();}function fd(s){var v=num(s.value);(s===d1?d2:d1).value=r2(totDev-v);var w=r2(v/totDev*totEur);(s===d1?e1:e2).value=w;(s===d1?e2:e1).value=r2(totEur-w);recalc();}e1.addEventListener("input",function(){fe(e1);});e2.addEventListener("input",function(){fe(e2);});if(ismc&&d1&&d2){d1.addEventListener("input",function(){fd(d1);});d2.addEventListener("input",function(){fd(d2);});}recalc();})();</script>';
 				}
 			}
 		} else {
@@ -1192,21 +1268,21 @@ if ($socid > 0) {
 					print '<tr class="oddeven">';
 					print '<td>'.dol_print_date($db->jdate($obj->dc), 'dayhour').'</td>';
 					if (preg_match('/\(CREDIT_NOTE\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturestatic->id = $obj->fk_facture_source;
 						$facturestatic->ref = $obj->invoice_source_ref;
 						$facturestatic->type = $obj->type;
 						print preg_replace('/\(CREDIT_NOTE\)/', $langs->trans("CreditNote"), $obj->description).'<br>'.$facturestatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(DEPOSIT\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturestatic->id = $obj->fk_facture_source;
 						$facturestatic->ref = $obj->invoice_source_ref;
 						$facturestatic->type = $obj->type;
 						print preg_replace('/\(DEPOSIT\)/', $langs->trans("InvoiceDeposit"), $obj->description).'<br>'.$facturestatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(EXCESS RECEIVED\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturestatic->id = $obj->fk_facture_source;
 						$facturestatic->ref = $obj->invoice_source_ref;
 						$facturestatic->type = $obj->type;
@@ -1219,7 +1295,9 @@ if ($socid > 0) {
 					}
 					print '<td class="left nowrap">';
 					if ($obj->invoiceid) {
-						print '<a href="'.DOL_URL_ROOT.'/compta/facture/card.php?facid='.$obj->invoiceid.'">'.img_object($langs->trans("ShowBill"), 'bill').' '.$obj->ref.'</a>';
+						$facturestatic->id = $obj->invoiceid;
+						$facturestatic->ref = $obj->ref;
+						print $facturestatic->getNomUrl(1);
 					}
 					print '</td>';
 					print '<td class="right nowraponall amount">'.price($obj->amount_ht).'</td>';
@@ -1231,7 +1309,7 @@ if ($socid > 0) {
 					if (isModEnabled('multicurrency')) {
 						print '<td class="right">'.price($obj->multicurrency_amount_ttc).'</td>';
 					}
-					print '<td class="tdoverflowmax100">';
+					print '<td class="tdoverflowmax300">';
 					print $tmpuser->getNomUrl(-1);
 					print '</td>';
 
@@ -1362,21 +1440,21 @@ if ($socid > 0) {
 					print '<tr class="oddeven">';
 					print '<td>'.dol_print_date($db->jdate($obj->dc), 'dayhour').'</td>';
 					if (preg_match('/\(CREDIT_NOTE\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturefournstatic->id = $obj->fk_invoice_supplier_source;
 						$facturefournstatic->ref = $obj->invoice_source_ref;
 						$facturefournstatic->type = $obj->type;
 						print preg_replace('/\(CREDIT_NOTE\)/', $langs->trans("CreditNote"), $obj->description).'<br>'.$facturefournstatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(DEPOSIT\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturefournstatic->id = $obj->fk_invoice_supplier_source;
 						$facturefournstatic->ref = $obj->invoice_source_ref;
 						$facturefournstatic->type = $obj->type;
 						print preg_replace('/\(DEPOSIT\)/', $langs->trans("InvoiceDeposit"), $obj->description).'<br>'.$facturefournstatic->getNomURl(1);
 						print '</td>';
 					} elseif (preg_match('/\(EXCESS PAID\)/', $obj->description)) {
-						print '<td class="tdoverflowmax100">';
+						print '<td class="tdoverflowmax300">';
 						$facturefournstatic->id = $obj->fk_invoice_supplier_source;
 						$facturefournstatic->ref = $obj->invoice_source_ref;
 						$facturefournstatic->type = $obj->type;
@@ -1389,7 +1467,9 @@ if ($socid > 0) {
 					}
 					print '<td class="left nowrap">';
 					if ($obj->invoiceid) {
-						print '<a href="'.DOL_URL_ROOT.'/fourn/facture/card.php?facid='.$obj->invoiceid.'">'.img_object($langs->trans("ShowBill"), 'bill').' '.$obj->ref.'</a>';
+						$facturefournstatic->id = $obj->invoiceid;
+						$facturefournstatic->ref = $obj->ref;
+						print $facturefournstatic->getNomUrl(1);
 					}
 					print '</td>';
 					print '<td class="right nowraponall amount">'.price($obj->amount_ht).'</td>';
@@ -1401,7 +1481,7 @@ if ($socid > 0) {
 					if (isModEnabled('multicurrency')) {
 						print '<td class="right nowraponall amount">'.price($obj->multicurrency_amount_ttc).'</td>';
 					}
-					print '<td class="tdoverflowmax100">';
+					print '<td class="tdoverflowmax300">';
 					print $tmpuser->getNomUrl(-1);
 					print '</td>';
 

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1111,6 +1111,9 @@ if (empty($reshook)) {
 			$discount->fk_soc = $object->socid;
 			$discount->socid = $object->socid;
 			$discount->fk_facture_source = $object->id;
+			// Carry the currency and rate of the source invoice so the resulting discount keeps its foreign-currency identity
+			$discount->multicurrency_code = $object->multicurrency_code;
+			$discount->multicurrency_tx = $object->multicurrency_tx;
 
 			$error = 0;
 
@@ -6420,6 +6423,7 @@ if ($action == 'create') {
 			$creditnoteamount = 0;
 			$depositamount = 0;
 			$sql = "SELECT re.rowid, re.amount_ht, re.amount_tva, re.amount_ttc,";
+			$sql .= " re.multicurrency_amount_ttc, re.multicurrency_code, re.multicurrency_tx,";
 			$sql .= " re.description, re.fk_facture_source";
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe_remise_except as re";
 			$sql .= " WHERE fk_facture = ".((int) $object->id);
@@ -6441,6 +6445,14 @@ if ($action == 'create') {
 						print $langs->trans("Deposit").' ';
 					}
 					print $invoice->getNomUrl(0);
+					// Foreign-currency amount and rate, kept on a single line in the (wide) label cell (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+					if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($obj->multicurrency_code)) {
+						print ' <span class="small nowraponall">'.price($obj->multicurrency_amount_ttc, 0, $langs, 1, -1, -1, $obj->multicurrency_code);
+						if (!empty($obj->multicurrency_tx) && $obj->multicurrency_tx > 0) {
+							print ' - '.$langs->trans('Rate').' : '.price2num($obj->multicurrency_tx, 'MU');
+						}
+						print '</span>';
+					}
 					print '</span>';
 					print '</td>';
 					// Delete discount

--- a/htdocs/core/class/discount.class.php
+++ b/htdocs/core/class/discount.class.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Noé Cendrier		<noe.cendrier@altairis.fr>
  * Copyright (C) 2026		Vincent de Grandpré	<vincent@de-grandpre.quebec>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -109,6 +110,16 @@ class DiscountAbsolute extends CommonObject
 	 * @var float
 	 */
 	public $multicurrency_subprice;
+
+	/**
+	 * @var string Currency code of the credit (invoice currency)
+	 */
+	public $multicurrency_code;
+
+	/**
+	 * @var float Exchange rate of the credit
+	 */
+	public $multicurrency_tx;
 
 	/**
 	 * @var int
@@ -235,6 +246,7 @@ class DiscountAbsolute extends CommonObject
 		$sql .= " sr.fk_user,";
 		$sql .= " sr.amount_ht, sr.amount_tva, sr.amount_localtax1, sr.amount_localtax2, sr.amount_ttc, sr.tva_tx, sr.localtax1_tx, sr.localtax1_type, sr.localtax2_tx, sr.localtax2_type, sr.vat_src_code,";
 		$sql .= " sr.multicurrency_amount_ht, sr.multicurrency_amount_tva, sr.multicurrency_amount_ttc,";
+		$sql .= " sr.multicurrency_code, sr.multicurrency_tx,";
 		$sql .= " sr.fk_facture_line, sr.fk_facture, sr.fk_facture_source, sr.fk_invoice_supplier_line, sr.fk_invoice_supplier, sr.fk_invoice_supplier_source, sr.description,";
 		$sql .= " sr.datec,";
 		$sql .= " f.ref as ref_facture_source, f.type as type_facture_source,";
@@ -281,6 +293,8 @@ class DiscountAbsolute extends CommonObject
 				$this->multicurrency_amount_ht = $this->multicurrency_total_ht;
 				$this->multicurrency_amount_tva = $this->multicurrency_total_tva;
 				$this->multicurrency_amount_ttc = $this->multicurrency_total_ttc;
+				$this->multicurrency_code = $obj->multicurrency_code;
+				$this->multicurrency_tx = $obj->multicurrency_tx;
 
 				$this->tva_tx = $obj->tva_tx;
 				$this->localtax1_tx = $obj->localtax1_tx;
@@ -1127,6 +1141,11 @@ class DiscountAbsolute extends CommonObject
 		$newdiscount2->localtax2_tx = $this->localtax2_tx;
 		$newdiscount1->vat_src_code = $this->vat_src_code;
 		$newdiscount2->vat_src_code = $this->vat_src_code;
+		// Carry the currency and rate so generateFromAmount() recomputes the foreign-currency amount of each part (was lost on split)
+		$newdiscount1->multicurrency_code = $this->multicurrency_code;
+		$newdiscount2->multicurrency_code = $this->multicurrency_code;
+		$newdiscount1->multicurrency_tx = $this->multicurrency_tx;
+		$newdiscount2->multicurrency_tx = $this->multicurrency_tx;
 
 		$newdiscount1->generateFromAmount($amount_ttc1, 1, $newdiscount1->tva_tx, $newdiscount1->localtax1_tx, $newdiscount1->localtax2_tx, $this->localtax1_type, $this->localtax2_type);
 		$newdiscount2->generateFromAmount($amount_ttc2, 1, $newdiscount2->tva_tx, $newdiscount2->localtax1_tx, $newdiscount2->localtax2_tx, $this->localtax1_type, $this->localtax2_type);

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -7781,7 +7781,8 @@ class Form
 			return '';
 		}
 
-		return ' <span class="opacitymedium">('.implode(', ', $tmparray).')</span>';
+		// On its own line: appended inline it can push the card left column into the right one
+		return '<br><span class="opacitymedium">('.implode(', ', $tmparray).')</span>';
 	}
 
 

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2562,6 +2562,7 @@ class Form
 
 		// Search for the discounts
 		$sql = "SELECT re.rowid, re.amount_ht, re.amount_tva, re.amount_ttc,";
+		$sql .= " re.multicurrency_amount_ttc, re.multicurrency_code, re.multicurrency_tx,";
 		$sql .= " re.description, re.fk_facture_source, re.fk_invoice_supplier_source";
 		if ($showsourceinvoice) {
 			// Resolve the source invoice (customer or supplier) in the main query instead of one fetch per line
@@ -2639,7 +2640,17 @@ class Form
 						}
 					}
 
-					print '<option value="' . $obj->rowid . '"' . $selectstring . $disabled . '>' . $desc . ' (' . price($obj->amount_ht) . ' ' . $langs->trans("HT") . ' - ' . price($obj->amount_ttc) . ' ' . $langs->trans("TTC") . ')</option>';
+					// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, append the foreign amount and rate of the credit
+					$multicurrencyinfo = '';
+					if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($obj->multicurrency_code)) {
+						$multicurrencyinfo = ' (' . price($obj->multicurrency_amount_ttc, 0, $langs, 1, -1, -1, $obj->multicurrency_code);
+						if (!empty($obj->multicurrency_tx) && $obj->multicurrency_tx > 0) {
+							$multicurrencyinfo .= ' - ' . $langs->trans('Rate') . ' : ' . price2num($obj->multicurrency_tx, 'MU');
+						}
+						$multicurrencyinfo .= ')';
+					}
+
+					print '<option value="' . $obj->rowid . '"' . $selectstring . $disabled . '>' . $desc . ' (' . price($obj->amount_ht) . ' ' . $langs->trans("HT") . ' - ' . price($obj->amount_ttc) . ' ' . $langs->trans("TTC") . ')' . $multicurrencyinfo . '</option>';
 					$i++;
 				}
 			}
@@ -7669,6 +7680,8 @@ class Form
 				}
 			}
 			print $langs->trans($translationKey, price($amount, 0, $langs, 0, 0, -1, $conf->currency));
+			// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, also show the foreign-currency value and rate of the available credits
+			print $this->getMulticurrencyCreditsInfo($socid, $discount_type, $filter);
 			if (empty($hidelist)) {
 				print ' ';
 			}
@@ -7713,6 +7726,62 @@ class Form
 				print "0";
 			}
 		}
+	}
+
+	/**
+	 * Build a short HTML label with the foreign-currency value and the exchange rate of the available
+	 * multicurrency credits of a third party, to enrich the "available discounts/credits" messages.
+	 * Returns an empty string when the option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS is off, the
+	 * multicurrency module is disabled, or no available credit carries a currency code.
+	 *
+	 * @param	int		$socid			Third party id
+	 * @param	int		$discount_type	0 = customer discount, 1 = supplier discount
+	 * @param	string	$filter			Same SQL filter used to compute the company-currency total
+	 * @return	string					HTML fragment (empty string if nothing to show)
+	 */
+	public function getMulticurrencyCreditsInfo($socid, $discount_type = 0, $filter = '')
+	{
+		global $langs;
+
+		if (!getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') || !isModEnabled('multicurrency')) {
+			return '';
+		}
+
+		$sql = "SELECT multicurrency_code, SUM(multicurrency_amount_ttc) as mc_total, MIN(multicurrency_tx) as mintx, MAX(multicurrency_tx) as maxtx";
+		$sql .= " FROM ".MAIN_DB_PREFIX."societe_remise_except";
+		$sql .= " WHERE fk_soc = ".((int) $socid);
+		$sql .= " AND discount_type = ".((int) $discount_type);
+		if (!empty($discount_type)) {
+			$sql .= " AND fk_invoice_supplier IS NULL AND fk_invoice_supplier_line IS NULL";
+		} else {
+			$sql .= " AND fk_facture IS NULL AND fk_facture_line IS NULL";
+		}
+		if ($filter) {
+			$sql .= " AND (".$filter.")";  // @phan-suppress-current-line SqlInjection
+		}
+		$sql .= " AND multicurrency_code IS NOT NULL AND multicurrency_code <> ''";
+		$sql .= " GROUP BY multicurrency_code";
+
+		$resql = $this->db->query($sql);
+		if (!$resql) {
+			return '';
+		}
+
+		$tmparray = array();
+		while ($obj = $this->db->fetch_object($resql)) {
+			$txt = price($obj->mc_total, 0, $langs, 1, -1, -1, $obj->multicurrency_code);
+			if ($obj->mintx > 0 && $obj->mintx == $obj->maxtx) {
+				$txt .= ' - '.$langs->trans('Rate').' : '.price2num($obj->mintx, 'MU');
+			}
+			$tmparray[] = $txt;
+		}
+		$this->db->free($resql);
+
+		if (empty($tmparray)) {
+			return '';
+		}
+
+		return ' <span class="opacitymedium">('.implode(', ', $tmparray).')</span>';
 	}
 
 

--- a/htdocs/core/tpl/object_discounts.tpl.php
+++ b/htdocs/core/tpl/object_discounts.tpl.php
@@ -101,6 +101,7 @@ if ($absolute_discount > 0) {
 	if (!empty($cannotApplyDiscount) || !$isInvoice || $isNewObject || $object->statut > $objclassname::STATUS_DRAFT || $object->type == $objclassname::TYPE_CREDIT_NOTE || $object->type == $objclassname::TYPE_DEPOSIT) {
 		$translationKey = empty($discount_type) ? 'CompanyHasDownPaymentOrCommercialDiscount' : 'HasDownPaymentOrCommercialDiscountFromSupplier';
 		$text = $langs->trans($translationKey, price($absolute_discount, 0, $langs, 1, -1, -1, $conf->currency));
+		$text .= $form->getMulticurrencyCreditsInfo($thirdparty->id, $discount_type, $filterabsolutediscount);
 
 		if ($isInvoice && !$isNewObject && $object->statut > $objclassname::STATUS_DRAFT && $object->type != $objclassname::TYPE_CREDIT_NOTE && $object->type != $objclassname::TYPE_DEPOSIT) {
 			$text = $form->textwithpicto($text, $langs->trans('AbsoluteDiscountUse'));
@@ -131,6 +132,7 @@ if ($absolute_creditnote > 0) {
 	if (!empty($cannotApplyDiscount) || !$isInvoice || $isNewObject || $object->statut != $objclassname::STATUS_VALIDATED || $object->type == $objclassname::TYPE_CREDIT_NOTE) {
 		$translationKey = empty($discount_type) ? 'CompanyHasCreditNote' : 'HasCreditNoteFromSupplier';
 		$text = $langs->trans($translationKey, price($absolute_creditnote, 0, $langs, 1, -1, -1, $conf->currency));
+		$text .= $form->getMulticurrencyCreditsInfo($thirdparty->id, $discount_type, $filtercreditnote);
 
 		if ($isInvoice && !$isNewObject && $object->statut == $objclassname::STATUS_DRAFT && $object->type != $objclassname::TYPE_DEPOSIT) {
 			$text = $form->textwithpicto($text, $langs->trans('CreditNoteDepositUse'));

--- a/htdocs/core/tpl/object_discounts.tpl.php
+++ b/htdocs/core/tpl/object_discounts.tpl.php
@@ -3,6 +3,7 @@
 /* Copyright (C) 2018		ATM Consulting		<support@atm-consulting.fr>
  * Copyright (C) 2021-2024  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2025-2026	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		José MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -579,24 +579,82 @@ if (empty($reshook)) {
 
 			//var_dump($object->getRemainToPay(0));
 			//var_dump($discount->amount_ttc);exit;
-			$remaintopay = $object->getRemainToPay(0);
-			if (price2num($discount->amount_ttc) > price2num($remaintopay)) {
-				// TODO Split the discount in 2 automatically
-				$error++;
-				setEventMessages($langs->trans("ErrorDiscountLargerThanRemainToPaySplitItBefore"), null, 'errors');
+			// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, when the credit is in the invoice currency, compare and settle
+			// in that currency (the company-currency amounts may use different exchange rates and would compare wrongly).
+			$usemccompare = (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+				&& !empty($discount->multicurrency_code) && !empty($object->multicurrency_code)
+				&& $discount->multicurrency_code == $object->multicurrency_code && $object->multicurrency_code != $conf->currency);
+			$remaintopay = $usemccompare ? $object->getRemainToPay(1) : $object->getRemainToPay(0);
+			$discountamountforcompare = $usemccompare ? $discount->multicurrency_amount_ttc : $discount->amount_ttc;
+			$discounttolink = $discount;
+			$depositwassplit = false;
+			$splitappliedmsg = '';
+			$splitremainmsg = '';
+			if (price2num($discountamountforcompare, 'MT') > price2num($remaintopay, 'MT')) {
+				if ((float) $remaintopay <= 0) {
+					$error++;
+					setEventMessages($langs->trans("ErrorDiscountLargerThanRemainToPaySplitItBefore"), null, 'errors');
+				} else {
+					// Credit larger than the remaining: split it automatically, apply up to the remaining amount (max, in the invoice currency) and keep the rest available
+					$depositeur = (float) $discount->amount_ttc;
+					$depositdev = (float) $discount->multicurrency_amount_ttc;
+					$remaindev = 0.0;
+					if ($usemccompare && $depositdev != 0) {
+						$applydev = (float) $remaintopay;
+						$applyeur = (float) price2num($applydev / $depositdev * $depositeur, 'MT');
+					} else {
+						$applyeur = (float) $remaintopay;
+						$applydev = ($depositeur != 0 ? (float) price2num($applyeur / $depositeur * $depositdev, 'MT') : 0);
+					}
+					$splitparts = $discount->splitAmount($applyeur, (float) price2num($depositeur - $applyeur, 'MT'));
+					$applypart = $splitparts[0];
+					$remainpart = $splitparts[1];
+					if (!empty($discount->multicurrency_code) && $depositdev != 0) {
+						$remaindev = (float) price2num($depositdev - $applydev, 'MT');
+						$applypart->multicurrency_amount_ttc = $applydev;
+						$applypart->multicurrency_amount_ht = price2num($applydev / (1 + (float) $applypart->tva_tx / 100), 'MT');
+						$applypart->multicurrency_amount_tva = price2num($applydev - (float) $applypart->multicurrency_amount_ht);
+						$remainpart->multicurrency_amount_ttc = $remaindev;
+						$remainpart->multicurrency_amount_ht = price2num($remaindev / (1 + (float) $remainpart->tva_tx / 100), 'MT');
+						$remainpart->multicurrency_amount_tva = price2num($remaindev - (float) $remainpart->multicurrency_amount_ht);
+					}
+					$discount->fk_facture_source = 0;
+					$discount->fk_invoice_supplier_source = 0;
+					$resdelete = $discount->delete($user);
+					$newidapply = $applypart->create($user);
+					$newidremain = $remainpart->create($user);
+					if ($resdelete > 0 && $newidapply > 0 && $newidremain > 0) {
+						$discounttolink = new DiscountAbsolute($db);
+						$discounttolink->fetch($newidapply);
+						// Build a positive feedback message about the automatic split (amount applied / amount kept available)
+						$depositwassplit = true;
+						$splitappliedmsg = price($applyeur, 0, $langs, 1, -1, -1, $conf->currency);
+						$splitremainmsg = price((float) price2num($depositeur - $applyeur, 'MT'), 0, $langs, 1, -1, -1, $conf->currency);
+						if (!empty($discount->multicurrency_code) && $depositdev != 0) {
+							$splitappliedmsg .= ' / '.price($applydev, 0, $langs, 1, -1, -1, $discount->multicurrency_code);
+							$splitremainmsg .= ' / '.price($remaindev, 0, $langs, 1, -1, -1, $discount->multicurrency_code);
+						}
+					} else {
+						$error++;
+						setEventMessages($langs->trans("Error"), null, 'errors');
+					}
+				}
 			}
 
 			if (!$error) {
-				$result = $discount->link_to_invoice(0, $id);
+				$result = $discounttolink->link_to_invoice(0, $id);
 				if ($result < 0) {
 					$error++;
-					setEventMessages($discount->error, $discount->errors, 'errors');
+					setEventMessages($discounttolink->error, $discounttolink->errors, 'errors');
 				}
 			}
 			if (!$error) {
-				$newremaintopay = $object->getRemainToPay(0);
+				$newremaintopay = $usemccompare ? $object->getRemainToPay(1) : $object->getRemainToPay(0);
 				if ($newremaintopay == 0) {
 					$object->setPaid($user);
+				}
+				if ($depositwassplit) {
+					setEventMessages($langs->trans('DepositSplitAutomaticallyApplied', $splitappliedmsg, $splitremainmsg), null, 'warnings');
 				}
 			}
 		}
@@ -4161,6 +4219,7 @@ if ($action == 'create') {
 				$depositamount = 0;
 
 				$sql = "SELECT re.rowid, re.amount_ht, re.amount_tva, re.amount_ttc,";
+				$sql .= " re.multicurrency_amount_ttc, re.multicurrency_code, re.multicurrency_tx,";
 				$sql .= " re.description, re.fk_invoice_supplier_source";
 				$sql .= " FROM ".MAIN_DB_PREFIX."societe_remise_except as re";
 				$sql .= " WHERE fk_invoice_supplier = ".((int) $object->id);
@@ -4188,7 +4247,16 @@ if ($action == 'create') {
 						print '</a>';
 						print '</td>';
 						// Amount
-						print '<td class="right">'.price($obj->amount_ttc).'</td>';
+						print '<td class="right">'.price($obj->amount_ttc);
+						// Amount in the invoice currency and rate as a sub-line, consistent with payments (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+						if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency') && !empty($obj->multicurrency_code)) {
+							print '<br><span class="opacitymedium small">'.price($obj->multicurrency_amount_ttc, 0, $langs, 1, -1, -1, $obj->multicurrency_code);
+							if (!empty($obj->multicurrency_tx) && $obj->multicurrency_tx > 0) {
+								print '<br>'.$langs->trans('Rate').' : '.price2num($obj->multicurrency_tx, 'MU');
+							}
+							print '</span>';
+						}
+						print '</td>';
 						print '</tr>';
 						$i++;
 						if ($invoice->type == FactureFournisseur::TYPE_CREDIT_NOTE) {

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -753,3 +753,7 @@ CreditNoteNotCreatedErrorOnDiscount=Credit note for <b>%s</b> not created: error
 CreditNoteNotCreatedAlreadyConverted=Credit note for <b>%s</b> not created: invoice already converted
 CreditNotesCreated=%s credit note(s) created
 ThisMassActionIsOnlyForInvoices=This mass action is only available for invoices
+
+# Deposit/credit split in the invoice currency (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+Part=Part
+DepositSplitAutomaticallyApplied=The available credit was larger than the remaining amount to pay and was split automatically: %s applied to this invoice, %s kept as an available credit for later use.


### PR DESCRIPTION
Second part of the real-amounts series (builds on the option introduced by #39665; independent code paths, reviewable on its own).

## What this solves

On an invoice in a foreign currency, the deposits and credit notes generated from it lose that currency: `DiscountAbsolute` stored no `multicurrency_code` / `multicurrency_tx`, so what was paid in USD is later consumed as a company-currency value converted at whatever rate applies. The real foreign value of the credit is lost on the way.

## What it adds

Gated by option `MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS` (off by default):

- `DiscountAbsolute` persists `multicurrency_code` / `multicurrency_tx`, and `generateFromAmount()` recomputes the foreign value at that rate;
- converting an invoice into a discount carries its currency and rate (customer and supplier cards);
- applying a credit larger than the remaining amount **splits it automatically in both currencies**; the split confirmation form of `comm/remx.php` shows the two columns (company currency / invoice currency) and keeps them synced at the discount rate;
- the available-discounts selectors and the discounts block of the cards show the foreign amount and the rate as a sub-line (new `Form::getMulticurrencyCreditsInfo()`).

## Relationship with the recent fixes by @lvessiller

This PR builds on the merged fixes #38971, #38972 and #38973, which persist the currency code/rate when a discount is created or an invoice is converted. It completes them one level up: it **declares** the `multicurrency_code` / `multicurrency_tx` properties on `DiscountAbsolute` that those fixes use dynamically (dynamic properties are deprecated since PHP 8.2), reads them back in `fetch()`, and carries them through `splitAmount()` so a split keeps the foreign identity of each part.

## Compatibility

Option unset ⇒ unchanged behaviour. The `societe_remise_except` table already carries the two columns; no schema change.

## Tested

Supplier deposit in USD paid at real amounts → converted to discount carrying USD + the real rate → applied on a final invoice: the foreign balance is consumed exactly, the company-currency residual is the exchange difference. Auto-split verified in both currencies.

Here are several screenshot:
<img width="2300" height="780" alt="pr39666_remises_devise" src="https://github.com/user-attachments/assets/00c0bf39-71f0-4236-879b-eb29b64e139b" />

Here are the AutoSplit ScreenShots :
<img width="2100" height="300" alt="pr39666_autosplit_avant" src="https://github.com/user-attachments/assets/38457e0f-59c0-4202-9059-ead5e296d892" />
<img width="1600" height="150" alt="pr39666_autosplit_message" src="https://github.com/user-attachments/assets/8c7bac65-4dd9-4c0e-8808-bc1dd7c40922" />
<img width="2100" height="800" alt="pr39666_autosplit_resultat" src="https://github.com/user-attachments/assets/5369b6ea-9fb8-4d3d-829e-b6010eea67c0" />
