### PR TITLE
NEW Show the exchange difference and allow re-aligning the invoice rate (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)

### DIFF
--- a/htdocs/core/tpl/object_currency_amount.tpl.php
+++ b/htdocs/core/tpl/object_currency_amount.tpl.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2024       Laurent Destailleur	    <eldy@users.sourceforge.net>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -109,6 +110,10 @@ if (isModEnabled('multicurrency')) {
 				print '</a>';
 				print '</div>';
 			}
+		}
+		// Extra content next to the rate (e.g. the multicurrency rate re-alignment buttons), set by the calling page
+		if (!empty($morehtmlmulticurrencyrate)) {
+			print $morehtmlmulticurrencyrate;
 		}
 		print '</td></tr>';
 	}

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -760,6 +760,56 @@ if (empty($reshook)) {
 		}
 		header('Location: '.dolBuildUrl($_SERVER["PHP_SELF"], ['id' => $id]));
 		exit();
+	} elseif ($action == 'confirm_realignmulticurrencyrate' && $confirm == 'yes' && $usercancreate) {
+		// Align the invoice multicurrency rate on the real effective rate so the exchange difference is absorbed (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		$object->fetch($id);
+		$object->fetch_thirdparty();
+		$object->fetch_lines();
+		if (!getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') || !isModEnabled('multicurrency') || empty($object->multicurrency_code) || $object->multicurrency_code == $conf->currency) {
+			setEventMessages($langs->trans('NotAvailable'), null, 'errors');
+		} elseif ($object->getVentilExportCompta() != 0) {
+			setEventMessages($langs->trans('ErrorCannotRealignRateInvoiceTransferredInAccountancy'), null, 'errors');
+		} else {
+			$realeurpaid = (float) $object->getSommePaiement(0) + (float) $object->getSumCreditNotesUsed(0) + (float) $object->getSumDepositsUsed(0);
+			$foreignpaid = (float) $object->getSommePaiement(1) + (float) $object->getSumCreditNotesUsed(1) + (float) $object->getSumDepositsUsed(1);
+			if ($realeurpaid != 0 && $foreignpaid != 0) {
+				$neweffectivetx = (float) round($foreignpaid / $realeurpaid, 8); // 8 = max precision of multicurrency_tx column, to minimize the residual exchange difference
+				$db->begin();
+				require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+				// Keep the rate before re-alignment to allow restoring it later
+				dolibarr_set_const($db, 'MULTICURRENCY_REALIGN_BACKUP_invoice_supplier_'.$object->id, (string) $object->multicurrency_tx, 'chaine', 0, '', $conf->entity);
+				$result = $object->setMulticurrencyRate($neweffectivetx, 1);
+				if ($result > 0) {
+					$db->commit();
+					setEventMessages($langs->trans('InvoiceRateRealigned', price2num($neweffectivetx, 'MU')), null, 'mesgs');
+				} else {
+					$db->rollback();
+					setEventMessages($object->error, $object->errors, 'errors');
+				}
+			} else {
+				setEventMessages($langs->trans('NotAvailable'), null, 'warnings');
+			}
+		}
+		$action = '';
+	} elseif ($action == 'confirm_revertmulticurrencyrate' && $confirm == 'yes' && $usercancreate) {
+		// Restore the invoice multicurrency rate to its value before the last re-alignment (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		$object->fetch($id);
+		$object->fetch_lines();
+		$backuptx = getDolGlobalString('MULTICURRENCY_REALIGN_BACKUP_invoice_supplier_'.$object->id);
+		if ($backuptx !== '' && $object->getVentilExportCompta() == 0) {
+			$db->begin();
+			$result = $object->setMulticurrencyRate((float) $backuptx, 1);
+			if ($result > 0) {
+				require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
+				dolibarr_del_const($db, 'MULTICURRENCY_REALIGN_BACKUP_invoice_supplier_'.$object->id, $conf->entity);
+				$db->commit();
+				setEventMessages($langs->trans('InvoiceRateReverted', price2num($backuptx, 'MU')), null, 'mesgs');
+			} else {
+				$db->rollback();
+				setEventMessages($object->error, $object->errors, 'errors');
+			}
+		}
+		$action = '';
 	} elseif ($action == 'confirm_converttoreduc' && $confirm == 'yes' && $usercancreate) {
 		// Convertir en reduc
 		$object->fetch($id);
@@ -3319,6 +3369,20 @@ if ($action == 'create') {
 
 		$formconfirm = '';
 
+		// Confirmation of the multicurrency rate re-alignment on the real effective rate (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if ($action == 'realignmulticurrencyrate') {
+			$realeurpaidtmp = (float) $object->getSommePaiement(0) + (float) $object->getSumCreditNotesUsed(0) + (float) $object->getSumDepositsUsed(0);
+			$foreignpaidtmp = (float) $object->getSommePaiement(1) + (float) $object->getSumCreditNotesUsed(1) + (float) $object->getSumDepositsUsed(1);
+			$neweffectivetxtmp = ($realeurpaidtmp != 0) ? round($foreignpaidtmp / $realeurpaidtmp, 8) : 0;
+			$formconfirm = $form->formconfirm($_SERVER['PHP_SELF'].'?facid='.$object->id, $langs->trans('RealignInvoiceRateOnRealRate'), $langs->trans('ConfirmRealignInvoiceRate', price2num($object->multicurrency_tx, 'MU'), $neweffectivetxtmp), 'confirm_realignmulticurrencyrate', '', 'yes', 1);
+		}
+
+		// Confirmation of the multicurrency rate restore to its previous value (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+		if ($action == 'revertmulticurrencyrate') {
+			$backuptxtmp = getDolGlobalString('MULTICURRENCY_REALIGN_BACKUP_invoice_supplier_'.$object->id);
+			$formconfirm = $form->formconfirm($_SERVER['PHP_SELF'].'?facid='.$object->id, $langs->trans('RevertInvoiceRateRealign'), $langs->trans('ConfirmRevertInvoiceRate', price2num($backuptxtmp, 'MU')), 'confirm_revertmulticurrencyrate', '', 'yes', 1);
+		}
+
 		// Confirmation de la conversion de l'avoir en reduc
 		if ($action == 'converttoreduc') {
 			$type_fac = '';
@@ -3925,6 +3989,28 @@ if ($action == 'create') {
 
 			print '<table class="border tableforfield centpercent">';
 
+			// Build the exchange gain/loss info and the rate re-alignment buttons shown next to the rate (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+			$morehtmlmulticurrencyrate = '';
+			if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+				&& !empty($object->multicurrency_code) && $object->multicurrency_code != $conf->currency) {
+				$realeurpaidtmp = (float) $object->getSommePaiement(0) + (float) $object->getSumCreditNotesUsed(0) + (float) $object->getSumDepositsUsed(0);
+				$foreignpaidtmp = (float) $object->getSommePaiement(1) + (float) $object->getSumCreditNotesUsed(1) + (float) $object->getSumDepositsUsed(1);
+				$exchangedifftmp = (!empty($object->multicurrency_tx)) ? price2num(($foreignpaidtmp / $object->multicurrency_tx) - $realeurpaidtmp, 'MT') : 0;
+				$canrealign = ($usercancreate && ($object->status == FactureFournisseur::STATUS_VALIDATED || !empty($object->paye)) && $object->getVentilExportCompta() == 0);
+				if ($foreignpaidtmp != 0 && (float) $exchangedifftmp != 0) {
+					// Exchange gain/loss amount, next to the rate
+					$morehtmlmulticurrencyrate .= '<div class="inline-block paddingleft opacitymedium">'.$langs->trans((float) $exchangedifftmp >= 0 ? 'ExchangeGain' : 'ExchangeLoss').' : '.price($exchangedifftmp, 0, $langs, 1, -1, -1, $conf->currency).'</div>';
+					// Short "Align" button with an info tooltip explaining what it does
+					if ($canrealign) {
+						$morehtmlmulticurrencyrate .= '<div class="inline-block paddingleft"><a class="button smallpaddingimp" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&action=realignmulticurrencyrate&token='.newToken().'">'.dol_escape_htmltag($langs->trans('RealignInvoiceRateShort')).'</a> '.$form->textwithpicto('', $langs->trans('RealignInvoiceRateOnRealRate')).'</div>';
+					}
+				}
+				$backuptxtmp = getDolGlobalString('MULTICURRENCY_REALIGN_BACKUP_invoice_supplier_'.$object->id);
+				if ($canrealign && $backuptxtmp !== '') {
+					$morehtmlmulticurrencyrate .= '<div class="inline-block paddingleft"><a class="button smallpaddingimp" href="'.$_SERVER["PHP_SELF"].'?facid='.$object->id.'&action=revertmulticurrencyrate&token='.newToken().'">'.dol_escape_htmltag($langs->trans('RevertInvoiceRateShort')).'</a> '.$form->textwithpicto('', $langs->trans('RevertInvoiceRateRealign')).'</div>';
+				}
+			}
+
 			include DOL_DOCUMENT_ROOT.'/core/tpl/object_currency_amount.tpl.php';
 
 			print '<tr>';
@@ -4296,6 +4382,21 @@ if ($action == 'create') {
 					//print '<td></td>';
 					print '<td class="right'.($resteapayeraffiche ? ' amountremaintopaynoresize' : (' '.$cssforamountpaymentcomplete)).'">'.price(price2num($multicurrency_resteapayer, 'MT'), 0, $langs, 1, -1, -1, $object->multicurrency_code).'</td>';
 					print '</tr>';
+				}
+				// Exchange gain/loss line, right after "Remainder to pay, original currency" - red on loss, orange on gain, nothing if zero (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+				if (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+						&& !empty($object->multicurrency_code) && $object->multicurrency_code != $conf->currency) {
+						$realeurpaidexch = (float) $object->getSommePaiement(0) + (float) $object->getSumCreditNotesUsed(0) + (float) $object->getSumDepositsUsed(0);
+						$foreignpaidexch = (float) $object->getSommePaiement(1) + (float) $object->getSumCreditNotesUsed(1) + (float) $object->getSumDepositsUsed(1);
+						$exchangediffline = (!empty($object->multicurrency_tx)) ? price2num(($foreignpaidexch / $object->multicurrency_tx) - $realeurpaidexch, 'MT') : 0;
+					if ($foreignpaidexch != 0 && (float) $exchangediffline != 0) {
+							$exchangecolor = ((float) $exchangediffline >= 0) ? '#e67e22' : '#c0392b'; // orange = exchange gain, red = exchange loss
+							print '<tr><td colspan="'.($nbcols + 1).'" class="right">';
+							print '<span style="color: '.$exchangecolor.';">'.$langs->trans((float) $exchangediffline >= 0 ? 'ExchangeGain' : 'ExchangeLoss').'</span>';
+							print '</td>';
+							print '<td class="right nowrap" style="color: '.$exchangecolor.';">'.price($exchangediffline, 0, $langs, 1, -1, -1, $conf->currency).'</td>';
+							print '</tr>';
+					}
 				}
 			} else { // Credit note
 				$cssforamountpaymentcomplete = 'amountpaymentneutral';

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -753,3 +753,16 @@ CreditNoteNotCreatedErrorOnDiscount=Credit note for <b>%s</b> not created: error
 CreditNoteNotCreatedAlreadyConverted=Credit note for <b>%s</b> not created: invoice already converted
 CreditNotesCreated=%s credit note(s) created
 ThisMassActionIsOnlyForInvoices=This mass action is only available for invoices
+
+# Multicurrency exchange difference on consumption (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+ExchangeGain=Exchange gain
+ExchangeLoss=Exchange loss
+RealignInvoiceRateOnRealRate=Align the invoice exchange rate on the real rate
+RealignInvoiceRateShort=Align
+ConfirmRealignInvoiceRate=The invoice exchange rate will be changed from %s to %s and the invoice amounts recomputed accordingly, so the exchange difference is absorbed. Recorded payments and bank entries are kept unchanged. Do you confirm?
+InvoiceRateRealigned=Invoice exchange rate aligned on the real rate (%s)
+ErrorCannotRealignRateInvoiceTransferredInAccountancy=Cannot align the exchange rate: this invoice is already recorded in accountancy.
+RevertInvoiceRateRealign=Restore the previous exchange rate
+RevertInvoiceRateShort=Restore
+ConfirmRevertInvoiceRate=The invoice exchange rate will be restored to its previous value (%s) and the invoice amounts recomputed accordingly. Do you confirm?
+InvoiceRateReverted=Invoice exchange rate restored to its previous value (%s)


### PR DESCRIPTION
Third part of the real-amounts series (builds on #39665 and #39666; independent code paths, reviewable on its own).

## What this solves

An invoice in a foreign currency settled at the real amounts (#39665) keeps a residual in the company currency: the difference between the invoice-rate conversion and what was really paid — the realised exchange gain or loss. Today Dolibarr neither shows it nor offers anything to deal with it.

## What it adds

Gated by option `MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS` (off by default), on the supplier invoice card:

- next to the exchange rate, the **realised exchange difference** (foreign amount settled ÷ invoice rate − real company amount paid);
- an exchange gain/loss line in the totals block, right after "Remainder to pay, original currency" (red on loss, orange on gain, hidden when zero);
- an opt-in **Align** button that re-rates the invoice `multicurrency_tx` to the realised effective rate via `setMulticurrencyRate()`, so the difference is absorbed — guarded by a confirm dialog and write permission, refused once the invoice is recorded in accountancy; recorded payments and bank entries are left unchanged. A **Restore** button reverts to the rate before the alignment.
- **No mutation by default**: standard accounting settles the foreign debt at face value and books the delta as an FX result. The accounting booking of the difference is deliberately out of scope here.

A generic `$morehtmlmulticurrencyrate` slot is added to `core/tpl/object_currency_amount.tpl.php` to host content next to the rate (empty for other callers, no change for them).

NOTE for reviewers: the pre-alignment rate is currently backed up in a per-invoice constant (provisional — an extrafield or a column can replace it if preferred).

## Accounting follow-up — input welcome from @eldy and @aspangaro

This PR deliberately stops at **measuring and displaying** the realised exchange difference (plus the opt-in Align convenience). The proper accounting treatment is a planned follow-up we would like to design with the accountancy maintainers rather than improvise here:

- booking the realised difference as a financial expense/income (accounts **666/766** in the French chart, or the equivalent per chart) instead of absorbing it into the rate;
- the **timing** question: book at payment time, or at period closing / revaluation;
- the lettering of the company-currency residual on the supplier account.

Our position so far: the invoice keeps its face value in the foreign currency, the payments record the real amounts (#39665), and the company-currency residual is an FX **result** that belongs to the accountancy module — not to the invoice. The Align button is only an opt-in for users who prefer to absorb the difference *before* the transfer to accountancy (it is refused after). Scope and design of the booking part are open — happy to adjust or split as you prefer.

## Tested

USD/TWD supplier invoices paid at real amounts: difference displayed next to the rate and in the totals, Align absorbs it (foreign balance unchanged, payments untouched), Restore brings the previous rate back, both refused after transfer to accountancy.

Here is a screenshot:
<img width="1140" height="860" alt="pr39667_exchange_loss_align" src="https://github.com/user-attachments/assets/eb106a5f-a366-4eb6-8d00-13c27f714d2c" />

<img width="1006" height="605" alt="39667-2" src="https://github.com/user-attachments/assets/29e2d3a9-7a88-4e44-b1a5-53a68caf49b0" />

<img width="984" height="647" alt="39667-1" src="https://github.com/user-attachments/assets/e58bef11-96cb-4350-bd02-c827479f4b79" />


