### PR TITLE
fix #38919 keep line breaks in text that is HTML only due to entities

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -7576,6 +7576,14 @@ function dol_htmlentitiesbr($stringtoencode, $nl2brmode = 0, $pagecodefrom = 'UT
 		if ($removelasteolbr) {
 			$newstring = preg_replace('/<br>$/i', '', $newstring); // Remove last <br> (remove only last one)
 		}
+		// If the text is seen as HTML only because it contains entities (like &gt; or &amp;) but has no real tag,
+		// its newlines would otherwise be kept as-is and lost on render, so convert them to <br> (#38919).
+		if (!preg_match('/<\/?[a-zA-Z][a-zA-Z0-9]*(\s[^>]*)?>/', $newstring) && preg_match('/(\r\n|\r|\n)/', $newstring)) {
+			if ($removelasteolbr) {
+				$newstring = preg_replace('/(\r\n|\r|\n)$/', '', $newstring);
+			}
+			$newstring = dol_nl2br($newstring, $nl2brmode);
+		}
 		$newstring = strtr($newstring, array('&'=>'__and__', '<'=>'__lt__', '>'=>'__gt__', '"'=>'__dquot__'));
 		$newstring = dol_htmlentities($newstring, ENT_COMPAT, $pagecodefrom); // Make entity encoding
 		$newstring = strtr($newstring, array('__and__'=>'&', '__lt__'=>'<', '__gt__'=>'>', '__dquot__'=>'"'));


### PR DESCRIPTION
When a description contains an entity such as &gt; or &amp; but no real tag, dol_htmlentitiesbr() still takes its HTML branch (dol_textishtml() returns true on entities). That branch does not run nl2br, so the literal newlines were left as-is and collapsed onto a single line when a PDF or document was generated.

This adds, in the HTML branch, a conversion of newlines to <br> only when the string contains no real tag. Text with any actual tag (b, div, p, br, ...) is left untouched, and plain text keeps going through the existing else branch. Verified that 'from EUR2.00 &gt; EUR2.50' + newline and 'Tom &amp; Jerry' + newline now keep their break, while '<div>a</div>', '<p>a</p>', '<b>bold</b>' and 'line1<br>line2' are unchanged.

This is the document/PDF render path. The related save-time stripping of a bare pseudo-tag is a separate fix in PR #38920.