### PR TITLE
QUAL Discount selector: show the source invoice of deposits and credit notes, supplier side included (option MAIN_SHOW_FACNUMBER_IN_DISCOUNT_LIST)

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2571,7 +2571,7 @@ class Form
 		dol_syslog(get_class($this) . "::select_remises", LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {
-			print '<select id="select_' . $htmlname . '" class="flat maxwidth200onsmartphone" name="' . $htmlname . '">';
+			print '<select id="select_' . $htmlname . '" class="flat maxwidth300 maxwidth200onsmartphone" name="' . $htmlname . '">';
 			$num = $this->db->num_rows($resql);
 
 			$qualifiedlines = $num;

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -2536,17 +2536,37 @@ class Form
 		// phpcs:enable
 		global $langs, $conf;
 
+		$showsourceinvoice = getDolGlobalString('MAIN_SHOW_FACNUMBER_IN_DISCOUNT_LIST');
+
 		// Search for the discounts
 		$sql = "SELECT re.rowid, re.amount_ht, re.amount_tva, re.amount_ttc,";
-		$sql .= " re.description, re.fk_facture_source";
+		$sql .= " re.description, re.fk_facture_source, re.fk_invoice_supplier_source";
+		if ($showsourceinvoice) {
+			// Resolve the source invoice (customer or supplier) in the main query instead of one fetch per line
+			$sql .= ", f.ref as src_cust_ref, f.datef as src_cust_date";
+			$sql .= ", ff.ref as src_supp_ref, ff.datef as src_supp_date";
+		}
 		$sql .= " FROM " . $this->db->prefix() . "societe_remise_except as re";
+		if ($showsourceinvoice) {
+			$sql .= " LEFT JOIN " . $this->db->prefix() . "facture as f ON f.rowid = re.fk_facture_source";
+			$sql .= " LEFT JOIN " . $this->db->prefix() . "facture_fourn as ff ON ff.rowid = re.fk_invoice_supplier_source";
+		}
 		$sql .= " WHERE re.fk_soc = " . (int) $socid;
 		$sql .= " AND re.entity = " . ((int) $conf->entity);
 		if ($filter) {
 			$sanitizedfilter = $filter;  // @phan-suppress-current-line SqlInjection
+			if ($showsourceinvoice) {
+				// The joined tables also carry a fk_facture_source column: qualify unprefixed references of the caller filter
+				$sanitizedfilter = preg_replace('/(?<![a-zA-Z0-9_.])fk_facture_source\b/', 're.fk_facture_source', $sanitizedfilter);
+			}
 			$sql .= " AND " . $sanitizedfilter;
 		}
-		$sql .= " ORDER BY re.description ASC";
+		if ($showsourceinvoice) {
+			// When the source invoices are shown, their date is the natural order (oldest deposit first)
+			$sql .= " ORDER BY COALESCE(ff.datef, f.datef, re.datec) ASC, re.rowid ASC";
+		} else {
+			$sql .= " ORDER BY re.description ASC";
+		}
 
 		dol_syslog(get_class($this) . "::select_remises", LOG_DEBUG);
 		$resql = $this->db->query($sql);
@@ -2586,10 +2606,14 @@ class Form
 						$disabled = ' disabled';
 					}
 
-					if (getDolGlobalString('MAIN_SHOW_FACNUMBER_IN_DISCOUNT_LIST') && !empty($obj->fk_facture_source)) {
-						$tmpfac = new Facture($this->db);
-						if ($tmpfac->fetch($obj->fk_facture_source) > 0) {
-							$desc = $desc . ' - ' . $tmpfac->ref;
+					if ($showsourceinvoice) {
+						$srcref = !empty($obj->src_supp_ref) ? $obj->src_supp_ref : (!empty($obj->src_cust_ref) ? $obj->src_cust_ref : '');
+						$srcdate = !empty($obj->src_supp_date) ? $obj->src_supp_date : (!empty($obj->src_cust_date) ? $obj->src_cust_date : '');
+						if ($srcref) {
+							$desc = $desc . ' - ' . $srcref;
+							if ($srcdate) {
+								$desc .= ' (' . dol_print_date($this->db->jdate($srcdate), 'day') . ')';
+							}
 						}
 					}
 


### PR DESCRIPTION
## What this improves

The option `MAIN_SHOW_FACNUMBER_IN_DISCOUNT_LIST` appends the source invoice ref to each entry of the available-discounts selector — useful as soon as a thirdparty holds several deposits. But the current implementation has three gaps:

1. **customer sources only**: `fk_invoice_supplier_source` is ignored, so supplier deposits/credit notes never show their source;
2. **one `Facture` fetch per option** (N+1 queries): ten available credits mean ten extra SQL round-trips just to print refs;
3. **ref only, no order**: no date is shown and the list stays sorted by description, which is meaningless when consuming deposits chronologically.

## What it does

When the option is on:
- the source invoice (customer **or** supplier) is resolved with two LEFT JOINs in the main query — the per-line fetch is removed;
- the entry shows `… - SOURCE_REF (date)`;
- the list is sorted by the source invoice date (oldest first), the natural order to consume deposits; entries without a source fall back to their creation date.

When the option is off: strictly unchanged (same query, same order, same labels).

## A latent bug fixed on the way

Once `llx_facture` / `llx_facture_fourn` are joined, an unprefixed `fk_facture_source` in the optional `$filter` of `select_remises()` becomes **ambiguous** (all three tables carry that column) and raises a SQL error — the invoice card passes exactly such a filter. The patch qualifies unprefixed references (`re.fk_facture_source`) when the joins are present.

## Compatibility

- Option unset ⇒ no join, no sort change, no label change.
- No schema change; `fk_invoice_supplier_source` already exists.
- Same rendering convention as today (`desc - ref`), completed with the date.

Screenshots:
<img width="2880" height="1800" alt="_selE_before" src="https://github.com/user-attachments/assets/1c4ed6ae-09d1-4b03-8a53-37b2e2b79025" />
<img width="2880" height="1800" alt="_selE_after" src="https://github.com/user-attachments/assets/8c0cc2fd-e2d8-4c35-8aac-f912cf987679" />


