### PR TITLE
[Sponge] Removal of non-essential information from the delivery addre…

### DIFF
--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -2501,9 +2501,6 @@ class pdf_sponge extends ModelePDFFactures
 
 			$carac_client_name = is_object($thirdparty) ? pdfBuildThirdpartyName($thirdparty, $outputlangs) : '';
 
-			$mode = 'target';
-			$carac_client = pdf_build_address($outputlangs, $this->emetteur, $object->thirdparty, ($usecontact ? $object->contact : ''), ($usecontact ? 1 : 0), $mode, $object);
-
 			// Show recipient
 			$widthrecbox = getDolGlobalString('MAIN_PDF_USE_ISO_LOCATION') ? 92 : 100;
 			if ($this->page_largeur < 210) {
@@ -2536,8 +2533,6 @@ class pdf_sponge extends ModelePDFFactures
 			// Show recipient information
 			$pdf->SetFont('', '', $default_font_size - 1);
 			$pdf->SetXY($posx + 2, $posy);
-			// @phan-suppress-next-line PhanPluginSuspiciousParamOrder
-			$pdf->MultiCell($widthrecbox - 2, 4, $carac_client, 0, $ltrdirection);
 
 			// Show shipping/delivery address
 			if (getDolGlobalInt('INVOICE_SHOW_SHIPPING_ADDRESS')) {


### PR DESCRIPTION
Here is the link to the issue : https://github.com/Dolibarr/dolibarr/issues/39289

Delivery address includes VAT number and SIRET which are not needed on delivery address.

<img width="729" height="326" alt="626652249-5b8303c8-1d29-4481-8f8b-a9479a26be2a" src="https://github.com/user-attachments/assets/a3bc927f-5938-419d-ae5e-876101aa5b22" />


