### PR TITLE
FIX Virtual stock: apply SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK to the reception side

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -19,6 +19,7 @@
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Lenin Rivas				<lenin.rivas777@gmail.com>
  * Copyright (C) 2026		Anthony Berton			<anthony.berton@bb2a.fr>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -6571,7 +6571,7 @@ class Product extends CommonObject
 		}
 		// Include reception lines
 		if (isModEnabled("supplier_order") || isModEnabled("supplier_invoice")) {
-			$filterStatus = '4';
+			$filterStatus = getDolGlobalString('SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK', '4');
 			if (isset($includedraftpoforvirtual)) {
 				$filterStatus = '0,'.$filterStatus;
 			}


### PR DESCRIPTION
`load_virtual_stock()` adds `(supplier orders − receptions already made)` to the theoretical stock.

The supplier-order side honours the option `SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK`, but the reception side is filtered on the hardcoded supplier order status `'4'`. Both halves of the same subtraction must run on the same population of supplier orders — otherwise orders are dropped from the first half while their receptions are still subtracted in the second one, and **the virtual stock ends up lower than the real stock**.

### How to reproduce (no custom code involved)

With `SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK = 3` — a legitimate setting meaning "only count orders that are sent, not those already partially received" — and stock incremented on reception:

1. Create a supplier order for 10 units → status 3 (ordered). Virtual stock = real + 10. ✔
2. Receive 4 units → the order moves to status 4 (partially received), real stock becomes 4.
3. Order side: status 4 is no longer in the list → contributes 0. Reception side: still hardcoded to `'4'` → subtracts 4.

**Virtual stock = 0, while the real stock is 4.** Expected: 4.

The default value (`3,4`) hides the problem, which is why it goes unnoticed: both halves then cover the same set of orders. Any other value breaks the symmetry.

This option is typically tuned on instances where the theoretical stock feeds an online shop — often alongside a `loadvirtualstock` hook narrowing the calculation to a subset of warehouses — and must not promise goods that are still months away.

### Evidence from a real instance

On a production database with long supplier lead times, the option is set so that pending supplier orders are excluded from the virtual stock. Replaying both filters against that data gives `0` on the order side, but **12 units on the reception side**, spread over 4 products that are already physically in stock and fully received. Those products would be shown with a theoretical stock below their real stock — unavailable on the webshop although they are on the shelf.

That instance has in fact been running **this exact change** as a local core patch for that very reason, which is also why the problem is not visible there today. This PR is that patch, contributed back.

### About the earlier review comment

It was noted in 2024 that receptions are read from a different table with different statuses. Looking at the code, `load_stats_reception()` does read the *quantities* from `llx_receptiondet_batch` (`llx_commande_fournisseur_dispatch` in v14), but its status filter is applied to **`cf.fk_statut`** — the status of the supplier order in `llx_commande_fournisseur`, which is exactly what this option defines. The reception rows only provide the quantities. This was already the case on the `14.0` branch of the original PR.

### A side effect worth having: "count no supplier order" becomes expressible

Once both halves honour the option, a value that matches no status becomes a meaningful setting rather than a trick: no supplier order is counted, **and no reception is subtracted either**, so the theoretical stock only moves with actual stock movements and the other flows. That is a legitimate choice for businesses whose supplier lead times are so long, or so unreliable, that a pending order is not a promise they want to publish.

`-1` is the natural value for it, since an order status will never be negative. Today the same intent can only be expressed by picking a number that happens to be unused — `8`, which sits in the gap between `STATUS_CANCELED_AFTER_ORDER = 7` and `STATUS_REFUSED = 9` — and that silently stops working the day this number becomes a real status. It also only half works, which is exactly the bug this PR fixes: the orders disappear while their receptions keep being subtracted.

The option currently has **no interface at all**. A follow-up PR will expose it on the stock setup page with an explicit "none" choice, so this no longer depends on folklore.

### Default behaviour is unchanged

When the option is not set, `'4'` is still used.

**Question for the maintainers:** should the fallback be `'4'` (kept here, strictly no change) or `'3,4'` to mirror the supplier-order side exactly? In practice both are equivalent, since an order in status 3 has no reception rows yet.

### Out of scope, on purpose

Whether `load_stats_reception()` should also take the stock-increment setting (`STOCK_CALCULATE_ON_RECEPTION` / `_CLOSE`) into account is a separate and deeper question, tracked in #27130. This PR only makes the two halves of the existing calculation consistent.

Supersedes #30481, which targeted the now end-of-life `14.0` branch.
