### PR TITLE
NEW Make the manufacturing order statuses used for virtual stock configurable

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -19,6 +19,7 @@
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Lenin Rivas				<lenin.rivas777@gmail.com>
  * Copyright (C) 2026		Anthony Berton			<anthony.berton@bb2a.fr>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -6583,7 +6583,8 @@ class Product extends CommonObject
 		}
 		// Include manufacturing
 		if (isModEnabled('mrp')) {
-			$result = $this->load_stats_inproduction(0, '1,2', 1, $dateofvirtualstock);
+			$filterStatus = getDolGlobalString('MO_STATUS_FOR_VIRTUAL_STOCK', '1,2');
+			$result = $this->load_stats_inproduction(0, $filterStatus, 1, $dateofvirtualstock);
 			if ($result < 0) {
 				dol_print_error($this->db, $this->error);
 			}
@@ -6642,7 +6643,7 @@ class Product extends CommonObject
 		if (!empty($this->stock_warehouse) && getDolGlobalString('STOCK_ALLOW_VIRTUAL_STOCK_PER_WAREHOUSE')) {
 			foreach ($this->stock_warehouse as $warehouseid => $stockwarehouse) {
 				if (isModEnabled('mrp')) {
-					$result = $this->load_stats_inproduction(0, '1,2', 1, $dateofvirtualstock, $warehouseid);
+					$result = $this->load_stats_inproduction(0, getDolGlobalString('MO_STATUS_FOR_VIRTUAL_STOCK', '1,2'), 1, $dateofvirtualstock, $warehouseid);
 					if ($result < 0) {
 						dol_print_error($this->db, $this->error);
 					}


### PR DESCRIPTION
The virtual stock calculation already lets the statuses of **supplier orders** be chosen, through `SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK`:

```php
$filterStatus = getDolGlobalString('SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK', '3,4');
$result = $this->load_stats_commande_fournisseur(0, $filterStatus, 1, $dateofvirtualstock);
```

The **manufacturing** side has no equivalent — the statuses are written in the code, twice:

```php
$result = $this->load_stats_inproduction(0, '1,2', 1, $dateofvirtualstock);
```

So every manufacturing order that has been validated projects its plan onto the theoretical stock: its components are deducted and its output is announced. There is currently no way to say that only the orders **actually started** (`STATUS_INPROGRESS`) should count, or that manufacturing should not be projected at all.

That matters because `STATUS_VALIDATED` means *validated, not started yet*. On a shop that validates its manufacturing orders well in advance, the theoretical stock announces goods whose production has not begun — the manufacturing counterpart of the problem that `SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK` exists to solve for purchases.

### What this PR does

`MO_STATUS_FOR_VIRTUAL_STOCK` now holds that list, with the current values as its default. Both call sites are covered, including the per-warehouse virtual stock.

The name follows the two conventions already in place: `..._STATUS_FOR_VIRTUAL_STOCK` like its supplier counterpart, and the `MO_` prefix already used by `MO_ALSO_CANCEL_CONSUMED_AND_PRODUCED_LINES_BY_DEFAULT`.

### Default behaviour is unchanged

`getDolGlobalString('MO_STATUS_FOR_VIRTUAL_STOCK', '1,2')` returns the current hardcoded list when the option is not set, so an instance that does not configure anything behaves exactly as before.

### On the missing setup screen

Neither this option nor `SUPPLIER_ORDER_STATUS_FOR_VIRTUAL_STOCK` appears on any setup page today. Rather than adding a lone field here, a separate PR will expose **both** on the stock setup page, so the two sides of the calculation are configured in the same place and in the same way.
