### PR TITLE
NEW Asset shortcut on a supplier invoice line follows the account it is bound to

### DIFF
--- a/htdocs/core/tpl/objectline_view.tpl.php
+++ b/htdocs/core/tpl/objectline_view.tpl.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2024-2026  Alexandre Spangaro  <alexandre@inovea-conseil.com>
  * Copyright (C) 2024-2025  Frédéric France		<frederic.france@free.fr>
  * Copyright (C) 2025       Lenin Rivas			<lenin.rivas777@gmail.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -639,29 +640,42 @@ if ($this->status == 0 && $tmppermtoedit && $action != 'selectlines') {
 	if (isModEnabled('asset') && $object->element == 'invoice_supplier') {
 		print '<td class="linecolasset center">';
 		$coldisplay++;
+		// The line qualifies either by the accounting codes carried by its product, or by the
+		// account it has actually been bound to: a line can be bound to an asset account while
+		// its product is not set up for it, or while it has no product at all.
+		$boundaccount = empty($line->fk_code_ventilation) ? 0 : (int) $line->fk_code_ventilation;
 		if (
-			$product_static !== null
-			&&
+			$boundaccount > 0
+			||
 			(
-				!empty($product_static->accountancy_code_buy) ||
-				!empty($product_static->accountancy_code_buy_intra) ||
-				!empty($product_static->accountancy_code_buy_export)
+				$product_static !== null
+				&&
+				(
+					!empty($product_static->accountancy_code_buy) ||
+					!empty($product_static->accountancy_code_buy_intra) ||
+					!empty($product_static->accountancy_code_buy_export)
+				)
 			)
 		) {
 			$accountancy_category_asset = getDolGlobalString('ASSET_ACCOUNTANCY_CATEGORY');
 			$sanitized_filters = array();
-			if (!empty($product_static->accountancy_code_buy)) {
-				$sanitized_filters[] = "account_number = '" . $this->db->escape($product_static->accountancy_code_buy) . "'";
+			if ($product_static !== null) {
+				if (!empty($product_static->accountancy_code_buy)) {
+					$sanitized_filters[] = "account_number = '" . $this->db->escape($product_static->accountancy_code_buy) . "'";
+				}
+				if (!empty($product_static->accountancy_code_buy_intra)) {
+					$sanitized_filters[] = "account_number = '" . $this->db->escape($product_static->accountancy_code_buy_intra) . "'";
+				}
+				if (!empty($product_static->accountancy_code_buy_export)) {
+					$sanitized_filters[] = "account_number = '" . $this->db->escape($product_static->accountancy_code_buy_export) . "'";
+				}
 			}
-			if (!empty($product_static->accountancy_code_buy_intra)) {
-				$sanitized_filters[] = "account_number = '" . $this->db->escape($product_static->accountancy_code_buy_intra) . "'";
-			}
-			if (!empty($product_static->accountancy_code_buy_export)) {
-				$sanitized_filters[] = "account_number = '" . $this->db->escape($product_static->accountancy_code_buy_export) . "'";
+			if ($boundaccount > 0) {
+				$sanitized_filters[] = "rowid = " . ((int) $boundaccount);
 			}
 			$sql = "SELECT COUNT(*) AS found";
 			$sql .= " FROM " . MAIN_DB_PREFIX . "accounting_account";
-			$sql .= " WHERE pcg_type = '" . $this->db->escape($conf->global->ASSET_ACCOUNTANCY_CATEGORY) . "'";
+			$sql .= " WHERE pcg_type = '" . $this->db->escape($accountancy_category_asset) . "'";
 			$sql .= " AND (" . implode(' OR ', $sanitized_filters). ")";
 			$resql_asset = $this->db->query($sql);
 			if (!$resql_asset) {


### PR DESCRIPTION
On a supplier invoice, the asset column offers a shortcut to create an asset from a line. Whether that shortcut appears is decided from the **product**:

```php
if (
    $product_static !== null
    &&
    (
        !empty($product_static->accountancy_code_buy) ||
        !empty($product_static->accountancy_code_buy_intra) ||
        !empty($product_static->accountancy_code_buy_export)
    )
) {
```

and the account is then looked up among those product codes, filtered on `ASSET_ACCOUNTANCY_CATEGORY`.

### What this misses

The line has already been bound to an account — `fk_code_ventilation` — and that account is the one the entry will actually use. It is not consulted here.

So the shortcut is missing exactly where the accounting says it should appear:

- a line **bound to an asset account** whose product is not set up with that code, because the purchase was one-off, or because the code was fixed at binding time rather than on the product;
- a line **with no product at all** — a free-text line, which is common for equipment invoiced without a catalogue reference. `$product_static` is null, so the block is skipped whatever the line was bound to.

Conversely the shortcut can appear on a line whose product carries an asset code but which was bound elsewhere. The product tells what was expected; the binding tells what was decided.

### What this PR changes

The line qualifies **either** by its product codes, as before, **or** by the account it is bound to. The bound account joins the same `ASSET_ACCOUNTANCY_CATEGORY` lookup, so the category still decides — only the way a candidate account is found is widened.

```php
$boundaccount = empty($line->fk_code_ventilation) ? 0 : (int) $line->fk_code_ventilation;
...
if ($boundaccount > 0) {
    $sanitized_filters[] = "rowid = " . $boundaccount;
}
```

`$product_static` may now be null when the block runs, so reading the product codes is guarded.

### One line of tidy-up in passing

The SQL used `$conf->global->ASSET_ACCOUNTANCY_CATEGORY` while `$accountancy_category_asset` was computed from `getDolGlobalString()` on the line above and left unused. The variable is now used. Same value, and no notice when the constant is not set.

### Default behaviour is unchanged

A line with no bound account behaves exactly as before: `$boundaccount` is 0, no condition is added, the product codes alone decide. Nothing changes for installations that do not bind their supplier invoice lines, and no line loses the shortcut it had.

### No automated test

The block lives in a template rendered inside a supplier invoice card, which the test suite has no fixture for. This PR adds no test.
