### PR TITLE
NEW Auto-split an over-sized deposit/credit applied to a customer invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -23,6 +23,7 @@
  * Copyright (C) 2026		Vincent de Grandpré			<vincent@de-grandpre.quebec>
  * Copyright (C) 2026		Joachim Küter				<git-jk@bloxera.com>
  * Copyright (C) 2026		Lionel Vessiller			<lvessiller@open-dsi.fr>
+ * Copyright (C) 2026		José MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -709,18 +710,73 @@ if (empty($reshook)) {
 
 			//var_dump($object->getRemainToPay(0));
 			//var_dump($discount->amount_ttc);exit;
-			$remaintopay = $object->getRemainToPay(0);
-			if (price2num($discount->total_ttc) > price2num($remaintopay)) {
-				// TODO Split the discount in 2 automatically
-				$error++;
-				setEventMessages($langs->trans("ErrorDiscountLargerThanRemainToPaySplitItBefore"), null, 'errors');
+			// Under MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS, when the credit is in the invoice currency, compare and settle
+			// in that currency (the company-currency amounts may use different exchange rates and would compare wrongly).
+			$usemccompare = (getDolGlobalInt('MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS') && isModEnabled('multicurrency')
+				&& !empty($discount->multicurrency_code) && !empty($object->multicurrency_code)
+				&& $discount->multicurrency_code == $object->multicurrency_code && $object->multicurrency_code != $conf->currency);
+			$remaintopay = $usemccompare ? $object->getRemainToPay(1) : $object->getRemainToPay(0);
+			$discountamountforcompare = $usemccompare ? $discount->multicurrency_amount_ttc : $discount->amount_ttc;
+			$discounttolink = $discount;
+			$depositwassplit = false;
+			$splitappliedmsg = '';
+			$splitremainmsg = '';
+			if (price2num($discountamountforcompare, 'MT') > price2num($remaintopay, 'MT')) {
+				if ((float) $remaintopay <= 0) {
+					$error++;
+					setEventMessages($langs->trans("ErrorDiscountLargerThanRemainToPaySplitItBefore"), null, 'errors');
+				} else {
+					// Credit larger than the remaining: split it automatically, apply up to the remaining amount (max, in the invoice currency) and keep the rest available
+					$depositeur = (float) $discount->amount_ttc;
+					$depositdev = (float) $discount->multicurrency_amount_ttc;
+					if ($usemccompare && $depositdev != 0) {
+						$applydev = (float) $remaintopay;
+						$applyeur = (float) price2num($applydev / $depositdev * $depositeur, 'MT');
+					} else {
+						$applyeur = (float) $remaintopay;
+						$applydev = ($depositeur != 0 ? (float) price2num($applyeur / $depositeur * $depositdev, 'MT') : 0);
+					}
+					$splitparts = $discount->splitAmount($applyeur, (float) price2num($depositeur - $applyeur, 'MT'));
+					$applypart = $splitparts[0];
+					$remainpart = $splitparts[1];
+					$remaindev = 0.0;
+					if (!empty($discount->multicurrency_code) && $depositdev != 0) {
+						$remaindev = (float) price2num($depositdev - $applydev, 'MT');
+						$applypart->multicurrency_amount_ttc = $applydev;
+						$applypart->multicurrency_amount_ht = price2num($applydev / (1 + (float) $applypart->tva_tx / 100), 'MT');
+						$applypart->multicurrency_amount_tva = price2num($applydev - (float) $applypart->multicurrency_amount_ht);
+						$remainpart->multicurrency_amount_ttc = $remaindev;
+						$remainpart->multicurrency_amount_ht = price2num($remaindev / (1 + (float) $remainpart->tva_tx / 100), 'MT');
+						$remainpart->multicurrency_amount_tva = price2num($remaindev - (float) $remainpart->multicurrency_amount_ht);
+					}
+					$discount->fk_facture_source = 0;
+					$discount->fk_invoice_supplier_source = 0;
+					$resdelete = $discount->delete($user);
+					$newidapply = $applypart->create($user);
+					$newidremain = $remainpart->create($user);
+					if ($resdelete > 0 && $newidapply > 0 && $newidremain > 0) {
+						$discounttolink = new DiscountAbsolute($db);
+						$discounttolink->fetch($newidapply);
+						// Build a positive feedback message about the automatic split (amount applied / amount kept available)
+						$depositwassplit = true;
+						$splitappliedmsg = price($applyeur, 0, $langs, 1, -1, -1, $conf->currency);
+						$splitremainmsg = price((float) price2num($depositeur - $applyeur, 'MT'), 0, $langs, 1, -1, -1, $conf->currency);
+						if (!empty($discount->multicurrency_code) && $depositdev != 0) {
+							$splitappliedmsg .= ' / '.price($applydev, 0, $langs, 1, -1, -1, $discount->multicurrency_code);
+							$splitremainmsg .= ' / '.price($remaindev, 0, $langs, 1, -1, -1, $discount->multicurrency_code);
+						}
+					} else {
+						$error++;
+						setEventMessages($langs->trans("Error"), null, 'errors');
+					}
+				}
 			}
 
 			if (!$error) {
-				$result = $discount->link_to_invoice(0, $id);
+				$result = $discounttolink->link_to_invoice(0, $id);
 				if ($result < 0) {
 					$error++;
-					setEventMessages($discount->error, $discount->errors, 'errors');
+					setEventMessages($discounttolink->error, $discounttolink->errors, 'errors');
 				}
 			}
 
@@ -730,10 +786,13 @@ if (empty($reshook)) {
 				// yet a legally issued document (ref is still PROV-...), so closing it would
 				// leave it stuck as paid+PROV (see #37744).
 				if ($object->status == Facture::STATUS_VALIDATED) {
-					$newremaintopay = $object->getRemainToPay(0);
+					$newremaintopay = $usemccompare ? $object->getRemainToPay(1) : $object->getRemainToPay(0);
 					if ($newremaintopay == 0) {
 						$object->setPaid($user);
 					}
+				}
+				if ($depositwassplit) {
+					setEventMessages($langs->trans('DepositSplitAutomaticallyApplied', $splitappliedmsg, $splitremainmsg), null, 'warnings');
 				}
 			}
 		}

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -752,3 +752,5 @@ CreditNoteNotCreatedErrorOnDiscount=Credit note for <b>%s</b> not created: error
 CreditNoteNotCreatedAlreadyConverted=Credit note for <b>%s</b> not created: invoice already converted
 CreditNotesCreated=%s credit note(s) created
 ThisMassActionIsOnlyForInvoices=This mass action is only available for invoices
+# Deposit/credit split in the invoice currency (option MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS)
+DepositSplitAutomaticallyApplied=The available credit was larger than the remaining amount to pay and was split automatically: %s applied to this invoice, %s kept as an available credit for later use.


### PR DESCRIPTION
## Purpose

When an available credit (converted deposit or credit note) is applied as **payment** on a customer invoice and its amount is **larger than the remaining amount to pay**, the card currently raises `ErrorDiscountLargerThanRemainToPaySplitItBefore` and forces the user to split the discount manually — while the code itself carries a `// TODO Split the discount in 2 automatically`.

This PR implements that TODO: the credit is split automatically, a part equal to the remaining amount is applied, and the rest stays as an available credit. A confirmation message details both amounts.

## Behaviour

- Default: plain company-currency auto-split (same behaviour as the supplier side).
- Under the option `MULTICURRENCY_PAYMENT_USE_REAL_AMOUNTS` **and** when the credit carries the invoice currency: the comparison and the split are done **in the invoice currency** (the company-currency amounts may have been valued at different exchange rates and would compare wrongly). The split parts carry both the company-currency and the foreign-currency amounts, and the paid status is decided on the foreign balance.
- The `setPaid` call keeps the existing guard for still-draft invoices (#37744).
- If the remaining amount is already ≤ 0, the previous error message is kept.

## Notes for review

- Customer mirror of the supplier-side auto-split introduced in #39666; both PRs add the same `DepositSplitAutomaticallyApplied` key to `en_US/bills.lang` (trivial merge overlap, whichever lands second).
- Without #39666 the multicurrency branch is simply inert (credits carry no foreign amounts) and the EUR auto-split still works.
- Tested end-to-end on a develop instance: credit 4 000 € / $5 000 (rate 1.25) applied to a 2 400 € / $3 000 invoice → 2 400 € / $3 000 applied (invoice paid, foreign balance 0), 1 600 € / $2 000 kept available, source deposit link preserved on both parts.