### PR TITLE
FIX #36232 Backport to 22.0: drop reference to non-existent fk_user_done in upcoming-events box

### DIFF
--- a/htdocs/core/boxes/box_actions_future.php
+++ b/htdocs/core/boxes/box_actions_future.php
@@ -107,7 +107,7 @@ class box_actions_future extends ModeleBoxes
 				$sql .= " AND s.rowid = ".((int) $user->socid);
 			}
 			if (!$user->hasRight('agenda', 'allactions', 'read')) {
-				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id)." OR a.fk_user_done = ".((int) $user->id).")";
+				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id).")";
 			}
 			$sql .= " AND a.datep > '".$this->db->idate($now)."'";
 			$sql .= " ORDER BY a.datep ASC";


### PR DESCRIPTION
Backport of #38689 (commit 1699531b638, already merged into `develop`) to the `22.0` maintenance branch, where the bug is still present.

## Problem

`htdocs/core/boxes/box_actions_future.php` builds its visibility clause with a third predicate on `a.fk_user_done`:

```php
if (!$user->hasRight("agenda", "allactions", "read")) {
    $sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id)." OR a.fk_user_done = ".((int) $user->id).")";
}
```

`llx_actioncomm` has no `fk_user_done` column — it was migrated to `fk_user_action` by the 3.5 -> 3.6 schema change. The query therefore fails with:

```
Unknown column 'a.fk_user_done' in 'WHERE'
```

## Who is affected

Only users **without** the `agenda -> allactions -> read` permission, since the clause is added only in that branch. Administrators and managers never see it, which makes the report look user-specific. Reproduced on 22.0.4 with a standard sales user: the "Next upcoming events" widget on the home page renders the SQL error, and the full query, in place of its content.

## Fix

Drop the extra `OR`. `fk_user_action` already covers the "owner of action" case, which is what `fk_user_done` meant before the column rename. Identical to the change already accepted on `develop`.

One file, one line. No functional change for users holding `allactions`.