### PR TITLE
FIX #39658 Shorten accounting transaction template FK name

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -93,7 +93,7 @@ CREATE TABLE llx_accounting_transaction_template_det (
 ) ENGINE=innodb;
 
 ALTER TABLE llx_accounting_transaction_template_det ADD INDEX idx_accounting_transaction_template_det_rowid (rowid);
-ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT llx_accounting_transaction_template_det_fk_transaction_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
+ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT fk_accounting_transaction_template_det_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
 
 create table llx_categorie_mo
 (

--- a/htdocs/install/mysql/tables/llx_accounting_transaction_template_det-accounting.key.sql
+++ b/htdocs/install/mysql/tables/llx_accounting_transaction_template_det-accounting.key.sql
@@ -19,4 +19,4 @@
 -- ============================================================================
 
 ALTER TABLE llx_accounting_transaction_template_det ADD INDEX idx_accounting_transaction_template_det_rowid (rowid);
-ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT llx_accounting_transaction_template_det_fk_transaction_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
+ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT fk_accounting_transaction_template_det_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);


### PR DESCRIPTION
# FIX #39658 Shorten accounting transaction template FK name

During the v23 to v24 migration, the accounting transaction template detail foreign key constraint name includes the replaceable llx_ table prefix. With a custom DB prefix longer than llx_, MariaDB/MySQL can exceed the 64-character identifier limit.

This renames the constraint in both the 23.0.0-24.0.0 migration and the fresh-install key file to a stable fk_ name that does not carry the DB prefix.

Tests:
- git diff --check HEAD~1 HEAD
- scanned 23.0.0-24.0.0.sql identifiers after llxzz_ prefix substitution: no INDEX/CONSTRAINT name exceeds 64 characters