### PR TITLE
NEW Make Payment and SupplierPayment getNomUrl tooltips hookable

### DIFF
--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -1396,6 +1396,36 @@ class Paiement extends CommonObject
 	 *  @param	string	$morecss		Add more CSS
 	 *	@return	string					String with URL
 	 */
+	/**
+	 * Return array with content of the tooltip, so the getNomUrl() tooltip becomes hookable
+	 * (a module can toggle, reorder or add entries through the getTooltipContent hook).
+	 *
+	 * @param  array<string,mixed>  $params  Params to construct tooltip data
+	 * @return array<string,string>          Data to show in tooltip
+	 */
+	public function getTooltipContentArray($params)
+	{
+		global $conf, $langs;
+
+		$datas = array();
+		$datas['picto'] = img_picto('', $this->picto).' <u>'.$langs->trans("Payment").'</u>';
+		$datas['ref'] = '<br><strong>'.$langs->trans("Ref").':</strong> '.$this->ref;
+		$dateofpayment = ($this->datepaye ? $this->datepaye : $this->date);
+		if ($dateofpayment) {
+			$tmparray = dol_getdate($dateofpayment);
+			if ($tmparray['seconds'] == 0 && $tmparray['minutes'] == 0 && ($tmparray['hours'] == 0 || $tmparray['hours'] == 12)) {	// We set hours to 0:00 or 12:00 because we don't know it
+				$datas['date'] = '<br><strong>'.$langs->trans("Date").':</strong> '.dol_print_date($dateofpayment, 'day');
+			} else {	// Hours was set to real date of payment (special case for POS for example)
+				$datas['date'] = '<br><strong>'.$langs->trans("Date").':</strong> '.dol_print_date($dateofpayment, 'dayhour', 'tzuser');
+			}
+		}
+		if ($this->amount) {
+			$datas['amount'] = '<br><strong>'.$langs->trans("Amount").':</strong> '.price($this->amount, 0, $langs, 1, -1, -1, $conf->currency);
+		}
+
+		return $datas;
+	}
+
 	public function getNomUrl($withpicto = 0, $option = '', $mode = 'withlistofinvoices', $notooltip = 0, $morecss = '')
 	{
 		global $conf, $langs, $hookmanager;
@@ -1406,21 +1436,8 @@ class Paiement extends CommonObject
 
 		$result = '';
 
-		$label = img_picto('', $this->picto).' <u>'.$langs->trans("Payment").'</u><br>';
-		$label .= '<strong>'.$langs->trans("Ref").':</strong> '.$this->ref;
-		$dateofpayment = ($this->datepaye ? $this->datepaye : $this->date);
-		if ($dateofpayment) {
-			$label .= '<br><strong>'.$langs->trans("Date").':</strong> ';
-			$tmparray = dol_getdate($dateofpayment);
-			if ($tmparray['seconds'] == 0 && $tmparray['minutes'] == 0 && ($tmparray['hours'] == 0 || $tmparray['hours'] == 12)) {	// We set hours to 0:00 or 12:00 because we don't know it
-				$label .= dol_print_date($dateofpayment, 'day');
-			} else {	// Hours was set to real date of payment (special case for POS for example)
-				$label .= dol_print_date($dateofpayment, 'dayhour', 'tzuser');
-			}
-		}
-		if ($this->amount) {
-			$label .= '<br><strong>'.$langs->trans("Amount").':</strong> '.price($this->amount, 0, $langs, 1, -1, -1, $conf->currency);
-		}
+		$params = array();
+		$label = $this->getTooltipContent($params);
 		if ($mode == 'withlistofinvoices') {
 			$arraybill = $this->getBillsArray();
 			if (is_array($arraybill) && count($arraybill) > 0) {

--- a/htdocs/compta/paiement/class/paiement.class.php
+++ b/htdocs/compta/paiement/class/paiement.class.php
@@ -1387,16 +1387,6 @@ class Paiement extends CommonObject
 
 
 	/**
-	 *  Return clickable name (with picto eventually)
-	 *
-	 *	@param	int		$withpicto		0=No picto, 1=Include picto into link, 2=Only picto
-	 *	@param	string	$option			What the link points to
-	 *  @param  string  $mode           'withlistofinvoices'=Include list of invoices into tooltip
-	 *  @param	int  	$notooltip		1=Disable tooltip
-	 *  @param	string	$morecss		Add more CSS
-	 *	@return	string					String with URL
-	 */
-	/**
 	 * Return array with content of the tooltip, so the getNomUrl() tooltip becomes hookable
 	 * (a module can toggle, reorder or add entries through the getTooltipContent hook).
 	 *
@@ -1426,6 +1416,16 @@ class Paiement extends CommonObject
 		return $datas;
 	}
 
+	/**
+	 *  Return clickable name (with picto eventually)
+	 *
+	 *	@param	int		$withpicto		0=No picto, 1=Include picto into link, 2=Only picto
+	 *	@param	string	$option			What the link points to
+	 *  @param  string  $mode           'withlistofinvoices'=Include list of invoices into tooltip
+	 *  @param	int  	$notooltip		1=Disable tooltip
+	 *  @param	string	$morecss		Add more CSS
+	 *	@return	string					String with URL
+	 */
 	public function getNomUrl($withpicto = 0, $option = '', $mode = 'withlistofinvoices', $notooltip = 0, $morecss = '')
 	{
 		global $conf, $langs, $hookmanager;

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -706,6 +706,33 @@ class PaiementFourn extends Paiement
 	 *  @param		string	$morecss		Add more CSS
 	 *	@return		string					String with URL
 	 */
+	/**
+	 * Return array with content of the tooltip, so the getNomUrl() tooltip becomes hookable
+	 * (a module can toggle, reorder or add entries through the getTooltipContent hook).
+	 *
+	 * @param  array<string,mixed>  $params  Params to construct tooltip data
+	 * @return array<string,string>          Data to show in tooltip
+	 */
+	public function getTooltipContentArray($params)
+	{
+		global $conf, $langs;
+
+		$reflabel = $params['reflabel'] ?? $this->ref;
+
+		$datas = array();
+		$datas['picto'] = img_picto('', $this->picto).' <u>'.$langs->trans("Payment").'</u>';
+		$datas['ref'] = '<br><strong>'.$langs->trans("Ref").':</strong> '.$reflabel;
+		$dateofpayment = ($this->datepaye ? $this->datepaye : $this->date);
+		if ($dateofpayment) {
+			$datas['date'] = '<br><strong>'.$langs->trans("Date").':</strong> '.dol_print_date($dateofpayment, 'dayhour', 'tzuser');
+		}
+		if ($this->amount) {
+			$datas['amount'] = '<br><strong>'.$langs->trans("Amount").':</strong> '.price($this->amount, 0, $langs, 1, -1, -1, $conf->currency);
+		}
+
+		return $datas;
+	}
+
 	public function getNomUrl($withpicto = 0, $option = '', $mode = 'withlistofinvoices', $notooltip = 0, $morecss = '')
 	{
 		global $langs, $conf, $hookmanager;
@@ -726,15 +753,8 @@ class PaiementFourn extends Paiement
 			$text = $langs->trans($reg[1]);
 		}
 
-		$label = img_picto('', $this->picto).' <u>'.$langs->trans("Payment").'</u><br>';
-		$label .= '<strong>'.$langs->trans("Ref").':</strong> '.$text;
-		$dateofpayment = ($this->datepaye ? $this->datepaye : $this->date);
-		if ($dateofpayment) {
-			$label .= '<br><strong>'.$langs->trans("Date").':</strong> '.dol_print_date($dateofpayment, 'dayhour', 'tzuser');
-		}
-		if ($this->amount) {
-			$label .= '<br><strong>'.$langs->trans("Amount").':</strong> '.price($this->amount, 0, $langs, 1, -1, -1, $conf->currency);
-		}
+		$params = array('reflabel' => $text);
+		$label = $this->getTooltipContent($params);
 
 		$linkclose = '';
 		if (empty($notooltip)) {

--- a/htdocs/fourn/class/paiementfourn.class.php
+++ b/htdocs/fourn/class/paiementfourn.class.php
@@ -733,6 +733,16 @@ class PaiementFourn extends Paiement
 		return $datas;
 	}
 
+	/**
+	 *	Return clickable name (with picto eventually)
+	 *
+	 *	@param		int		$withpicto		0=No picto, 1=Include picto into link, 2=Only picto
+	 *	@param		string	$option			What is the link pointing to
+	 *  @param		string  $mode           'withlistofinvoices'=Include list of invoices into tooltip
+	 *  @param		int  	$notooltip		1=Disable tooltip
+	 *  @param		string	$morecss		Add more CSS
+	 *	@return		string					String with URL
+	 */
 	public function getNomUrl($withpicto = 0, $option = '', $mode = 'withlistofinvoices', $notooltip = 0, $morecss = '')
 	{
 		global $langs, $conf, $hookmanager;


### PR DESCRIPTION
Sibling of #39629 (which made the supplier documents' `getNomUrl()` tooltips hookable), for the two payment objects.

## The gap

`Payment::getNomUrl()` and `PaiementFourn::getNomUrl()` build their tooltip label **inline**:

```php
$label = img_picto('', $this->picto).' <u>'.$langs->trans("Payment").'</u><br>';
$label .= '<strong>'.$langs->trans("Ref").':</strong> '.$this->ref;
...
```

Because the label never goes through `CommonObject::getTooltipContent()`, the `getTooltipContent` hook is **never fired** for payments — a module cannot add, reorder or toggle a tooltip entry (a bank-reconciliation line, a payment status…) the way it already can on every object that uses `getTooltipContent()`.

## What this PR does

Each class now exposes its label through a `getTooltipContentArray()` method, and `getNomUrl()` builds the label with:

```php
$label = $this->getTooltipContent($params);
```

- Same rendered tooltip by default (the array is imploded into the exact same string).
- The `getTooltipContent` hook now runs for payments, so modules can adjust the tooltip.
- For the supplier payment, the reference label computed from the parentheses handling is passed through `$params['reflabel']`, so `getTooltipContentArray()` stays free of `getNomUrl()` locals.
- `Payment::getNomUrl()`'s optional list-of-invoices block is left untouched (still appended after the hookable part).

## Default behaviour is unchanged

No functional change to the default output, no schema change. Only the way the label is assembled changes, which is what makes it hookable.
