### PR TITLE
Fix #39561 test the cleanup delete in Expedition::manageStockMvtOnEvt

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -2287,7 +2287,17 @@ class Expedition extends CommonObject
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sqldelete = "DELETE FROM ".MAIN_DB_PREFIX."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".MAIN_DB_PREFIX."product_batch as pb)";
 				$resqldelete = $this->db->query($sqldelete);
-				// We do not test error, it can fails if there is child in batch details
+				// The NOT IN clause already excludes the rows still referenced by product_batch (the only child FK on
+				// product_stock), so this DELETE can not fail on a child constraint. Any failure is a real error, in
+				// particular a deadlock (1213) that rolls back the whole transaction including the stock movements just
+				// recorded; if we swallowed it, the caller would commit an empty transaction and report a success while
+				// the movements were lost.
+				if (!$resqldelete) {
+					$this->error = $this->db->lasterror();
+					$this->errors[] = $this->db->lasterror();
+					$error++;
+					break;
+				}
 			}
 		} else {
 			$this->error = $this->db->lasterror();


### PR DESCRIPTION
Follow-up to #39593, reported by @DasOif on that PR: the same pattern exists in Expedition::manageStockMvtOnEvt().

The method runs the cleanup DELETE on product_stock after each stock movement of the shipment and ignores its result:

```php
$resqldelete = $this->db->query($sqldelete);
// We do not test error, it can fails if there is child in batch details
```

The comment does not match the query. The NOT IN clause already excludes the rows still referenced by product_batch, which is the only child FK on product_stock, so this DELETE can not fail on a child constraint, and any failure is a real error.

It matters on an InnoDB deadlock (1213), which rolls back the whole transaction including the stock movements just recorded. The method still returned 1, so the two callers, valid() and setClosed(), committed an empty transaction and reported a success while the movements were lost.

Verified on a real shipment with a detail line, by making the cleanup DELETE fail for real: before the patch manageStockMvtOnEvt() returns 1 and sets no error, after it returns -1 and surfaces the error, so the callers roll back.