### PR TITLE
Fix #39584 complete top-menu url only when mainmenu and leftmenu are absent

### DIFF
--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -499,7 +499,10 @@ function print_eldy_menu($db, $atarget, $type_user, &$tabMenu, &$menu, $noout = 
 			$url = $shorturl = $tmp[0];
 			$param = (isset($tmp[1]) ? $tmp[1] : '');
 
-			if ((!preg_match('/mainmenu/i', $param)) || !preg_match('/leftmenu/i', $param)) {
+			// Complete the url only when neither mainmenu nor leftmenu is already set, like print_left_eldy_menu() does.
+			// With a OR, a url already carrying only mainmenu got a second one, and a url already carrying only leftmenu
+			// got an empty leftmenu appended that overrode the real value.
+			if ((!preg_match('/mainmenu/i', $param)) && (!preg_match('/leftmenu/i', $param))) {
 				$param .= ($param ? '&' : '').'mainmenu='.$newTabMenu[$i]['mainmenu'].'&leftmenu=';
 			}
 			//$url.="idmenu=".$newTabMenu[$i]['rowid'];    // Already done by menuLoad


### PR DESCRIPTION
Replaces #39604, which targeted develop and had picked up unrelated commits through a merge of develop. This one is a single commit on 18.0, where the faulty line is identical.

print_eldy_menu() completed the link url with a OR, so the completion also ran when one of the two parameters was already there. A url already carrying only mainmenu got a second mainmenu, and a url already carrying only leftmenu got an empty leftmenu appended. PHP keeps the last occurrence of a repeated query parameter, so that trailing empty leftmenu overrode the real one and the left menu was lost, which is the reported symptom.

print_left_eldy_menu() already uses a AND for the very same completion, so the top menu is now aligned with it.

Checked every url shape: no parameter, unrelated parameters only, and both parameters already present are byte identical before and after. Only the three broken shapes change: mainmenu alone no longer gets duplicated, and leftmenu alone, with or without other parameters, keeps its value instead of being emptied.