### PR TITLE
FIX Contract clone: third-party filter excluded pure supplier companies

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1410,7 +1410,7 @@ if ($action == 'create') {
 			);
 			$formconfirm = $form->formconfirm($_SERVER['PHP_SELF']."?id=".$object->id, $langs->trans("ActivateAllOnContract"), $langs->trans("ConfirmActivateAllOnContract"), "confirm_activate", $formquestion, 'yes', 1, 280);
 		} elseif ($action == 'clone') {
-			$filter = '(s.client:IN:1,2,3)';
+			$filter = '(s.client:IN:1,2,3) OR (s.fournisseur:=:1)';
 			// Clone confirmation
 			$formquestion = array(array('type' => 'other', 'name' => 'socid', 'label' => $langs->trans("SelectThirdParty"), 'value' => $form->select_company(GETPOSTINT('socid'), 'socid', $filter)));
 			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ToClone'), $langs->trans('ConfirmCloneContract', $object->ref), 'confirm_clone', $formquestion, 'yes', 1);


### PR DESCRIPTION
## Summary
The contract clone confirmation dialog's third-party picker filters on
`(s.client:IN:1,2,3)`, which only matches companies flagged as customer
or prospect. A company flagged purely as a supplier (`client=0`,
`fournisseur=1`) can never be selected as the clone target, even though
creating a contract directly already allows any third-party type.

Broadened the filter to `(s.client:IN:1,2,3) OR (s.fournisseur:=:1)` so
pure-supplier companies are selectable too.

## Impact
Affects `htdocs/contrat/card.php` only, one line. No schema change, no
new files, no behavior change for existing customer/prospect selection.

## Test plan
- [x] Create a third party with `Client = No`, `Fournisseur = Yes`
- [x] Validate any existing contract, click "Clone"
- [x] Confirm the pure-supplier third party now appears in the clone
      dialog's third-party dropdown
- [x] Confirm existing customers/prospects still appear (regression
      check on the added `OR`)
      
Before:
<img width="2000" height="793" alt="before-fix" src="https://github.com/user-attachments/assets/8ba9d693-765f-4f85-88e1-c147b6e37ab7" />

After:
<img width="1991" height="783" alt="after-fix" src="https://github.com/user-attachments/assets/0d16b562-ece8-41e4-a5e0-2f611e3b35ee" />
