### PR TITLE
FIX Request-URI Too Long when validating a confirm box with many fields

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5897,6 +5897,7 @@ class Form
 			}
 
 			$postconfirmas = 'GET';
+			$maxurllengthforget = getDolGlobalInt('MAIN_MAX_URL_LENGTH_FOR_GET', 2000);
 
 			$formconfirm .= '
                     resizable: false,
@@ -5929,7 +5930,7 @@ class Form
                          	var urljump = pageyes + (pageyes.indexOf("?") < 0 ? "?" : "&") + options;
             				if (pageyes.length > 0) {';
 			if ($postconfirmas == 'GET') {
-				$formconfirm .= 'location.href = urljump;';
+				$formconfirm .= 'dolSubmitConfirmForm(urljump, pageyes, options, ' . $maxurllengthforget . ');';
 			} else {
 				$formconfirm .= $jsforcursor;
 				$formconfirm .= 'var post = $.post(
@@ -5961,7 +5962,7 @@ class Form
                          	//alert(urljump);
             				if (pageno.length > 0) {';
 			if ($postconfirmas == 'GET') {
-				$formconfirm .= 'location.href = urljump;';
+				$formconfirm .= 'dolSubmitConfirmForm(urljump, pageno, options, ' . $maxurllengthforget . ');';
 			} else {
 				$formconfirm .= $jsforcursor;
 				$formconfirm .= 'var post = $.post(

--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -1121,6 +1121,44 @@ function getParameterByName(name, valueifnotfound)
 	return results === null ? valueifnotfound : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
+/*
+ * Submit the form of a confirm box. Jump to the target url with a GET, but submit a POST form
+ * instead when this url is too long to be accepted by the web server ("Request-URI Too Long").
+ *
+ * @param	urljump				Target url with all its parameters, for the GET
+ * @param	page				Target page, used as action of the POST form
+ * @param	options				Parameters of the form, as a query string (token included)
+ * @param	maxurllength		Max length of an url we accept to use with a GET
+ * @return	void
+ */
+function dolSubmitConfirmForm(urljump, page, options, maxurllength)
+{
+	if (urljump.length <= maxurllength) {
+		location.href = urljump;
+		return;
+	}
+
+	console.log("dolSubmitConfirmForm: url is "+urljump.length+" chars long, we submit a POST form instead of a GET");
+
+	var form = document.createElement("form");
+	form.method = "POST";
+	form.action = page;
+	form.style.display = "none";
+
+	options.split("&").forEach(function(param) {
+		if (param === "") return;
+		var pos = param.indexOf("=");
+		var input = document.createElement("input");
+		input.type = "hidden";
+		input.name = (pos < 0 ? param : param.substring(0, pos));
+		input.value = (pos < 0 ? "" : decodeURIComponent(param.substring(pos + 1)));
+		form.appendChild(input);
+	});
+
+	document.body.appendChild(form);
+	form.submit();
+}
+
 /**
  * Get the list of possible operators for a given field type that we can use in the generic filter.
  */


### PR DESCRIPTION
# FIX Request-URI Too Long when validating a confirm box with many fields

## Problem

When the user validates an ajax confirm box built by `Form::formconfirm()`, every field
of the box is propagated into the url of a GET (`location.href = urljump`). This is
hardcoded (`$postconfirmas = 'GET'`) since 45c4a6ce1c2.

When the box holds many fields, the url exceeds what the web server accepts and the
request is rejected before reaching PHP:

```
Request-URI Too Long
The requested URL's length exceeds the capacity limit for this server
```

(Apache `LimitRequestLine` defaults to 8190.)

## How to reproduce

1. Create a project with a few hundred tasks (~350).
2. Open the *Contacts* tab of the project and add an internal user.
3. In the *Assign the person to the tasks* confirm box, click Yes.

`projet/contact.php` builds two fields per task (`person_<id>` and `person_role_<id>`),
so with 341 tasks the url is about 16 kb: the feature is simply unusable on a large
project.

## Fix

The confirm box now submits a POST form instead of jumping to the url, but only when
the url would be too long:

- shorter than `MAIN_MAX_URL_LENGTH_FOR_GET` (2000 by default): unchanged, `location.href`
  as before, so every other confirm box of the application keeps its current behaviour;
- longer: a hidden form is built from the same parameters (CSRF token included, it is
  already the first parameter of `options`) and submitted.

The form is submitted natively with `form.submit()`, **not** with `$.post()`. This is
deliberate: the `$.post()` + `$("body").html(data)` implementation is the one reverted by
45c4a6ce1c2 because it broke the wait cursor and the file downloads. A native submit is
an ordinary navigation with a POST body, so neither issue can come back.

The target page keeps its query string as the form action, so `action`, `confirm` and the
id of the object stay readable, and `GETPOST()` reads the other parameters from `$_POST`.

The new js function lives in `core/js/lib_head.js.php`, which is loaded whenever the ajax
confirm box exists (both depend on `use_javascript_ajax`). The threshold stays on the PHP
side and is passed as an argument, so changing the constant takes effect immediately
instead of waiting for the browser cache of the js file to expire.

## Tests

On a project with 341 tasks:

| Case | Result |
|---|---|
| Add an internal user, *select all*, 16 tasks already assigned | 325 assignments created, expected role, no duplicate |
| Add an external contact, *select all*, no task already assigned | 341 assignments created |
| Short confirm boxes (delete, validate, close...) | still a GET, unchanged |

684 fields are posted, which stays below the default `max_input_vars` of 1000.

