### PR TITLE
FIX : task ref numbering uses current year instead of project one

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -2273,6 +2273,8 @@ class Task extends CommonObjectLine
 
 		$origin_task->fetch($fromid);
 
+		$clone_task->date_c = $datec;	// Set the new creation date before computing the ref, else the numbering mask uses the source task year
+
 		$defaultref = '';
 		$obj = !getDolGlobalString('PROJECT_TASK_ADDON') ? 'mod_task_simple' : $conf->global->PROJECT_TASK_ADDON;
 		if (getDolGlobalString('PROJECT_TASK_ADDON') && is_readable(DOL_DOCUMENT_ROOT."/core/modules/project/task/" . getDolGlobalString('PROJECT_TASK_ADDON').".php")) {
@@ -2288,7 +2290,6 @@ class Task extends CommonObjectLine
 		$clone_task->ref				= $defaultref;
 		$clone_task->fk_project = $project_id;
 		$clone_task->fk_task_parent = $parent_task_id;
-		$clone_task->date_c = $datec;
 		$clone_task->planned_workload = $origin_task->planned_workload;
 		$clone_task->rang = $origin_task->rang;
 		$clone_task->priority = $origin_task->priority;

--- a/htdocs/projet/tasks.php
+++ b/htdocs/projet/tasks.php
@@ -774,7 +774,9 @@ if ($action == 'create' && $user->hasRight('projet', 'creer') && (empty($object-
 		require_once DOL_DOCUMENT_ROOT."/core/modules/project/task/" . getDolGlobalString('PROJECT_TASK_ADDON').'.php';
 		$modTask = new $classnamemodtask();
 		'@phan-var-force ModeleNumRefTask $modTask';
-		$defaultref = $modTask->getNextValue($object->thirdparty, $object);
+		$tasktmp = new Task($db);	// Numbering modules expect a Task object (and use its creation date), not the project
+		$tasktmp->fk_project = $object->id;
+		$defaultref = $modTask->getNextValue($object->thirdparty, $tasktmp);
 	}
 
 	if (is_numeric($defaultref) && $defaultref <= 0) {


### PR DESCRIPTION
## Problem

The task numbering modules (`mod_task_simple`, `mod_task_universal`) build the ref from `$object->date_c`, expecting a `Task`. Two callers feed them the wrong date:

- `projet/tasks.php` passes the **Project** object, so a task created on an old project gets the project creation year (e.g. `TK23xx-0001` instead of `TK26xx-0001`).
- `Task::createFromClone()` computes the ref before assigning the new `date_c`, so a clone inherits the year of the source task.

## Fix

- `projet/tasks.php`: pass a new `Task` object (with `fk_project` set). Its empty `date_c` makes the numbering module fall back to `dol_now()`.
- `Task::createFromClone()`: set `date_c` before computing the ref (the now-redundant later assignment is removed).

## How to test

1. Set the task numbering model to *Universal* with a mask containing `{yy}`, e.g. `TK{yy}{mm}-{0000}`.
2. Create a task on a project created in a previous year → the ref must use the current year.
3. Clone a task created in a previous year → the ref must use the current year.
