### PR TITLE
Fix #39690 avoid division by zero in the turnover statistics

### DIFF
--- a/htdocs/compta/stats/index.php
+++ b/htdocs/compta/stats/index.php
@@ -460,22 +460,24 @@ for ($mois = 1 + $nb_mois_decalage; $mois <= 12 + $nb_mois_decalage; $mois++) {
 			//var_dump($annee.' '.$year_end.' '.$mois.' '.$month_end);
 			if ($annee < $year_end || ($annee == $year_end && $mois <= $month_end)) {
 				if ($annee_decalage > $minyear && $case <= $casenow) {
-					if (!empty($cum[$caseprev]) && !empty($cum[$case])) {
+					// Compare as float: the amounts come from a SQL SUM() and reach us as strings like "0.00",
+					// for which empty() is false, so a plain !empty() guard let a division by zero through.
+					if ((float) $cum[$caseprev] != 0 && (float) $cum[$case] != 0) {
 						$percent = (round(($cum[$case] - $cum[$caseprev]) / $cum[$caseprev], 4) * 100);
 						//print "X $cum[$case] - $cum[$caseprev] - $cum[$caseprev] - $percent X";
 						print ($percent >= 0 ? "+$percent" : "$percent").'%';
 					}
-					if (!empty($cum[$caseprev]) && empty($cum[$case])) {
+					if ((float) $cum[$caseprev] != 0 && (float) $cum[$case] == 0) {
 						print '-100%';
 					}
-					if (empty($cum[$caseprev]) && !empty($cum[$case])) {
+					if ((float) $cum[$caseprev] == 0 && (float) $cum[$case] != 0) {
 						//print '<td class="right">+Inf%</td>';
 						print '-';
 					}
-					if (isset($cum[$caseprev]) && empty($cum[$caseprev]) && empty($cum[$case])) {
+					if (isset($cum[$caseprev]) && (float) $cum[$caseprev] == 0 && (float) $cum[$case] == 0) {
 						print '+0%';
 					}
-					if (!isset($cum[$caseprev]) && empty($cum[$case])) {
+					if (!isset($cum[$caseprev]) && (float) $cum[$case] == 0) {
 						print '-';
 					}
 				} else {
@@ -600,19 +602,20 @@ for ($annee = $year_start; $annee <= $year_end; $annee++) {
 
 	// Pourcentage total
 	if ($annee > $minyear && $annee <= max($nowyear, $maxyear)) {
-		if (!empty($total[$annee - 1]) && !empty($total[$annee])) {
+		// Same as above: a SUM() returned as "0.00" is not empty(), so compare as float.
+		if ((float) $total[$annee - 1] != 0 && (float) $total[$annee] != 0) {
 			$percent = (round(($total[$annee] - $total[$annee - 1]) / $total[$annee - 1], 4) * 100);
 			print '<td class="nowrap borderrightlight right">';
 			print ($percent >= 0 ? "+$percent" : "$percent").'%';
 			print '</td>';
 		}
-		if (!empty($total[$annee - 1]) && empty($total[$annee])) {
+		if ((float) $total[$annee - 1] != 0 && (float) $total[$annee] == 0) {
 			print '<td class="borderrightlight right">-100%</td>';
 		}
-		if (empty($total[$annee - 1]) && !empty($total[$annee])) {
+		if ((float) $total[$annee - 1] == 0 && (float) $total[$annee] != 0) {
 			print '<td class="borderrightlight right">+'.$langs->trans('Inf').'%</td>';
 		}
-		if (empty($total[$annee - 1]) && empty($total[$annee])) {
+		if ((float) $total[$annee - 1] == 0 && (float) $total[$annee] == 0) {
 			print '<td class="borderrightlight right">+0%</td>';
 		}
 	} else {

--- a/htdocs/compta/stats/index.php
+++ b/htdocs/compta/stats/index.php
@@ -460,24 +460,27 @@ for ($mois = 1 + $nb_mois_decalage; $mois <= 12 + $nb_mois_decalage; $mois++) {
 			//var_dump($annee.' '.$year_end.' '.$mois.' '.$month_end);
 			if ($annee < $year_end || ($annee == $year_end && $mois <= $month_end)) {
 				if ($annee_decalage > $minyear && $case <= $casenow) {
-					// Compare as float: the amounts come from a SQL SUM() and reach us as strings like "0.00",
-					// for which empty() is false, so a plain !empty() guard let a division by zero through.
-					if ((float) $cum[$caseprev] != 0 && (float) $cum[$case] != 0) {
-						$percent = (round(($cum[$case] - $cum[$caseprev]) / $cum[$caseprev], 4) * 100);
-						//print "X $cum[$case] - $cum[$caseprev] - $cum[$caseprev] - $percent X";
+					// The amounts come from a SQL SUM() and reach us as strings like "0.00", for which empty()
+					// is false, so a plain !empty() guard let a division by zero through. Cast to float, but
+					// only when the key exists: $cum is filled for the months returned by the query, so a
+					// month with no movement has no key at all and a direct cast would emit a warning.
+					$prevcum = (!empty($cum[$caseprev]) ? (float) $cum[$caseprev] : 0);
+					$curcum = (!empty($cum[$case]) ? (float) $cum[$case] : 0);
+					if ($prevcum != 0 && $curcum != 0) {
+						$percent = (round(($curcum - $prevcum) / $prevcum, 4) * 100);
 						print ($percent >= 0 ? "+$percent" : "$percent").'%';
 					}
-					if ((float) $cum[$caseprev] != 0 && (float) $cum[$case] == 0) {
+					if ($prevcum != 0 && $curcum == 0) {
 						print '-100%';
 					}
-					if ((float) $cum[$caseprev] == 0 && (float) $cum[$case] != 0) {
+					if ($prevcum == 0 && $curcum != 0) {
 						//print '<td class="right">+Inf%</td>';
 						print '-';
 					}
-					if (isset($cum[$caseprev]) && (float) $cum[$caseprev] == 0 && (float) $cum[$case] == 0) {
+					if (isset($cum[$caseprev]) && $prevcum == 0 && $curcum == 0) {
 						print '+0%';
 					}
-					if (!isset($cum[$caseprev]) && (float) $cum[$case] == 0) {
+					if (!isset($cum[$caseprev]) && $curcum == 0) {
 						print '-';
 					}
 				} else {
@@ -602,20 +605,23 @@ for ($annee = $year_start; $annee <= $year_end; $annee++) {
 
 	// Pourcentage total
 	if ($annee > $minyear && $annee <= max($nowyear, $maxyear)) {
-		// Same as above: a SUM() returned as "0.00" is not empty(), so compare as float.
-		if ((float) $total[$annee - 1] != 0 && (float) $total[$annee] != 0) {
-			$percent = (round(($total[$annee] - $total[$annee - 1]) / $total[$annee - 1], 4) * 100);
+		// Same as above: a SUM() returned as "0.00" is not empty(), so cast to float, but only when the
+		// key exists. $total has no entry for a year with no movement, the first year in particular.
+		$prevtotal = (!empty($total[$annee - 1]) ? (float) $total[$annee - 1] : 0);
+		$curtotal = (!empty($total[$annee]) ? (float) $total[$annee] : 0);
+		if ($prevtotal != 0 && $curtotal != 0) {
+			$percent = (round(($curtotal - $prevtotal) / $prevtotal, 4) * 100);
 			print '<td class="nowrap borderrightlight right">';
 			print ($percent >= 0 ? "+$percent" : "$percent").'%';
 			print '</td>';
 		}
-		if ((float) $total[$annee - 1] != 0 && (float) $total[$annee] == 0) {
+		if ($prevtotal != 0 && $curtotal == 0) {
 			print '<td class="borderrightlight right">-100%</td>';
 		}
-		if ((float) $total[$annee - 1] == 0 && (float) $total[$annee] != 0) {
+		if ($prevtotal == 0 && $curtotal != 0) {
 			print '<td class="borderrightlight right">+'.$langs->trans('Inf').'%</td>';
 		}
-		if ((float) $total[$annee - 1] == 0 && (float) $total[$annee] == 0) {
+		if ($prevtotal == 0 && $curtotal == 0) {
 			print '<td class="borderrightlight right">+0%</td>';
 		}
 	} else {


### PR DESCRIPTION
The monthly and yearly percentage columns of compta/stats/index.php guard their division with empty(). The amounts come from a SQL SUM() and reach PHP as strings such as "0.00", for which empty() returns false, so the guard lets a zero through and the division throws an uncaught DivisionByZeroError. With display_errors off, as on most production setups, the page simply stops rendering in the middle of the table.

Reproduced with the exact code shape: with a previous cumulative of "0.00" and a current one of "1500.00", the old guard passes and the division throws.

The guards now compare as float, so "0.00" is treated as zero. The sibling branches printing -100%, -, +Inf% and +0% are converted the same way on purpose: converting only the division would leave a "0.00" value matching none of the branches, and the cell would render empty.

Checked every combination, old versus new:

| prev -> cur | before | after |
| --- | --- | --- |
| "0.00" -> "1500.00" | DivisionByZeroError | - |
| "0.00" -> "0.00" | DivisionByZeroError | +0% |
| "1500.00" -> "0.00" | -100% | -100% |
| "1000.00" -> "1500.00" | +50% | +50% |
| "0" -> "1500.00" | - | - |

Only the two crashing cases change, every case that already worked renders identically. Both occurrences in the file are fixed, the monthly cumulative and the yearly total. Present from 18.0 up to develop.