### PR TITLE
FIX #39690 Division by zero in turnover collected report

### DIFF
--- a/htdocs/compta/stats/index.php
+++ b/htdocs/compta/stats/index.php
@@ -499,12 +499,12 @@ for ($mois = 1 + $nb_mois_decalage; $mois <= 12 + $nb_mois_decalage; $mois++) {
 			if ($annee < $year_end || ($annee == $year_end && $mois <= $month_end)) {
 				if ($annee_decalage > $minyear && $case <= $casenow) {
 					if ($modecompta=='CREANCES-DETTES') {
-						$cumulative_previous_year = (!empty($cumulative_ht[$caseprev])?$cumulative_ht[$caseprev]:0);
-						$cumulative_year = (!empty($cumulative_ht[$case])?$cumulative_ht[$case]:0);
+						$cumulative_previous_year = (!empty($cumulative_ht[$caseprev]) ? (float) $cumulative_ht[$caseprev] : 0);
+						$cumulative_year = (!empty($cumulative_ht[$case]) ? (float) $cumulative_ht[$case] : 0);
 						$isset_cumulative_previous_year = isset($cumulative_ht[$caseprev]);
 					} else {
-						$cumulative_previous_year = (!empty($cumulative[$caseprev])?$cumulative[$caseprev]:0);
-						$cumulative_year = (!empty($cumulative[$case])?$cumulative[$case]:0);
+						$cumulative_previous_year = (!empty($cumulative[$caseprev]) ? (float) $cumulative[$caseprev] : 0);
+						$cumulative_year = (!empty($cumulative[$case]) ? (float) $cumulative[$case] : 0);
 						$isset_cumulative_previous_year = isset($cumulative_ht[$caseprev]);
 					}
 					if (!empty($cumulative_previous_year) && !empty($cumulative_year)) {
@@ -648,11 +648,11 @@ for ($annee = $year_start; $annee <= $year_end; $annee++) {
 	// Pourcentage total
 	if ($annee > $minyear && $annee <= max($nowyear, $maxyear)) {
 		if ($modecompta == 'CREANCES-DETTES') {
-			$total_previous_year = (!empty($total_ht[$annee - 1])?$total_ht[$annee - 1]:0);
-			$total_year = (!empty($total_ht[$annee])?$total_ht[$annee]:0);
+			$total_previous_year = (!empty($total_ht[$annee - 1]) ? (float) $total_ht[$annee - 1] : 0);
+			$total_year = (!empty($total_ht[$annee]) ? (float) $total_ht[$annee] : 0);
 		} else {
-			$total_previous_year = (!empty($total[$annee - 1])?$total[$annee - 1]:0);
-			$total_year = (!empty($total[$annee])?$total[$annee]:0);
+			$total_previous_year = (!empty($total[$annee - 1]) ? (float) $total[$annee - 1] : 0);
+			$total_year = (!empty($total[$annee]) ? (float) $total[$annee] : 0);
 		}
 		if (!empty($total_previous_year) && !empty($total_year)) {
 			$percent = (round(($total_year - $total_previous_year) / $total_previous_year, 4) * 100);


### PR DESCRIPTION
FIX #39690

Cast SUM() results to float before the empty() check used to guard the year-over-year percentage calculation. MySQL/PostgreSQL return SUM() as a numeric string (e.g. "0.00"), which empty() does not treat as empty, so the divisor could be zero and threw an uncaught DivisionByZeroError, silently truncating the report (see #<issuenum> and the earlier regression in #29843/#32655).
<img width="949" height="1133" alt="zerodivisionsolved" src="https://github.com/user-attachments/assets/02fa2038-0c1d-4e46-be52-9d80d9ae8ef8" />
