### PR TITLE
FIX Clone link uses filesystem path instead of URL in various_payment…

### DIFF
--- a/htdocs/compta/bank/various_payment/card.php
+++ b/htdocs/compta/bank/various_payment/card.php
@@ -798,7 +798,7 @@ if ($id) {
 
 	// Clone
 	if ($permissiontoadd) {
-		print '<div class="inline-block divButAction"><a class="butAction butActionClone" href="' . dolBuildUrl(DOL_DOCUMENT_ROOT."/compta/bank/various_payment/card.php", ['id' => $object->id, 'action' => 'clone']).'">'.$langs->trans("ToClone") . "</a></div>";
+		print '<div class="inline-block divButAction"><a class="butAction butActionClone" href="' . dolBuildUrl(DOL_URL_ROOT."/compta/bank/various_payment/card.php", ['id' => $object->id, 'action' => 'clone']).'">'.$langs->trans("ToClone") . "</a></div>";
 	}
 
 	// Delete


### PR DESCRIPTION
…/card.php

FIX Various Payment clone link is an invalid filesystem path

In v23, the clone link on various_payment/card.php was built with dol_buildpath("/compta/bank/various_payment/card.php", 1), which correctly produces a URL.

In v24 this was replaced by:
dolBuildUrl(DOL_DOCUMENT_ROOT."/compta/bank/various_payment/card.php", [...])

DOL_DOCUMENT_ROOT is a filesystem path constant (normally used for PHP require/include), not a URL. As a result, the "Clone" button's href contains the server's disk path (e.g. /var/www/compta/bank/various_payment/card.php) instead of a valid relative or absolute URL, causing a 404 on click.

On the same page, the "Delete" button correctly uses a relative path (card.php?...) and works fine, confirming this is isolated to the Clone button and is not a server configuration issue.

Fix: replace DOL_DOCUMENT_ROOT with DOL_URL_ROOT in the dolBuildUrl() call for this button.

Steps to reproduce:
1. Open a Various Payment entry (compta/bank/various_payment/card.php?id=X)
2. Click "Clone"
3. Observe the 404 (the URL shown in the browser contains the server's disk path)

Tested on Dolibarr 24.0.0, after migration from 23.0.2.





