### PR TITLE
Fix #39699 support sqlfilters on the salaries API list

### DIFF
--- a/htdocs/salaries/class/api_salaries.class.php
+++ b/htdocs/salaries/class/api_salaries.class.php
@@ -68,13 +68,14 @@ class Salaries extends DolibarrApi
 	 * @param string    $sortorder  Sort order
 	 * @param int       $limit      Limit for list
 	 * @param int       $page       Page number
+	 * @param string    $sqlfilters Other criteria to filter answers separated by a comma. Syntax example "(t.fk_user:=:6) and (t.datep:>:'20250101')"
 	 * @return array                List of salary objects
 	 * @phan-return Salary[]
 	 * @phpstan-return Salary[]
 	 *
 	 * @throws RestException
 	 */
-	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0)
+	public function index($sortfield = "t.rowid", $sortorder = 'ASC', $limit = 100, $page = 0, $sqlfilters = '')
 	{
 		$list = array();
 
@@ -88,10 +89,19 @@ class Salaries extends DolibarrApi
 		$sql .= ' WHERE t.entity IN ('.getEntity('user').')';
 		if (!DolibarrApiAccess::$user->hasRight('salaries', 'readall')) {
 			if (!DolibarrApiAccess::$user->hasRight('salaries', 'readchild')) {
-				$sql .= ' AND t.fk_user = '.((int) DolibarrApiAccess::$user->id).')';
+				$sql .= ' AND t.fk_user = '.((int) DolibarrApiAccess::$user->id);
 			} else {
 				$childids = DolibarrApiAccess::$user->getAllChildIds(1);
 				$sql .= ' AND t.fk_user IN ('.$this->db->sanitize(implode(',', $childids)).')';
+			}
+		}
+
+		// Add sql filters
+		if ($sqlfilters) {
+			$errormessage = '';
+			$sql .= forgeSQLFromUniversalSearchCriteria($sqlfilters, $errormessage);
+			if ($errormessage) {
+				throw new RestException(400, 'Error when validating parameter sqlfilters -> '.$errormessage);
 			}
 		}
 


### PR DESCRIPTION
GET /salaries accepted a sqlfilters parameter in the url but index() had no such argument, so the criteria were silently dropped and every record the user may read was returned, which is what the report describes.

The parameter is now declared and applied through forgeSQLFromUniversalSearchCriteria(), following the pattern of the other list endpoints, and an invalid filter answers 400 instead of being ignored.

While in the same query I removed a stray closing parenthesis. For a user without the readall permission the WHERE clause ended with "t.fk_user = <id>)", which MariaDB rejects:

    ERROR 1064 (42000): You have an error in your SQL syntax ... near ')'

so the endpoint was broken for those users regardless of any filter. It is in the same statement as the reported bug, hence the single patch.

Verified against the database: the previous clause fails with a syntax error while the corrected one runs, and forgeSQLFromUniversalSearchCriteria('(t.fk_user:=:6)') yields " AND ((t.fk_user = 6))", giving a valid filtered query.

Present on 23.0, 24.0 and develop, this code path does not exist on 21.0 and 22.0.