### PR TITLE
Fix #39703 allow document upload on a supplier payment

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -513,6 +513,11 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
 					$createok = 0;
 					$nbko++;
 				}
+			} elseif ($feature == 'payment_supplier') {	// Permission to write on a payment of an invoice is permission to edit an invoice.
+				if (!$user->hasRight('fournisseur', 'facture', 'creer')) {
+					$createok = 0;
+					$nbko++;
+				}
 			} elseif ($feature == 'webhook') {
 				if (empty($user->admin)) {
 					$createok = 0;


### PR DESCRIPTION
restrictedArea() handles the payment_supplier feature in the read section (line 395) and in the delete section (line 610), but the write section, 458 to 586, had no case for it. $createok therefore kept its default and any action needing write permission was refused, which is what happens when uploading a file on fourn/paiement/document.php since the upload sets sendit.

On the regression window, the report says it worked before 24.0 and that is right, but not because a case was removed. The two payment_supplier cases are present identically from 21.0 to develop. What changed is the call site: until 23.0, fourn/paiement/document.php called

    restrictedArea($user, $object->element, $object->id, 'paiementfourn', '');

while $object was not instantiated yet, so the feature was empty and the check was effectively a no-op. 24.0 moved the fetch above the call, which is correct, and that turned the dormant check on and exposed the missing case.

The new write case mirrors the existing delete one, permission to write on a payment of a supplier invoice is the permission to edit that invoice:

    if (!$user->hasRight('fournisseur', 'facture', 'creer')) { $createok = 0; $nbko++; }

Checked both directions so this does not widen access: a user with fournisseur/facture/creer is allowed, a user without it is still denied.

Also affects fourn/paiement/card.php and info.php, which pass the same feature, though only document.php reaches the write branch today.