### PR TITLE
Fix #39668 read localtax2 from the discount when inserting a discount line

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2931,8 +2931,8 @@ class Facture extends CommonInvoice
 			$facligne->tva_tx = $remise->tva_tx;
 			$facligne->localtax1_tx = $remise->localtax1_tx;
 			$facligne->localtax1_type = (int) $remise->localtax1_type;
-			$facligne->localtax2_tx = $remise->localtax1_tx;
-			$facligne->localtax2_type = (int) $remise->localtax1_type;
+			$facligne->localtax2_tx = $remise->localtax2_tx;
+			$facligne->localtax2_type = (int) $remise->localtax2_type;
 			$facligne->subprice = -(float) $remise->total_ht;
 			$facligne->fk_product = 0; // Predefined Product ID
 			$facligne->qty = 1;


### PR DESCRIPTION
Facture::insert_discount() builds the invoice line from the discount, and the second local tax was copied from the first one:

    $facligne->localtax1_tx = $remise->localtax1_tx;
    $facligne->localtax1_type = (int) $remise->localtax1_type;
    $facligne->localtax2_tx = $remise->localtax1_tx;      // localtax1 instead of localtax2
    $facligne->localtax2_type = (int) $remise->localtax1_type;

So the line is created with localtax2 equal to the localtax1 rate of the discount rather than its own localtax2. DiscountAbsolute does load and store localtax2_tx and localtax2_type, discount.class.php:288-289, so the correct values were available, they were just not read.

For the reported Quebec setup the dictionary row is taux = 5 with localtax1 = 9.975 and localtax2 = 0, so the discount line ends up carrying 9.975 twice instead of once, and the tax totals of the invoice no longer reconcile, which matches the duplicated tax line in the report.

Effect of the change on a discount holding two distinct local taxes:

| field | before | after |
| --- | --- | --- |
| localtax2_tx | 9.975 (the localtax1 rate) | 2.5 (its own rate) |

The local tax propagation itself was introduced in 24.0 by the DiscountAbsolute refactor, 5b95397100f (#38808). 23.0 and earlier only set tva_tx on that line, so only 24.0 and develop are affected and there is nothing to backport.

Note this fixes the propagation of the rate to the discount line. The report also mentions the compound rate shown as "5% (TPS+TVQ)" in the discount list, which is a display concern in a different place, I have not touched it here.