### PR TITLE
Fix #37566 sum every previous situation for the progress shown on the PDF

### DIFF
--- a/htdocs/core/lib/pdf.lib.php
+++ b/htdocs/core/lib/pdf.lib.php
@@ -2523,8 +2523,22 @@ function pdf_getlineprogress($object, $i, $outputlangs, $hidedetails = 0, $hookm
 				// - old mode but we want to show a delta or
 				// - new mode but we want to show a total
 				$prev_progress = 0;
-				if (method_exists($object->lines[$i], 'get_prev_progress')) {
-					$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
+				if ($isCumulative) {
+					// old mode: the previous line already holds the running total
+					if (method_exists($object->lines[$i], 'get_prev_progress')) {
+						$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
+					}
+				} else {
+					// new mode: each line holds its own delta, so we must sum every previous one.
+					// get_prev_progress() only reads the line pointed by fk_prev_id, which is the last
+					// delta and not the accumulated progress, so it under-reports from the third
+					// situation on. getAllPrevProgress() walks the whole fk_prev_id chain, and it is
+					// what the screen uses to compute the same value.
+					if (method_exists($object->lines[$i], 'getAllPrevProgress')) {
+						$prev_progress = $object->lines[$i]->getAllPrevProgress($object->id);
+					} elseif (method_exists($object->lines[$i], 'get_prev_progress')) {
+						$prev_progress = $object->lines[$i]->get_prev_progress($object->id);
+					}
 				}
 				$result = $isCumulative ?
 					// old mode: we need to compute the delta (total - sum of previous)


### PR DESCRIPTION
With INVOICE_USE_SITUATION set to 2 each invoice line stores its own progress delta, so the total to print is the sum of all previous deltas plus the current one.

pdf_getlineprogress() computed that total with get_prev_progress(), which reads only the line pointed by fk_prev_id, factureligne.class.php:943, so it returns the last delta rather than the accumulated progress. The first two situations still look right, because at that point the previous delta is the whole history, and it drifts from the third one on, which matches the title of the report.

With the reported situations of 10, 10 and 30 percent:

| situation | printed before | printed after | expected |
| --- | --- | --- | --- |
| s1 | 10% | 10% | 10% |
| s2 | 20% | 20% | 20% |
| s3 | 40% | 50% | 50% |

The screen was already correct because compta/facture/card.php:3344 uses getAllPrevProgress() for that mode, which walks the whole fk_prev_id chain. The PDF now uses the same method, which is why sponge and octopus both showed the wrong value: they share pdf_getlineprogress().

The cumulative mode is untouched and keeps calling get_prev_progress(), where the previous line already holds the running total. Checked that mode 1 still prints 10, 10 and 30 for the same cycle. The new call stays behind method_exists() since pdf_getlineprogress() also runs for propal and order objects that do not implement it.

The mode aware code in pdf.lib.php starts at 23.0, so this targets 23.0. The report is against 22.0.4, where that branch of the function does not exist yet.