### PR TITLE
Fix #39327 stop accepting an online payment for an abandoned invoice

### DIFF
--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -2441,10 +2441,11 @@ if ($action != 'dopayment') {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("OrderBilled").'</div>';
 		} elseif ($source == 'invoice' && $object->paye) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("InvoicePaid").'</div>';
-		} elseif ($source == 'invoice' && $object->status == Facture::STATUS_ABANDONED && !getDolGlobalString('ONLINE_PAYMENT_ACCEPT_ABANDONED_INVOICE')) {
-			// An abandoned invoice is closed with no payment expected, for instance when it has been replaced,
-			// so the link must not keep accepting a payment. ONLINE_PAYMENT_ACCEPT_ABANDONED_INVOICE restores
-			// the previous behaviour for setups that still collect on such invoices.
+		} elseif ($source == 'invoice' && $object->status == Facture::STATUS_ABANDONED && $object->close_code == Facture::CLOSECODE_REPLACED) {
+			// Only refuse the payment when the invoice was closed because it has been replaced: the amount is
+			// then claimed by the replacement invoice and paying this link would pay it twice. An invoice
+			// abandoned for any other reason, a bad debt for instance, keeps its link usable, since a customer
+			// paying it anyway is a good outcome.
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("Abandoned").'</div>';
 		} elseif ($source == 'donation' && $object->paid) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("DonationPaid").'</div>';

--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -2441,6 +2441,11 @@ if ($action != 'dopayment') {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("OrderBilled").'</div>';
 		} elseif ($source == 'invoice' && $object->paye) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("InvoicePaid").'</div>';
+		} elseif ($source == 'invoice' && $object->status == Facture::STATUS_ABANDONED && !getDolGlobalString('ONLINE_PAYMENT_ACCEPT_ABANDONED_INVOICE')) {
+			// An abandoned invoice is closed with no payment expected, for instance when it has been replaced,
+			// so the link must not keep accepting a payment. ONLINE_PAYMENT_ACCEPT_ABANDONED_INVOICE restores
+			// the previous behaviour for setups that still collect on such invoices.
+			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("Abandoned").'</div>';
 		} elseif ($source == 'donation' && $object->paid) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("DonationPaid").'</div>';
 		} else {


### PR DESCRIPTION
The public payment page decides whether an invoice can still be paid by looking at the paye flag only, newpayment.php around line 2442. Facture::setCanceled() sets fk_statut to STATUS_ABANDONED and never touches paye, which stays at 0, so an invoice closed after being replaced keeps showing a working payment form and its Stripe link stays usable. That is the reported behaviour, and paying that link pays an amount already claimed by the replacement invoice.

Following @aspangaro's review, the refusal is limited to that case only, tested on close_code against CLOSECODE_REPLACED. An invoice abandoned for any other reason keeps its link usable, since a customer paying it anyway is a good outcome.

| invoice | before | after |
| --- | --- | --- |
| draft | form shown | form shown |
| validated | form shown | form shown |
| abandoned, replaced | form shown | refused |
| abandoned, bad customer | form shown | form shown |
| abandoned, abandon or other | form shown | form shown |
| closed and paid | refused | refused |

The message reuses the existing Abandoned key of bills.lang, already loaded on that page, so no new translation key is introduced and there is nothing to add on Transifex.

The guard is missing on every branch from 18.0 to develop. This targets 23.0, the version of the report.