### PR TITLE
Qual: Reduce redundant queries on user/group permissions pages

### DIFF
--- a/htdocs/core/extrafieldsinexport.inc.php
+++ b/htdocs/core/extrafieldsinexport.inc.php
@@ -39,12 +39,25 @@ if (empty($keyforselect) || empty($keyforelement) || empty($keyforaliasextra)) {
 }
 
 // Add extra fields
-$sql = "SELECT name, label, type, param, fieldcomputed, fielddefault FROM ".MAIN_DB_PREFIX."extrafields";
-$sql .= " WHERE elementtype = '".$this->db->escape($keyforselect)."' AND type <> 'separate' AND entity IN (0, ".((int) $conf->entity).') ORDER BY pos ASC';
-//print $sql;
-$resql = $this->db->query($sql);
-if ($resql) {    // This can fail when class is used on old database (during migration for example)
-	while ($obj = $this->db->fetch_object($resql)) {
+// The list of extrafields for a given elementtype/entity is identical for every module that exports it,
+// so it is cached for the duration of the request instead of being re-queried on each inclusion of this file
+// (a page like user/perms.php that instantiates every module can otherwise trigger the same query dozens of times).
+$cachekey = $keyforselect.'_'.$conf->entity;
+if (!isset($conf->cache['extrafieldsinexport'][$cachekey])) {
+	$sql = "SELECT name, label, type, param, fieldcomputed, fielddefault FROM ".MAIN_DB_PREFIX."extrafields";
+	$sql .= " WHERE elementtype = '".$this->db->escape($keyforselect)."' AND type <> 'separate' AND entity IN (0, ".((int) $conf->entity).') ORDER BY pos ASC';
+	//print $sql;
+	$tmparrayextrafieldsinexport = array();
+	$resql = $this->db->query($sql);
+	if ($resql) {    // This can fail when class is used on old database (during migration for example)
+		while ($obj = $this->db->fetch_object($resql)) {
+			$tmparrayextrafieldsinexport[] = $obj;
+		}
+	}
+	$conf->cache['extrafieldsinexport'][$cachekey] = $tmparrayextrafieldsinexport;
+}
+if (!empty($conf->cache['extrafieldsinexport'][$cachekey])) {
+	foreach ($conf->cache['extrafieldsinexport'][$cachekey] as $obj) {
 		$fieldname = $keyforaliasextra.'.'.$obj->name;
 		$fieldlabel = ucfirst($obj->label);
 		$typeFilter = "Text";

--- a/htdocs/core/extrafieldsinexport.inc.php
+++ b/htdocs/core/extrafieldsinexport.inc.php
@@ -26,6 +26,7 @@
 '
 @phan-var-force DolibarrModules $this
 @phan-var-force int $r
+@phan-var-force stdClass $obj
 ';
 
 // $keyforselect = name of main table

--- a/htdocs/core/extrafieldsinexport.inc.php
+++ b/htdocs/core/extrafieldsinexport.inc.php
@@ -26,7 +26,6 @@
 '
 @phan-var-force DolibarrModules $this
 @phan-var-force int $r
-@phan-var-force stdClass $obj
 ';
 
 // $keyforselect = name of main table
@@ -59,6 +58,7 @@ if (!isset($conf->cache['extrafieldsinexport'][$cachekey])) {
 }
 if (!empty($conf->cache['extrafieldsinexport'][$cachekey])) {
 	foreach ($conf->cache['extrafieldsinexport'][$cachekey] as $obj) {
+		'@phan-var-force stdClass $obj';
 		$fieldname = $keyforaliasextra.'.'.$obj->name;
 		$fieldlabel = ucfirst($obj->label);
 		$typeFilter = "Text";

--- a/htdocs/core/extrafieldsinimport.inc.php
+++ b/htdocs/core/extrafieldsinimport.inc.php
@@ -36,12 +36,25 @@ if (empty($keyforselect) || empty($keyforelement) || empty($keyforaliasextra)) {
 }
 
 // Add extra fields
-$sql = "SELECT name, label, type, param, fieldcomputed, fielddefault, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields";
-$sql .= " WHERE elementtype = '".$this->db->escape($keyforselect)."' AND type <> 'separate' AND entity IN (0, ".((int) $conf->entity).') ORDER BY pos ASC';
-//print $sql;
-$resql = $this->db->query($sql);
-if ($resql) {    // This can fail when class is used on old database (during migration for example)
-	while ($obj = $this->db->fetch_object($resql)) {
+// The list of extrafields for a given elementtype/entity is identical for every module that imports it,
+// so it is cached for the duration of the request instead of being re-queried on each inclusion of this file
+// (a page like user/perms.php that instantiates every module can otherwise trigger the same query dozens of times).
+$cachekey = $keyforselect.'_'.$conf->entity;
+if (!isset($conf->cache['extrafieldsinimport'][$cachekey])) {
+	$sql = "SELECT name, label, type, param, fieldcomputed, fielddefault, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields";
+	$sql .= " WHERE elementtype = '".$this->db->escape($keyforselect)."' AND type <> 'separate' AND entity IN (0, ".((int) $conf->entity).') ORDER BY pos ASC';
+	//print $sql;
+	$tmparrayextrafieldsinimport = array();
+	$resql = $this->db->query($sql);
+	if ($resql) {    // This can fail when class is used on old database (during migration for example)
+		while ($obj = $this->db->fetch_object($resql)) {
+			$tmparrayextrafieldsinimport[] = $obj;
+		}
+	}
+	$conf->cache['extrafieldsinimport'][$cachekey] = $tmparrayextrafieldsinimport;
+}
+if (!empty($conf->cache['extrafieldsinimport'][$cachekey])) {
+	foreach ($conf->cache['extrafieldsinimport'][$cachekey] as $obj) {
 		$fieldname = $keyforaliasextra.'.'.$obj->name;
 		$fieldlabel = ucfirst($obj->label);
 		$typeFilter = "Text";

--- a/htdocs/core/extrafieldsinimport.inc.php
+++ b/htdocs/core/extrafieldsinimport.inc.php
@@ -23,7 +23,10 @@
  * @var string $keyforaliasextra
  * @var int $r
  */
-'@phan-var-force DolibarrModules $this';
+'
+@phan-var-force DolibarrModules $this
+@phan-var-force stdClass $obj
+';
 
 // $keyforselect = name of main table
 // keyforelement = name of picto

--- a/htdocs/core/extrafieldsinimport.inc.php
+++ b/htdocs/core/extrafieldsinimport.inc.php
@@ -23,10 +23,7 @@
  * @var string $keyforaliasextra
  * @var int $r
  */
-'
-@phan-var-force DolibarrModules $this
-@phan-var-force stdClass $obj
-';
+'@phan-var-force DolibarrModules $this';
 
 // $keyforselect = name of main table
 // keyforelement = name of picto
@@ -58,6 +55,7 @@ if (!isset($conf->cache['extrafieldsinimport'][$cachekey])) {
 }
 if (!empty($conf->cache['extrafieldsinimport'][$cachekey])) {
 	foreach ($conf->cache['extrafieldsinimport'][$cachekey] as $obj) {
+		'@phan-var-force stdClass $obj';
 		$fieldname = $keyforaliasextra.'.'.$obj->name;
 		$fieldlabel = ucfirst($obj->label);
 		$typeFilter = "Text";

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -1981,9 +1981,13 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 	 * @param  int<0,1>	$reinitadminperms 	If 1, we also grant them to all admin users
 	 * @param  ?int		$force_entity     	Force current entity
 	 * @param  int<0,1> $notrigger        	1=Does not execute triggers, 0= execute triggers
+	 * @param  ?array<int,int>	$existingrightsdefids	Optional preloaded map of rights_def.id => 1 already present for the target entity (as returned
+	 *                                                  by a single "SELECT id FROM llx_rights_def WHERE entity = X" done by the caller). When provided,
+	 *                                                  it is used instead of issuing one "SELECT count(*)" query per permission of this module - useful
+	 *                                                  for callers (like user/perms.php) that call insert_permissions() in a loop for many modules.
 	 * @return int		                	Error count (0 if OK)
 	 */
-	public function insert_permissions($reinitadminperms = 0, $force_entity = null, $notrigger = 0)
+	public function insert_permissions($reinitadminperms = 0, $force_entity = null, $notrigger = 0, $existingrightsdefids = null)
 	{
 		// phpcs:enable
 		global $conf, $user;
@@ -2042,14 +2046,24 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 					$r_enabled	= $this->rights[$key][self::KEY_ENABLED] ?? '1';
 
 					// Search if perm already present
-					$sql = "SELECT count(*) as nb FROM ".MAIN_DB_PREFIX."rights_def";
-					$sql .= " WHERE entity = ".((int) $entity);
-					$sql .= " AND id = ".((int) $r_id);
+					if ($existingrightsdefids !== null) {
+						$rightalreadyexists = !empty($existingrightsdefids[$r_id]);
+					} else {
+						$sql = "SELECT count(*) as nb FROM ".MAIN_DB_PREFIX."rights_def";
+						$sql .= " WHERE entity = ".((int) $entity);
+						$sql .= " AND id = ".((int) $r_id);
 
-					$resqlselect = $this->db->query($sql);
-					if ($resqlselect) {
-						$objcount = $this->db->fetch_object($resqlselect);
-						if ($objcount && $objcount->nb == 0) {
+						$rightalreadyexists = true; // Assume it exists if the select fails, so we never try to insert on a query error
+						$resqlselect = $this->db->query($sql);
+						if ($resqlselect) {
+							$objcount = $this->db->fetch_object($resqlselect);
+							$rightalreadyexists = !($objcount && $objcount->nb == 0);
+							$this->db->free($resqlselect);
+						}
+					}
+
+					if (!$rightalreadyexists) {
+						{
 							$sql = "INSERT INTO ".MAIN_DB_PREFIX."rights_def (";
 							$sql .= "id";
 							$sql .= ", entity";
@@ -2094,8 +2108,6 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 
 							$this->db->free($resqlinsert);
 						}
-
-						$this->db->free($resqlselect);
 					}
 
 					// If we want to init permissions on admin users

--- a/htdocs/core/modules/DolibarrModules.class.php
+++ b/htdocs/core/modules/DolibarrModules.class.php
@@ -2063,51 +2063,49 @@ class DolibarrModules // Can not be abstract, because we need to instantiate it 
 					}
 
 					if (!$rightalreadyexists) {
-						{
-							$sql = "INSERT INTO ".MAIN_DB_PREFIX."rights_def (";
-							$sql .= "id";
-							$sql .= ", entity";
-							$sql .= ", libelle";
-							$sql .= ", module";
-							$sql .= ", module_origin";
-							$sql .= ", module_position";		// Not that module_position can be fixed eynamically when accessing page user/perms.php
-							$sql .= ", family";
-							$sql .= ", family_position";
-							$sql .= ", type";	// Not used yet
-							$sql .= ", bydefault";
-							$sql .= ", perms";
-							$sql .= ", subperms";
-							$sql .= ", enabled";
-							$sql .= ") VALUES (";
-							$sql .= ((int) $r_id);
-							$sql .= ", ".((int) $entity);
-							$sql .= ", '".$this->db->escape($r_label)."'";
-							$sql .= ", '".$this->db->escape($r_module)."'";
-							$sql .= ", '".$this->db->escape($r_module_origin)."'";
-							$sql .= ", '".$this->db->escape((string) $r_module_position)."'";
-							$sql .= ", '".$this->db->escape($r_family)."'";
-							$sql .= ", '".$this->db->escape((string) $r_family_position)."'";
-							$sql .= ", '".$this->db->escape($r_type)."'";	// Not used yet
-							$sql .= ", ".((int) $r_default);
-							$sql .= ", '".$this->db->escape($r_perms)."'";
-							$sql .= ", '".$this->db->escape($r_subperms)."'";
-							$sql .= ", '".$this->db->escape($r_enabled)."'";
-							$sql .= ")";
+						$sql = "INSERT INTO ".MAIN_DB_PREFIX."rights_def (";
+						$sql .= "id";
+						$sql .= ", entity";
+						$sql .= ", libelle";
+						$sql .= ", module";
+						$sql .= ", module_origin";
+						$sql .= ", module_position";		// Not that module_position can be fixed eynamically when accessing page user/perms.php
+						$sql .= ", family";
+						$sql .= ", family_position";
+						$sql .= ", type";	// Not used yet
+						$sql .= ", bydefault";
+						$sql .= ", perms";
+						$sql .= ", subperms";
+						$sql .= ", enabled";
+						$sql .= ") VALUES (";
+						$sql .= ((int) $r_id);
+						$sql .= ", ".((int) $entity);
+						$sql .= ", '".$this->db->escape($r_label)."'";
+						$sql .= ", '".$this->db->escape($r_module)."'";
+						$sql .= ", '".$this->db->escape($r_module_origin)."'";
+						$sql .= ", '".$this->db->escape((string) $r_module_position)."'";
+						$sql .= ", '".$this->db->escape($r_family)."'";
+						$sql .= ", '".$this->db->escape((string) $r_family_position)."'";
+						$sql .= ", '".$this->db->escape($r_type)."'";	// Not used yet
+						$sql .= ", ".((int) $r_default);
+						$sql .= ", '".$this->db->escape($r_perms)."'";
+						$sql .= ", '".$this->db->escape($r_subperms)."'";
+						$sql .= ", '".$this->db->escape($r_enabled)."'";
+						$sql .= ")";
 
-							$resqlinsert = $this->db->query($sql, 1);
+						$resqlinsert = $this->db->query($sql, 1);
 
-							if (!$resqlinsert) {
-								if ($this->db->errno() != "DB_ERROR_RECORD_ALREADY_EXISTS") {
-									$this->error = $this->db->lasterror();
-									$err++;
-									break;
-								} else {
-									dol_syslog(get_class($this)."::insert_permissions record already exists", LOG_INFO);
-								}
+						if (!$resqlinsert) {
+							if ($this->db->errno() != "DB_ERROR_RECORD_ALREADY_EXISTS") {
+								$this->error = $this->db->lasterror();
+								$err++;
+								break;
+							} else {
+								dol_syslog(get_class($this)."::insert_permissions record already exists", LOG_INFO);
 							}
-
-							$this->db->free($resqlinsert);
 						}
+
+						$this->db->free($resqlinsert);
 					}
 
 					// If we want to init permissions on admin users

--- a/htdocs/user/group/perms.php
+++ b/htdocs/user/group/perms.php
@@ -184,6 +184,39 @@ $modulesdir = dolGetModulesDirs();
 // Modules to ignore depending on supplier module mode
 $excludedModules = getDolGlobalInt('MAIN_USE_NEW_SUPPLIERMOD') ? array('modFournisseur') : array('modSupplierOrder', 'modSupplierInvoice');
 
+// Preload MAIN_MODULE_* enablement for the target entity in one query, so we can skip calling
+// insert_permissions() (which starts by re-checking this same enablement with its own query) on
+// every disabled module found on disk. If we are looking at our own entity, $conf->global already
+// has this cached from bootstrap and no query is needed at all.
+if ($entity == $conf->entity) {
+	$enabledmoduleconst = (array) $conf->global;
+} else {
+	$enabledmoduleconst = array();
+	$sql = "SELECT ".$db->decrypt('name')." as name, ".$db->decrypt('value')." as value";
+	$sql .= " FROM ".MAIN_DB_PREFIX."const";
+	$sql .= " WHERE entity IN (0, ".((int) $entity).")";
+	$sql .= " ORDER BY entity"; // entity 0 first, then entity-specific overrides it
+	$resql = $db->query($sql);
+	if ($resql) {
+		while ($obj = $db->fetch_object($resql)) {
+			$enabledmoduleconst[$obj->name] = $obj->value;
+		}
+		$db->free($resql);
+	}
+}
+
+// Preload the ids of rights already present in llx_rights_def for this entity in one query, so insert_permissions()
+// below can check existence in-memory instead of issuing one "SELECT count(*)" query per permission of every module.
+$existingrightsdefids = array();
+$sql = "SELECT id FROM ".MAIN_DB_PREFIX."rights_def WHERE entity = ".((int) $entity);
+$resql = $db->query($sql);
+if ($resql) {
+	while ($obj = $db->fetch_object($resql)) {
+		$existingrightsdefids[$obj->id] = 1;
+	}
+	$db->free($resql);
+}
+
 $db->begin();
 
 foreach ($modulesdir as $dir) {
@@ -212,7 +245,11 @@ foreach ($modulesdir as $dir) {
 					}
 					// Load all permissions
 					if ($objMod->rights_class) {
-						$objMod->insert_permissions(0, $entity);
+						// Skip the DB round trip insert_permissions() would do just to find out the
+						// module is disabled for this entity - we already know from the preload above.
+						if (empty($objMod->const_name) || !empty($enabledmoduleconst[$objMod->const_name])) {
+							$objMod->insert_permissions(0, $entity, 0, $existingrightsdefids);
+						}
 						$modules[$objMod->rights_class] = $objMod;
 					}
 				}
@@ -231,6 +268,7 @@ $sql .= " FROM ".MAIN_DB_PREFIX."rights_def as r,";
 $sql .= " ".MAIN_DB_PREFIX."usergroup_rights as gr";
 $sql .= " WHERE gr.fk_id = r.id";
 $sql .= " AND gr.entity = ".((int) $entity);
+$sql .= " AND r.entity = ".((int) $entity);
 $sql .= " AND gr.fk_usergroup = ".((int) $object->id);
 
 dol_syslog("get user perms", LOG_DEBUG);

--- a/htdocs/user/perms.php
+++ b/htdocs/user/perms.php
@@ -178,6 +178,39 @@ $modulesdir = dolGetModulesDirs();
 // Modules to ignore depending on supplier module mode
 $excludedModules = getDolGlobalInt('MAIN_USE_NEW_SUPPLIERMOD') ? array('modFournisseur') : array('modSupplierOrder', 'modSupplierInvoice');
 
+// Preload MAIN_MODULE_* enablement for the target entity in one query, so we can skip calling
+// insert_permissions() (which starts by re-checking this same enablement with its own query) on
+// every disabled module found on disk. If we are looking at our own entity, $conf->global already
+// has this cached from bootstrap and no query is needed at all.
+if ($entity == $conf->entity) {
+	$enabledmoduleconst = (array) $conf->global;
+} else {
+	$enabledmoduleconst = array();
+	$sql = "SELECT ".$db->decrypt('name')." as name, ".$db->decrypt('value')." as value";
+	$sql .= " FROM ".MAIN_DB_PREFIX."const";
+	$sql .= " WHERE entity IN (0, ".((int) $entity).")";
+	$sql .= " ORDER BY entity"; // entity 0 first, then entity-specific overrides it
+	$resql = $db->query($sql);
+	if ($resql) {
+		while ($obj = $db->fetch_object($resql)) {
+			$enabledmoduleconst[$obj->name] = $obj->value;
+		}
+		$db->free($resql);
+	}
+}
+
+// Preload the ids of rights already present in llx_rights_def for this entity in one query, so insert_permissions()
+// below can check existence in-memory instead of issuing one "SELECT count(*)" query per permission of every module.
+$existingrightsdefids = array();
+$sql = "SELECT id FROM ".MAIN_DB_PREFIX."rights_def WHERE entity = ".((int) $entity);
+$resql = $db->query($sql);
+if ($resql) {
+	while ($obj = $db->fetch_object($resql)) {
+		$existingrightsdefids[$obj->id] = 1;
+	}
+	$db->free($resql);
+}
+
 foreach ($modulesdir as $dir) {
 	$handle = @opendir(dol_osencode($dir));
 	if (is_resource($handle)) {
@@ -204,7 +237,11 @@ foreach ($modulesdir as $dir) {
 					}
 					// Load all permissions
 					if ($objMod->rights_class) {
-						$objMod->insert_permissions(0, $entity);
+						// Skip the DB round trip insert_permissions() would do just to find out the
+						// module is disabled for this entity - we already know from the preload above.
+						if (empty($objMod->const_name) || !empty($enabledmoduleconst[$objMod->const_name])) {
+							$objMod->insert_permissions(0, $entity, 0, $existingrightsdefids);
+						}
 						$modules[$objMod->rights_class] = $objMod;
 						//print "modules[".$objMod->rights_class."]=$objMod;";
 					}


### PR DESCRIPTION
Cache extrafields lookups per request and batch rights_def existence checks instead of issuing them once per module/permission.


