### PR TITLE
Fix #39618 show a readable message when the third party is not a vendor

### DIFF
--- a/htdocs/fourn/card.php
+++ b/htdocs/fourn/card.php
@@ -217,8 +217,21 @@ if ($id > 0 && empty($object->id)) {
 	// Load data of third party
 	$res = $object->fetch($id);
 	if ($object->id <= 0) {
-		dol_print_error($db, $object->error);
-		exit(1);
+		if ($object->error) {
+			dol_print_error($db, $object->error);
+			exit(1);
+		}
+		// Fournisseur::fetch() filters on s.fournisseur > 0, so a third party that exists but is no
+		// longer a vendor returns no row and no database error. Show a readable message with a link to
+		// the generic card instead of the technical error page (#39618).
+		$langs->load("errors");
+		llxHeader('', $langs->trans("ThirdParty").' - '.$langs->trans('Supplier'));
+		print '<div class="warning">'.$langs->trans("ErrorRecordNotFound").' ('.$langs->trans("Supplier").')';
+		print ' <a href="'.DOL_URL_ROOT.'/societe/card.php?socid='.((int) $id).'">'.$langs->trans("ThirdParty").'</a>';
+		print '</div>';
+		llxFooter();
+		$db->close();
+		exit(0);
 	}
 }
 


### PR DESCRIPTION
Per @eldy on the issue: "Switching to remove supplier flag is a rare case, so a clear error message would be enough."

Fournisseur::fetch() filters on s.fournisseur > 0, societe/class/societe.class.php:2012, so a third party that still exists but is no longer flagged as a vendor returns no row and sets no database error. fourn/card.php:221 then called dol_print_error($db, $object->error) with nothing to report, which rendered the generic technical error page. That is what a stored link to /fourn/card.php?socid=X gives after the third party has been switched from vendor to customer, which is the reported symptom.

A real database failure still goes to dol_print_error(). Only the not-a-vendor case gets the readable message, with a link to the generic third party card so the user can carry on.

Verified on 23.0.4 against the reported scenario:

- fournisseur=0, client=1: was the technical error page, now HTTP 200 with "Enregistrement non trouvé. (Fournisseur)" and a link to /societe/card.php?socid=X
- fournisseur=1: unchanged, the vendor card renders normally and no warning is shown

The message reuses the existing ErrorRecordNotFound, Supplier and ThirdParty keys, with $langs->load("errors") since that file is not loaded by this page, so no new translation key is introduced and there is nothing to add on Transifex.