### PR TITLE
Fix #39327 add an option to refuse payment on any abandoned invoice

### DIFF
--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -2441,11 +2441,14 @@ if ($action != 'dopayment') {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("OrderBilled").'</div>';
 		} elseif ($source == 'invoice' && $object->paye) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("InvoicePaid").'</div>';
-		} elseif ($source == 'invoice' && $object->status == Facture::STATUS_ABANDONED && $object->close_code == Facture::CLOSECODE_REPLACED) {
+		} elseif ($source == 'invoice' && $object->status == Facture::STATUS_ABANDONED && ($object->close_code == Facture::CLOSECODE_REPLACED || getDolGlobalString('ONLINE_PAYMENT_REFUSE_ABANDONED_INVOICE'))) {
 			// Only refuse the payment when the invoice was closed because it has been replaced: the amount is
 			// then claimed by the replacement invoice and paying this link would pay it twice. An invoice
 			// abandoned for any other reason, a bad debt for instance, keeps its link usable, since a customer
 			// paying it anyway is a good outcome.
+			// ONLINE_PAYMENT_REFUSE_ABANDONED_INVOICE extends the refusal to every abandoned invoice, for
+			// jurisdictions where collecting is no longer allowed once a receivable has been written off or
+			// sent to collections (#39327).
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("Abandoned").'</div>';
 		} elseif ($source == 'donation' && $object->paid) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("DonationPaid").'</div>';

--- a/htdocs/public/payment/newpayment.php
+++ b/htdocs/public/payment/newpayment.php
@@ -2441,14 +2441,14 @@ if ($action != 'dopayment') {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("OrderBilled").'</div>';
 		} elseif ($source == 'invoice' && $object->paye) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("InvoicePaid").'</div>';
-		} elseif ($source == 'invoice' && $object->status == Facture::STATUS_ABANDONED && ($object->close_code == Facture::CLOSECODE_REPLACED || getDolGlobalString('ONLINE_PAYMENT_REFUSE_ABANDONED_INVOICE'))) {
+		} elseif ($source == 'invoice' && $object->status == Facture::STATUS_ABANDONED && ($object->close_code == Facture::CLOSECODE_REPLACED || getDolGlobalString('INVOICE_ONLINE_PAYMENT_REFUSED_WHATEVER_IS_ABANDON_REASON'))) {
 			// Only refuse the payment when the invoice was closed because it has been replaced: the amount is
 			// then claimed by the replacement invoice and paying this link would pay it twice. An invoice
 			// abandoned for any other reason, a bad debt for instance, keeps its link usable, since a customer
 			// paying it anyway is a good outcome.
-			// ONLINE_PAYMENT_REFUSE_ABANDONED_INVOICE extends the refusal to every abandoned invoice, for
-			// jurisdictions where collecting is no longer allowed once a receivable has been written off or
-			// sent to collections (#39327).
+			// INVOICE_ONLINE_PAYMENT_REFUSED_WHATEVER_IS_ABANDON_REASON extends the refusal to every
+			// abandoned invoice, for jurisdictions where collecting is no longer allowed once a
+			// receivable has been written off or sent to collections (#39327).
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("Abandoned").'</div>';
 		} elseif ($source == 'donation' && $object->paid) {
 			print '<br><br><div class="amountpaymentcomplete size12x wrapimp">'.$langs->trans("DonationPaid").'</div>';


### PR DESCRIPTION
Follow-up to #39713, requested by @meuchels on the issue: "in our state if an invoice goes to collections you are no longer authorized to collect on it. therefore abandon the invoice should kill the link. maybe it should be optional??"

The guard merged in #39713 refuses the payment only when close_code is 'replaced', which is the right default and what @aspangaro asked for: a customer determined to pay an invoice abandoned as a bad debt is a good outcome, so the link stays usable. But in jurisdictions where a written off or collections-bound receivable may no longer be collected by the creditor, the link has to die whatever the close code.

ONLINE_PAYMENT_REFUSE_ABANDONED_INVOICE extends the refusal to every abandoned invoice, off by default.

| invoice | default, unchanged | with the constant |
| --- | --- | --- |
| validated | form shown | form shown |
| abandoned, replaced | refused | refused |
| abandoned, bad customer | form shown | refused |
| abandoned, abandon | form shown | refused |
| abandoned, other | form shown | refused |
| closed and paid | refused | refused |

So nothing changes for anyone who does not set it, and both readings of the law are supported. No new translation key, the existing Abandoned string of bills.lang is reused as in #39713.