### PR TITLE
FIX Wrong stock valuation when MultiCompany PMP per entity is enabled

### DIFF
--- a/htdocs/product/stock/card.php
+++ b/htdocs/product/stock/card.php
@@ -716,7 +716,10 @@ if ($action == 'create') {
 			$sql .= "p.accountancy_code_buy_export,";
 			$sql .= 'p.barcode,';
 			if ($separatedPMP) {
-				$sql .= " pa.pmp as ppmp,";
+				// COALESCE: a product may have no row yet in llx_product_perentity (rows are created
+				// on the first stock movement), so fall back on the global p.pmp like Product::fetch()
+				// does, instead of showing an empty AWP.
+				$sql .= " COALESCE(pa.pmp, p.pmp) as ppmp,";
 			} else {
 				$sql .= " p.pmp as ppmp,";
 			}
@@ -724,7 +727,13 @@ if ($action == 'create') {
 			if (getDolGlobalString('PRODUCT_USE_UNITS')) {
 				$sql .= ",fk_unit";
 			}
-			$sql .= ", (ps.reel * p.pmp) as svalue";
+			// svalue is the sort key of the "estimated value" column, so it must use the same AWP
+			// as ppmp above (the displayed value is recomputed in PHP from ppmp).
+			if ($separatedPMP) {
+				$sql .= ", (ps.reel * COALESCE(pa.pmp, p.pmp)) as svalue";
+			} else {
+				$sql .= ", (ps.reel * p.pmp) as svalue";
+			}
 			// Add fields from hooks
 			$parameters = array('context' => 'warehousecard');
 			$reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters); // Note that $action and $object may have been modified by hook
@@ -735,7 +744,9 @@ if ($action == 'create') {
 			$sql .= " FROM ".MAIN_DB_PREFIX."product_stock as ps, ".MAIN_DB_PREFIX."product as p";
 
 			if ($separatedPMP) {
-				$sql .= ", ".MAIN_DB_PREFIX."product_perentity as pa";
+				// LEFT JOIN (not an inner join): a product with no llx_product_perentity row must
+				// still be listed in the warehouse content, falling back on the global p.pmp.
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product_perentity as pa ON pa.fk_product = p.rowid AND pa.entity = ".((int) $conf->entity);
 			}
 			$parameters = array('context' => 'warehousecard');
 			$reshook = $hookmanager->executeHooks('printFieldListFrom', $parameters); // Note that $action and $object may have been modified by hook
@@ -748,9 +759,6 @@ if ($action == 'create') {
 			$sql .= " AND ps.reel <> 0"; // We do not show if stock is 0 (no product in this warehouse)
 			$sql .= " AND ps.fk_entrepot = ".((int) $object->id);
 
-			if ($separatedPMP) {
-				$sql .= " AND pa.fk_product = p.rowid AND pa.entity = ".(int) $conf->entity;
-			}
 			$parameters = array('context' => 'warehousecard');
 			$reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters); // Note that $action and $object may have been modified by hook
 			if ($reshook > 0) {			//Note that $sql is replaced if reshook > 0

--- a/htdocs/product/stock/class/entrepot.class.php
+++ b/htdocs/product/stock/class/entrepot.class.php
@@ -723,19 +723,21 @@ class Entrepot extends CommonObject
 		}
 
 		if ($separatedPMP) {
-			$sql = "SELECT sum(ps.reel) as nb, sum(ps.reel * pa.pmp) as value";
+			// COALESCE: a product may have no row yet in llx_product_perentity (rows are created on
+			// the first stock movement), so fall back on the global p.pmp like Product::fetch() does,
+			// instead of valuing such a product at 0.
+			$sql = "SELECT sum(ps.reel) as nb, sum(ps.reel * COALESCE(pa.pmp, p.pmp)) as value";
 		} else {
 			$sql = "SELECT sum(ps.reel) as nb, sum(ps.reel * p.pmp) as value";
 		}
 		$sql .= " FROM ".$this->db->prefix()."product_stock as ps";
 		$sql .= ", ".$this->db->prefix()."product as p";
 		if ($separatedPMP) {
-			$sql .= ", ".$this->db->prefix()."product_perentity as pa";
+			// LEFT JOIN (not an inner join): a product with no llx_product_perentity row must still
+			// be counted in nb and valued using the global p.pmp.
+			$sql .= " LEFT JOIN ".$this->db->prefix()."product_perentity as pa ON pa.fk_product = p.rowid AND pa.entity = ".((int) $conf->entity);
 		}
 		$sql .= " WHERE ps.fk_entrepot = ".((int) $this->id);
-		if ($separatedPMP) {
-			$sql .= " AND pa.fk_product = p.rowid AND pa.entity = ". (int) $conf->entity;
-		}
 		$sql .= " AND ps.fk_product = p.rowid";
 		//print $sql;
 		$result = $this->db->query($sql);

--- a/htdocs/product/stock/list.php
+++ b/htdocs/product/stock/list.php
@@ -231,7 +231,10 @@ if (!empty($extrafields->attributes[$object->table_element]['label'])) {
 $separatedPMP = false;
 if (getDolGlobalString('MULTICOMPANY_PRODUCT_SHARING_ENABLED') && getDolGlobalString('MULTICOMPANY_PMP_PER_ENTITY_ENABLED')) {
 	$separatedPMP = true;
-	$sql .= ", SUM(pa.pmp * ps.reel) as estimatedvalue, SUM(p.price * ps.reel) as sellvalue, SUM(ps.reel) as stockqty";
+	// COALESCE: a product may have no row yet in llx_product_perentity (rows are created on the
+	// first stock movement), so fall back on the global p.pmp like Product::fetch() does, instead
+	// of valuing such a product at 0.
+	$sql .= ", SUM(COALESCE(pa.pmp, p.pmp) * ps.reel) as estimatedvalue, SUM(p.price * ps.reel) as sellvalue, SUM(ps.reel) as stockqty";
 } else {
 	$sql .= ", SUM(p.pmp * ps.reel) as estimatedvalue, SUM(p.price * ps.reel) as sellvalue, SUM(ps.reel) as stockqty";
 }


### PR DESCRIPTION
Rows in llx_product_perentity are only created on the first stock movement of a product in an entity, so a product with no row yet is the norm on an existing database, not an edge case. Product::fetch() already handles this by falling back on the global llx_product.pmp, but three other places did not, each in a different way:

- Entrepot::nb_products(): inner join, so such a product was excluded from both the product count and the warehouse value.
- product/stock/card.php: inner join, so such a product did not appear at all in the warehouse content list.
- product/stock/list.php: left join but no fallback, so pa.pmp was NULL and the product was valued at 0.

Align all three on the behaviour of Product::fetch(): left join plus an explicit COALESCE(pa.pmp, p.pmp) fallback. Behaviour is unchanged when the llx_product_perentity row exists.

Also fix product/stock/card.php where the "estimated value" column mixed both sources: ppmp (displayed) used pa.pmp while svalue (its sort key) used p.pmp, so the column did not sort on the value it showed.

