### PR TITLE
FIX Extra comma breaks SQL INSERT when transferring invoices to bookkeeping

### DIFF
--- a/htdocs/accountancy/class/bookkeeping.class.php
+++ b/htdocs/accountancy/class/bookkeeping.class.php
@@ -455,7 +455,7 @@ class BookKeeping extends CommonObject
 				$sql .= ", ".((float) $this->credit);
 				$sql .= ", ".((float) $this->montant);
 				$sql .= ", ".(!empty($this->sens) ? ("'".$this->db->escape($this->sens)."'") : "NULL");
-				$sql .= ", ".((int) $this->fk_user_author).",";
+				$sql .= ", ".((int) $this->fk_user_author);
 				$sql .= ", '".$this->db->idate($now)."'";
 				$sql .= ", '".$this->db->escape($this->code_journal)."'";
 				$sql .= ", ".(!empty($this->journal_label) ? ("'".$this->db->escape($this->journal_label)."'") : "NULL");


### PR DESCRIPTION
Bookkeeping::create() builds the INSERT statement by concatenating field values line by line. The fk_user_author value line ended with a stray trailing comma in addition to the leading comma the next line already adds, producing two commas back to back in the VALUES list ("..., 3,, '2026-...', ..."), an invalid SQL statement.

This made every single call to Bookkeeping::create() fail, so nothing could ever be transferred from the sales/purchases journals into llx_accounting_bookkeeping (Accountancy > Journals > Transfer). Found while testing the BOOKKEEPING accounting mode against real invoice data.

Reproduce: enable the Accounting module, configure default accounting accounts and a fiscal period, then try "Record transactions in accounting" from the sells or purchases journal on any validated invoice — it fails with a MySQL syntax error every time.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# UIUX|Uiux [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

