### PR TITLE
NEW Wire up BOOKKEEPING accounting mode in turnover reports

### DIFF
--- a/htdocs/compta/stats/cabyuser.php
+++ b/htdocs/compta/stats/cabyuser.php
@@ -188,10 +188,6 @@ llxHeader();
 
 $form = new Form($db);
 
-// TODO Report from bookkeeping not yet available, so we switch on report on business events
-if ($modecompta == "BOOKKEEPING") {
-	$modecompta = "CREANCES-DETTES";
-}
 if ($modecompta == "BOOKKEEPINGCOLLECTED") {
 	$modecompta = "RECETTES-DEPENSES";
 }
@@ -225,7 +221,10 @@ if ($modecompta == "CREANCES-DETTES") {
 	$builddate = dol_now();
 	//$exportlink=$langs->trans("NotYetAvailable");
 } elseif ($modecompta == "BOOKKEEPING") {
-	// TODO
+	$name = $langs->trans("Turnover").', '.$langs->trans("ByUserAuthorOfInvoice");
+	$calcmode = $langs->trans("CalcModeBookkeeping");
+	$description = $langs->trans("RulesCADue");
+	$builddate = dol_now();
 } elseif ($modecompta == "BOOKKEEPINGCOLLECTED") {
 	// TODO
 }
@@ -291,12 +290,36 @@ if ($modecompta == 'CREANCES-DETTES') {
 	if ($date_start && $date_end) {
 		$sql .= " AND p.datep >= '".$db->idate($date_start)."' AND p.datep <= '".$db->idate($date_end)."'";
 	}
-} // elseif ($modecompta == "BOOKKEEPING") {
-// } elseif ($modecompta == "BOOKKEEPINGCOLLECTED") {
+} elseif ($modecompta == "BOOKKEEPING") {
+	// Turnover per invoice author computed from the accounting ledger. Each posting is linked back to
+	// its source invoice via fk_doc (reliable at invoice level, unlike fk_docdet which the transfer
+	// engine does not preserve when several lines share the same account). HT is the sum of postings
+	// on INCOME-type accounts; TTC is the amount posted on the customer subledger line of the invoice.
+	$charofaccountstring = dol_getIdFromCode($db, getDolGlobalString('CHARTOFACCOUNTS'), 'accounting_system', 'rowid', 'pcg_version');
+
+	$sql = "SELECT u.rowid as rowid, u.lastname as name, u.firstname as firstname,";
+	$sql .= " SUM(CASE WHEN b.subledger_account IS NOT NULL AND b.subledger_account != '' THEN b.debit - b.credit ELSE 0 END) as amount_ttc,";
+	$sql .= " SUM(CASE WHEN aa.pcg_type = 'INCOME' THEN b.credit - b.debit ELSE 0 END) as amount";
+	$sql .= " FROM ".MAIN_DB_PREFIX."accounting_bookkeeping as b";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."facture as f ON f.rowid = b.fk_doc AND b.doc_type = 'customer_invoice'";
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."user as u ON u.rowid = f.fk_user_author";
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."accounting_account as aa ON aa.account_number = b.numero_compte AND aa.entity = b.entity AND aa.fk_pcg_version = '".$db->escape($charofaccountstring)."'";
+	$sql .= " WHERE 1=1";
+	if ($date_start && $date_end) {
+		$sql .= " AND b.doc_date >= '".$db->idate($date_start)."' AND b.doc_date <= '".$db->idate($date_end)."'";
+	}
+} // elseif ($modecompta == "BOOKKEEPINGCOLLECTED") {
 // }
-$sql .= " AND f.entity IN (".getEntity('invoice').")";
-if ($socid) {
-	$sql .= " AND f.fk_soc = ".((int) $socid);
+if ($modecompta == 'BOOKKEEPING') {
+	$sql .= " AND b.entity = ".((int) $conf->entity);
+	if ($socid) {
+		$sql .= " AND f.fk_soc = ".((int) $socid);
+	}
+} else {
+	$sql .= " AND f.entity IN (".getEntity('invoice').")";
+	if ($socid) {
+		$sql .= " AND f.fk_soc = ".((int) $socid);
+	}
 }
 $sql .= " GROUP BY u.rowid, u.lastname, u.firstname";
 $sql .= " ORDER BY u.rowid";
@@ -468,7 +491,7 @@ if (count($amount)) {
 			} else {
 				//print '<a href="'.DOL_URL_ROOT.'/compta/paiement/list.php?userid=-1">';
 			}
-		} elseif ($modecompta == 'CREANCES-DETTES') {
+		} elseif ($modecompta == 'CREANCES-DETTES' || $modecompta == 'BOOKKEEPING') {
 			if ($key > 0) {
 				print '<a href="'.DOL_URL_ROOT.'/compta/facture/list.php?userid='.$key.'">';
 			} else {
@@ -532,7 +555,7 @@ if (count($amount)) {
 	// Total
 	print '<tr class="liste_total">';
 	print '<td>'.$langs->trans("Total").'</td>';
-	if ($modecompta != 'CREANCES-DETTES') {
+	if ($modecompta == 'RECETTES-DEPENSES') {
 		print '<td></td>';
 	} else {
 		print '<td class="right">'.price($catotal_ht).'</td>';

--- a/htdocs/compta/stats/casoc.php
+++ b/htdocs/compta/stats/casoc.php
@@ -223,10 +223,6 @@ $form = new Form($db);
 $thirdparty_static = new Societe($db);
 $formother = new FormOther($db);
 
-// TODO Report from bookkeeping not yet available, so we switch on report on business events
-if ($modecompta == "BOOKKEEPING") {
-	$modecompta = "CREANCES-DETTES";
-}
 if ($modecompta == "BOOKKEEPINGCOLLECTED") {
 	$modecompta = "RECETTES-DEPENSES";
 }
@@ -259,8 +255,12 @@ if ($modecompta == "CREANCES-DETTES") {
 	$description .= $langs->trans("DepositsAreIncluded");
 	$builddate = dol_now();
 	//$exportlink=$langs->trans("NotYetAvailable");
-} // elseif ($modecompta == "BOOKKEEPING") {
-// } elseif ($modecompta == "BOOKKEEPINGCOLLECTED") {
+} elseif ($modecompta == "BOOKKEEPING") {
+	$name = $langs->trans("Turnover").', '.$langs->trans("ByThirdParties");
+	$calcmode = $langs->trans("CalcModeBookkeeping");
+	$description = $langs->trans("RulesCADue");
+	$builddate = dol_now();
+} // elseif ($modecompta == "BOOKKEEPINGCOLLECTED") {
 // }
 $period = $form->selectDate($date_start, 'date_start', 0, 0, 0, '', 1, 0, 0, '', '', '', '', 1, '', '', 'tzserver');
 $period .= ' - ';
@@ -345,9 +345,40 @@ if ($modecompta == 'CREANCES-DETTES') {
 		$sql .= ")";
 		$sql .= " AND cs.fk_categorie = c.rowid AND cs.fk_soc = s.rowid";
 	}
-} // elseif ($modecompta == "BOOKKEEPING") {
-// } elseif ($modecompta == "BOOKKEEPINGCOLLECTED") {
-// }
+} elseif ($modecompta == "BOOKKEEPING") {
+	// Turnover computed from the accounting ledger (llx_accounting_bookkeeping): HT is the sum of
+	// postings on INCOME-type accounts, TTC is the amount posted on the thirdparty subledger line
+	// (the customer control account line of each invoice), matched back to the thirdparty by
+	// thirdparty_code (set at transfer time from societe.code_client, see accountancy/journal/sellsjournal.php).
+	$charofaccountstring = dol_getIdFromCode($db, getDolGlobalString('CHARTOFACCOUNTS'), 'accounting_system', 'rowid', 'pcg_version');
+
+	$sql = "SELECT s.rowid as socid, s.nom as name, s.name_alias, s.zip, s.town, s.fk_pays,";
+	$sql .= " SUM(CASE WHEN b.subledger_account IS NOT NULL AND b.subledger_account != '' THEN b.debit - b.credit ELSE 0 END) as amount_ttc,";
+	$sql .= " SUM(CASE WHEN aa.pcg_type = 'INCOME' THEN b.credit - b.debit ELSE 0 END) as amount";
+	$sql .= " FROM ".MAIN_DB_PREFIX."accounting_bookkeeping as b";
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."accounting_account as aa ON aa.account_number = b.numero_compte AND aa.entity = b.entity AND aa.fk_pcg_version = '".$db->escape($charofaccountstring)."'";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."societe as s ON s.code_client = b.thirdparty_code";
+	if ($selected_cat === -2) {	// Without any category
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."categorie_societe as cs ON s.rowid = cs.fk_soc";
+	} elseif ($selected_cat) { 	// Into a specific category
+		$sql .= ", ".MAIN_DB_PREFIX."categorie as c, ".MAIN_DB_PREFIX."categorie_societe as cs";
+	}
+	$sql .= " WHERE b.doc_type = 'customer_invoice'";
+	$sql .= " AND b.thirdparty_code IS NOT NULL AND b.thirdparty_code != ''";
+	if ($date_start && $date_end) {
+		$sql .= " AND b.doc_date >= '".$db->idate($date_start)."' AND b.doc_date <= '".$db->idate($date_end)."'";
+	}
+	if ($selected_cat === -2) {	// Without any category
+		$sql .= " AND cs.fk_soc is null";
+	} elseif ($selected_cat) {	// Into a specific category
+		$sql .= " AND (c.rowid = ".((int) $selected_cat);
+		if ($subcat) {
+			$sql .= " OR c.fk_parent = ".((int) $selected_cat);
+		}
+		$sql .= ")";
+		$sql .= " AND cs.fk_categorie = c.rowid AND cs.fk_soc = s.rowid";
+	}
+}
 if (!empty($search_societe)) {
 	$sql .= natural_search('s.nom', $search_societe);
 }
@@ -360,9 +391,16 @@ if (!empty($search_town)) {
 if ($search_country > 0) {
 	$sql .= ' AND s.fk_pays = '.((int) $search_country);
 }
-$sql .= " AND f.entity IN (".getEntity('invoice').")";
-if ($socid) {
-	$sql .= " AND f.fk_soc = ".((int) $socid);
+if ($modecompta == 'BOOKKEEPING') {
+	$sql .= " AND b.entity = ".((int) $conf->entity);
+	if ($socid) {
+		$sql .= " AND s.rowid = ".((int) $socid);
+	}
+} else {
+	$sql .= " AND f.entity IN (".getEntity('invoice').")";
+	if ($socid) {
+		$sql .= " AND f.fk_soc = ".((int) $socid);
+	}
 }
 $sql .= " GROUP BY s.rowid, s.nom, s.name_alias, s.zip, s.town, s.fk_pays";
 $sql .= " ORDER BY s.rowid";
@@ -667,7 +705,7 @@ if (count($amount)) {
 
 		// Amount w/o VAT
 		print '<td class="right">';
-		if ($modecompta != 'CREANCES-DETTES') {
+		if ($modecompta == 'RECETTES-DEPENSES') {
 			if ($key > 0) {
 				print '<a href="'.DOL_URL_ROOT.'/compta/paiement/list.php?socid='.$key.'">';
 			} else {
@@ -727,7 +765,7 @@ if (count($amount)) {
 	print '<td>&nbsp;</td>';
 	print '<td>&nbsp;</td>';
 	print '<td>&nbsp;</td>';
-	if ($modecompta != 'CREANCES-DETTES') {
+	if ($modecompta == 'RECETTES-DEPENSES') {
 		print '<td></td>';
 	} else {
 		print '<td class="right">'.price($catotal_ht).'</td>';

--- a/htdocs/compta/stats/supplier_turnover_by_thirdparty.php
+++ b/htdocs/compta/stats/supplier_turnover_by_thirdparty.php
@@ -253,9 +253,10 @@ if ($modecompta == "CREANCES-DETTES") {
 
 	$builddate = dol_now();
 } elseif ($modecompta == "BOOKKEEPING") {
-	// TODO
-} elseif ($modecompta == "BOOKKEEPINGCOLLECTED") {
-	// TODO
+	$name = $langs->trans("PurchaseTurnover").', '.$langs->trans("ByThirdParties");
+	$calcmode = $langs->trans("CalcModeBookkeeping");
+	$description = $langs->trans("RulesPurchaseTurnoverDue");
+	$builddate = dol_now();
 }
 
 $period = $form->selectDate($date_start, 'date_start', 0, 0, 0, '', 1, 0, 0, '', '', '', '', 1, '', '', 'tzserver');
@@ -363,6 +364,24 @@ if ($modecompta == 'CREANCES-DETTES') {
 		$sql .= ")";
 		$sql .= " AND cs.fk_categorie = c.rowid AND cs.fk_soc = s.rowid";
 	}
+} elseif ($modecompta == "BOOKKEEPING") {
+	// Purchase turnover computed from the accounting ledger. HT is the sum of postings on
+	// EXPENSE-type accounts; TTC is the amount posted on the supplier subledger line of the invoice.
+	// Thirdparty_code is set at transfer time from societe.code_fournisseur (see
+	// accountancy/journal/purchasesjournal.php).
+	$charofaccountstring = dol_getIdFromCode($db, getDolGlobalString('CHARTOFACCOUNTS'), 'accounting_system', 'rowid', 'pcg_version');
+
+	$sql = "SELECT s.rowid as socid, s.nom as name, s.zip, s.town, s.fk_pays,";
+	$sql .= " SUM(CASE WHEN b.subledger_account IS NOT NULL AND b.subledger_account != '' THEN b.credit - b.debit ELSE 0 END) as amount_ttc,";
+	$sql .= " SUM(CASE WHEN aa.pcg_type = 'EXPENSE' THEN b.debit - b.credit ELSE 0 END) as amount";
+	$sql .= " FROM ".MAIN_DB_PREFIX."accounting_bookkeeping as b";
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."accounting_account as aa ON aa.account_number = b.numero_compte AND aa.entity = b.entity AND aa.fk_pcg_version = '".$db->escape($charofaccountstring)."'";
+	$sql .= " INNER JOIN ".MAIN_DB_PREFIX."societe as s ON s.code_fournisseur = b.thirdparty_code";
+	$sql .= " WHERE b.doc_type = 'supplier_invoice'";
+	$sql .= " AND b.thirdparty_code IS NOT NULL AND b.thirdparty_code != ''";
+	if ($date_start && $date_end) {
+		$sql .= " AND b.doc_date >= '".$db->idate($date_start)."' AND b.doc_date <= '".$db->idate($date_end)."'";
+	}
 }
 if (!empty($search_societe)) {
 	$sql .= natural_search('s.nom', $search_societe);
@@ -376,9 +395,16 @@ if (!empty($search_town)) {
 if ($search_country > 0) {
 	$sql .= ' AND s.fk_pays = '.((int) $search_country);
 }
-$sql .= " AND f.entity IN (".getEntity('supplier_invoice').")";
-if ($socid) {
-	$sql .= " AND f.fk_soc = ".((int) $socid);
+if ($modecompta == 'BOOKKEEPING') {
+	$sql .= " AND b.entity = ".((int) $conf->entity);
+	if ($socid) {
+		$sql .= " AND s.rowid = ".((int) $socid);
+	}
+} else {
+	$sql .= " AND f.entity IN (".getEntity('supplier_invoice').")";
+	if ($socid) {
+		$sql .= " AND f.fk_soc = ".((int) $socid);
+	}
 }
 $sql .= " GROUP BY s.rowid, s.nom, s.zip, s.town, s.fk_pays";
 $sql .= " ORDER BY s.rowid";
@@ -631,7 +657,7 @@ if (count($amount)) {
 
 		// Amount w/o VAT
 		print '<td class="right">';
-		if ($modecompta != 'CREANCES-DETTES') {
+		if ($modecompta == 'RECETTES-DEPENSES') {
 			if ($key > 0) {
 				print '<a href="'.DOL_URL_ROOT.'/fourn/facture/paiement/list.php?socid='.$key.'">';
 			} else {
@@ -649,7 +675,7 @@ if (count($amount)) {
 
 		// Amount with VAT
 		print '<td class="right">';
-		if ($modecompta != 'CREANCES-DETTES') {
+		if ($modecompta == 'RECETTES-DEPENSES') {
 			if ($key > 0) {
 				print '<a href="'.DOL_URL_ROOT.'/fourn/facture/paiement/list.php?socid='.$key.'">';
 			} else {
@@ -691,7 +717,7 @@ if (count($amount)) {
 	print '<td></td>';
 	print '<td></td>';
 	print '<td></td>';
-	if ($modecompta != 'CREANCES-DETTES') {
+	if ($modecompta == 'RECETTES-DEPENSES') {
 		print '<td></td>';
 	} else {
 		print '<td class="right">'.price($catotal_ht).'</td>';


### PR DESCRIPTION
Turnover, by third party (casoc.php), by user (cabyuser.php), and purchase turnover by third party (supplier_turnover_by_thirdparty.php) all offer a "Bookkeeping" mode in their UI, but silently fell back to CREANCES-DETTES (accrual on invoice dates) instead, ignoring the selected mode. compta/resultat/index.php already had a working BOOKKEEPING query to use as a reference.

Each report now queries llx_accounting_bookkeeping directly: HT is the sum of postings on INCOME/EXPENSE-type accounts, TTC is the amount posted on the customer/supplier subledger line of the invoice. Also fixed a legacy display condition in all three (`!= 'CREANCES-DETTES'`) that assumed only two modes could ever exist and so hid the HT column for BOOKKEEPING mode even where the query supplied it correctly.

Requires the accounting-transfer fix in a separate commit/PR (Bookkeeping::create() had a SQL syntax bug preventing any data from ever reaching llx_accounting_bookkeeping) to have real data to show.

Not included: cabyprodserv.php (turnover by product/service) and byratecountry.php (by VAT rate). Both group by individual invoice line, but the sales/purchases journal transfer aggregates ledger postings by (invoice, account) and does not preserve a reliable per-line reference (fk_docdet is always 0), so a correct per-line breakdown isn't recoverable from the ledger as currently written. Implementing it would mean changing what the transfer engine records, which is a bigger and riskier change than this PR's scope.
supplier_turnover.php (by month) already had a correct BOOKKEEPING implementation and needed no change.

Manually verified: transferred real invoices into the ledger and confirmed BOOKKEEPING mode's totals and per-row breakdown match CREANCES-DETTES exactly for the same dataset, as expected before any payments are recorded.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# UIUX|Uiux [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

