### PR TITLE
NEW Make the dictionary caches filterable through the loadDictionaryCache hook

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5090,7 +5090,6 @@ class Form
 				$i++;
 			}
 
-			$hookmanager->initHooks(array('dictionarycache'));
 			$parameters = array('dictionary' => 'paymentterm');
 			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 			if (empty($reshook)) {
@@ -5370,7 +5369,6 @@ class Form
 				$i++;
 			}
 
-			$hookmanager->initHooks(array('dictionarycache'));
 			$parameters = array('dictionary' => 'paymenttype');
 			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 			if (empty($reshook)) {
@@ -7946,7 +7944,6 @@ class Form
 					$this->cache_vatrates[$obj->rowid] = $tmparray;
 				}
 
-				$hookmanager->initHooks(array('dictionarycache'));
 				$parameters = array('dictionary' => 'vatrate', 'country_code' => $country_code);
 				$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 				if (empty($reshook)) {

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -5090,7 +5090,8 @@ class Form
 				$i++;
 			}
 
-			$parameters = array('context' => 'paymentterm');
+			$hookmanager->initHooks(array('dictionarycache'));
+			$parameters = array('dictionary' => 'paymentterm');
 			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 			if (empty($reshook)) {
 				if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
@@ -5369,7 +5370,8 @@ class Form
 				$i++;
 			}
 
-			$parameters = array('context' => 'paymenttype');
+			$hookmanager->initHooks(array('dictionarycache'));
+			$parameters = array('dictionary' => 'paymenttype');
 			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 			if (empty($reshook)) {
 				if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
@@ -7884,7 +7886,7 @@ class Form
 	public function load_cache_vatrates($country_code)
 	{
 		// phpcs:enable
-		global $langs, $user;
+		global $langs, $user, $hookmanager;
 
 		$num = count($this->cache_vatrates);
 		if ($num > 0) {
@@ -7893,7 +7895,9 @@ class Form
 
 		dol_syslog(__METHOD__, LOG_DEBUG);
 
-		$sql = "SELECT t.rowid, t.type_vat, t.code, t.taux, t.localtax1, t.localtax1_type, t.localtax2, t.localtax2_type, t.recuperableonly, t.einvoice_vatex";
+		// entity and fk_pays are returned so a hook on loadDictionaryCache can tell two rows apart
+		// when the dictionary is read across entities (most rows carry an empty code)
+		$sql = "SELECT t.rowid, t.entity, t.fk_pays, t.type_vat, t.code, t.taux, t.localtax1, t.localtax1_type, t.localtax2, t.localtax2_type, t.recuperableonly, t.einvoice_vatex";
 		$sql .= " FROM ".$this->db->prefix()."c_tva as t, ".$this->db->prefix()."c_country as c";
 		$sql .= " WHERE t.fk_pays = c.rowid";
 		$sql .= " AND t.active > 0";
@@ -7910,6 +7914,8 @@ class Form
 
 					$tmparray = array();
 					$tmparray['rowid']			= (int) $obj->rowid;
+					$tmparray['entity']			= (int) $obj->entity;
+					$tmparray['fk_pays']		= (int) $obj->fk_pays;
 					$tmparray['type_vat']		= ($obj->type_vat <= 0 ? 0 : $obj->type_vat);	// Some version have type_vat corrupted with value -1
 					$tmparray['code']			= $obj->code;
 					$tmparray['txtva']			= $obj->taux;
@@ -7940,7 +7946,18 @@ class Form
 					$this->cache_vatrates[$obj->rowid] = $tmparray;
 				}
 
-				return $num;
+				$hookmanager->initHooks(array('dictionarycache'));
+				$parameters = array('dictionary' => 'vatrate', 'country_code' => $country_code);
+				$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
+				if (empty($reshook)) {
+					if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
+						$this->cache_vatrates = array_merge($this->cache_vatrates, $hookmanager->resArray);
+					}
+				} else {
+					$this->cache_vatrates = $hookmanager->resArray;
+				}
+
+				return count($this->cache_vatrates);
 			} else {
 				$this->error = '<span class="error">';
 				$this->error .= $langs->trans("ErrorNoVATRateDefinedForSellerCountry", $country_code);

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1402,7 +1402,6 @@ class Ticket extends CommonObject
 				$i++;
 			}
 
-			$hookmanager->initHooks(array('dictionarycache'));
 			$parameters = array('dictionary' => 'tickettype');
 			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 			if (empty($reshook)) {
@@ -1474,7 +1473,6 @@ class Ticket extends CommonObject
 			}
 			$conf->cache['category_tickets'] = $categorytickets;
 
-			$hookmanager->initHooks(array('dictionarycache'));
 			$parameters = array('dictionary' => 'ticketcategory', 'publicgroup' => $publicgroup);
 			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 			if (empty($reshook)) {
@@ -1533,7 +1531,6 @@ class Ticket extends CommonObject
 			}
 			$conf->cache['severity_tickets'] = $severitytickets;
 
-			$hookmanager->initHooks(array('dictionarycache'));
 			$parameters = array('dictionary' => 'ticketseverity');
 			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
 			if (empty($reshook)) {

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1372,14 +1372,16 @@ class Ticket extends CommonObject
 	 */
 	public function loadCacheTypesTickets()
 	{
-		global $langs;
+		global $langs, $hookmanager;
 
 		if (!empty($this->cache_types_tickets) && count($this->cache_types_tickets)) {
 			return 0;
 		}
 		// Cache deja charge
 
-		$sql = "SELECT rowid, code, label, use_default, pos, description";
+		// entity is returned so a hook on loadDictionaryCache can tell two rows apart when the
+		// dictionary is read across entities
+		$sql = "SELECT rowid, entity, code, label, use_default, pos, description";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_ticket_type";
 		$sql .= " WHERE entity IN (".getEntity('c_ticket_type').")";
 		$sql .= " AND active > 0";
@@ -1396,9 +1398,22 @@ class Ticket extends CommonObject
 				$this->cache_types_tickets[$obj->rowid]['label'] = $label;
 				$this->cache_types_tickets[$obj->rowid]['use_default'] = $obj->use_default;
 				$this->cache_types_tickets[$obj->rowid]['pos'] = $obj->pos;
+				$this->cache_types_tickets[$obj->rowid]['entity'] = (int) $obj->entity;
 				$i++;
 			}
-			return $num;
+
+			$hookmanager->initHooks(array('dictionarycache'));
+			$parameters = array('dictionary' => 'tickettype');
+			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
+			if (empty($reshook)) {
+				if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
+					$this->cache_types_tickets = array_merge($this->cache_types_tickets, $hookmanager->resArray);
+				}
+			} else {
+				$this->cache_types_tickets = $hookmanager->resArray;
+			}
+
+			return count($this->cache_types_tickets);
 		} else {
 			dol_print_error($this->db);
 			return -1;
@@ -1413,14 +1428,16 @@ class Ticket extends CommonObject
 	 */
 	public function loadCacheCategoriesTickets($publicgroup = -1)
 	{
-		global $conf, $langs;
+		global $conf, $langs, $hookmanager;
 
 		if ($publicgroup == -1 && !empty($conf->cache['category_tickets']) && count($conf->cache['category_tickets'])) {
 			// Cache already loaded
 			return 0;
 		}
 
-		$sql = "SELECT rowid, code, label, use_default, pos, description, public, active, force_severity, fk_parent";
+		// entity is returned so a hook on loadDictionaryCache can tell two rows apart when the
+		// dictionary is read across entities
+		$sql = "SELECT rowid, entity, code, label, use_default, pos, description, public, active, force_severity, fk_parent";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_ticket_category";
 		$sql .= " WHERE entity IN (".getEntity('c_ticket_category').")";
 		$sql .= " AND active > 0";
@@ -1451,11 +1468,24 @@ class Ticket extends CommonObject
 				// Warning: You should not use this and recompute the translated string into caller code to get the value into expected language
 				$label = ($langs->trans("TicketCategoryShort".$obj->code) != "TicketCategoryShort".$obj->code ? $langs->trans("TicketCategoryShort".$obj->code) : ($obj->label != '-' ? $obj->label : ''));
 				$categorytickets[$obj->rowid]['label'] = $label;
+				$categorytickets[$obj->rowid]['entity'] = (int) $obj->entity;
 
 				$i++;
 			}
 			$conf->cache['category_tickets'] = $categorytickets;
-			return $num;
+
+			$hookmanager->initHooks(array('dictionarycache'));
+			$parameters = array('dictionary' => 'ticketcategory', 'publicgroup' => $publicgroup);
+			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
+			if (empty($reshook)) {
+				if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
+					$conf->cache['category_tickets'] = array_merge($conf->cache['category_tickets'], $hookmanager->resArray);
+				}
+			} else {
+				$conf->cache['category_tickets'] = $hookmanager->resArray;
+			}
+
+			return count($conf->cache['category_tickets']);
 		} else {
 			dol_print_error($this->db);
 			return -1;
@@ -1469,14 +1499,16 @@ class Ticket extends CommonObject
 	 */
 	public function loadCacheSeveritiesTickets()
 	{
-		global $conf, $langs;
+		global $conf, $langs, $hookmanager;
 
 		if (!empty($conf->cache['severity_tickets']) && count($conf->cache['severity_tickets'])) {
 			// Cache already loaded
 			return 0;
 		}
 
-		$sql = "SELECT rowid, code, label, use_default, pos, description";
+		// entity is returned so a hook on loadDictionaryCache can tell two rows apart when the
+		// dictionary is read across entities
+		$sql = "SELECT rowid, entity, code, label, use_default, pos, description";
 		$sql .= " FROM ".MAIN_DB_PREFIX."c_ticket_severity";
 		$sql .= " WHERE entity IN (".getEntity('c_ticket_severity').")";
 		$sql .= " AND active > 0";
@@ -1496,10 +1528,23 @@ class Ticket extends CommonObject
 				$severitytickets[$obj->rowid]['label'] = $label;
 				$severitytickets[$obj->rowid]['use_default'] = $obj->use_default;
 				$severitytickets[$obj->rowid]['pos'] = $obj->pos;
+				$severitytickets[$obj->rowid]['entity'] = (int) $obj->entity;
 				$i++;
 			}
 			$conf->cache['severity_tickets'] = $severitytickets;
-			return $num;
+
+			$hookmanager->initHooks(array('dictionarycache'));
+			$parameters = array('dictionary' => 'ticketseverity');
+			$reshook = $hookmanager->executeHooks('loadDictionaryCache', $parameters, $this); // Note that $action and $object may have been modified by hook
+			if (empty($reshook)) {
+				if (is_array($hookmanager->resArray) && count($hookmanager->resArray)) {
+					$conf->cache['severity_tickets'] = array_merge($conf->cache['severity_tickets'], $hookmanager->resArray);
+				}
+			} else {
+				$conf->cache['severity_tickets'] = $hookmanager->resArray;
+			}
+
+			return count($conf->cache['severity_tickets']);
 		} else {
 			dol_print_error($this->db);
 			return -1;


### PR DESCRIPTION

The loadDictionaryCache hook existed on the payment term and payment type caches, but no module could actually use it:

- The dictionary was named through $parameters['context'], which HookManager::executeHooks() overwrites with the list of hook contexts before calling the hook. The name never reached the module, so it had no way to tell which dictionary it was given. Renamed to 'dictionary'.
- The hook relied on whatever contexts the calling page had initialised, so it only fired on some pages. Each loader now calls initHooks('dictionarycache'), which merges into the existing contexts and is therefore side effect free.
- The cached rows did not carry their entity, so a module could not tell two rows apart when the dictionary is read across several entities. The entity is now selected and cached (plus fk_pays for VAT rates, whose code is empty on most rows and cannot identify them on its own).

Extend the hook to the VAT rates and to the three ticket dictionaries (type, category, severity), so the whole set of entity aware dictionaries loaded in a cache can be filtered the same way.
