### PR TITLE
FIX TakePOS option to keep the quantity and its stock on one line

### DIFF
--- a/htdocs/takepos/admin/appearance.php
+++ b/htdocs/takepos/admin/appearance.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2011-2017 Juanjo Menent		<jmenent@2byte.es>
  * Copyright (C) 2019-2020 Andreu Bisquerra Gaya		<jove@bisquerra.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026       Jose Martinez           <jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2022-2023	Christophe Battarel		<christophe.battarel@altairis.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2026       Jose Martinez           <jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2312,7 +2313,9 @@ if ($placeid > 0) {
 					$htmlforlines .= '<td class="right">'.price($line->subprice).'</td>';
 				}
 				$htmlforlines .= '<td class="right">'.vatrate(price2num($line->remise_percent), true).'</td>';
-				$htmlforlines .= '<td class="right">';
+				// nowraponall keeps the qty and its '(stock)' block on one line: on narrow layouts
+				// the native display otherwise wraps over three lines inside the qty column.
+				$htmlforlines .= '<td class="right nowraponall">';
 				$htmlforlines .= $line->qty;
 				if (isModEnabled('stock') && $user->hasRight('stock', 'mouvement', 'lire')) {
 					$constantforkey = 'CASHDESK_ID_WAREHOUSE'.$_SESSION["takeposterminal"];


### PR DESCRIPTION
## The gap

When the stock is shown next to the quantity of a sale line (default behaviour unless `TAKEPOS_HIDE_STOCK_ON_LINE` is set), the `(stock)` block wraps over up to **three lines** in narrow layouts:

```
1 (
📦
1)
```

The qty cell carries no nowrap rule, while its neighbour cells already use `nowraponall`.

## What this PR does

A new option **`TAKEPOS_NO_WRAP_LINE_STOCK`**, **off by default** and placed next to the existing "Hide stock on line" option (Setup → TakePOS → Appearance), adds the standard `nowraponall` class to the qty cell, so the quantity and its stock stay on one line.

## Default behaviour is unchanged

The option is off by default: the cell keeps its current classes and nothing changes.
