### PR TITLE
Fix PHP warnings and error

### DIFF
--- a/htdocs/fichinter/class/fichinterligne.class.php
+++ b/htdocs/fichinter/class/fichinterligne.class.php
@@ -130,23 +130,27 @@ class FichinterLigne extends CommonObjectLine
 
 		$resql = $this->db->query($sql);
 		if ($resql) {
-			$objp = $this->db->fetch_object($resql);
-			$this->rowid          	= $objp->rowid;
-			$this->id               = $objp->rowid;
-			$this->fk_fichinter   	= $objp->fk_fichinter;
-			$this->date = $this->db->jdate($objp->date);
-			$this->datei = $this->db->jdate($objp->date);	// For backward compatibility
-			$this->desc           	= $objp->description;
-			$this->duration       	= $objp->duree;
-			$this->rang           	= $objp->rang;
+			if ($this->db->num_rows($resql)) {
+				$objp = $this->db->fetch_object($resql);
+				$this->rowid          	= $objp->rowid;
+				$this->id               = $objp->rowid;
+				$this->fk_fichinter   	= $objp->fk_fichinter;
+				$this->date = $this->db->jdate($objp->date);
+				$this->datei = $this->db->jdate($objp->date);	// For backward compatibility
+				$this->desc           	= $objp->description;
+				$this->duration       	= $objp->duree;
+				$this->rang           	= $objp->rang;
 
-			$this->extraparams = !empty($objp->extraparams) ? (array) json_decode($objp->extraparams, true) : array();
+				$this->extraparams = !empty($objp->extraparams) ? (array) json_decode($objp->extraparams, true) : array();
 
-			$this->db->free($resql);
+				$this->db->free($resql);
 
-			$this->fetch_optionals();
+				$this->fetch_optionals();
 
-			return 1;
+				return 1;
+			}
+
+			return 0;
 		} else {
 			$this->error = $this->db->error().' sql='.$sql;
 			return -1;

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -647,6 +647,12 @@ if (!defined('NOLOGIN')) {
 		}
 		// TODO Remove use of $_COOKIE['login_dolibarr'] by replacing line with $usertotest = GETPOST("username", "alpha", $allowedmethodtopostusername); ?
 		$usertotest = (!empty($_COOKIE['login_dolibarr']) ? preg_replace('/[^a-zA-Z0-9_@\-\.]/', '', $_COOKIE['login_dolibarr']) : GETPOST("username", "alpha", $allowedmethodtopostusername));
+		if (is_array($usertotest)) {
+			// An array-shaped username (ex: ?username[]=x) is not sanitized by GETPOST('alpha')
+			// (sanitizeVal only processes scalars for this check) and would otherwise flow unchanged into
+			// checkLoginPassEntity() -> User::fetch(), crashing on trim() with a TypeError (see user.class.php).
+			$usertotest = '';
+		}
 		$passwordtotest = GETPOST('password', 'password', $allowedmethodtopostusername);
 		$entitytotest = (GETPOSTINT('entity') ? GETPOSTINT('entity') : (!empty($conf->entity) ? $conf->entity : 1));
 

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -647,7 +647,7 @@ if (!defined('NOLOGIN')) {
 		}
 		// TODO Remove use of $_COOKIE['login_dolibarr'] by replacing line with $usertotest = GETPOST("username", "alpha", $allowedmethodtopostusername); ?
 		$usertotest = (!empty($_COOKIE['login_dolibarr']) ? preg_replace('/[^a-zA-Z0-9_@\-\.]/', '', $_COOKIE['login_dolibarr']) : GETPOST("username", "alpha", $allowedmethodtopostusername));
-		if (is_array($usertotest)) {
+		if (!is_string($usertotest)) {
 			// An array-shaped username (ex: ?username[]=x) is not sanitized by GETPOST('alpha')
 			// (sanitizeVal only processes scalars for this check) and would otherwise flow unchanged into
 			// checkLoginPassEntity() -> User::fetch(), crashing on trim() with a TypeError (see user.class.php).


### PR DESCRIPTION
main.inc.php constructs $usertotest from GETPOST("username", "alpha", ...) or the login_dolibarr cookie. GETPOST's internal checker (sanitizeVal(), case 'alpha') does nothing when the value is an array (if (!is_array($out)) — otherwise skip): a request shaping ?username[]=x traverses the entire authentication pipeline unsanitized, up to User::fetch() which calls trim($login) → fatal on arrays. This is reproducible by any anonymous visitor, on any page, as long as there is no active session (the AJAX endpoint is heavily used).

The function `FichinterLigne::fetch($rowid)` (htdocs/fichinter/class/fichinterligne.class.php) executed the query and then directly accessed the properties of `$objp` (`fetch_object()`) without checking `num_rows()`. When the requested ID did not correspond to any row (e.g., a row that had already been deleted, an outdated ID in a form), `$objp` returned `false`, resulting in 6 warnings: "Attempt to read property on null." The function still returned `1` (success) with all properties set to null, silently masking the failure. The sister class `Fichinter::fetch()` already handles this case correctly (`if ($this->db->num_rows($resql)) { ... } return 0;`), confirming that this is an inconsistency/oversight in the core code at this specific point.
