### PR TITLE
Fix PHP Warnings

### DIFF
--- a/htdocs/compta/sociales/card.php
+++ b/htdocs/compta/sociales/card.php
@@ -94,7 +94,7 @@ if ($id > 0 || $ref) {
 
 $permissiontoread = $user->hasRight('tax', 'charges', 'lire');
 $permissiontoadd = $user->hasRight('tax', 'charges', 'creer'); // Used by the include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
-$permissiontodelete = $user->rights->tax->charges->supprimer || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_UNPAID);
+$permissiontodelete = $user->hasRight('tax', 'charges', 'supprimer') || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_UNPAID);
 $permissionnote = $user->hasRight('tax', 'charges', 'creer'); // Used by the include of actions_setnotes.inc.php
 $permissiondellink = $user->hasRight('tax', 'charges', 'creer'); // Used by the include of actions_dellink.inc.php
 $upload_dir = $conf->tax->multidir_output[isset($object->entity) ? $object->entity : 1];

--- a/htdocs/install/upgrade.php
+++ b/htdocs/install/upgrade.php
@@ -394,7 +394,7 @@ if (!GETPOST('action', 'aZ09') || preg_match('/upgrade/i', GETPOST('action', 'aZ
 					$handlemodule = @opendir($dirroot); // $dirroot may be '..'
 					if (is_resource($handlemodule)) {
 						while (($filemodule = readdir($handlemodule)) !== false) {
-							if (!preg_match('/\./', $filemodule) && is_dir($dirroot.'/'.$filemodule.'/sql')) {	// We exclude filemodule that contains . (are not directories) and are not directories.
+							if (!preg_match('/\./', $filemodule) && @is_dir($dirroot.'/'.$filemodule.'/sql')) {	// We exclude filemodule that contains . (are not directories) and are not directories. $dirroot may be '..' (see opendir() above), same open_basedir edge case, silence it here too
 								//print "Scan for ".$dirroot . '/' . $filemodule . '/sql/'.$file;
 								if (is_file($dirroot.'/'.$filemodule.'/sql/dolibarr_'.$file)) {
 									$modulesfile[$dirroot.'/'.$filemodule.'/sql/dolibarr_'.$file] = '/'.$filemodule.'/sql/dolibarr_'.$file;

--- a/htdocs/product/class/productcustomerprice.class.php
+++ b/htdocs/product/class/productcustomerprice.class.php
@@ -1062,7 +1062,7 @@ class ProductCustomerPrice extends CommonObject
 						// If line do not exits then create it
 						$prodsocpricenew = new ProductCustomerPrice($this->db);
 						$prodsocpricenew->fk_soc = $obj->rowid;
-						$prodsocpricenew->ref_customer = $obj->ref_customer;
+						$prodsocpricenew->ref_customer = $this->ref_customer; // $obj only selects s.rowid (societe), ref_customer belongs to $this (the price line being propagated)
 						$prodsocpricenew->fk_product = $this->fk_product;
 						$prodsocpricenew->price = $this->price;
 						$prodsocpricenew->price_min = $this->price_min;

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -2938,7 +2938,7 @@ class Ticket extends CommonObject
 									$array_external = array(array('id' => -1, 'firstname' => '', 'lastname' => $object->origin_replyto, 'email' => $object->origin_replyto, 'libelle' => $langs->transnoentities('Customer'), 'socid' => 0));
 									$external_contacts = array_merge($external_contacts, $array_external);
 								} elseif (empty($object->fk_soc) && !empty($object->origin_email)) {
-									$array_external = array(array('id' => -1, 'firstname' => '', 'lastname' => $object->origin_email, 'email' => $object->thirdparty->email, 'libelle' => $langs->transnoentities('Customer'), 'socid' => $object->thirdparty->id));
+									$array_external = array(array('id' => -1, 'firstname' => '', 'lastname' => $object->origin_email, 'email' => $object->origin_email, 'libelle' => $langs->transnoentities('Customer'), 'socid' => 0)); // no fk_soc here, so $object->thirdparty was never fetched (mirrors the origin_replyto branch above)
 									$external_contacts = array_merge($external_contacts, $array_external);
 								}
 							}


### PR DESCRIPTION
1. compta/sociales/card.php:97 — $user->rights->tax->charges->supprimer (direct access prohibited) instead of $user->hasRight(), even though the four neighboring lines already use the native method.

Fix: $user->hasRight('tax', 'charges', 'supprimer').

2. product/class/productcustomerprice.class.php:1065 — in setPriceOnAffiliateThirdparty(), the query only selects s.rowid (from the societe table), but the code was reading $obj->ref_customer — a field that only exists on $this (the propagated price row), not on the child company.

Fix: $this->ref_customer instead of $obj->ref_customer.

3. ticket/class/ticket.class.php:2941 — The origin_email branch (ticket without a linked third party, empty fk_soc) was reading $object->thirdparty->email/->id, whereas $object->thirdparty is never loaded in this case (only the fk_soc branch directly above performs fetch_thirdparty()). Copy-pasted manifest: the sibling branch origin_replyto handles this case correctly with socid => 0.

Fix: 'email' => $object->origin_email, 'socid' => 0, aligned with the origin_replyto branch.

4. install/upgrade.php:397 — The developer already knew that $dirroot can be '..' (explicit comment, opendir() protected by @ directly above), but had forgotten to protect the following is_dir() against the same open_basedir overflow.

Fix: Added @ to is_dir(), consistent with the neighboring opendir() line.