### PR TITLE
Fix wrong default PDF model for product document generation

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -96,13 +96,13 @@ class modProduct extends DolibarrModules
 				'pricing rule by default',
 				0,
 			],
-			/*[
+			[
 				"PRODUCT_ADDON_PDF",
 				"chaine",
 				"standard",
 				'Default module for document generation',
 				0,
-			],*/
+			],
 		];
 
 		// Boxes

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -6165,7 +6165,7 @@ class Product extends CommonObject
 
 		// Positionne le modele sur le nom du modele a utiliser
 		if (!dol_strlen($modele)) {
-			$modele = getDolGlobalString('PRODUCT_ADDON_PDF', 'strato');
+			$modele = getDolGlobalString('PRODUCT_ADDON_PDF', 'standard');
 		}
 
 		$modelpath = "core/modules/product/doc/";


### PR DESCRIPTION
Product::generateDocument() falls back to model 'strato' when PRODUCT_ADDON_PDF is not set, but 'strato' only exists as a doc generator for contracts (core/modules/contract/doc/pdf_strato.modules.php), never for products - this has been a bug since the generateDocument() method was first added in 2017 (commit b813144edb). On any install where the constant was never explicitly set, sending a product by email (or generating its document) fails with:
'Failed to load doc generator with modelpaths=core/modules/product/doc/
- modele=strato'.

Fix the fallback to 'standard', matching the only real model actually shipped for products (core/modules/product/doc/pdf_standard.modules.php).

Also uncomment the PRODUCT_ADDON_PDF constant initialization in modProduct.class.php (already present, correctly set to 'standard', but disabled since 2017 for no documented reason) so future module activations set it explicitly instead of relying on the fallback.


