### PR TITLE
Fix #39697 tolerate the categorie_mo foreign key when MRP is disabled

### DIFF
--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -508,6 +508,14 @@ function run_sql($sqlfile, $silent = 1, $entity = 0, $usesavepoint = 1, $handler
 					'DB_ERROR_PRIMARY_KEY_ALREADY_EXISTS',
 					'DB_ERROR_22P02'
 				);
+				// The foreign key of the category link tables can target a table owned by a module that is not
+				// enabled, llx_categorie_mo referencing llx_mrp_mo for instance, so the key can not be created
+				// yet. The module creates it when it is enabled. Elsewhere this error must stay fatal, since it
+				// is what reports orphans or duplicates when a key is added on corrupted data.
+				if (preg_match('/^\s*ALTER\s+TABLE\s+[^\s]+_categorie_mo\s.*REFERENCES\s+[^\s(]+_mrp_mo\s*\(/i', $newsql)) {
+					$okerrors[] = 'DB_ERROR_CANNOT_ADD_FOREIGN_KEY_CONSTRAINT';
+				}
+
 				if ($okerror == 'none') {
 					$okerrors = array();
 				}


### PR DESCRIPTION
Switched to option 3 as suggested in review.

llx_mrp_mo belongs to the MRP module, so on an instance where MRP was never enabled the foreign key added by the migration can not be created. MySQL reports that as DB_ERROR_CANNOT_ADD_FOREIGN_KEY_CONSTRAINT, which is not in $okerrors, and the upgrade stops. MariaDB reports the same situation as 1005 (DB_ERROR_CANNOT_CREATE), which is already tolerated, so the problem only shows on MySQL.

The exception is scoped to this one key: it requires the altered table to end with _categorie_mo and the referenced table to end with _mrp_mo. Anywhere else the error stays fatal, since it is also what reports orphans or duplicates when a key is added on corrupted data.

No DDL is added to the transaction, and the migration instruction is kept, so a database that already has llx_mrp_mo still gets the key.

Verified on MariaDB 10.11: the llx_categorie FK still applies, the mrp_mo FK fails with 1005 while llx_mrp_mo is absent, and it is created normally once the table exists. The pattern was checked against the real statements including a custom table prefix (llx0i_), and it does not match the llx_categorie key on the same table, an index on the same table, or unrelated tables.