### PR TITLE
FIX - Fix GETPOST with restricthtml when you pass a string who is not an html but characteres is encoded to html code so the result is a mixed string (case with description fields when WYSIWYG not activated)

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -1413,7 +1413,11 @@ function sanitizeVal($out = '', $check = 'alphanohtml', $filter = null, $options
 		case 'restricthtmlallowiframe':
 		case 'restricthtmlallowlinkscript':	// Allow link and script tag for head section.
 		case 'restricthtmlallowunvalid':
-			$out = dol_htmlwithnojs($out, 1, $check);
+			if (dol_textishtml($out)) {
+				$out = dol_htmlwithnojs($out, 1, $check);
+			} else {
+				$out = dol_string_nohtmltag($out, 0);
+			}
 			break;
 		case 'custom':
 			if (!empty($out)) {

--- a/test/phpunit/SecurityGETPOSTTest.php
+++ b/test/phpunit/SecurityGETPOSTTest.php
@@ -280,7 +280,7 @@ class SecurityGETPOSTTest extends CommonClassTest
 
 		$result = GETPOST("param8e", 'restricthtml');
 		print __METHOD__." result param8e = ".$result."\n";
-		$this->assertEquals('', $result);
+		$this->assertEquals('<123abc is not html to clean', $result);
 
 		$result = GETPOST("param12", 'restricthtml');
 		print __METHOD__." result=".$result."\n";


### PR DESCRIPTION
Fix GETPOST with restricthtml when you pass a string who is not an html but characteres is encoded to html code so the result is a mixed string (case with description fields when WYSIWYG not activated)

Case when WYSIWYG is not activated
When you had a characters who can be encoded in html code in the description of a product line (in order for example)

**For :**
<img width="1200" height="214" alt="image" src="https://github.com/user-attachments/assets/7ad63480-2f71-4f0e-9cfe-3e9fac8fb0e0" />

**Before :** 
In tooltip : 
<img width="1156" height="274" alt="image" src="https://github.com/user-attachments/assets/572efa8f-0c8c-4927-9134-ba0430f6d7c6" />
Re-edit line : 
<img width="1120" height="210" alt="image" src="https://github.com/user-attachments/assets/52c96ca3-7632-411e-8ab2-4e609263815d" />
In PDF : 
<img width="572" height="112" alt="image" src="https://github.com/user-attachments/assets/295234be-fe88-4fd8-8d4b-20b1b9e6cd25" />

**After fix:**
In tooltip : 
<img width="1038" height="225" alt="image" src="https://github.com/user-attachments/assets/4b4378ef-bd8b-4d9b-bc9a-f397ab05fe90" />
Re-edit line : 
<img width="930" height="203" alt="image" src="https://github.com/user-attachments/assets/2b2b816c-a0c6-4257-9697-eaca25c04adb" />
In PDF : 
<img width="498" height="112" alt="image" src="https://github.com/user-attachments/assets/43e6f5bb-5e57-4c01-bd8c-686082af145f" />

I have fix the phpunit test for the case 'param8e' equal to '<123abc is not html to clean' who waiting empty value for the mode 'restricthtml' of GETPOST but '<123abc is not html to clean' is as written not a html string so GETPOST must return '<123abc is not html to clean' and not ''