### PR TITLE
FIX : Fix fatal error in_array() on null in fourn/paiement/list.php

### DIFF
--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -179,6 +179,8 @@ if (empty($reshook)) {
 	}
 }
 
+$arrayofselected = !empty($arrayofselected) && is_array($arrayofselected) ? $arrayofselected : array();
+
 /*
  * View
  */

--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -144,6 +144,8 @@ if ((!$user->hasRight("fournisseur", "facture", "lire") && !getDolGlobalString('
 	accessforbidden();
 }
 
+$arrayofselected = !empty($arrayofselected) && is_array($arrayofselected) ? $arrayofselected : array();
+
 
 /*
  * Actions
@@ -179,10 +181,11 @@ if (empty($reshook)) {
 	}
 }
 
-$arrayofselected = !empty($arrayofselected) && is_array($arrayofselected) ? $arrayofselected : array();
+
 /*
  * View
  */
+
 $title = $langs->trans('ListPayment');
 $help_url = '';
 

--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -180,7 +180,6 @@ if (empty($reshook)) {
 }
 
 $arrayofselected = !empty($arrayofselected) && is_array($arrayofselected) ? $arrayofselected : array();
-
 /*
  * View
  */


### PR DESCRIPTION
# FIX Fatal error in_array() on fourn/paiement/list

`$arrayofselected` was never initialized in `htdocs/fourn/paiement/list.php`, unlike other list pages (e.g. `compta/paiement/list.php`). When the mass-action checkbox column is displayed, `in_array($object->id, $arrayofselected)` is called with `$arrayofselected` still `null`, causing a fatal `TypeError` on PHP 8+ (`in_array(): Argument #2 ($haystack) must be of type array, null given`).

Add the missing initialization of `$arrayofselected` from `$toselect`, consistent with other supplier/customer payment list pages.
