### PR TITLE
FIX: make OAuth2 connection errors say what is actually wrong

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -1208,7 +1208,8 @@ class CMailFile
 						if (is_object($tokenobj)) {
 							$this->smtps->setToken($tokenobj->getAccessToken());
 						} else {
-							$this->error = "Token not found";
+							$this->error = "OAuth2 token not found for service '".$OAUTH_SERVICENAME."' (setup constant ".$keyforsmtpoauthservice.", send context '".$this->sendcontext."'). Compare it with the service column of llx_oauth_token.";
+							dol_syslog("CMailFile::sendfile: ".$this->error, LOG_ERR);
 						}
 					} catch (Exception $e) {
 						// Return an error if token not found
@@ -1393,8 +1394,8 @@ class CMailFile
 							$this->transport->setAuthMode('XOAUTH2');
 							$this->transport->setPassword($tokenobj->getAccessToken());
 						} else {
-							$this->errors[] = "Token not found";
-							dol_syslog("CMailFile::sendfile: OAuth2 token object is not valid", LOG_ERR);
+							$this->errors[] = "OAuth2 token not found for service '".$OAUTH_SERVICENAME."' (setup constant ".$keyforsmtpoauthservice.", send context '".$this->sendcontext."'). Compare it with the service column of llx_oauth_token.";
+							dol_syslog("CMailFile::sendfile: ".end($this->errors), LOG_ERR);
 						}
 					} catch (Exception $e) {
 						// Return an error if token not found

--- a/htdocs/core/lib/oauth.lib.php
+++ b/htdocs/core/lib/oauth.lib.php
@@ -357,7 +357,8 @@ function getSupportedOauth2Array()
 		// CRITICAL: Use ONLY outlook.office.com scopes here, do NOT mix with Graph scopes (openid/profile/email).
 		// Mixing two resource namespaces in one token request causes AADSTS28000 error.
 		// offline_access is a neutral scope (no resource prefix) and is allowed alongside any resource.
-		// Azure permissions required: Microsoft Graph > Delegated > SMTP.Send and IMAP.AccessAsUser.All
+		// Azure delegated permissions must be declared on the 'Office 365 Exchange Online' API (service principal 00000002-0000-0ff1-ce00-000000000000), NOT on Microsoft Graph.
+		// Both APIs expose permissions named SMTP.Send and IMAP.AccessAsUser.All: granting the Graph ones leaves the token request for outlook.office.com without any matching consent.
 		'availablescopes' => 'offline_access,https://outlook.office.com/SMTP.Send,https://outlook.office.com/IMAP.AccessAsUser.All',
 		'returnurl' => '/core/modules/oauth/microsoft3_oauthcallback.php'
 	);
@@ -376,6 +377,41 @@ function getSupportedOauth2Array()
 	return $supportedoauth2array;
 }
 
+
+/**
+ * Return a human readable diagnostic of the setup of an OAuth2 provider entry, to append to an
+ * error message or a log line. Only tells whether each constant is filled, never their value.
+ *
+ * @param	string	$genericstring		Provider key in uppercase used to build the constants (example: 'MICROSOFT3')
+ * @param	string	$keyforprovider		Label of the provider entry, empty for the unnamed one
+ * @return	string						Example: "service=Microsoft3-mylabel, entity=1, OAUTH_MICROSOFT3-mylabel_ID=set, OAUTH_MICROSOFT3-mylabel_SCOPE=MISSING"
+ */
+function getOauthSetupDiagnostic($genericstring, $keyforprovider = '')
+{
+	global $conf;
+
+	$prefix = 'OAUTH_'.$genericstring.($keyforprovider ? '-'.$keyforprovider : '');
+
+	$found = array();
+	foreach ($conf->global as $constname => $constvalue) {
+		if (strpos($constname, $prefix.'_') === 0) {
+			$found[$constname] = empty($constvalue) ? 'EMPTY' : 'set';
+		}
+	}
+	// _SCOPE feeds the 'state' parameter, so a provider entry never saved with scopes has no such constant at all.
+	if (!isset($found[$prefix.'_SCOPE'])) {
+		$found[$prefix.'_SCOPE'] = 'MISSING';
+	}
+	ksort($found);
+
+	$out = 'service='.ucfirst(strtolower($genericstring)).($keyforprovider ? '-'.$keyforprovider : '');
+	$out .= ', entity='.$conf->entity;
+	foreach ($found as $constname => $status) {
+		$out .= ', '.$constname.'='.$status;
+	}
+
+	return $out;
+}
 
 /**
  * Return array of tabs to used on pages to setup cron module.

--- a/htdocs/core/modules/oauth/microsoft2_oauthcallback.php
+++ b/htdocs/core/modules/oauth/microsoft2_oauthcallback.php
@@ -26,6 +26,7 @@
 // Load Dolibarr environment
 require '../../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/includes/OAuth/bootstrap.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php';
 /**
  * @var Conf $conf
  * @var DoliDB $db
@@ -97,7 +98,9 @@ if ($state) {
 	$requestedpermissionsarray = explode(',', $state); // Example: 'user'. 'state' parameter is standard to retrieve some parameters back
 }
 if ($action != 'delete' && empty($requestedpermissionsarray)) {
-	print 'Error, parameter state is not defined';
+	$langs->load("oauth");
+	print $langs->trans("OAuthErrorNoScopeInState", 'OAUTH_'.$genericstring.($keyforprovider ? '-'.$keyforprovider : '').'_SCOPE');
+	print '<br>'.dol_escape_htmltag(getOauthSetupDiagnostic($genericstring, $keyforprovider));
 	exit;
 }
 //var_dump($requestedpermissionsarray);exit;
@@ -132,13 +135,13 @@ if (empty($apiService)) {
 $langs->load("oauth");
 
 if (!getDolGlobalString($keyforparamid)) {
-	accessforbidden('Setup of service is not complete. Customer ID is missing');
+	accessforbidden('Setup of service is not complete. Customer ID is missing ('.$keyforparamid.')');
 }
 if (!getDolGlobalString($keyforparamsecret)) {
-	accessforbidden('Setup of service is not complete. Secret key is missing');
+	accessforbidden('Setup of service is not complete. Secret key is missing ('.$keyforparamsecret.')');
 }
 if (!getDolGlobalString($keyforparamtenant)) {
-	accessforbidden('Setup of service is not complete. Tenant/Annuary ID key is missing');
+	accessforbidden('Setup of service is not complete. Tenant/Annuary ID key is missing ('.$keyforparamtenant.')');
 }
 
 
@@ -196,7 +199,10 @@ if (GETPOST('code') || GETPOST('error')) {     // We are coming from oauth provi
 		header('Location: '.$backtourl);
 		exit();
 	} catch (Exception $e) {
-		print $e->getMessage();
+		$diag = getOauthSetupDiagnostic($genericstring, $keyforprovider);
+		dol_syslog(basename(__FILE__).' requestAccessToken failed: '.$e->getMessage().' - '.$diag, LOG_ERR);
+		print $langs->trans("OAuthErrorTokenRequestFailed", dol_escape_htmltag($e->getMessage()));
+		print '<br>'.dol_escape_htmltag($diag);
 	}
 } else {
 	// If we enter this page without 'code' parameter, we arrive here. This is the case when we want to get the redirect

--- a/htdocs/core/modules/oauth/microsoft3_oauthcallback.php
+++ b/htdocs/core/modules/oauth/microsoft3_oauthcallback.php
@@ -32,6 +32,7 @@
 // Load Dolibarr environment
 require '../../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/includes/OAuth/bootstrap.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php';
 /**
  * @var Conf $conf
  * @var DoliDB $db
@@ -98,7 +99,9 @@ if ($state) {
 	$requestedpermissionsarray = explode(',', $state); // Example: 'user'. 'state' parameter is standard to retrieve some parameters back
 }
 if ($action != 'delete' && empty($requestedpermissionsarray)) {
-	print 'Error, parameter state is not defined';
+	$langs->load("oauth");
+	print $langs->trans("OAuthErrorNoScopeInState", 'OAUTH_'.$genericstring.($keyforprovider ? '-'.$keyforprovider : '').'_SCOPE');
+	print '<br>'.dol_escape_htmltag(getOauthSetupDiagnostic($genericstring, $keyforprovider));
 	exit;
 }
 
@@ -119,13 +122,13 @@ if (empty($apiService)) {
 $langs->load("oauth");
 
 if (!getDolGlobalString($keyforparamid)) {
-	accessforbidden('Setup of service is not complete. Customer ID is missing');
+	accessforbidden('Setup of service is not complete. Customer ID is missing ('.$keyforparamid.')');
 }
 if (!getDolGlobalString($keyforparamsecret)) {
-	accessforbidden('Setup of service is not complete. Secret key is missing');
+	accessforbidden('Setup of service is not complete. Secret key is missing ('.$keyforparamsecret.')');
 }
 if (!getDolGlobalString($keyforparamtenant)) {
-	accessforbidden('Setup of service is not complete. Tenant/Annuary ID key is missing');
+	accessforbidden('Setup of service is not complete. Tenant/Annuary ID key is missing ('.$keyforparamtenant.')');
 }
 
 /*
@@ -174,7 +177,10 @@ if (GETPOST('code') || GETPOST('error')) {     // We are coming from oauth provi
 		header('Location: '.$backtourl);
 		exit();
 	} catch (Exception $e) {
-		print $e->getMessage();
+		$diag = getOauthSetupDiagnostic($genericstring, $keyforprovider);
+		dol_syslog(basename(__FILE__).' requestAccessToken failed: '.$e->getMessage().' - '.$diag, LOG_ERR);
+		print $langs->trans("OAuthErrorTokenRequestFailed", dol_escape_htmltag($e->getMessage()));
+		print '<br>'.dol_escape_htmltag($diag);
 	}
 } else {
 	// If we enter this page without 'code' parameter, we arrive here. This is the case when we want to get the redirect

--- a/htdocs/core/modules/oauth/microsoft_oauthcallback.php
+++ b/htdocs/core/modules/oauth/microsoft_oauthcallback.php
@@ -26,6 +26,7 @@
 // Load Dolibarr environment
 require '../../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/includes/OAuth/bootstrap.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/oauth.lib.php';
 /**
  * @var Conf $conf
  * @var DoliDB $db
@@ -94,7 +95,9 @@ if ($state) {
 	$requestedpermissionsarray = explode(',', $state); // Example: 'user'. 'state' parameter is standard to retrieve some parameters back
 }
 if ($action != 'delete' && empty($requestedpermissionsarray)) {
-	print 'Error, parameter state is not defined';
+	$langs->load("oauth");
+	print $langs->trans("OAuthErrorNoScopeInState", 'OAUTH_'.$genericstring.($keyforprovider ? '-'.$keyforprovider : '').'_SCOPE');
+	print '<br>'.dol_escape_htmltag(getOauthSetupDiagnostic($genericstring, $keyforprovider));
 	exit;
 }
 //var_dump($requestedpermissionsarray);exit;
@@ -129,13 +132,13 @@ if (empty($apiService)) {
 $langs->load("oauth");
 
 if (!getDolGlobalString($keyforparamid)) {
-	accessforbidden('Setup of service is not complete. Customer ID is missing');
+	accessforbidden('Setup of service is not complete. Customer ID is missing ('.$keyforparamid.')');
 }
 if (!getDolGlobalString($keyforparamsecret)) {
-	accessforbidden('Setup of service is not complete. Secret key is missing');
+	accessforbidden('Setup of service is not complete. Secret key is missing ('.$keyforparamsecret.')');
 }
 if (!getDolGlobalString($keyforparamtenant)) {
-	accessforbidden('Setup of service is not complete. Tenant/Annuary ID key is missing');
+	accessforbidden('Setup of service is not complete. Tenant/Annuary ID key is missing ('.$keyforparamtenant.')');
 }
 
 
@@ -193,7 +196,10 @@ if (GETPOST('code') || GETPOST('error')) {     // We are coming from oauth provi
 		header('Location: '.$backtourl);
 		exit();
 	} catch (Exception $e) {
-		print $e->getMessage();
+		$diag = getOauthSetupDiagnostic($genericstring, $keyforprovider);
+		dol_syslog(basename(__FILE__).' requestAccessToken failed: '.$e->getMessage().' - '.$diag, LOG_ERR);
+		print $langs->trans("OAuthErrorTokenRequestFailed", dol_escape_htmltag($e->getMessage()));
+		print '<br>'.dol_escape_htmltag($diag);
 	}
 } else {
 	// If we enter this page without 'code' parameter, we arrive here. This is the case when we want to get the redirect

--- a/htdocs/includes/OAuth/Common/Storage/DoliStorage.php
+++ b/htdocs/includes/OAuth/Common/Storage/DoliStorage.php
@@ -89,6 +89,22 @@ class DoliStorage implements TokenStorageInterface
 	}
 
 	/**
+	 * Build the storage key of a service: the service name suffixed by the provider label when there is one.
+	 *
+	 * @param	string	$service	Service name, with or without the provider label already appended
+	 * @return	string				Value stored into the 'service' column of llx_oauth_token
+	 */
+	private function getServiceKey($service)
+	{
+		if (empty($this->keyforprovider)) {
+			return $service;
+		}
+
+		// Strip a label already present so the method stays idempotent, then append it
+		return preg_replace('/\-'.preg_quote($this->keyforprovider, '/').'$/', '', $service).'-'.$this->keyforprovider;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function retrieveAccessToken($service)
@@ -99,7 +115,7 @@ class DoliStorage implements TokenStorageInterface
 			return $this->tokens[$service];
 		}
 
-		throw new TokenNotFoundException('Token not found in db, are you sure you stored it?');
+		throw new TokenNotFoundException('Token not found in db for service \''.$this->getServiceKey($service).'\' and entity IN ('.getEntity('oauth_token').'). Check the service column of llx_oauth_token, are you sure you stored it?');
 	}
 
 	/**
@@ -113,13 +129,7 @@ class DoliStorage implements TokenStorageInterface
 		//var_dump($token);
 		dol_syslog(__METHOD__." storeAccessToken service=".$service);
 
-		$servicepluskeyforprovider = $service;
-		if (!empty($this->keyforprovider)) {
-			// We clean the keyforprovider after the - to be sure it is not present
-			$servicepluskeyforprovider = preg_replace('/\-'.preg_quote($this->keyforprovider, '/').'$/', '', $servicepluskeyforprovider);
-			// Now we add the keyforprovider
-			$servicepluskeyforprovider .= '-'.$this->keyforprovider;
-		}
+		$servicepluskeyforprovider = $this->getServiceKey($service);
 
 		include_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
 		$serializedToken = serialize($tokenobj);
@@ -179,13 +189,7 @@ class DoliStorage implements TokenStorageInterface
 		// get from db
 		dol_syslog("hasAccessToken service=".$service);
 
-		$servicepluskeyforprovider = $service;
-		if (!empty($this->keyforprovider)) {
-			// We clean the keyforprovider after the - to be sure it is not present
-			$servicepluskeyforprovider = preg_replace('/\-'.preg_quote($this->keyforprovider, '/').'$/', '', $servicepluskeyforprovider);
-			// Now we add the keyforprovider
-			$servicepluskeyforprovider .= '-'.$this->keyforprovider;
-		}
+		$servicepluskeyforprovider = $this->getServiceKey($service);
 
 		$sql = "SELECT token, datec, tms, state FROM ".MAIN_DB_PREFIX."oauth_token";
 		$sql .= " WHERE service = '".$this->db->escape($servicepluskeyforprovider)."'";
@@ -260,13 +264,7 @@ class DoliStorage implements TokenStorageInterface
 	{
 		// TODO Remove token using a loop on each $service
 		/*
-		$servicepluskeyforprovider = $service;
-		if (!empty($this->keyforprovider)) {
-			// We clean the keyforprovider after the - to be sure it is not present
-			$servicepluskeyforprovider = preg_replace('/\-'.preg_quote($this->keyforprovider, '/').'$/', '', $servicepluskeyforprovider);
-			// Now we add the keyforprovider
-			$servicepluskeyforprovider .= '-'.$this->keyforprovider;
-		}
+		$servicepluskeyforprovider = $this->getServiceKey($service);
 		*/
 
 		// allow chaining

--- a/htdocs/langs/en_US/oauth.lang
+++ b/htdocs/langs/en_US/oauth.lang
@@ -51,3 +51,5 @@ RefreshTokenHelp=Use the Refresh Token to get a new Access Token
 OldTokenWasExpiredItHasBeenRefresh=Old token was expired, it has been refreshed
 OldTokenWasNotExpiredButItHasBeenRefresh=Old token was not expired but it has been refreshed
 OAuthErrorStateDiffers=Value for state=%s differs from value in session. Code is refused.
+OAuthErrorNoScopeInState=No scope received into the 'state' parameter. Dolibarr uses 'state' to carry the list of requested scopes, so this means the constant %s is empty or missing. Go to Home - Setup - Modules - OAuth, tick the scopes of this provider and save.
+OAuthErrorTokenRequestFailed=The OAuth provider refused to exchange the authorization code for a token. Answer of the provider: %s

--- a/htdocs/langs/fr_FR/oauth.lang
+++ b/htdocs/langs/fr_FR/oauth.lang
@@ -51,3 +51,5 @@ RefreshTokenHelp=Utilisez le jeton d'actualisation pour obtenir un nouveau jeton
 OldTokenWasExpiredItHasBeenRefresh=L'ancien jeton avait expiré, il a été actualisé
 OldTokenWasNotExpiredButItHasBeenRefresh=L'ancien jeton n'avait pas expiré mais il a été actualisé
 OAuthErrorStateDiffers=La valeur de l'état %s diffère de la valeur de la session. Le code est refusé.
+OAuthErrorNoScopeInState=Aucun périmètre (scope) reçu dans le paramètre 'state'. Dolibarr utilise 'state' pour transporter la liste des périmètres demandés : la constante %s est donc vide ou absente. Allez dans Accueil - Configuration - Modules - OAuth, cochez les périmètres de ce fournisseur puis enregistrez.
+OAuthErrorTokenRequestFailed=Le fournisseur OAuth a refusé d'échanger le code d'autorisation contre un jeton. Réponse du fournisseur : %s


### PR DESCRIPTION
Diagnosing an OAuth2 setup currently means reading the source. Every failure prints a short sentence that mentions neither the service, nor the entity, nor the constant at fault. Tracking one broken Microsoft Exchange Online setup took a full day, and every single step was a message that had the information but did not print it.

This PR adds that context and fixes one comment that actively sends people the wrong way.

### The misleading comment

`getSupportedOauth2Array()` says, for `OAUTH_MICROSOFT3_NAME`:

```php
// Azure permissions required: Microsoft Graph > Delegated > SMTP.Send and IMAP.AccessAsUser.All
```

The scopes requested are `https://outlook.office.com/SMTP.Send` and `https://outlook.office.com/IMAP.AccessAsUser.All`, whose resource is **Office 365 Exchange Online** (service principal `00000002-0000-0ff1-ce00-000000000000`), not Microsoft Graph (`00000003-0000-0000-c000-000000000000`).

Both APIs expose delegated permissions with those exact names. Declaring them on Graph produces a consent screen showing Graph scopes and a grant the token request can never match. The comment is corrected.

### `getOauthSetupDiagnostic()`

New helper in `oauth.lib.php`. Given a provider key and a label, it returns the service name, the entity, and for every `OAUTH_<provider>_*` constant whether it is `set`, `EMPTY` or `MISSING`. **Values are never included**, only their presence. `_SCOPE` is reported even when the constant does not exist at all, since that is the case that produces the most confusing failure.

### `state` is the scope list, and the message never said so

`microsoft`, `microsoft2` and `microsoft3` printed:

```
Error, parameter state is not defined
```

This reads as an anti-CSRF failure, and that is how it gets diagnosed: people look at session cookies, `SameSite`, vhosts and redirect URIs. None of it applies. Dolibarr hijacks `state` to carry the comma-separated scope list, so the real meaning is *the `_SCOPE` constant is empty* — which happens on **every freshly created provider entry**, because `admin/oauth.php` `action=add` writes only `_ID`. The anti-CSRF comparison lives further down, produces a different message (`OAuthErrorStateDiffers`), and is guarded by `isset()`, so a lost session silently skips it and can never produce this message.

The new text names the constant to fill and where to fill it, and appends the diagnostic.

### Other messages

- Token exchange failure: printed only `$e->getMessage()`. It now prints the provider answer (`invalid_client`, `AADSTS...`) with a sentence saying what failed, appends the diagnostic, and logs both.
- The three `accessforbidden()` calls name the constant that is missing.
- `DoliStorage::retrieveAccessToken()`: `Token not found in db, are you sure you stored it?` now names **the service key looked up** and the entity filter — exactly what one needs to compare with the `service` column of `llx_oauth_token`.
- `CMailFile`: `Token not found` now names the service, the setup constant read and the send context.

### One refactor

The service key computation was inlined identically three times in `DoliStorage`; it moves to a private `getServiceKey()`.

### Noticed, deliberately left alone

Three other places in `DoliStorage` (`clearToken`, `storeAuthorizationState`, `hasAuthorizationState`) build the same key with a **different** formula: `$service.($this->keyforprovider ? '-'.$this->keyforprovider : '')`, without first stripping a label already present. Passing a full service name such as `Microsoft3-mylabel` there yields `Microsoft3-mylabel-mylabel` and silently matches nothing. Unifying them would change behaviour, so it is out of scope for a diagnostics PR — flagging it here instead.

No behaviour change otherwise: only message text, one new helper, one corrected comment, two new translation keys.