### PR TITLE
Qual: Use dolBuildUrl() in dolGetButtonAction() and clean commented var_dump() in user

### DIFF
--- a/htdocs/user/api_token/card.php
+++ b/htdocs/user/api_token/card.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2010-2015  Regis Houssin               <regis.houssin@inodbox.com>
  * Copyright (C) 2013	    Florian Henry               <florian.henry@open-concept.pro.com>
  * Copyright (C) 2018       Ferran Marcet               <fmarcet@2byte.es>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -335,7 +335,7 @@ if ($action == 'create') {
 
 	print '</table>';
 	print '<div class="tabsAction">';
-	print dolGetButtonAction($langs->trans('Delete'), '', 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&tokenid='.$token->token_id.'&action=delete&token='.newToken(), '', $canedittoken);
+	print dolGetButtonAction($langs->trans('Delete'), '', 'delete', dolBuildUrl($_SERVER["PHP_SELF"], ['id' => $object->id, 'tokenid' => $token->token_id, 'action' => 'delete'], true), '', $canedittoken);
 	print '</div>';
 	print '</div>';
 

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -2589,8 +2589,6 @@ if ($action == 'create' || $action == 'adduserldap') {
 				print '<td>';
 				$nbAdmin = $user->getNbOfUsers('active', '', 1);
 				$nbSuperAdmin = $user->getNbOfUsers('active', 'superadmin', 1);
-				//var_dump($nbAdmin);
-				//var_dump($nbSuperAdmin);
 				if ($user->admin								// Need to be admin to allow downgrade of an admin
 				&& ($user->id != $object->id)                   // Don't downgrade ourself
 				&& (

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -2311,7 +2311,7 @@ if ($action == 'create' || $action == 'adduserldap') {
 					} elseif (($user->id != $id && $permissiontoeditpasswordandsee) && $object->login && !$object->ldap_sid &&
 					((!isModEnabled('multicompany') && $object->entity == $user->entity) || !$user->entity || ($object->entity == $conf->entity) || (getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && $object->entity == 1))) {
 						unset($params['attr']['title']);
-						print dolGetButtonAction($langs->trans('ReinitPassword'), '', 'default', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=password&token='.newToken(), '', true, $params);
+						print dolGetButtonAction($langs->trans('ReinitPassword'), '', 'default', dolBuildUrl($_SERVER['PHP_SELF'], ['id' => $object->id, 'action' => 'password'], true), '', true, $params);
 					}
 
 					if ($object->status == $object::STATUS_DISABLED) {
@@ -2321,7 +2321,7 @@ if ($action == 'create' || $action == 'adduserldap') {
 					((!isModEnabled('multicompany') && $object->entity == $user->entity) || !$user->entity || ($object->entity == $conf->entity) || (getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && $object->entity == 1))) {
 						if ($object->email) {
 							unset($params['attr']['title']);
-							print dolGetButtonAction($langs->trans('SendNewPassword'), '', 'default', $_SERVER['PHP_SELF'].'?id='.$object->id.'&action=passwordsend&token='.newToken(), '', true, $params);
+							print dolGetButtonAction($langs->trans('SendNewPassword'), '', 'default', dolBuildUrl($_SERVER['PHP_SELF'], ['id' => $object->id, 'action' => 'passwordsend'], true), '', true, $params);
 						} else {
 							$params['attr']['title'] = $langs->trans('NoEMail');
 							print dolGetButtonAction($langs->trans('SendNewPassword'), '', 'default', $_SERVER['PHP_SELF'].'#', '', false, $params);
@@ -2332,13 +2332,13 @@ if ($action == 'create' || $action == 'adduserldap') {
 				if ($user->id != $id && $permissiontodisable && $object->status == User::STATUS_DISABLED &&
 				((!isModEnabled('multicompany') && $object->entity == $user->entity) || !$user->entity || ($object->entity == $conf->entity) || (getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && $object->entity == 1))) {
 					unset($params['attr']['title']);
-					print dolGetButtonAction($langs->trans('Reactivate'), '', 'default', $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=enable&token='.newToken(), '', true, $params);
+					print dolGetButtonAction($langs->trans('Reactivate'), '', 'default', dolBuildUrl($_SERVER['PHP_SELF'], ['id' => $object->id, 'action' => 'enable'], true), '', true, $params);
 				}
 				// Disable user
 				if ($user->id != $id && $permissiontodisable && $object->status == User::STATUS_ENABLED &&
 				((!isModEnabled('multicompany') && $object->entity == $user->entity) || !$user->entity || ($object->entity == $conf->entity) || (getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && $object->entity == 1))) {
 					unset($params['attr']['title']);
-					print dolGetButtonAction($langs->trans('DisableUser'), '', 'default', $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=disable&token='.newToken(), '', true, $params);
+					print dolGetButtonAction($langs->trans('DisableUser'), '', 'default', dolBuildUrl($_SERVER['PHP_SELF'], ['id' => $object->id, 'action' => 'disable'], true), '', true, $params);
 				} else {
 					if ($user->id == $id) {
 						$params['attr']['title'] = $langs->trans('CantDisableYourself');
@@ -2350,10 +2350,10 @@ if ($action == 'create' || $action == 'adduserldap') {
 				((!isModEnabled('multicompany') && $object->entity == $user->entity) || !$user->entity || ($object->entity == $conf->entity) || (getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && $object->entity == 1))) {
 					if ($user->admin || !$object->admin) { // If user edited is admin, delete is possible on for an admin
 						unset($params['attr']['title']);
-						print dolGetButtonAction($langs->trans('DeleteUser'), '', 'default', $_SERVER['PHP_SELF'].'?action=delete&token='.newToken().'&id='.$object->id, '', true, $params);
+						print dolGetButtonAction($langs->trans('DeleteUser'), '', 'default', dolBuildUrl($_SERVER['PHP_SELF'], ['action' => 'delete', 'id' => $object->id], true), '', true, $params);
 					} else {
 						$params['attr']['title'] = $langs->trans('MustBeAdminToDeleteOtherAdmin');
-						print dolGetButtonAction($langs->trans('DeleteUser'), '', 'default', $_SERVER['PHP_SELF'].'?action=delete&token='.newToken().'&id='.$object->id, '', false, $params);
+						print dolGetButtonAction($langs->trans('DeleteUser'), '', 'default', dolBuildUrl($_SERVER['PHP_SELF'], ['action' => 'delete', 'id' => $object->id], true), '', false, $params);
 					}
 				}
 			}

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -1015,9 +1015,6 @@ class User extends CommonObject
 
 		// In $conf->modules, we have 'accounting', 'product', 'facture', ...
 		// In $user->rights, we have 'accounting', 'produit', 'facture', ...
-		//var_dump($this->rights->$rightsPath);
-		//var_dump($conf->modules);
-		//if ($module == 'fournisseur') { var_dump($module.' '.isModEnabled($module).' '.$rightsPath.' '.$permlevel1.' '.$permlevel2); }
 
 		if (!isModEnabled($module)) {
 			return 0;
@@ -1050,8 +1047,6 @@ class User extends CommonObject
 			$permlevel1 = 'recruitmentjobposition';
 		}
 
-		//var_dump($this->rights);
-		//var_dump($rightsPath.' '.$permlevel1.' '.$permlevel2);
 		if (empty($rightsPath) || empty($this->rights) || empty($this->rights->$rightsPath) || empty($permlevel1)) {
 			return 0;
 		}

--- a/htdocs/user/group/ldap.php
+++ b/htdocs/user/group/ldap.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2006-2012  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2006-2017  Regis Houssin           <regis.houssin@inodbox.com>
- * Copyright (C) 2019-2024  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2019-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -190,7 +190,6 @@ if ($result > 0) {
 
 	$records = $ldap->getAttribute($dn, $search);
 
-	//var_dump($records);
 
 	// Show tree
 	if (((!is_numeric($records)) || $records != 0) && (!isset($records['count']) || $records['count'] > 0)) {

--- a/htdocs/user/group/perms.php
+++ b/htdocs/user/group/perms.php
@@ -126,7 +126,6 @@ if (empty($reshook)) {
 		$qs = preg_replace('/&action=addrights/', '', $qs);
 		$qs = preg_replace('/&token=[0-9a-f]+/i', '', $qs);
 		$qs = preg_replace('/&confirm=yes/', '', $qs);
-		//var_dump($qs);exit;
 		header("Location: ".$_SERVER["PHP_SELF"].($qs ? "?".$qs : ""));
 		exit;
 	}
@@ -151,7 +150,6 @@ if (empty($reshook)) {
 		$qs = preg_replace('/&action=delrights/', '', $qs);
 		$qs = preg_replace('/&token=[0-9a-f]+/i', '', $qs);
 		$qs = preg_replace('/&confirm=yes/', '', $qs);
-		//var_dump($qs);exit;
 		header("Location: ".$_SERVER["PHP_SELF"].($qs ? "?".$qs : ""));
 		exit;
 	}
@@ -387,7 +385,6 @@ if ($result) {
 	$num = $db->num_rows($result);
 	$i = 0;
 
-	//var_dump($cookietohidegrouparray);
 
 	while ($i < $num) {
 		$obj = $db->fetch_object($result);
@@ -449,7 +446,6 @@ foreach ($arrayofpermission as $i => $obj) {
 		$ishidden = 0;
 	}
 	$isexpanded = ! $ishidden;
-	//var_dump("isexpanded=".$isexpanded);
 
 	$permsgroupbyentitypluszero = array();
 	if (!empty($permsgroupbyentity[0])) {
@@ -458,7 +454,6 @@ foreach ($arrayofpermission as $i => $obj) {
 	if (!empty($permsgroupbyentity[$entity])) {
 		$permsgroupbyentitypluszero = array_merge($permsgroupbyentitypluszero, $permsgroupbyentity[$entity]);
 	}
-	//var_dump($permsgroupbyentitypluszero);
 
 	// Break found, it's a new module to catch
 	if (isset($obj->module) && ($oldmod != $obj->module)) {
@@ -473,7 +468,6 @@ foreach ($arrayofpermission as $i => $obj) {
 			$ishidden = 0;
 		}
 		$isexpanded = ! $ishidden;
-		//var_dump('$obj->module='.$obj->module.' isexpanded='.$isexpanded);
 
 		// Break detected, we get objMod
 		$objMod = $modules[$obj->module];

--- a/htdocs/user/hierarchy.php
+++ b/htdocs/user/hierarchy.php
@@ -142,7 +142,6 @@ if (!is_array($user_arbo) && $user_arbo < 0) {
 } else {
 	// Define fulltree array
 	$fulltree = $user_arbo;
-	//var_dump($fulltree);
 	// Define data (format for treeview)
 	$data = array();
 	$data[0] = array('rowid' => 0, 'fk_menu' => -1, 'title' => 'racine', 'mainmenu' => '', 'leftmenu' => '', 'fk_mainmenu' => '', 'fk_leftmenu' => '');
@@ -255,7 +254,6 @@ if (!is_array($user_arbo) && $user_arbo < 0) {
 					} else {
 						$parentfound = 1;
 					}
-					//var_dump($data[$idparent]);
 				} else {
 					// We should not be here. If a record has a parent id, parent id should be into $user_arbo_all
 					$data[$key]['fk_menu'] = -2;
@@ -276,7 +274,6 @@ if (!is_array($user_arbo) && $user_arbo < 0) {
 			}
 		}
 	}
-	//var_dump($data);exit;
 
 	$param = "&search_status=".urlencode($search_status);
 	$param = "&contextpage=".urlencode($contextpage);

--- a/htdocs/user/perms.php
+++ b/htdocs/user/perms.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2012       Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2020       Tobias Sekan            <tobias.sekan@startmail.com>
  * Copyright (C) 2024       MDW                     <mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025-2026  Charlene Benke          <charlene@patas-monkey.com>
  * Copyright (C) 2026       Alexandre Spangaro      <alexandre@inovea-conseil.com>
  *
@@ -135,7 +135,6 @@ if (empty($reshook)) {
 		$qs = preg_replace('/&action=addrights/', '', $qs);
 		$qs = preg_replace('/&token=[0-9a-f]+/i', '', $qs);
 		$qs = preg_replace('/&confirm=yes/', '', $qs);
-		//var_dump($qs);exit;
 		header("Location: ".$_SERVER["PHP_SELF"].($qs ? "?".$qs : ""));
 		exit;
 	}
@@ -522,7 +521,6 @@ if ($result) {
 	$num = $db->num_rows($result);
 	$i = 0;
 
-	//var_dump($cookietohidegrouparray);
 
 	while ($i < $num) {
 		$obj = $db->fetch_object($result);
@@ -592,7 +590,6 @@ foreach ($arrayofpermission as $i => $obj) {
 		$ishidden = 0;
 	}
 	$isexpanded = ! $ishidden;
-	//var_dump("isexpanded=".$isexpanded);
 
 	$permsgroupbyentitypluszero = array();
 	if (!empty($permsgroupbyentity[0])) {
@@ -601,7 +598,6 @@ foreach ($arrayofpermission as $i => $obj) {
 	if (!empty($permsgroupbyentity[$entity])) {
 		$permsgroupbyentitypluszero = array_merge($permsgroupbyentitypluszero, $permsgroupbyentity[$entity]);
 	}
-	//var_dump($permsgroupbyentitypluszero);
 
 	// Break found, it's a new module to catch
 	if (isset($obj->module) && ($oldmod != $obj->module)) {
@@ -616,7 +612,6 @@ foreach ($arrayofpermission as $i => $obj) {
 			$ishidden = 0;
 		}
 		$isexpanded = ! $ishidden;
-		//var_dump('$obj->module='.$obj->module.' isexpanded='.$isexpanded);
 
 		// Break detected, we get objMod
 		$objMod = $modules[$obj->module];


### PR DESCRIPTION
## Description

Housekeeping in `htdocs/user/`, same approach as #39778 (product) and #39779 (commande), split into two commits:

### 1. `Qual:` Use `dolBuildUrl()` in `dolGetButtonAction()` calls

Replace manual query-string concatenation with `dolBuildUrl($url, [...], true)`:

- `user/card.php`: ReinitPassword, SendNewPassword, Reactivate, DisableUser, DeleteUser (×2)
- `user/api_token/card.php`: Delete (keeps the `tokenid` param)

Same approach as commit 585afa14ded (`Qual: Use dolBuildUrl() ... in ecm`). No functional change: `dolBuildUrl(..., true)` adds the token instead of `.'&token='.newToken()`.

Buttons already using `dolBuildUrl()`, those with a bare `#` href (disabled), and the dropdown/array form are left untouched.

### 2. `Clean:` Remove commented-out `var_dump()` lines

Drop 22 dead `//var_dump(...)` debug lines across `user/card.php`, `user/class/user.class.php`, `user/perms.php`, `user/group/perms.php`, `user/group/ldap.php` and `user/hierarchy.php`.

## How to test

Open a user card / API token card and check the action-bar buttons still point to the right URLs and carry a valid CSRF token.