### PR TITLE
Fix #39730 keep the preview picto visible for long file names

### DIFF
--- a/htdocs/core/class/html.formfile.class.php
+++ b/htdocs/core/class/html.formfile.class.php
@@ -1310,7 +1310,16 @@ class FormFile
 
 
 					// File name
+					$editline = (GETPOST('action', 'aZ09') == 'editfile' && $file['name'] == basename(GETPOST('urlfile', 'alpha'))) ? 1 : 0;
+					$imgpreview = $editline ? '' : $this->showPreview($file, $modulepart, $filepath, 0, '&entity='.(!empty($object->entity) ? $object->entity : $conf->entity));
 					print '<td class="minwith200 tdoverflowmax500">';
+					// The preview picto is printed in the same cell, so reserve room for it, otherwise the
+					// ellipsis of the cell truncates the picto instead of the file name (see #39730).
+					if ($imgpreview) {
+						print '<span class="spanoverflow widthcentpercentminusx valignmiddle">';
+					} else {
+						print '<span class="spanoverflow">';
+					}
 
 					// Show file name with link to download
 					//print "XX".$file['name'];	//$file['name'] must be utf8
@@ -1343,9 +1352,11 @@ class FormFile
 						print dol_escape_htmltag(dol_trunc($filenametoshow, 200));
 						print '</a>';
 					}
+					print '</span>';
+
 					// Preview link
 					if (!$editline) {
-						print $this->showPreview($file, $modulepart, $filepath, 0, '&entity='.(!empty($object->entity) ? $object->entity : $conf->entity));
+						print $imgpreview;
 					}
 
 					print "</td>\n";


### PR DESCRIPTION
The preview picto is printed inside the same cell as the file name, and that cell carries tdoverflowmax500 (overflow hidden, ellipsis, nowrap). With a long name the ellipsis therefore truncates the picto instead of the name, so the preview link becomes unreachable. Zooming out widens the column and makes it reappear, which matches the reports.

showdocuments() already handles the same picto by wrapping the name in a span with widthcentpercentminusx, which reserves the picto width. list_of_documents() did not, so this aligns it on that existing pattern. No CSS change, both eldy and md already define the class.

The picto is computed before the cell so the reservation is only applied when a picto is actually printed, and skipped while renaming a file inline.

Checked in a browser at 760px with the real CSS: before the change the picto lands 344px outside the cell edge, after it sits inside and the name keeps its ellipsis.