### PR TITLE
FIX #39772 Rename provisional order documents

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -642,7 +642,7 @@ class Commande extends CommonOrder
 					if (@rename($dirsource, $dirdest)) {
 						dol_syslog("Rename ok");
 						// Rename docs starting with $oldref with $newref
-						$listoffiles = dol_dir_list($dirdest.'/'.$newref, 'files', 1, '^'.preg_quote($oldref, '/'));
+						$listoffiles = dol_dir_list($dirdest, 'files', 1, '^'.preg_quote($oldref, '/'));
 						foreach ($listoffiles as $fileentry) {
 							$dirsource = $fileentry['name'];
 							$dirdest = preg_replace('/^'.preg_quote($oldref, '/').'/', $newref, $dirsource);

--- a/test/phpunit/CommandeTest.php
+++ b/test/phpunit/CommandeTest.php
@@ -89,6 +89,8 @@ class CommandeTest extends CommonClassTest
 		$localobject = new Commande($db);
 		$param = array('tosell' => 1);
 		$localobject->initAsSpecimen($param);
+		// Persist a regular provisional order instead of keeping the specimen reference.
+		$localobject->ref = '';
 		$localobject->socid = $socid;
 		$result = $localobject->create($user);
 
@@ -164,10 +166,37 @@ class CommandeTest extends CommonClassTest
 		$langs = $this->savlangs;
 		$db = $this->savdb;
 
-		$result = $localobject->valid($user);
+		$oldref = dol_sanitizeFileName($localobject->ref);
+		$outputdir = getMultidirOutput($localobject);
+		$dirsource = $outputdir.'/'.$oldref;
+		$oldfile = $dirsource.'/'.$oldref.'.pdf';
+		$dirnew = '';
+		$newfile = '';
 
-		print __METHOD__." id=".$localobject->id." result=".$result."\n";
-		$this->assertLessThan($result, 0);
+		try {
+			$this->assertGreaterThanOrEqual(0, dol_mkdir($dirsource));
+			$this->assertNotFalse(file_put_contents($oldfile, 'Provisional order document'));
+
+			$result = $localobject->valid($user);
+
+			print __METHOD__." id=".$localobject->id." result=".$result."\n";
+			$this->assertLessThan($result, 0);
+
+			$newref = dol_sanitizeFileName($localobject->ref);
+			$dirnew = $outputdir.'/'.$newref;
+			$newfile = $dirnew.'/'.$newref.'.pdf';
+			$this->assertFileExists($newfile);
+			$this->assertFileNotExistsCompat($dirnew.'/'.$oldref.'.pdf');
+		} finally {
+			if ($newfile) {
+				@unlink($newfile);
+			}
+			@unlink($oldfile);
+			if ($dirnew) {
+				@rmdir($dirnew);
+			}
+			@rmdir($dirsource);
+		}
 		return $localobject;
 	}
 


### PR DESCRIPTION
## Fix

After `Commande::valid()` moves a draft order directory to its final reference, scan that final directory directly for files beginning with the provisional reference. The previous path appended the final reference a second time, so no provisional PDF was found or renamed.

## Test

`CommandeTest::testCommandeValid` creates a provisional PDF, validates the order, then checks that only the renamed final PDF remains.

Fixes #39772