### PR TITLE
FIX missing entity field + more bugs

### DIFF
--- a/htdocs/compta/sociales/card.php
+++ b/htdocs/compta/sociales/card.php
@@ -94,7 +94,7 @@ if ($id > 0 || $ref) {
 
 $permissiontoread = $user->hasRight('tax', 'charges', 'lire');
 $permissiontoadd = $user->hasRight('tax', 'charges', 'creer'); // Used by the include of actions_addupdatedelete.inc.php and actions_lineupdown.inc.php
-$permissiontodelete = $user->rights->tax->charges->supprimer || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_UNPAID);
+$permissiontodelete = $user->hasRight('tax', 'charges', 'supprimer') || ($permissiontoadd && isset($object->status) && $object->status == $object::STATUS_UNPAID);
 $permissionnote = $user->hasRight('tax', 'charges', 'creer'); // Used by the include of actions_setnotes.inc.php
 $permissiondellink = $user->hasRight('tax', 'charges', 'creer'); // Used by the include of actions_dellink.inc.php
 $upload_dir = $conf->tax->multidir_output[isset($object->entity) ? $object->entity : 1];

--- a/htdocs/fichinter/class/fichinterligne.class.php
+++ b/htdocs/fichinter/class/fichinterligne.class.php
@@ -130,23 +130,27 @@ class FichinterLigne extends CommonObjectLine
 
 		$resql = $this->db->query($sql);
 		if ($resql) {
-			$objp = $this->db->fetch_object($resql);
-			$this->rowid          	= $objp->rowid;
-			$this->id               = $objp->rowid;
-			$this->fk_fichinter   	= $objp->fk_fichinter;
-			$this->date = $this->db->jdate($objp->date);
-			$this->datei = $this->db->jdate($objp->date);	// For backward compatibility
-			$this->desc           	= $objp->description;
-			$this->duration       	= $objp->duree;
-			$this->rang           	= $objp->rang;
+			if ($this->db->num_rows($resql)) {
+				$objp = $this->db->fetch_object($resql);
+				$this->rowid          	= $objp->rowid;
+				$this->id               = $objp->rowid;
+				$this->fk_fichinter   	= $objp->fk_fichinter;
+				$this->date = $this->db->jdate($objp->date);
+				$this->datei = $this->db->jdate($objp->date);	// For backward compatibility
+				$this->desc           	= $objp->description;
+				$this->duration       	= $objp->duree;
+				$this->rang           	= $objp->rang;
 
-			$this->extraparams = !empty($objp->extraparams) ? (array) json_decode($objp->extraparams, true) : array();
+				$this->extraparams = !empty($objp->extraparams) ? (array) json_decode($objp->extraparams, true) : array();
 
-			$this->db->free($resql);
+				$this->db->free($resql);
 
-			$this->fetch_optionals();
+				$this->fetch_optionals();
 
-			return 1;
+				return 1;
+			}
+
+			return 0;
 		} else {
 			$this->error = $this->db->error().' sql='.$sql;
 			return -1;

--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -704,6 +704,8 @@ class FactureFournisseurRec extends CommonInvoice
 				$this->date_creation            = $obj->datec;
 				$this->date_modification        = $obj->tms;
 				$this->suspended                = $obj->suspended;
+				$this->statut                	= $obj->suspended; //for compatibility
+				$this->status                   = $obj->suspended; //for compatibility
 				$this->libelle                  = $obj->label;
 				$this->label                    = $obj->label;
 				$this->vat_src_code             = $obj->vat_src_code;
@@ -857,8 +859,8 @@ class FactureFournisseurRec extends CommonInvoice
 				$line->total_localtax2          = $objp->total_localtax2;
 				$line->total_ttc                = $objp->total_ttc;
 				$line->product_type             = $objp->product_type;
-				$line->date_start               = $this->db->jdate($objp->date_start);
-				$line->date_end                 = $this->db->jdate($objp->date_end);
+				$line->date_start               = $objp->date_start; // integer (not a date))
+				$line->date_end                 = $objp->date_end; // integer (not a date)
 				$line->info_bits                = $objp->info_bits	;
 				$line->special_code             = $objp->special_code;
 				$line->rang                     = $objp->rang;
@@ -1179,110 +1181,113 @@ class FactureFournisseurRec extends CommonInvoice
 			return -1;
 		}
 
-		// Clean parameters
-		$fk_product = empty($fk_product) ? 0 : $fk_product;
-		$label = empty($label) ? '' : $label;
-		$remise_percent = empty($remise_percent) ? 0 : price2num($remise_percent);
-		$qty = price2num($qty);
-		$info_bits = empty($info_bits) ? 0 : $info_bits;
-		$pu_ht          = price2num($pu_ht);
-		$pu_ttc         = price2num($pu_ttc);
-		$pu_ht_devise = price2num($pu_ht_devise);
+		if ($this->status == self::STATUS_NOTSUSPENDED) {
+			// Clean parameters
+			$fk_product = empty($fk_product) ? 0 : $fk_product;
+			$label = empty($label) ? '' : $label;
+			$remise_percent = empty($remise_percent) ? 0 : price2num($remise_percent);
+			$qty = price2num($qty);
+			$info_bits = empty($info_bits) ? 0 : $info_bits;
+			$pu_ht          = price2num($pu_ht);
+			$pu_ttc         = price2num($pu_ttc);
+			$pu_ht_devise = price2num($pu_ht_devise);
 
-		if (!preg_match('/\((.*)\)/', (string) $txtva)) {
-			$txtva = price2num($txtva); // $txtva can have format '5.0(XXX)' or '5'
+			if (!preg_match('/\((.*)\)/', (string) $txtva)) {
+				$txtva = price2num($txtva); // $txtva can have format '5.0(XXX)' or '5'
+			}
+
+			$txlocaltax1 = empty($txlocaltax1) ? 0 : price2num($txlocaltax1);
+			$txlocaltax2 = empty($txlocaltax2) ? 0 : price2num($txlocaltax2);
+			$this->multicurrency_total_ht = empty($this->multicurrency_total_ht) ? 0 : $this->multicurrency_total_ht;
+			$this->multicurrency_total_tva = empty($this->multicurrency_total_tva) ? 0 : $this->multicurrency_total_tva;
+			$this->multicurrency_total_ttc = empty($this->multicurrency_total_ttc) ? 0 : $this->multicurrency_total_ttc;
+
+			$pu = ($price_base_type == 'HT' ? $pu_ht : $pu_ttc);
+
+
+			// Calculate total with, without tax and tax from qty, pu, remise_percent and txtva
+			// TRES IMPORTANT: C'est au moment de l'insertion ligne qu'on doit stocker
+			// la part ht, tva et ttc, et ce au niveau de la ligne qui a son propre taux tva.
+
+			$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $this->thirdparty, $mysoc);
+
+			// Clean vat code
+			$vat_src_code = '';
+			$reg = array();
+			if (preg_match('/\((.*)\)/', $txtva, $reg)) {
+				$vat_src_code = $reg[1];
+				$txtva = preg_replace('/\s*\(.*\)/', '', $txtva); // Remove code into vatrate.
+			}
+
+			$tabprice = calcul_price_total((float) $qty, (float) $pu, $remise_percent, $txtva, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $type, $mysoc, $localtaxes_type, 100, $this->multicurrency_tx, (float) $pu_ht_devise);
+
+			$total_ht  = $tabprice[0];
+			$total_tva = $tabprice[1];
+			$total_ttc = $tabprice[2];
+			$total_localtax1 = $tabprice[9];
+			$total_localtax2 = $tabprice[10];
+			$pu_ht  = $tabprice[3];
+			$pu_tva = $tabprice[4];
+			$pu_ttc = $tabprice[5];
+
+			// MultiCurrency
+			$multicurrency_total_ht  = $tabprice[16];
+			$multicurrency_total_tva = $tabprice[17];
+			$multicurrency_total_ttc = $tabprice[18];
+			$pu_ht_devise = $tabprice[19];
+
+			$product_type = $type;
+			if ($fk_product) {
+				$product = new Product($this->db);
+				$result = $product->fetch($fk_product);
+				$product_type = $product->type;
+			}
+
+			$sql = 'UPDATE ' . MAIN_DB_PREFIX . 'facture_fourn_det_rec SET';
+			$sql .= ' fk_facture_fourn = ' . ((int) $facid);
+			$sql .= ', fk_product = ' . ($fk_product > 0 ? ((int) $fk_product) : 'null');
+			$sql .= ", ref = '" . $this->db->escape($ref) . "'";
+			$sql .= ", label = '" . $this->db->escape($label) . "'";
+			$sql .= ", description = '" . $this->db->escape($desc) . "'";
+			$sql .= ', pu_ht = ' . price2num($pu_ht);
+			$sql .= ', qty = ' . price2num($qty);
+			$sql .= ", remise_percent = '" . price2num($remise_percent) . "'";
+			$sql .= ", vat_src_code = '" . $this->db->escape($vat_src_code) . "'";
+			$sql .= ', tva_tx = ' . price2num($txtva);
+			$sql .= ', localtax1_tx = ' . (float) $txlocaltax1;
+			$sql .= ", localtax1_type = '" . $this->db->escape($localtaxes_type[0]) . "'";
+			$sql .= ', localtax2_tx = ' . (float) $txlocaltax2;
+			$sql .= ", localtax2_type = '" . $this->db->escape($localtaxes_type[2]) . "'";
+			$sql .= ", total_ht = '" . price2num($total_ht) . "'";
+			$sql .= ", total_tva = '" . price2num($total_tva) . "'";
+			$sql .= ", total_localtax1 = '" . price2num($total_localtax1) . "'";
+			$sql .= ", total_localtax2 = '" . price2num($total_localtax2) . "'";
+			$sql .= ", total_ttc = '" . price2num($total_ttc) . "'";
+			$sql .= ', product_type = ' . (int) $product_type;
+			$sql .= ', date_start = ' . (empty($date_start) ? 'NULL' : (int) $date_start);
+			$sql .= ', date_end = ' . (empty($date_end) ? 'NULL' : (int) $date_end);
+			$sql .= ', info_bits = ' . (int) $info_bits;
+			$sql .= ', special_code = ' . (int) $special_code;
+			$sql .= ', rang = ' . (int) $rang;
+			$sql .= ', fk_unit = ' . ($fk_unit ? "'" . $this->db->escape($fk_unit) . "'" : 'null');
+			$sql .= ', fk_user_modif = ' . (int) $user->id;
+			$sql .= ', multicurrency_subprice = '.price2num($pu_ht_devise);
+			$sql .= ', multicurrency_total_ht = '.price2num($multicurrency_total_ht);
+			$sql .= ', multicurrency_total_tva = '.price2num($multicurrency_total_tva);
+			$sql .= ', multicurrency_total_ttc = '.price2num($multicurrency_total_ttc);
+			$sql .= ' WHERE rowid = ' . (int) $rowid;
+
+			dol_syslog(get_class($this). '::updateline', LOG_DEBUG);
+			if ($this->db->query($sql)) {
+				$this->id = $facid;
+				$this->update_price();
+				return 1;
+			} else {
+				$this->error = $this->db->lasterror();
+				return -1;
+			}
 		}
-
-		$txlocaltax1 = empty($txlocaltax1) ? 0 : price2num($txlocaltax1);
-		$txlocaltax2 = empty($txlocaltax2) ? 0 : price2num($txlocaltax2);
-		$this->multicurrency_total_ht = empty($this->multicurrency_total_ht) ? 0 : $this->multicurrency_total_ht;
-		$this->multicurrency_total_tva = empty($this->multicurrency_total_tva) ? 0 : $this->multicurrency_total_tva;
-		$this->multicurrency_total_ttc = empty($this->multicurrency_total_ttc) ? 0 : $this->multicurrency_total_ttc;
-
-		$pu = ($price_base_type == 'HT' ? $pu_ht : $pu_ttc);
-
-
-		// Calculate total with, without tax and tax from qty, pu, remise_percent and txtva
-		// TRES IMPORTANT: C'est au moment de l'insertion ligne qu'on doit stocker
-		// la part ht, tva et ttc, et ce au niveau de la ligne qui a son propre taux tva.
-
-		$localtaxes_type = getLocalTaxesFromRate($txtva, 0, $this->thirdparty, $mysoc);
-
-		// Clean vat code
-		$vat_src_code = '';
-		$reg = array();
-		if (preg_match('/\((.*)\)/', $txtva, $reg)) {
-			$vat_src_code = $reg[1];
-			$txtva = preg_replace('/\s*\(.*\)/', '', $txtva); // Remove code into vatrate.
-		}
-
-		$tabprice = calcul_price_total((float) $qty, (float) $pu, $remise_percent, $txtva, $txlocaltax1, $txlocaltax2, 0, $price_base_type, $info_bits, $type, $mysoc, $localtaxes_type, 100, $this->multicurrency_tx, (float) $pu_ht_devise);
-
-		$total_ht  = $tabprice[0];
-		$total_tva = $tabprice[1];
-		$total_ttc = $tabprice[2];
-		$total_localtax1 = $tabprice[9];
-		$total_localtax2 = $tabprice[10];
-		$pu_ht  = $tabprice[3];
-		$pu_tva = $tabprice[4];
-		$pu_ttc = $tabprice[5];
-
-		// MultiCurrency
-		$multicurrency_total_ht  = $tabprice[16];
-		$multicurrency_total_tva = $tabprice[17];
-		$multicurrency_total_ttc = $tabprice[18];
-		$pu_ht_devise = $tabprice[19];
-
-		$product_type = $type;
-		if ($fk_product) {
-			$product = new Product($this->db);
-			$result = $product->fetch($fk_product);
-			$product_type = $product->type;
-		}
-
-		$sql = 'UPDATE ' . MAIN_DB_PREFIX . 'facture_fourn_det_rec SET';
-		$sql .= ' fk_facture_fourn = ' . ((int) $facid);
-		$sql .= ', fk_product = ' . ($fk_product > 0 ? ((int) $fk_product) : 'null');
-		$sql .= ", ref = '" . $this->db->escape($ref) . "'";
-		$sql .= ", label = '" . $this->db->escape($label) . "'";
-		$sql .= ", description = '" . $this->db->escape($desc) . "'";
-		$sql .= ', pu_ht = ' . price2num($pu_ht);
-		$sql .= ', qty = ' . price2num($qty);
-		$sql .= ", remise_percent = '" . price2num($remise_percent) . "'";
-		$sql .= ", vat_src_code = '" . $this->db->escape($vat_src_code) . "'";
-		$sql .= ', tva_tx = ' . price2num($txtva);
-		$sql .= ', localtax1_tx = ' . (float) $txlocaltax1;
-		$sql .= ", localtax1_type = '" . $this->db->escape($localtaxes_type[0]) . "'";
-		$sql .= ', localtax2_tx = ' . (float) $txlocaltax2;
-		$sql .= ", localtax2_type = '" . $this->db->escape($localtaxes_type[2]) . "'";
-		$sql .= ", total_ht = '" . price2num($total_ht) . "'";
-		$sql .= ", total_tva = '" . price2num($total_tva) . "'";
-		$sql .= ", total_localtax1 = '" . price2num($total_localtax1) . "'";
-		$sql .= ", total_localtax2 = '" . price2num($total_localtax2) . "'";
-		$sql .= ", total_ttc = '" . price2num($total_ttc) . "'";
-		$sql .= ', product_type = ' . (int) $product_type;
-		$sql .= ', date_start = ' . (empty($date_start) ? 'NULL' : (int) $date_start);
-		$sql .= ', date_end = ' . (empty($date_end) ? 'NULL' : (int) $date_end);
-		$sql .= ', info_bits = ' . (int) $info_bits;
-		$sql .= ', special_code = ' . (int) $special_code;
-		$sql .= ', rang = ' . (int) $rang;
-		$sql .= ', fk_unit = ' . ($fk_unit ? "'" . $this->db->escape($fk_unit) . "'" : 'null');
-		$sql .= ', fk_user_modif = ' . (int) $user;
-		$sql .= ', multicurrency_subprice = '.price2num($pu_ht_devise);
-		$sql .= ', multicurrency_total_ht = '.price2num($multicurrency_total_ht);
-		$sql .= ', multicurrency_total_tva = '.price2num($multicurrency_total_tva);
-		$sql .= ', multicurrency_total_ttc = '.price2num($multicurrency_total_ttc);
-		$sql .= ' WHERE rowid = ' . (int) $rowid;
-
-		dol_syslog(get_class($this). '::updateline', LOG_DEBUG);
-		if ($this->db->query($sql)) {
-			$this->id = $facid;
-			$this->update_price();
-			return 1;
-		} else {
-			$this->error = $this->db->lasterror();
-			return -1;
-		}
+		return 0;
 	}
 
 

--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -694,9 +694,9 @@ class FactureFournisseurRec extends CommonInvoice
 				$keyforref = $this->table_ref_field;
 
 				$this->id                       = $obj->rowid;
-				$this->titre                    = $obj->title;
+				$this->titre                    = $obj->title;	// deprecated
 				$this->title                    = $obj->title;
-				$this->subtype				          = $obj->subtype;
+				$this->subtype				    = $obj->subtype;
 				$this->ref                      = $obj->title;
 				$this->ref_supplier             = $obj->ref_supplier;
 				$this->entity                   = $obj->entity;
@@ -704,9 +704,9 @@ class FactureFournisseurRec extends CommonInvoice
 				$this->date_creation            = $obj->datec;
 				$this->date_modification        = $obj->tms;
 				$this->suspended                = $obj->suspended;
-				$this->statut                	= $obj->suspended; //for compatibility
-				$this->status                   = $obj->suspended; //for compatibility
-				$this->libelle                  = $obj->label;
+				$this->statut                	= $obj->suspended;	//deprecated
+				$this->status                   = $obj->suspended;	//for compatibility
+				$this->libelle                  = $obj->label;	// deprecated
 				$this->label                    = $obj->label;
 				$this->vat_src_code             = $obj->vat_src_code;
 				$this->total_localtax1          = $obj->localtax1;
@@ -723,7 +723,7 @@ class FactureFournisseurRec extends CommonInvoice
 				$this->mode_reglement           = $obj->mode_reglement_libelle;
 				$this->cond_reglement_id        = $obj->fk_cond_reglement;
 				$this->cond_reglement_code      = $obj->cond_reglement_code;
-				$this->cond_reglement           = $obj->cond_reglement_libelle;
+				$this->cond_reglement           = $obj->cond_reglement_libelle;	// deprecated
 				$this->cond_reglement_doc       = $obj->cond_reglement_libelle_doc;
 				$this->date_lim_reglement       = $this->db->jdate($obj->date_lim_reglement);
 				$this->note_private             = $obj->note_private;

--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -1525,7 +1525,7 @@ if ($action == 'create') {
         	<input type="hidden" name="id" value="' . $object->id . '">
         	';
 
-		if (!empty($conf->use_javascript_ajax) && $object->statut == 0) {
+		if (!empty($conf->use_javascript_ajax) && $object->statut == FactureFournisseurRec::STATUS_NOTSUSPENDED) {
 			include DOL_DOCUMENT_ROOT . '/core/tpl/ajaxrow.tpl.php';
 		}
 

--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -1291,7 +1291,7 @@ if ($action == 'create') {
 		print '<table width="100%" class="nobordernopadding"><tr><td class="nowrap">';
 		print $langs->trans('BankAccount');
 		print '<td>';
-		if ($action != 'editbankaccount' && $usercancreate && $object->statut == FactureFournisseurRec::STATUS_NOTSUSPENDED) {
+		if ($action != 'editbankaccount' && $usercancreate && $object->status == FactureFournisseurRec::STATUS_NOTSUSPENDED) {
 			print '<td class="right"><a class="editfielda" href="' . $_SERVER['PHP_SELF'] . '?action=editbankaccount&token=' . newToken() . '&id=' . $object->id . '">' . img_edit($langs->trans('SetBankAccount'), 1) . '</a></td>';
 		}
 		print '</tr></table>';
@@ -1312,7 +1312,7 @@ if ($action == 'create') {
 		print '<table class="nobordernopadding centpercent"><tr><td class="nowrap">';
 		print $langs->trans('Model');
 		print '<td>';
-		if ($action != 'editmodelpdf' && $usercancreate && $object->statut == FactureFournisseurRec::STATUS_NOTSUSPENDED) {
+		if ($action != 'editmodelpdf' && $usercancreate && $object->status == FactureFournisseurRec::STATUS_NOTSUSPENDED) {
 			print '<td class="right"><a class="editfielda" href="' . $_SERVER['PHP_SELF'] . '?action=editmodelpdf&token=' . newToken() . '&id=' . $object->id . '">' . img_edit($langs->trans('SetModel'), 1) . '</a></td>';
 		}
 		print '</tr></table>';
@@ -1419,7 +1419,7 @@ if ($action == 'create') {
 			}
 			//var_dump(dol_print_date($object->date_when+60, 'dayhour').' - '.dol_print_date($now, 'dayhour'));
 			if (! $object->isMaxNbGenReached()) {
-				if (! $object->suspended && $action != 'editdate_when' && $object->frequency > 0 && $object->date_when && $object->date_when < $now) {
+				if (empty($object->suspended) && $action != 'editdate_when' && $object->frequency > 0 && $object->date_when && $object->date_when < $now) {
 					print img_warning($langs->trans("Late"));
 				}
 			} else {
@@ -1525,7 +1525,7 @@ if ($action == 'create') {
         	<input type="hidden" name="id" value="' . $object->id . '">
         	';
 
-		if (!empty($conf->use_javascript_ajax) && $object->statut == FactureFournisseurRec::STATUS_NOTSUSPENDED) {
+		if (!empty($conf->use_javascript_ajax) && $object->status == FactureFournisseurRec::STATUS_NOTSUSPENDED) {
 			include DOL_DOCUMENT_ROOT . '/core/tpl/ajaxrow.tpl.php';
 		}
 
@@ -1537,13 +1537,12 @@ if ($action == 'create') {
 			global $canchangeproduct;
 			$canchangeproduct = 0;
 
-			$object->statut = $object->suspended;
 			$object->printObjectLines($action, $object->thirdparty, $mysoc, $lineid, 0); // No date selector for template invoice
 		}
 
 		// Form to add new line
 		//TODO : Droits
-		if ($object->statut == $object::STATUS_DRAFT && $usercancreate && $action != 'valid' && $action != 'editline') {
+		if ($object->status == FactureFournisseurRec::STATUS_NOTSUSPENDED && $usercancreate && $action != 'valid' && $action != 'editline') {
 			if ($action != 'editline') {
 				// Add free products/services
 

--- a/htdocs/fourn/facture/list-rec.php
+++ b/htdocs/fourn/facture/list-rec.php
@@ -290,7 +290,7 @@ $today = dol_mktime(23, 59, 59, $tmparray['mon'], $tmparray['mday'], $tmparray['
 // Build and execute select
 // --------------------------------------------------------------------
 
-$sql = "SELECT s.nom as name, s.rowid as socid, f.rowid as facid, f.titre as title, f.total_ht, f.total_tva, f.total_ttc, f.frequency, f.unit_frequency,";
+$sql = "SELECT s.nom as name, s.rowid as socid, f.rowid as facid, f.entity, f.titre as title, f.total_ht, f.total_tva, f.total_ttc, f.frequency, f.unit_frequency,";
 $sql .= " f.nb_gen_done, f.nb_gen_max, f.date_last_gen, f.date_when, f.suspended,";
 $sql .= " f.datec, f.fk_user_author, f.tms, f.fk_user_modif,";
 $sql .= " f.fk_cond_reglement, f.fk_mode_reglement";

--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -144,6 +144,8 @@ if ((!$user->hasRight("fournisseur", "facture", "lire") && !getDolGlobalString('
 	accessforbidden();
 }
 
+$arrayofselected = !empty($arrayofselected) && is_array($arrayofselected) ? $arrayofselected : array();
+
 
 /*
  * Actions
@@ -179,9 +181,11 @@ if (empty($reshook)) {
 	}
 }
 
+
 /*
  * View
  */
+
 $title = $langs->trans('ListPayment');
 $help_url = '';
 

--- a/htdocs/install/upgrade.php
+++ b/htdocs/install/upgrade.php
@@ -394,7 +394,7 @@ if (!GETPOST('action', 'aZ09') || preg_match('/upgrade/i', GETPOST('action', 'aZ
 					$handlemodule = @opendir($dirroot); // $dirroot may be '..'
 					if (is_resource($handlemodule)) {
 						while (($filemodule = readdir($handlemodule)) !== false) {
-							if (!preg_match('/\./', $filemodule) && is_dir($dirroot.'/'.$filemodule.'/sql')) {	// We exclude filemodule that contains . (are not directories) and are not directories.
+							if (!preg_match('/\./', $filemodule) && @is_dir($dirroot.'/'.$filemodule.'/sql')) {	// We exclude filemodule that contains . (are not directories) and are not directories. $dirroot may be '..' (see opendir() above), same open_basedir edge case, silence it here too
 								//print "Scan for ".$dirroot . '/' . $filemodule . '/sql/'.$file;
 								if (is_file($dirroot.'/'.$filemodule.'/sql/dolibarr_'.$file)) {
 									$modulesfile[$dirroot.'/'.$filemodule.'/sql/dolibarr_'.$file] = '/'.$filemodule.'/sql/dolibarr_'.$file;

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -647,6 +647,12 @@ if (!defined('NOLOGIN')) {
 		}
 		// TODO Remove use of $_COOKIE['login_dolibarr'] by replacing line with $usertotest = GETPOST("username", "alpha", $allowedmethodtopostusername); ?
 		$usertotest = (!empty($_COOKIE['login_dolibarr']) ? preg_replace('/[^a-zA-Z0-9_@\-\.]/', '', $_COOKIE['login_dolibarr']) : GETPOST("username", "alpha", $allowedmethodtopostusername));
+		if (!is_string($usertotest)) {
+			// An array-shaped username (ex: ?username[]=x) is not sanitized by GETPOST('alpha')
+			// (sanitizeVal only processes scalars for this check) and would otherwise flow unchanged into
+			// checkLoginPassEntity() -> User::fetch(), crashing on trim() with a TypeError (see user.class.php).
+			$usertotest = '';
+		}
 		$passwordtotest = GETPOST('password', 'password', $allowedmethodtopostusername);
 		$entitytotest = (GETPOSTINT('entity') ? GETPOSTINT('entity') : (!empty($conf->entity) ? $conf->entity : 1));
 

--- a/htdocs/product/class/productcustomerprice.class.php
+++ b/htdocs/product/class/productcustomerprice.class.php
@@ -1062,7 +1062,7 @@ class ProductCustomerPrice extends CommonObject
 						// If line do not exits then create it
 						$prodsocpricenew = new ProductCustomerPrice($this->db);
 						$prodsocpricenew->fk_soc = $obj->rowid;
-						$prodsocpricenew->ref_customer = $obj->ref_customer;
+						$prodsocpricenew->ref_customer = $this->ref_customer; // $obj only selects s.rowid (societe), ref_customer belongs to $this (the price line being propagated)
 						$prodsocpricenew->fk_product = $this->fk_product;
 						$prodsocpricenew->price = $this->price;
 						$prodsocpricenew->price_min = $this->price_min;

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -2938,7 +2938,7 @@ class Ticket extends CommonObject
 									$array_external = array(array('id' => -1, 'firstname' => '', 'lastname' => $object->origin_replyto, 'email' => $object->origin_replyto, 'libelle' => $langs->transnoentities('Customer'), 'socid' => 0));
 									$external_contacts = array_merge($external_contacts, $array_external);
 								} elseif (empty($object->fk_soc) && !empty($object->origin_email)) {
-									$array_external = array(array('id' => -1, 'firstname' => '', 'lastname' => $object->origin_email, 'email' => $object->thirdparty->email, 'libelle' => $langs->transnoentities('Customer'), 'socid' => $object->thirdparty->id));
+									$array_external = array(array('id' => -1, 'firstname' => '', 'lastname' => $object->origin_email, 'email' => $object->origin_email, 'libelle' => $langs->transnoentities('Customer'), 'socid' => 0)); // no fk_soc here, so $object->thirdparty was never fetched (mirrors the origin_replyto branch above)
 									$external_contacts = array_merge($external_contacts, $array_external);
 								}
 							}


### PR DESCRIPTION
Rebased version of #36454 (closed by the stale bot) on top of current 22.0. The bugs it fixes are still present:
- `f.entity` missing from the SQL query in `list-rec.php`
- `$this->status`/`$this->statut` never set in `fetch()` (only `$this->suspended` is)
- `card-rec.php` uses `$object->statut` (undefined) instead of `$object->status` in several places
- `updateline()`: `fk_user_modif = (int) $user` instead of `$user->id`