### PR TITLE
QUAL uniformize createFromClone() for Order/Proposal/Invoice + multicompany compatibility

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -217,6 +217,10 @@ if (empty($reshook)) {
 			setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('IdThirdParty')), null, 'errors');
 		} else {
 			if ($object->id > 0) {
+				// We clone object to avoid to denaturate loaded object when setting some properties for clone or if createFromClone modifies the object.
+				$objectutil = dol_clone($object, 1);
+				'@phan-var-force Propal $objectutil';
+
 				if (getDolGlobalString('PROPAL_CLONE_DATE_DELIVERY')) {
 					//Get difference between old and new delivery date and change lines according to difference
 					$date_delivery = dol_mktime(
@@ -227,7 +231,7 @@ if (empty($reshook)) {
 						GETPOSTINT('date_deliveryday'),
 						GETPOSTINT('date_deliveryyear')
 					);
-					$date_delivery_old = $object->delivery_date;
+					$date_delivery_old = $objectutil->delivery_date;
 					if (!empty($date_delivery_old) && !empty($date_delivery)) {
 						//Attempt to get the date without possible hour rounding errors
 						$old_date_delivery = dol_mktime(
@@ -241,8 +245,8 @@ if (empty($reshook)) {
 						//Calculate the difference and apply if necessary
 						$difference = $date_delivery - $old_date_delivery;
 						if ($difference != 0) {
-							$object->delivery_date = $date_delivery;
-							foreach ($object->lines as $line) {
+							$objectutil->delivery_date = $date_delivery;
+							foreach ($objectutil->lines as $line) {
 								if (isset($line->date_start)) {
 									$line->date_start +=  $difference;
 								}
@@ -254,11 +258,11 @@ if (empty($reshook)) {
 					}
 				}
 
-				$result = $object->createFromClone($user, $socid, (GETPOSTISSET('entity') ? GETPOSTINT('entity') : null), (GETPOST('update_prices') == 'on'), (GETPOST('update_desc') == 'on'));
+				$result = $objectutil->createFromClone($user, $socid, (GETPOSTISSET('entity') ? GETPOSTINT('entity') : null), (GETPOST('update_prices') == 'on'), (GETPOST('update_desc') == 'on'));
 				if ($result > 0) {
 					$warningMsgLineList = array();
 					// check all product lines are to sell otherwise add a warning message for each product line is not to sell
-					foreach ($object->lines as $line) {
+					foreach ($objectutil->lines as $line) {
 						if (!is_object($line->product)) {
 							$line->fetch_product();
 						}
@@ -275,8 +279,8 @@ if (empty($reshook)) {
 					header("Location: " . $_SERVER['PHP_SELF'] . '?id=' . $result);
 					exit();
 				} else {
-					if (count($object->errors) > 0) {
-						setEventMessages($object->error, $object->errors, 'errors');
+					if (count($objectutil->errors) > 0) {
+						setEventMessages($objectutil->error, $objectutil->errors, 'errors');
 					}
 					$action = '';
 				}

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -233,11 +233,11 @@ if (empty($reshook)) {
 				// We clone object to avoid to denaturate loaded object when setting some properties for clone or if createFromClone modifies the object.
 				$objectutil = dol_clone($object, 1);
 
-				$result = $objectutil->createFromClone($user, $socid);
+				$result = $objectutil->createFromClone($user, $socid, (GETPOSTISSET('entity') ? GETPOSTINT('entity') : null));
 				if ($result > 0) {
 					$warningMsgLineList = array();
 					// check all product lines are to sell otherwise add a warning message for each product line is not to sell
-					foreach ($object->lines as $line) {
+					foreach ($objectutil->lines as $line) {
 						if (!is_object($line->product)) {
 							$line->fetch_product();
 						}

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1287,83 +1287,86 @@ class Commande extends CommonOrder
 	/**
 	 *	Load an object from its id and create a new one in database
 	 *
-	 *  @param	    User	$user		User making the clone
-	 *	@param		int		$socid		Id of thirdparty
-	 *	@return		int					New id of clone
+	 *  @param	    User	$user		    User making the clone
+	 *	@param		int		$socid		    Id of thirdparty
+	 *	@param		int		$forceentity	Entity id to force (used by multicompany to clone into another entity)
+	 *	@return		int					    New id of clone
 	 */
-	public function createFromClone(User $user, $socid = 0)
+	public function createFromClone(User $user, $socid = 0, $forceentity = null)
 	{
-		global $user, $hookmanager;
+		global $hookmanager;
 
 		$error = 0;
 
+		$object = new self($this->db);
+
 		$this->db->begin();
 
-		// get lines so they will be clone
-		foreach ($this->lines as $line) {
-			$line->fetch_optionals();
-		}
-
 		// Load source object
-		$objFrom = clone $this;
+		$object->fetch($this->id);
+
+		$objFrom = clone $object;
 
 		// Change socid if needed
-		if (!empty($socid) && $socid != $this->socid) {
+		if (!empty($socid) && $socid != $object->socid) {
 			$objsoc = new Societe($this->db);
 
 			if ($objsoc->fetch($socid) > 0) {
-				$this->socid = $objsoc->id;
-				$this->cond_reglement_id	= (!empty($objsoc->cond_reglement_id) ? $objsoc->cond_reglement_id : 0);
-				$this->deposit_percent		= (!empty($objsoc->deposit_percent) ? $objsoc->deposit_percent : '0');
-				$this->mode_reglement_id	= (!empty($objsoc->mode_reglement_id) ? $objsoc->mode_reglement_id : 0);
-				$this->fk_project = 0;
-				$this->fk_delivery_address = 0;
+				$object->socid = $objsoc->id;
+				$object->cond_reglement_id	= (!empty($objsoc->cond_reglement_id) ? $objsoc->cond_reglement_id : 0);
+				$object->deposit_percent		= (!empty($objsoc->deposit_percent) ? $objsoc->deposit_percent : '0');
+				$object->mode_reglement_id	= (!empty($objsoc->mode_reglement_id) ? $objsoc->mode_reglement_id : 0);
+				$object->fk_project = 0;
+				$object->fk_delivery_address = 0;
 			}
 
 			// TODO Change product price if multi-prices
 		}
 
-		$this->id = 0;
-		$this->ref = '';
-		$this->statut = self::STATUS_DRAFT;	// deprecated
-		$this->status = self::STATUS_DRAFT;
+		$object->entity = (!empty($forceentity) ? $forceentity : $object->entity);
+
+		$object->id = 0;
+		$object->ref = '';
+		$object->statut = self::STATUS_DRAFT;	// deprecated
+		$object->status = self::STATUS_DRAFT;
 
 		// Clear fields
-		$this->user_author_id = $user->id;
-		$this->user_validation_id = 0;
-		$this->date = dol_now();
-		$this->date_commande = dol_now();
-		$this->date_creation = '';
-		$this->date_validation = '';
+		$object->user_author_id = $user->id;
+		$object->user_validation_id = 0;
+		$object->date = dol_now();
+		$object->date_commande = dol_now();
+		$object->date_creation = '';
+		$object->date_validation = '';
 		if (!getDolGlobalString('MAIN_KEEP_REF_CUSTOMER_ON_CLONING')) {
-			$this->ref_client = '';
-			$this->ref_customer = '';
+			$object->ref_client = '';
+			$object->ref_customer = '';
 		}
 
 		// Do not clone ref_ext
-		$num = count($this->lines);
+		$num = count($object->lines);
 		for ($i = 0; $i < $num; $i++) {
-			$this->lines[$i]->ref_ext = '';
+			$object->lines[$i]->ref_ext = '';
 		}
 
 		// Create clone
-		$this->context['createfromclone'] = 'createfromclone';
-		$result = $this->create($user);
+		$object->context['createfromclone'] = 'createfromclone';
+		$result = $object->create($user);
 		if ($result < 0) {
 			$error++;
+			$this->setErrorsFromObject($object);
 		}
 
 		if (!$error) {
 			// copy internal contacts
-			if ($this->copy_linked_contact($objFrom, 'internal') < 0) {
+			if ($object->copy_linked_contact($objFrom, 'internal') < 0) {
 				$error++;
 			}
 		}
 
 		if (!$error) {
 			// copy external contacts if same company
-			if ($this->socid == $objFrom->socid) {
-				if ($this->copy_linked_contact($objFrom, 'external') < 0) {
+			if ($object->socid == $objFrom->socid) {
+				if ($object->copy_linked_contact($objFrom, 'external') < 0) {
 					$error++;
 				}
 			}
@@ -1372,9 +1375,9 @@ class Commande extends CommonOrder
 		if (!$error) {
 			// Hook of thirdparty module
 			if (is_object($hookmanager)) {
-				$parameters = array('objFrom' => $objFrom);
+				$parameters = array('objFrom' => $objFrom, 'clonedObj' => $object);
 				$action = '';
-				$reshook = $hookmanager->executeHooks('createFrom', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				$reshook = $hookmanager->executeHooks('createFrom', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 				if ($reshook < 0) {
 					$this->setErrorsFromObject($hookmanager);
 					$error++;
@@ -1382,12 +1385,12 @@ class Commande extends CommonOrder
 			}
 		}
 
-		unset($this->context['createfromclone']);
+		unset($object->context['createfromclone']);
 
 		// End
 		if (!$error) {
 			$this->db->commit();
-			return $this->id;
+			return $object->id;
 		} else {
 			$this->db->rollback();
 			return -1;

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1415,7 +1415,7 @@ class Facture extends CommonInvoice
 		if (!$error) {
 			// Hook of thirdparty module
 			if (is_object($hookmanager)) {
-				$parameters = array('objFrom' => $objFrom);
+				$parameters = array('objFrom' => $objFrom, 'clonedObj' => $object);
 				$action = '';
 				$reshook = $hookmanager->executeHooks('createFrom', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
 				if ($reshook < 0) {


### PR DESCRIPTION
Reworked follow-up to #32945 (closed by the stale bot), rebased against current 24.0 rather than the old develop-based history, since several parts of that PR were already implemented independently for Proposal/Invoice in the meantime. Only the remaining gaps are addressed here:

- `Commande::createFromClone()` still worked directly on `$this`, denaturing the loaded order (id reset to 0, ref cleared, status forced, etc) instead of building the clone on a fresh object like `Propal`/`Facture` already do.
- `Commande::createFromClone()` had no `$forceentity` parameter, unlike `Propal`/`Facture`, so multicompany couldn't clone an order into another entity.
- The `createFrom` hook was missing `clonedObj` in its parameters for `Commande` and `Facture` (only `Propal` had it), so modules could inspect the source object but not the newly created clone.
- `comm/propal/card.php` mutated the loaded `$object` (delivery_date, line dates) before cloning instead of using a `dol_clone()`'d working copy, unlike `commande/card.php` and `compta/facture/card.php` which already do this.

See #36454 comment thread for context on why #32945 needed a rebase rather than a reopen.