### PR TITLE
NEW: Add a cancel status on interventions

### DIFF
--- a/htdocs/core/modules/modFicheinter.class.php
+++ b/htdocs/core/modules/modFicheinter.class.php
@@ -127,6 +127,13 @@ class modFicheinter extends DolibarrModules
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
+		$this->rights[$r][0] = 63;
+		$this->rights[$r][1] = 'Annuler les fiches d\'intervention';
+		$this->rights[$r][2] = 'w';
+		$this->rights[$r][3] = 0;
+		$this->rights[$r][4] = 'cancel';
+
+		$r++;
 		$this->rights[$r][0] = 64;
 		$this->rights[$r][1] = 'Supprimer les fiches d\'intervention';
 		$this->rights[$r][2] = 'd';

--- a/htdocs/core/modules/modFicheinter.class.php
+++ b/htdocs/core/modules/modFicheinter.class.php
@@ -127,13 +127,6 @@ class modFicheinter extends DolibarrModules
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = 63;
-		$this->rights[$r][1] = 'Annuler les fiches d\'intervention';
-		$this->rights[$r][2] = 'w';
-		$this->rights[$r][3] = 0;
-		$this->rights[$r][4] = 'cancel';
-
-		$r++;
 		$this->rights[$r][0] = 64;
 		$this->rights[$r][1] = 'Supprimer les fiches d\'intervention';
 		$this->rights[$r][2] = 'd';

--- a/htdocs/fichinter/card-rec.php
+++ b/htdocs/fichinter/card-rec.php
@@ -789,7 +789,7 @@ if ($action == 'create') {
 			}
 
 			// Delete
-			print dolGetButtonAction($langs->trans("Delete"), '', 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&token='.newToken(), 'delete', $user->hasRight('ficheinter', 'supprimer'));
+			print dolGetButtonAction($langs->trans("Delete"), '', 'delete', dolBuildUrl($_SERVER["PHP_SELF"], ['id' => $object->id, 'action' => 'delete'], true), 'delete', $user->hasRight('ficheinter', 'supprimer'));
 
 			print '</div>';
 		} else {

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -740,7 +740,7 @@ if (empty($reshook)) {
 			$mesg = $object->error;
 		}
 	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $user->hasRight('ficheinter', 'cancel')) {
-		$result = $object->cancel();
+		$result = $object->setCanceled($user);
 
 		if ($result < 0) {
 			setEventMessages($object->error, $object->errors, 'errors');

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -739,7 +739,7 @@ if (empty($reshook)) {
 		} else {
 			$mesg = $object->error;
 		}
-	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $user->hasRight('ficheinter', 'cancel')) {
+	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $user->hasRight('ficheinter', 'supprimer')) {
 		$result = $object->setCanceled($user);
 
 		if ($result < 0) {
@@ -2037,7 +2037,7 @@ if ($action == 'create') {
 
 				// Cancel fichinter
 				if ($object->status == Fichinter::STATUS_VALIDATED) {
-					if ($user->hasRight('ficheinter', 'cancel')) {
+					if ($user->hasRight('ficheinter', 'supprimer')) {
 						print '<div class="inline-block divButAction"><a class="butActionDelete" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=cancel&token='.newToken().'">'.$langs->trans("Cancel").'</a></div>';
 					} else {
 						print '<div class="inline-block divButAction"><a class="butActionRefused classfortooltip" href="#">'.$langs->trans('Cancel').'</a></div>';

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -732,7 +732,7 @@ if (empty($reshook)) {
 		}
 	} elseif ($action == 'confirm_reopen' && $permissiontoadd) {
 		// Reopen
-		$result = $object->setStatut(Fichinter::STATUS_VALIDATED);
+		$result = $object->setReopen($user);
 		if ($result > 0) {
 			header('Location: '.$_SERVER["PHP_SELF"].'?id='.$object->id);
 			exit;

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -2046,7 +2046,7 @@ if ($action == 'create') {
 
 				// Delete
 				print '<div class="inline-block divButAction">';
-				print dolGetButtonAction($langs->trans("Delete"), '', 'delete', $_SERVER["PHP_SELF"].'?id='.$object->id.'&action=delete&token='.newToken(), 'delete', $permissiontodelete);
+				print dolGetButtonAction($langs->trans("Delete"), '', 'delete', dolBuildUrl($_SERVER["PHP_SELF"], ['id' => $object->id, 'action' => 'delete'], true), 'delete', $permissiontodelete);
 				print '</div>';
 			}
 		}

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -739,7 +739,7 @@ if (empty($reshook)) {
 		} else {
 			$mesg = $object->error;
 		}
-	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $user->hasRight('ficheinter', 'supprimer')) {
+	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $permissiontoadd) {
 		$result = $object->setCanceled($user);
 
 		if ($result < 0) {

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -739,6 +739,12 @@ if (empty($reshook)) {
 		} else {
 			$mesg = $object->error;
 		}
+	} elseif ($action == 'confirm_cancel' && $confirm == 'yes' && $user->hasRight('ficheinter', 'cancel')) {
+		$result = $object->cancel();
+
+		if ($result < 0) {
+			setEventMessages($object->error, $object->errors, 'errors');
+		}
 	} elseif ($action == 'updateline' && $permissiontoadd && GETPOST('save', 'alpha')) {
 		// Update an intervention line
 		$objectline = new FichinterLigne($db);
@@ -1345,6 +1351,11 @@ if ($action == 'create') {
 		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('ReOpen'), $langs->trans('ConfirmReopenIntervention', $object->ref), 'confirm_reopen', '', 0, 1);
 	}
 
+	// Confirm back to open
+	if ($action == 'cancel') {
+		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans("Cancel"), $langs->trans('ConfirmCancelIntervention', $object->ref), 'confirm_cancel', '', 0, 1);
+	}
+
 	// Confirm deletion of line
 	if ($action == 'ask_deleteline') {
 		$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id.'&line_id='.$lineid, $langs->trans('DeleteInterventionLine'), $langs->trans('ConfirmDeleteInterventionLine'), 'confirm_deleteline', '', 0, 1);
@@ -1948,7 +1959,7 @@ if ($action == 'create') {
 
 				// Send
 				if (empty($user->socid)) {
-					if ($object->status > Fichinter::STATUS_DRAFT) {
+					if ($object->status > Fichinter::STATUS_DRAFT && $object->status != Fichinter::STATUS_CANCELED) {
 						if (!getDolGlobalString('MAIN_USE_ADVANCED_PERMS') || $user->hasRight('ficheinter', 'ficheinter_advance', 'send')) {
 							print dolGetButtonAction('', $langs->trans('SendMail'), 'email', dolBuildUrl($_SERVER["PHP_SELF"], ['id' => $object->id, 'action' => 'presend', 'mode' => 'init'], true).'#formmailbeforetitle', '');
 						} else {
@@ -2006,7 +2017,7 @@ if ($action == 'create') {
 				}
 
 				// Sign
-				if ($object->status > Fichinter::STATUS_DRAFT) {
+				if ($object->status > Fichinter::STATUS_DRAFT && $object->status != Fichinter::STATUS_CLOSED && $object->status != Fichinter::STATUS_CANCELED) {
 					if ($object->signed_status != Fichinter::$SIGNED_STATUSES['STATUS_SIGNED_ALL']) {
 						print '<div class="inline-block divButAction"><a class="butAction" href="' . $_SERVER["PHP_SELF"] . '?id=' . $object->id . '&action=sign&token=' . newToken() . '">' . $langs->trans("InterventionSign") . '</a></div>';
 					} else {
@@ -2022,6 +2033,15 @@ if ($action == 'create') {
 				// Clone
 				if ($permissiontoadd) {
 					print '<div class="inline-block divButAction"><a class="butAction butActionClone" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&socid='.$object->socid.'&action=clone&token='.newToken().'&object=ficheinter">'.$langs->trans("ToClone").'</a></div>';
+				}
+
+				// Cancel fichinter
+				if ($object->status == Fichinter::STATUS_VALIDATED) {
+					if ($user->hasRight('ficheinter', 'cancel')) {
+						print '<div class="inline-block divButAction"><a class="butActionDelete" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&action=cancel&token='.newToken().'">'.$langs->trans("Cancel").'</a></div>';
+					} else {
+						print '<div class="inline-block divButAction"><a class="butActionRefused classfortooltip" href="#">'.$langs->trans('Cancel').'</a></div>';
+					}
 				}
 
 				// Delete

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -753,15 +753,19 @@ class Fichinter extends CommonObject
 	}
 
 	/**
-	 * 	Cancel an fichinter
+	 * 	Cancel an intervention
 	 *
-	 *	@return	int			Return integer <0 if KO, >0 if OK
+	 * 	@param      User	$user       Object user that cancel
+	 *  @param		int		$notrigger	1=Does not execute triggers, 0=Execute triggers
+	 *	@return		int					Return integer <0 if KO, 0 if nothing done, >0 if OK
 	 */
-	public function cancel()
+	public function setCanceled($user, $notrigger = 0)
 	{
-		global $user;
-
 		$error = 0;
+
+		if ($this->status == self::STATUS_CANCELED) {
+			return 0;
+		}
 
 		$this->db->begin();
 
@@ -770,15 +774,18 @@ class Fichinter extends CommonObject
 		$sql .= " fk_user_modif = ".((int) $user->id);
 		$sql .= " WHERE rowid = ".((int) $this->id);
 		$sql .= " AND fk_statut = ".self::STATUS_VALIDATED;
+		$sql .= " AND entity IN (".getEntity('intervention').")";
 
-		dol_syslog(get_class($this)."::cancel", LOG_DEBUG);
+		dol_syslog(get_class($this)."::setCanceled", LOG_DEBUG);
 		if ($this->db->query($sql)) {
-			// Call trigger
-			$result = $this->call_trigger('FICHINTER_CANCEL', $user);
-			if ($result < 0) {
-				$error++;
+			if (!$notrigger) {
+				// Call trigger
+				$result = $this->call_trigger('FICHINTER_CANCEL', $user);
+				if ($result < 0) {
+					$error++;
+				}
+				// End call triggers
 			}
-			// End call triggers
 
 			if (!$error) {
 				$this->status = self::STATUS_CANCELED;
@@ -787,7 +794,7 @@ class Fichinter extends CommonObject
 				return 1;
 			} else {
 				foreach ($this->errors as $errmsg) {
-					dol_syslog(get_class($this)."::cancel ".$errmsg, LOG_ERR);
+					dol_syslog(get_class($this)."::setCanceled ".$errmsg, LOG_ERR);
 					$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
 				}
 				$this->db->rollback();

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -809,8 +809,8 @@ class Fichinter extends CommonObject
 
 
 	/**
-	 *	Tag the fichinter as validated (opened)
-	 *	Function used when fichinter is reopend after being closed.
+	 *	Tag the intervention as validated (opened)
+	 *	Function used when the intervention is reopened after being closed or canceled.
 	 *
 	 *	@param      User	$user       Object user that change status
 	 *  @param		int		$notrigger	1=Does not execute triggers, 0=Execute triggers
@@ -822,7 +822,7 @@ class Fichinter extends CommonObject
 		$error = 0;
 
 		if ($this->statut != self::STATUS_CANCELED && $this->statut != self::STATUS_CLOSED) {
-			dol_syslog(get_class($this)."::set_reopen fichinter has not status closed", LOG_WARNING);
+			dol_syslog(get_class($this)."::setReopen intervention has not status closed or canceled", LOG_WARNING);
 			return 0;
 		}
 
@@ -833,7 +833,7 @@ class Fichinter extends CommonObject
 		$sql .= ", fk_user_modif = ".((int) $user->id);
 		$sql .= " WHERE rowid = ".((int) $this->id);
 
-		dol_syslog(get_class($this)."::set_reopen", LOG_DEBUG);
+		dol_syslog(get_class($this)."::setReopen", LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			if (!$notrigger) {
@@ -859,7 +859,7 @@ class Fichinter extends CommonObject
 			return 1;
 		} else {
 			foreach ($this->errors as $errmsg) {
-				dol_syslog(get_class($this)."::set_reopen ".$errmsg, LOG_ERR);
+				dol_syslog(get_class($this)."::setReopen ".$errmsg, LOG_ERR);
 				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
 			}
 			$this->db->rollback();

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -1019,8 +1019,6 @@ class Fichinter extends CommonObject
 		$statuscode = 'status'.$status;
 		if ($status == self::STATUS_BILLED || $status == self::STATUS_CLOSED) {
 			$statuscode = 'status6';
-		} elseif ($status == self::STATUS_CANCELED) {
-			$statuscode = 'status9';
 		}
 
 		$signed_label = ' (' . $this->getLibSignedStatus() . ')';

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -813,9 +813,10 @@ class Fichinter extends CommonObject
 	 *	Function used when fichinter is reopend after being closed.
 	 *
 	 *	@param      User	$user       Object user that change status
+	 *  @param		int		$notrigger	1=Does not execute triggers, 0=Execute triggers
 	 *	@return     int 	Return integer < 0 if KO, 0 if nothing is done, > 0 if OK
 	 */
-	public function setReopen($user)
+	public function setReopen($user, $notrigger = 0)
 	{
 		// phpcs:enable
 		$error = 0;
@@ -835,12 +836,14 @@ class Fichinter extends CommonObject
 		dol_syslog(get_class($this)."::set_reopen", LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {
-			// Call trigger
-			$result = $this->call_trigger('FICHINTER_REOPEN', $user);
-			if ($result < 0) {
-				$error++;
+			if (!$notrigger) {
+				// Call trigger
+				$result = $this->call_trigger('FICHINTER_REOPEN', $user);
+				if ($result < 0) {
+					$error++;
+				}
+				// End call triggers
 			}
-			// End call triggers
 		} else {
 			$error++;
 			$this->error = $this->db->lasterror();

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -773,14 +773,12 @@ class Fichinter extends CommonObject
 
 		dol_syslog(get_class($this)."::cancel", LOG_DEBUG);
 		if ($this->db->query($sql)) {
-			if (!$error) {
-				// Call trigger
-				$result = $this->call_trigger('FICHINTER_CANCEL', $user);
-				if ($result < 0) {
-					$error++;
-				}
-				// End call triggers
+			// Call trigger
+			$result = $this->call_trigger('FICHINTER_CANCEL', $user);
+			if ($result < 0) {
+				$error++;
 			}
+			// End call triggers
 
 			if (!$error) {
 				$this->status = self::STATUS_CANCELED;

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -6,7 +6,7 @@
  * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2015-2026  Charlene Benke          <charlene@patas-monkey.com>
  * Copyright (C) 2018       Nicolas ZABOURI	        <info@inovea-conseil.com>
- * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2023-2026  William Mead            <william@m34d.com>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  *
@@ -223,6 +223,11 @@ class Fichinter extends CommonObject
 	 * Closed
 	 */
 	const STATUS_CLOSED = 3;
+
+	/**
+	 * Canceled status
+	 */
+	const STATUS_CANCELED = 4;
 
 	/**
 	 * Date of delivery of receipt
@@ -748,6 +753,112 @@ class Fichinter extends CommonObject
 	}
 
 	/**
+	 * 	Cancel an fichinter
+	 *
+	 *	@return	int			Return integer <0 if KO, >0 if OK
+	 */
+	public function cancel()
+	{
+		global $user;
+
+		$error = 0;
+
+		$this->db->begin();
+
+		$sql = "UPDATE ".MAIN_DB_PREFIX."fichinter";
+		$sql .= " SET fk_statut = ".self::STATUS_CANCELED.",";
+		$sql .= " fk_user_modif = ".((int) $user->id);
+		$sql .= " WHERE rowid = ".((int) $this->id);
+		$sql .= " AND fk_statut = ".self::STATUS_VALIDATED;
+
+		dol_syslog(get_class($this)."::cancel", LOG_DEBUG);
+		if ($this->db->query($sql)) {
+			if (!$error) {
+				// Call trigger
+				$result = $this->call_trigger('FICHINTER_CANCEL', $user);
+				if ($result < 0) {
+					$error++;
+				}
+				// End call triggers
+			}
+
+			if (!$error) {
+				$this->status = self::STATUS_CANCELED;
+				$this->statut = self::STATUS_CANCELED;	// deprecated
+				$this->db->commit();
+				return 1;
+			} else {
+				foreach ($this->errors as $errmsg) {
+					dol_syslog(get_class($this)."::cancel ".$errmsg, LOG_ERR);
+					$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+				}
+				$this->db->rollback();
+				return -1 * $error;
+			}
+		} else {
+			$this->error = $this->db->error();
+			$this->db->rollback();
+			return -1;
+		}
+	}
+
+
+	/**
+	 *	Tag the fichinter as validated (opened)
+	 *	Function used when fichinter is reopend after being closed.
+	 *
+	 *	@param      User	$user       Object user that change status
+	 *	@return     int 	Return integer < 0 if KO, 0 if nothing is done, > 0 if OK
+	 */
+	public function setReopen($user)
+	{
+		// phpcs:enable
+		$error = 0;
+
+		if ($this->statut != self::STATUS_CANCELED && $this->statut != self::STATUS_CLOSED) {
+			dol_syslog(get_class($this)."::set_reopen fichinter has not status closed", LOG_WARNING);
+			return 0;
+		}
+
+		$this->db->begin();
+
+		$sql = 'UPDATE '.MAIN_DB_PREFIX.'fichinter';
+		$sql .= ' SET fk_statut='.self::STATUS_VALIDATED;
+		$sql .= ", fk_user_modif = ".((int) $user->id);
+		$sql .= " WHERE rowid = ".((int) $this->id);
+
+		dol_syslog(get_class($this)."::set_reopen", LOG_DEBUG);
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			// Call trigger
+			$result = $this->call_trigger('FICHINTER_REOPEN', $user);
+			if ($result < 0) {
+				$error++;
+			}
+			// End call triggers
+		} else {
+			$error++;
+			$this->error = $this->db->lasterror();
+			dol_print_error($this->db);
+		}
+
+		if (!$error) {
+			$this->statut = self::STATUS_VALIDATED;
+			$this->billed = 0;
+
+			$this->db->commit();
+			return 1;
+		} else {
+			foreach ($this->errors as $errmsg) {
+				dol_syslog(get_class($this)."::set_reopen ".$errmsg, LOG_ERR);
+				$this->error .= ($this->error ? ', '.$errmsg : $errmsg);
+			}
+			$this->db->rollback();
+			return -1 * $error;
+		}
+	}
+
+	/**
 	 *  Close intervention
 	 *
 	 * 	@param      User	$user       Object user that close
@@ -888,15 +999,19 @@ class Fichinter extends CommonObject
 			$this->labelStatus[self::STATUS_VALIDATED] = $langs->transnoentitiesnoconv('Validated');
 			$this->labelStatus[self::STATUS_BILLED] = $langs->transnoentitiesnoconv('StatusInterInvoiced');
 			$this->labelStatus[self::STATUS_CLOSED] = $langs->transnoentitiesnoconv('Done');
+			$this->labelStatus[self::STATUS_CANCELED] = $langs->transnoentitiesnoconv('Canceled');
 			$this->labelStatusShort[self::STATUS_DRAFT] = $langs->transnoentitiesnoconv('Draft');
 			$this->labelStatusShort[self::STATUS_VALIDATED] = $langs->transnoentitiesnoconv('Validated');
 			$this->labelStatusShort[self::STATUS_BILLED] = $langs->transnoentitiesnoconv('StatusInterInvoiced');
 			$this->labelStatusShort[self::STATUS_CLOSED] = $langs->transnoentitiesnoconv('Done');
+			$this->labelStatusShort[self::STATUS_CANCELED] = $langs->transnoentitiesnoconv('Canceled');
 		}
 
 		$statuscode = 'status'.$status;
 		if ($status == self::STATUS_BILLED || $status == self::STATUS_CLOSED) {
 			$statuscode = 'status6';
+		} elseif ($status == self::STATUS_CANCELED) {
+			$statuscode = 'status9';
 		}
 
 		$signed_label = ' (' . $this->getLibSignedStatus() . ')';

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -227,7 +227,7 @@ class Fichinter extends CommonObject
 	/**
 	 * Canceled status
 	 */
-	const STATUS_CANCELED = 4;
+	const STATUS_CANCELED = 9;
 
 	/**
 	 * Date of delivery of receipt

--- a/htdocs/fichinter/class/fichinter.class.php
+++ b/htdocs/fichinter/class/fichinter.class.php
@@ -851,7 +851,8 @@ class Fichinter extends CommonObject
 		}
 
 		if (!$error) {
-			$this->statut = self::STATUS_VALIDATED;
+			$this->status = self::STATUS_VALIDATED;
+			$this->statut = self::STATUS_VALIDATED;	// deprecated
 			$this->billed = 0;
 
 			$this->db->commit();

--- a/htdocs/fichinter/class/fichinterrec.class.php
+++ b/htdocs/fichinter/class/fichinterrec.class.php
@@ -243,7 +243,6 @@ class FichinterRec extends Fichinter
 				 */
 				$num = count($fichintsrc->lines);
 				for ($i = 0; $i < $num; $i++) {
-					//var_dump($fichintsrc->lines[$i]);
 					$result_insert = $this->addLineRec(
 						$fichintsrc->lines[$i]->desc,
 						$fichintsrc->lines[$i]->duration,

--- a/htdocs/fichinter/list.php
+++ b/htdocs/fichinter/list.php
@@ -744,17 +744,14 @@ if (!empty($arrayfields['f.note_private']['checked'])) {
 // Status
 if (!empty($arrayfields['f.fk_statut']['checked'])) {
 	print '<td class="liste_titre right parentonrightofpage">';
-	$liststatus = [
-		$object::STATUS_DRAFT => $langs->transnoentitiesnoconv('Draft'),
-		$object::STATUS_VALIDATED => $langs->transnoentitiesnoconv('Validated'),
-		$object::STATUS_BILLED => $langs->transnoentitiesnoconv('StatusInterInvoiced'),
-		$object::STATUS_CLOSED => $langs->transnoentitiesnoconv('Done'),
-	];
+	$objecttmp->getLibStatut();
+
 	if (!getDolGlobalString('FICHINTER_CLASSIFY_BILLED')) {
-		unset($liststatus[2]); // Option deprecated. In a future, billed must be managed with a dedicated field to 0 or 1
+		unset($objecttmp->labelStatus[Fichinter::STATUS_BILLED]); // Option deprecated. In a future, billed must be managed with a dedicated field to 0 or 1
 	}
+
 	// @phan-suppress-next-line PhanPluginSuspiciousParamOrder
-	print $form->selectarray('search_status', $liststatus, $search_status, 1, 0, 0, '', 1, 0, 0, '', 'search_status width100 onrightofpage');
+	print $form->selectarray('search_status', $objecttmp->labelStatus, $search_status, 1, 0, 0, '', 1, 0, 0, '', 'search_status width100 onrightofpage');
 	print '</td>';
 }
 // Signed status

--- a/htdocs/langs/en_US/interventions.lang
+++ b/htdocs/langs/en_US/interventions.lang
@@ -74,6 +74,7 @@ InterLineDesc=Line description intervention
 RepeatableIntervention=Template of intervention
 ToCreateAPredefinedIntervention=To create a predefined or recurring intervention, create a common intervention and convert it into intervention template
 ConfirmReopenIntervention=Are you sure you want to open back the intervention <b>%s</b>?
+ConfirmCancelIntervention=Are you sure you want to cancel the intervention <b>%s</b>?
 GenerateInter=Generate intervention
 FichinterNoContractLinked=Intervention %s has been created without a linked contract.
 ErrorFicheinterCompanyDoesNotExist=Company does not exist. Intervention has not been created.

--- a/htdocs/langs/fr_FR/interventions.lang
+++ b/htdocs/langs/fr_FR/interventions.lang
@@ -74,6 +74,7 @@ InterLineDesc=Description ligne intervention
 RepeatableIntervention=Modèle d'intervention
 ToCreateAPredefinedIntervention=Pour créer une intervention prédéfinie ou récurrente, créez une intervention standard et convertissez-la en modèle d'intervention
 ConfirmReopenIntervention=Êtes-vous sur de vouloir ré-ouvrir l'intervention <b>%s</b> ?
+ConfirmCancelIntervention=Êtes-vous sur de vouloir annuler l'intervention <b>%s</b> ?
 GenerateInter=Générer intervention
 FichinterNoContractLinked=L'intervention %s a été créée sans contrat lié.
 ErrorFicheinterCompanyDoesNotExist=L'entreprise n'existe pas. L'intervention n'a pas été créée.


### PR DESCRIPTION
## Description

Revival of #32918 (by @noec764), squashed and rebased on current `develop`, plus follow-up cleanup.

Adds a **Canceled** status (`Fichinter::STATUS_CANCELED = 4`) to interventions:

- `Fichinter::setCanceled($user, $notrigger = 0)` + `FICHINTER_CANCEL` trigger
- **Cancel** button + confirmation on the intervention card (visible when status = Validated)
- `Send` and `Sign` buttons hidden for canceled interventions
- canceled status added to the status filter on the list
- label + picto (`status9`) for the new status
- `ConfirmCancelIntervention` translation (en_US / fr_FR)

## Reopen

`Fichinter::setReopen($user, $notrigger = 0)` is now actually wired: the `confirm_reopen` action calls `$object->setReopen($user)` (which fires the `FICHINTER_REOPEN` trigger and guards on CLOSED/CANCELED) instead of a bare `setStatut()`. It reopens from **Closed or Canceled** back to Validated.

## Conventions / cleanup

- status setters follow the `setValid()` / `setClose()` convention of the class: `$user` as a parameter (not the global), `$notrigger`, and both `$this->status` + deprecated `$this->statut` kept in sync
- `card.php` button guards use `$object->status` (not the deprecated `->statut`)
- `dolBuildUrl()` used in the `dolGetButtonAction()` calls of `fichinter/`
- removed a commented-out `var_dump()`

## Notes

- SQL: no migration needed (status stored in the existing `fk_statut` column).

Credits: original work by @noec764 (#32918).