### PR TITLE
NEW Add right_position column to llx_rights_def

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -106,9 +106,9 @@ ALTER TABLE llx_product ADD INDEX idx_product_entity_tobuy (entity, tobuy);
 ALTER TABLE llx_product ADD INDEX idx_product_datec (datec);
 ALTER TABLE llx_product ADD INDEX idx_product_tms (tms);
 
--- Optional fine sort key for rights_def, used by rights filed into another module's
+-- Optional fine position for rights_def, used by rights filed into another module's
 -- section via module_origin (KEY_MODULE) to sort next to a given native right of that module
-ALTER TABLE llx_rights_def ADD COLUMN sort_order integer DEFAULT 0 NOT NULL AFTER family_position;
+ALTER TABLE llx_rights_def ADD COLUMN right_position integer DEFAULT 0 NOT NULL AFTER family_position;
 
 
 

--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -106,6 +106,10 @@ ALTER TABLE llx_product ADD INDEX idx_product_entity_tobuy (entity, tobuy);
 ALTER TABLE llx_product ADD INDEX idx_product_datec (datec);
 ALTER TABLE llx_product ADD INDEX idx_product_tms (tms);
 
+-- Optional fine sort key for rights_def, used by rights filed into another module's
+-- section via module_origin (KEY_MODULE) to sort next to a given native right of that module
+ALTER TABLE llx_rights_def ADD COLUMN sort_order integer DEFAULT 0 NOT NULL AFTER family_position;
+
 
 
 

--- a/htdocs/install/mysql/tables/llx_rights_def.sql
+++ b/htdocs/install/mysql/tables/llx_rights_def.sql
@@ -27,6 +27,7 @@ create table llx_rights_def
   module_position	integer DEFAULT 0 NOT NULL,
   family            varchar(64) NULL,
   family_position	integer DEFAULT 0 NOT NULL,
+  sort_order		integer DEFAULT 0 NOT NULL,	-- optional fine sort key inside the module/family group; when 0 (default), sorting falls back to id (unchanged behavior). Used by rights filed into another module's section via module_origin to sort next to a given native right (set to that right's id).
   perms				varchar(50),
   subperms			varchar(50),
   type				varchar(1),					-- deprecated

--- a/htdocs/install/mysql/tables/llx_rights_def.sql
+++ b/htdocs/install/mysql/tables/llx_rights_def.sql
@@ -27,7 +27,7 @@ create table llx_rights_def
   module_position	integer DEFAULT 0 NOT NULL,
   family            varchar(64) NULL,
   family_position	integer DEFAULT 0 NOT NULL,
-  sort_order		integer DEFAULT 0 NOT NULL,	-- optional fine sort key inside the module/family group; when 0 (default), sorting falls back to id (unchanged behavior). Used by rights filed into another module's section via module_origin to sort next to a given native right (set to that right's id).
+  right_position	integer DEFAULT 0 NOT NULL,	-- optional fine position inside the module/family group; when 0 (default), sorting falls back to id (unchanged behavior). Used by rights filed into another module's section via module_origin to sort next to a given native right (set to that right's id).
   perms				varchar(50),
   subperms			varchar(50),
   type				varchar(1),					-- deprecated


### PR DESCRIPTION
Structure-only split of #39736 (split into #39736 + this + follow-ups), per eldy's "PR mixing structure and code change" label.

Adds an optional `right_position` column to `llx_rights_def`, used by rights filed into another module's section via `module_origin` (see `DolibarrModules::KEY_MODULE`) to sort right after a given native right of that module instead of always trailing the whole group. Default 0 falls back to the existing id-based sort, so this alone changes no behavior.

No code references this column yet — that follows in a separate PR once this one is merged, so there's no window where deployed code expects a column that isn't there yet on a database that hasn't run the migration.