### PR TITLE
FIX hasRight() ignores module_origin for rights filed into another module's section

### DIFF
--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -1414,7 +1414,7 @@ class User extends CommonObject
 
 		if (!$alreadyloaded) {
 			// First user permissions
-			$sql = "SELECT DISTINCT r.module, r.perms, r.subperms";
+			$sql = "SELECT DISTINCT r.module, r.module_origin, r.perms, r.subperms";
 			$sql .= " FROM ".$this->db->prefix()."user_rights as ur,";
 			$sql .= " ".$this->db->prefix()."rights_def as r";
 			$sql .= " WHERE r.id = ur.fk_id";
@@ -1446,7 +1446,12 @@ class User extends CommonObject
 					$obj = $this->db->fetch_object($resql);
 
 					if ($obj) {
-						$module = $obj->module;
+						// module_origin (set only when the right was declared by another module
+						// via KEY_MODULE, to be filed into a foreign module's section of the
+						// permission grid) is the namespace actually used to check the right with
+						// hasRight(), so the declaring module keeps control of it regardless of
+						// which module's section it is grouped under for display.
+						$module = (!empty($obj->module_origin) ? $obj->module_origin : $obj->module);
 						$perms = $obj->perms;
 						$subperms = $obj->subperms;
 
@@ -1478,7 +1483,7 @@ class User extends CommonObject
 			}
 
 			// Now permissions of groups
-			$sql = "SELECT DISTINCT r.module, r.perms, r.subperms, r.entity";
+			$sql = "SELECT DISTINCT r.module, r.module_origin, r.perms, r.subperms, r.entity";
 			$sql .= " FROM ".$this->db->prefix()."usergroup_rights as gr,";
 			$sql .= " ".$this->db->prefix()."usergroup_user as gu,";
 			$sql .= " ".$this->db->prefix()."rights_def as r";
@@ -1519,7 +1524,12 @@ class User extends CommonObject
 					$obj = $this->db->fetch_object($resql);
 
 					if ($obj) {
-						$module = $obj->module;
+						// module_origin (set only when the right was declared by another module
+						// via KEY_MODULE, to be filed into a foreign module's section of the
+						// permission grid) is the namespace actually used to check the right with
+						// hasRight(), so the declaring module keeps control of it regardless of
+						// which module's section it is grouped under for display.
+						$module = (!empty($obj->module_origin) ? $obj->module_origin : $obj->module);
 						$perms = $obj->perms;
 						$subperms = $obj->subperms;
 

--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -620,7 +620,7 @@ class UserGroup extends CommonObject
 		}
 
 		// Load permission from group
-		$sql = "SELECT r.module, r.perms, r.subperms ";
+		$sql = "SELECT r.module, r.module_origin, r.perms, r.subperms ";
 		$sql .= " FROM ".$this->db->prefix()."usergroup_rights as u, ".$this->db->prefix()."rights_def as r";
 		$sql .= " WHERE r.id = u.fk_id";
 		$sql .= " AND r.entity = ".((int) $conf->entity);
@@ -640,7 +640,12 @@ class UserGroup extends CommonObject
 				$obj = $this->db->fetch_object($resql);
 
 				if ($obj) {
-					$module = $obj->module;
+					// module_origin (set only when the right was declared by another module via
+					// KEY_MODULE, to be filed into a foreign module's section of the permission
+					// grid) is the namespace actually used to check the right with hasRight(),
+					// so the declaring module keeps control of it regardless of which module's
+					// section it is grouped under for display.
+					$module = (!empty($obj->module_origin) ? $obj->module_origin : $obj->module);
 					$perms = $obj->perms;
 					$subperms = $obj->subperms;
 


### PR DESCRIPTION
Split out of #39736 per eldy's "PR to split into several PRs" label. Independent of the other pieces being split out — only uses the existing `module_origin` column, not `sort_order`.

`User::loadRights()` and `UserGroup::loadRights()` indexed `$user->rights` by the display module column (`r.module`) instead of `r.module_origin`. So a right declared by module A but filed into module B's section of the permission grid (`DolibarrModules::KEY_MODULE`) could never be resolved by `hasRight('A', ...)` — only by the wrong `hasRight('B', ...)`, i.e. the module that merely displays it, not the one that declared and is supposed to control it.