### PR TITLE
FIX inconsistent price_ht/price_ttc triple when VAT is recomputed for buyer

### DIFF
--- a/htdocs/product/ajax/products.php
+++ b/htdocs/product/ajax/products.php
@@ -272,6 +272,17 @@ if ($action == 'fetch' && !empty($id)) {
 					$outdefault_vat_code = '';
 				}
 			}
+
+			// The VAT rate above was just changed to the one applicable to this buyer, but price_ht/
+			// price_ttc are still whatever was set for the product/price line, so they can now be an
+			// inconsistent triple (e.g. a price defined as tax included, VAT rate now 0 for an EU
+			// reverse-charge buyer, but price_ttc is still the original tax-included amount). Off by
+			// default to keep historical behavior (price_ttc unchanged, whatever VAT rate applies);
+			// when enabled, price_ht is kept as the fixed reference and price_ttc is recomputed from
+			// it and the buyer's actual VAT rate instead.
+			if (getDolGlobalString('PRODUIT_RECALCULATE_TTC_ACCORDING_TO_BUYER_VAT') && isset($outprice_ht)) {
+				$outprice_ttc = price(price2num($outprice_ht) * (1 + ($outtva_tx / 100)));
+			}
 		}
 
 		$outjson = array(

--- a/htdocs/product/ajax/products.php
+++ b/htdocs/product/ajax/products.php
@@ -281,7 +281,7 @@ if ($action == 'fetch' && !empty($id)) {
 			// when enabled, price_ht is kept as the fixed reference and price_ttc is recomputed from
 			// it and the buyer's actual VAT rate instead.
 			if (getDolGlobalString('PRODUIT_RECALCULATE_TTC_ACCORDING_TO_BUYER_VAT') && isset($outprice_ht)) {
-				$outprice_ttc = price(price2num($outprice_ht) * (1 + ($outtva_tx / 100)));
+				$outprice_ttc = price((float) price2num($outprice_ht) * (1 + ($outtva_tx / 100)));
 			}
 		}
 


### PR DESCRIPTION
Replaces #32869 (closed as stale — targeted a line in `objectline_create.tpl.php` that has since been refactored away). Follow-up to the discussion there with @eldy on the actual root cause.

In `product/ajax/products.php`, when `addalsovatforthirdpartyid` recomputes the VAT rate applicable to the buyer (e.g. 0% for an EU reverse-charge customer), it only updates `tva_tx`/`default_vat_code` — `price_ht`/`price_ttc` stay whatever the product/price line had. That can return an inconsistent triple to the caller: e.g. a price defined tax included at 20% VAT, buyer's VAT recomputed to 0%, but `price_ttc` is still the original tax-included amount instead of matching `price_ht` at the new rate. This is the actual cause of the original bug report in #32869 (150€ charged instead of 125€ HT for an EU reverse-charge customer).

Which price should stay fixed while the other adjusts (final price fixed vs unit price excluding tax fixed) is a business choice that never reached a consensus in the #32869 thread, so this is behind a new hidden constant, **off by default** (keeps current behavior unchanged):

- unset (default): unchanged, `price_ttc` stays as returned for the product/price line
- `PRODUIT_RECALCULATE_TTC_ACCORDING_TO_BUYER_VAT`: `price_ht` is kept as the fixed reference and `price_ttc` is recomputed from it and the buyer's actual VAT rate