### PR TITLE
FIX: $arrayfields used before definition in don/list.php

### DIFF
--- a/htdocs/don/list.php
+++ b/htdocs/don/list.php
@@ -131,15 +131,16 @@ $fieldstosearchall = array(
 	'd.firstname' => 'Firstname',
 );
 $arrayfields = array();
-//$arrayfields['anotherfield'] = array('type'=>'integer', 'label'=>'AnotherField', 'checked'=>1, 'enabled'=>1, 'position'=>90, 'csslist'=>'right');
+// $arrayfields['anotherfield'] = array('type'=>'integer', 'label'=>'AnotherField', 'checked'=>1, 'enabled'=>1, 'position'=>90, 'csslist'=>'right');
+$object->fields = dol_sort_array($object->fields, 'position');
+$arrayfields = dol_sort_array($arrayfields, 'position');
+
 // Extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
 // Add hook to complete $arrayfield
 $parameters = array('arrayfields' => &$arrayfields);
 $reshook = $hookmanager->executeHooks('completeArrayFields', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 
-$object->fields = dol_sort_array($object->fields, 'position');
-$arrayfields = dol_sort_array($arrayfields, 'position');
 
 
 // Security check

--- a/htdocs/don/list.php
+++ b/htdocs/don/list.php
@@ -130,6 +130,8 @@ $fieldstosearchall = array(
 	'd.lastname' => 'Lastname',
 	'd.firstname' => 'Firstname',
 );
+$arrayfields = array();
+//$arrayfields['anotherfield'] = array('type'=>'integer', 'label'=>'AnotherField', 'checked'=>1, 'enabled'=>1, 'position'=>90, 'csslist'=>'right');
 // Extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_array_fields.tpl.php';
 // Add hook to complete $arrayfield
@@ -137,8 +139,6 @@ $parameters = array('arrayfields' => &$arrayfields);
 $reshook = $hookmanager->executeHooks('completeArrayFields', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
 
 $object->fields = dol_sort_array($object->fields, 'position');
-$arrayfields = array();
-//$arrayfields['anotherfield'] = array('type'=>'integer', 'label'=>'AnotherField', 'checked'=>1, 'enabled'=>1, 'position'=>90, 'csslist'=>'right');
 $arrayfields = dol_sort_array($arrayfields, 'position');
 
 


### PR DESCRIPTION
## Description

In `htdocs/don/list.php`, `$arrayfields` was:

1. used by reference in the `extrafields_list_array_fields.tpl.php` include and the `completeArrayFields` hook **before being initialized** (→ `Variable $arrayfields might not be defined`), then
2. reset with `$arrayfields = array();` **after** those steps, discarding whatever the extrafields template and the hook had added to the column selector.

Fix: initialize `$arrayfields = array();` before the include, and drop the late reset — same ordering as `contrat/list.php`, `societe/list.php`, `expedition/list.php`, etc.

```
htdocs/don/list.php:136  Variable $arrayfields might not be defined.  (variable.undefined)
```

## Test

Open the donations list (`don/list.php`): no PHP warning, and the column-selector dropdown now also lists extrafields / hook-provided columns.