### PR TITLE
NEW Stock movement list: add a filter on the origin type

### DIFF
--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -53,7 +53,7 @@ if (isModEnabled('project')) {
 }
 
 // Load translation files required by the page
-$langs->loadLangs(array('products', 'stocks', 'orders'));
+$langs->loadLangs(array('products', 'stocks', 'orders', 'bills', 'sendings', 'receptions', 'mrp'));
 if (isModEnabled('productbatch')) {
 	$langs->load("productbatch");
 }
@@ -95,6 +95,7 @@ $search_user = trim(GETPOST("search_user"));
 $search_batch = trim(GETPOST("search_batch"));
 $search_qty = trim(GETPOST("search_qty"));
 $search_type_mouvement = GETPOST('search_type_mouvement');
+$search_origintype = GETPOST('search_origintype', 'aZ09');
 $search_fk_project = GETPOST("search_fk_project");
 
 $type = GETPOSTINT("type");
@@ -252,6 +253,7 @@ if (empty($reshook)) {
 		$search_ref = '';
 		$search_movement = "";
 		$search_type_mouvement = "";
+		$search_origintype = "";
 		$search_inventorycode = "";
 		$search_product_ref = "";
 		$search_product = "";
@@ -797,6 +799,13 @@ if ($search_qty != '') {
 if ($search_type_mouvement != '' && $search_type_mouvement != '-1') {
 	$sql .= natural_search('m.type_mouvement', $search_type_mouvement, 2);
 }
+if ($search_origintype != '' && $search_origintype != '-1') {
+	if ($search_origintype == 'none') {
+		$sql .= " AND (m.origintype IS NULL OR m.origintype = '')";
+	} else {
+		$sql .= " AND m.origintype = '".$db->escape($search_origintype)."'";
+	}
+}
 // Add where from extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 // Add where from hooks
@@ -1093,6 +1102,9 @@ if ($search_inventorycode) {
 if ($search_type_mouvement) {
 	$param .= '&search_type_mouvement='.urlencode($search_type_mouvement);
 }
+if ($search_origintype) {
+	$param .= '&search_origintype='.urlencode($search_origintype);
+}
 if ($search_product_ref) {
 	$param .= '&search_product_ref='.urlencode($search_product_ref);
 }
@@ -1288,9 +1300,30 @@ if (!empty($arrayfields['m.label']['checked'])) {
 	print '</td>';
 }
 if (!empty($arrayfields['origin']['checked'])) {
-	// Origin of movement
+	// Origin of movement. The origin is a polymorphic couple (origintype, fk_origin) resolved in PHP,
+	// so it cannot be joined in SQL: we filter on the origin type, using the types get_origin() handles.
+	// Note: 'project' is not offered because _create() moves it to fk_projet and clears origintype,
+	// so no movement can ever carry origintype='project'.
 	print '<td class="liste_titre left">';
-	print '&nbsp; ';
+	$arrayoforigintypes = array(
+		'commande' => $langs->trans('Order'),
+		'shipping' => $langs->trans('Shipment'),
+		'facture' => $langs->trans('Invoice'),
+		'order_supplier' => $langs->trans('SupplierOrder'),
+		'invoice_supplier' => $langs->trans('SupplierInvoice'),
+		'reception' => $langs->trans('Reception'),
+		'inventory' => $langs->trans('Inventory'),
+		'mo' => $langs->trans('ManufacturingOrder'),
+		'user' => $langs->trans('User'),
+		'none' => $langs->trans('None'),
+	);
+	print '<select id="search_origintype" name="search_origintype" class="maxwidth150">';
+	print '<option value=""'.(($search_origintype == '') ? ' selected="selected"' : '').'>&nbsp;</option>';
+	foreach ($arrayoforigintypes as $keyorigintype => $valorigintype) {
+		print '<option value="'.$keyorigintype.'"'.(($search_origintype == $keyorigintype) ? ' selected="selected"' : '').'>'.dol_escape_htmltag($valorigintype).'</option>';
+	}
+	print '</select>';
+	print ajax_combobox('search_origintype');
 	print '</td>';
 }
 if (!empty($arrayfields['m.fk_projet']['checked'])) {

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2018-2022	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2019-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Problem

The **Origin** column of the stock movement list (`product/stock/movement_list.php`) is displayed but cannot be filtered. It is the only column of that list whose filter cell is empty — literally `print '&nbsp; ';`.

On a database with a real movement history this is quite limiting: there is no way to answer "show me every movement that came from a reception", or "show me the manual corrections that have no origin document at all".

## Why there was no filter

The origin is a **polymorphic couple** — `llx_stock_mouvement.origintype` (which table) + `fk_origin` (which row) — resolved at display time in PHP by `MouvementStock::get_origin()`. It is not a foreign key, so it cannot be joined in SQL and the origin reference cannot be searched generically.

## What this PR does

It filters on the **origin type**, which *is* a plain column, using a select built from the types `get_origin()` actually handles (order, shipment, invoice, purchase order, vendor invoice, reception, inventory, manufacturing order, project, user).

It also adds a **None** entry matching `origintype IS NULL OR origintype = ''`. That one is useful in practice: manual stock corrections and warehouse transfers are recorded by Dolibarr *without* an origin document (`Product::correct_stock()` stamps only an `inventorycode`), so "None" isolates exactly those.

`bills`, `sendings`, `receptions` and `mrp` are added to `loadLangs()` so the type labels are translated — the other keys are already covered by `main`/`orders`.

## Notes

- No schema change, no behaviour change, one file, +29/-3.
- The filter follows the existing pattern of the page (`search_*` variable, reset in the "remove filters" block, propagated in `$param`).
- Searching on the origin *reference* (e.g. a specific invoice number) is deliberately out of scope: it would need one JOIN per origin type.

## How to test

1. Go to Products/Services > Stock > Movements.
2. Use the new dropdown in the Origin column: pick *Reception* to see only movements created by receptions, *Invoice* for sales, *None* for manual corrections and transfers.
3. Check the filter survives paging and sorting, and that "Remove filter" clears it.

Motivation came from a migration where 9 years of stock history were imported and 99% of movements ended up carrying an origin — which made the inability to filter on it very visible.
