### PR TITLE
NEW Add hook getShippableInfos on order shippability computation

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4361,13 +4361,16 @@ class Commande extends CommonOrder
 	/**
 	 * Compute shippable status and tooltip/icon for the order.
 	 *
-	 * @param array<mixed> $options Extra options (reserved for future use)
-	 * @return  array<string,mixed>        Array with keys: has_product, shippable, texticon, textinfo, warning
-	 * /
+	 * Can be overridden by a module through the 'getShippableInfos' hook (context
+	 * '<element>dao'). The hook result is merged over the default skeleton, so every key of
+	 * the contract stays defined whatever the module returns.
+	 *
+	 * @param array<mixed> $options 	Extra options, forwarded as-is to the hook
+	 * @return  array<string,mixed>     Array with keys: has_product, shippable, texticon, textinfo, warning
 	 */
 	public function getShippableInfos(array $options = array()): array
 	{
-		global $conf, $langs;
+		global $conf, $langs, $hookmanager;
 
 		$langs->loadLangs(array('orders', 'sendings', 'stocks', 'products'));
 
@@ -4378,6 +4381,19 @@ class Commande extends CommonOrder
 			'textinfo'    => '',
 			'warning'     => false,
 		);
+
+		if (is_object($hookmanager)) {
+			$hookmanager->initHooks(array($this->element.'dao'));
+			$parameters = array('options' => $options);
+			$reshook = $hookmanager->executeHooks('getShippableInfos', $parameters, $this);
+			if ($reshook < 0) {
+				dol_syslog(__METHOD__.' hook getShippableInfos failed: '.$hookmanager->error, LOG_ERR);
+			}
+			if (!empty($hookmanager->resArray['shippableinfos'])
+				&& is_array($hookmanager->resArray['shippableinfos'])) {
+				return array_merge($result, $hookmanager->resArray['shippableinfos']);
+			}
+		}
 
 		// Requested naming for statuses
 		if ($this->status == self::STATUS_DRAFT || $this->status == self::STATUS_CLOSED) {

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4383,7 +4383,6 @@ class Commande extends CommonOrder
 		);
 
 		if (is_object($hookmanager)) {
-			$hookmanager->initHooks(array($this->element.'dao'));
 			$parameters = array('options' => $options);
 			$reshook = $hookmanager->executeHooks('getShippableInfos', $parameters, $this);
 			if ($reshook < 0) {


### PR DESCRIPTION
This hook lets a module replace the shippability status, icon and tooltip of a customer
order, computed by `Commande::getShippableInfos()` and displayed on the order card and
the order list.

Without the hook, a module has to patch core files: neither the method nor its callers
expose an extension point.