### PR TITLE
NEW: ModuleBuilder - Make the descriptor rights sync atomic, non-destructive and actually applied

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
+NEW: ModuleBuilder - Permissions of the module descriptor are now rewritten in a single atomic pass, a hand-written or dynamically built permissions section is detected and never overwritten, and the "update a permission" action actually applies its change
 NEW: Unify all per-object extrafields admin pages into a single secured page (htdocs/admin/extrafields.php), replacing ~79 near-identical wrapper pages with one whitelist-controlled controller
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,6 @@ English Dolibarr ChangeLog
 
 For users:
 ----------
-NEW: ModuleBuilder - Permissions of the module descriptor are now rewritten in a single atomic pass, a hand-written or dynamically built permissions section is detected and never overwritten, and the "update a permission" action actually applies its change
 NEW: Unify all per-object extrafields admin pages into a single secured page (htdocs/admin/extrafields.php), replacing ~79 near-identical wrapper pages with one whitelist-controlled controller
 NEW: Experimental module "Quick memo" to put post-it on any screens (#37422)
 NEW: Thirdparty bank account asks for bank country, state, currency and status (#38031)

--- a/htdocs/core/lib/modulebuilder.lib.php
+++ b/htdocs/core/lib/modulebuilder.lib.php
@@ -522,54 +522,36 @@ function checkExistComment($file, $number)
 	return -1;
 }
 /**
- * Delete all permissions
+ * Delete all permissions declared in the permissions section of a module descriptor.
  *
  * @param	string	$file         file with path
- * @return	void
+ * @return	int<-1,1>			  1 if OK, -1 if KO
  */
 function deletePerms($file)
 {
-	$start = "/* BEGIN MODULEBUILDER PERMISSIONS */";
-	$end = "/* END MODULEBUILDER PERMISSIONS */";
-	$i = 1;
-	$array = array();
-	$lines = file($file);
-	// Search for start and end lines
-	foreach ($lines as $i => $line) {
-		if (strpos($line, $start) !== false) {
-			$start_line = $i + 1;
+	require_once DOL_DOCUMENT_ROOT.'/modulebuilder/class/PermissionsBlock.class.php';
 
-			// Copy lines until the end on array
-			while (($line = $lines[++$i]) !== false) {
-				if (strpos($line, $end) !== false) {
-					$end_line = $i + 1;
-					break;
-				}
-				$array[] = $line;
-			}
-			break;
-		}
+	try {
+		$block = PermissionsBlock::fromFile($file);
+	} catch (\RuntimeException $e) {
+		dol_syslog('deletePerms '.$e->getMessage(), LOG_WARNING);
+		return -1;
 	}
-	$allContent = implode("", $array);
-	dolReplaceInFile($file, array($allContent => ''));
+
+	return $block->write('') < 0 ? -1 : 1;
 }
 
-/**
- *  Compare two values
- * @param	int|string	$a	value 1
- * @param	int|string	$b	value 2
- * @return	int<-1,1> 		<=0 if str1 is less than str2; > 0 if str1 is greater than str2, and 0 if they are equal.
- */
-function compareFirstValue($a, $b)
-{
-	return strcmp($a[0], $b[0]);
-}
 /**
  * Rewriting all permissions after any actions
+ *
+ * Kept for backward compatibility: this is a public core function that external modules may call.
+ * The signature and the 1/-1 contract are unchanged, the body delegates to
+ * DescriptorRightsSyncService.
+ *
  * @param	string		$file			filename or path
  * @param	array<int,string[]>	$permissions permissions existing in file
  * @param	?int		$key			key for permission needed
- * @param	?array{0:string,1:string}	$right           $right to update or add
+ * @param	?array<int,string>	$right		$right to update or add
  * @param	string		$objectname		name of object
  * @param	string		$module			name of module
  * @param	int<-2,2>	$action			0 for delete, 1 for add, 2 for update, -1 when delete object completely, -2 for generate rights after add
@@ -577,113 +559,68 @@ function compareFirstValue($a, $b)
  */
 function reWriteAllPermissions($file, $permissions, $key, $right, $objectname, $module, $action)
 {
-	$error = 0;
-	$rights = array();
-	if ($action == 0 && $key !== null) {
-		// delete right from permissions array
-		array_splice($permissions, array_search($permissions[$key], $permissions), 1);
-	} elseif ($action == 1) {
-		array_push($permissions, $right);
-	} elseif ($action == 2 && !empty($right) && $key !== null) {
-		// update right from permissions array
-		array_splice($permissions, array_search($permissions[$key], $permissions), 1, $right);
-	} elseif ($action == -1 && !empty($objectname)) {
-		// when delete object
-		$key = null;
-		$right = null;
-		foreach ($permissions as $perms) {
-			if ($perms[4] === strtolower($objectname)) {
-				array_splice($permissions, array_search($perms, $permissions), 1);
-			}
-		}
-	} elseif ($action == -2 && !empty($objectname) && !empty($module)) {
-		$key = null;
-		$right = null;
-		$objectOfRights = array();
-		//check if object already declared in rights file
-		foreach ($permissions as $right) {
-			$objectOfRights[] = $right[4];
-		}
-		if (in_array(strtolower($objectname), $objectOfRights)) {
-			$error++;
-		} else {
-			$permsToadd = array();
-			$perms = array(
-				'read' => 'Read '.$objectname.' object of '.ucfirst($module),
-				'write' => 'Create/Update '.$objectname.' object of '.ucfirst($module),
-				'delete' => 'Delete '.$objectname.' object of '.ucfirst($module)
-			);
-			$i = 0;
-			foreach ($perms as $index => $value) {
-				$permsToadd[$i][0] = '';
-				$permsToadd[$i][1] = $value;
-				$permsToadd[$i][4] = strtolower($objectname);
-				$permsToadd[$i][5] = $index;
-				array_push($permissions, $permsToadd[$i]);
-				$i++;
-			}
-		}
-	} else {
-		$error++;
+	require_once DOL_DOCUMENT_ROOT.'/modulebuilder/class/RightsSyncService.class.php';
+
+	$module = (string) $module;
+	$objectname = (string) $objectname;
+	$permissions = is_array($permissions) ? $permissions : array();
+	$right = is_array($right) ? $right : array();
+
+	// The legacy signature carries the module name only for action -2; the other actions recover
+	// it from the descriptor filename.
+	if ($module === '') {
+		$module = (string) preg_replace('/^mod|\.class\.php$/', '', basename($file));
 	}
-	'@phan-var-force array<int,string[]> $permissions';
-	if (!$error) {
-		// prepare permissions array
-		foreach (array_keys($permissions) as $i) {
-			$permissions[$i][0] = "\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', \$r + 1)";
-			$permissions[$i][1] = "\$this->rights[\$r][1] = '".$permissions[$i][1]."'";
-			$permissions[$i][4] = "\$this->rights[\$r][4] = '".$permissions[$i][4]."'";
-			$permissions[$i][5] = "\$this->rights[\$r][5] = '".$permissions[$i][5]."';\n\t\t";
-		}
-		// for group permissions by object
-		$perms_grouped = array();
-		foreach ($permissions as $perms) {
-			$object = $perms[4];
-			if (!isset($perms_grouped[$object])) {
-				$perms_grouped[$object] = array();
-			}
-			$perms_grouped[$object][] = $perms;
-		}
-		//$perms_grouped = array_values($perms_grouped);
-		$permissions = $perms_grouped;
 
-
-		// iterate over the objects
-		$o = 0;
-		foreach ($permissions as &$object) {
-			// get the object permission
-			$p = 1;
-			foreach ($object as &$obj) {
-				if (str_contains($obj[5], 'read')) {
-					$obj[0] = "\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', (".$o." * 10) + 0 + 1)";
-				} elseif (str_contains($obj[5], 'write')) {
-					$obj[0] = "\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', (".$o." * 10) + 1 + 1)";
-				} elseif (str_contains($obj[5], 'delete')) {
-					$obj[0] = "\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', (".$o." * 10) + 2 + 1)";
-				} else {
-					$obj[0] = "\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', (".$o." * 10) + ".$p." + 1)";
-					$p++;
-				}
-			}
-			usort($object, 'compareFirstValue');
-			$o++;
+	try {
+		switch ((int) $action) {
+			case -2:
+				$cmd = RightsSyncCommand::forObjectCreation($module, $file, $permissions, $objectname);
+				break;
+			case -1:
+				$cmd = RightsSyncCommand::forObjectDeletion($module, $file, $permissions, $objectname);
+				break;
+			case 1:
+				$cmd = RightsSyncCommand::forRightAddition(
+					$module,
+					$file,
+					$permissions,
+					(string) ($right[4] ?? ''),
+					(string) ($right[1] ?? ''),
+					(string) ($right[5] ?? '')
+				);
+				break;
+			case 2:
+				$cmd = RightsSyncCommand::forRightUpdate(
+					$module,
+					$file,
+					$permissions,
+					(int) $key,
+					(string) ($right[4] ?? ''),
+					(string) ($right[1] ?? ''),
+					(string) ($right[5] ?? '')
+				);
+				break;
+			case 0:
+				$cmd = RightsSyncCommand::forRightDeletion($module, $file, $permissions, (int) $key);
+				break;
+			default:
+				dol_syslog('reWriteAllPermissions got an unknown action: '.$action, LOG_WARNING);
+				return -1;
 		}
-
-		//convert to string
-		foreach ($permissions as $perms) {
-			foreach ($perms as $per) {
-				$rights[] = implode(";\n\t\t", $per)."\$r++;\n";
-			}
-		}
-		$rights_str = implode("\t\t", $rights);
-		// delete all permissions from file
-		deletePerms($file);
-		// rewrite all permissions again
-		dolReplaceInFile($file, array('/* BEGIN MODULEBUILDER PERMISSIONS */' => '/* BEGIN MODULEBUILDER PERMISSIONS */'."\n\t\t".$rights_str));
-		return 1;
-	} else {
+	} catch (\InvalidArgumentException $e) {
+		dol_syslog('reWriteAllPermissions '.$e->getMessage(), LOG_WARNING);
 		return -1;
 	}
+
+	$report = (new DescriptorRightsSyncService())->sync($cmd);
+
+	// The historical contract reports a skipped object creation as a failure.
+	if ($report->skipped > 0) {
+		return -1;
+	}
+
+	return $report->toLegacyReturnCode();
 }
 
 /**

--- a/htdocs/langs/en_US/modulebuilder.lang
+++ b/htdocs/langs/en_US/modulebuilder.lang
@@ -204,4 +204,4 @@ FieldsView=Fields view
 AIPromptExtrafield=AI Prompt
 AIPromptExtrafieldDesc=Enter here a prompt that should return a value and only the value. The substition variables are replaced into the prompt before calling the AI API.
 ModuleBuilderPermissionsNormalized=Some permissions were adjusted while rewriting the module descriptor:
-ModuleBuilderPermissionsBlockNotSafe=The permissions section of the module descriptor was left untouched because it cannot be rewritten safely:
+ModuleBuilderPermissionsNotChanged=The permissions section of the module descriptor was left unchanged:

--- a/htdocs/langs/en_US/modulebuilder.lang
+++ b/htdocs/langs/en_US/modulebuilder.lang
@@ -203,3 +203,5 @@ FieldsInsert=Fields insert
 FieldsView=Fields view
 AIPromptExtrafield=AI Prompt
 AIPromptExtrafieldDesc=Enter here a prompt that should return a value and only the value. The substition variables are replaced into the prompt before calling the AI API.
+ModuleBuilderPermissionsNormalized=Some permissions were adjusted while rewriting the module descriptor:
+ModuleBuilderPermissionsBlockNotSafe=The permissions section of the module descriptor was left untouched because it cannot be rewritten safely:

--- a/htdocs/langs/fr_FR/modulebuilder.lang
+++ b/htdocs/langs/fr_FR/modulebuilder.lang
@@ -204,4 +204,4 @@ FieldsView=Vue des champs
 AIPromptExtrafield=Invite IA
 AIPromptExtrafieldDesc=Saisissez ici une invite qui doit renvoyer la valeur et uniquement. Les variables de substitution sont insérées dans l'invite avant l'appel à l'API AI.
 ModuleBuilderPermissionsNormalized=Certaines permissions ont été ajustées lors de la réécriture du descripteur du module :
-ModuleBuilderPermissionsBlockNotSafe=La section des permissions du descripteur du module n'a pas été modifiée car elle ne peut pas être réécrite sans risque :
+ModuleBuilderPermissionsNotChanged=La section des permissions du descripteur du module n'a pas été modifiée :

--- a/htdocs/langs/fr_FR/modulebuilder.lang
+++ b/htdocs/langs/fr_FR/modulebuilder.lang
@@ -203,3 +203,5 @@ FieldsInsert=Insérer des champs
 FieldsView=Vue des champs
 AIPromptExtrafield=Invite IA
 AIPromptExtrafieldDesc=Saisissez ici une invite qui doit renvoyer la valeur et uniquement. Les variables de substitution sont insérées dans l'invite avant l'appel à l'API AI.
+ModuleBuilderPermissionsNormalized=Certaines permissions ont été ajustées lors de la réécriture du descripteur du module :
+ModuleBuilderPermissionsBlockNotSafe=La section des permissions du descripteur du module n'a pas été modifiée car elle ne peut pas être réécrite sans risque :

--- a/htdocs/modulebuilder/class/PermissionsBlock.class.php
+++ b/htdocs/modulebuilder/class/PermissionsBlock.class.php
@@ -304,9 +304,17 @@ final class PermissionsBlock
 			$assigned[] = array('offset' => $offset, 'right' => $right);
 		}
 
-		usort($assigned, static function (array $a, array $b): int {
-			return $a['offset'] <=> $b['offset'];
-		});
+		usort(
+			$assigned,
+			/**
+			 * @param 	array{offset:int,right:array<int,string>} $a First entry to compare
+			 * @param 	array{offset:int,right:array<int,string>} $b Second entry to compare
+			 * @return 	int
+			 */
+			static function (array $a, array $b): int {
+				return $a['offset'] <=> $b['offset'];
+			}
+		);
 
 		return $assigned;
 	}

--- a/htdocs/modulebuilder/class/PermissionsBlock.class.php
+++ b/htdocs/modulebuilder/class/PermissionsBlock.class.php
@@ -1,0 +1,167 @@
+<?php
+/* Copyright (C) 2026 ATM Consulting <support@atm-consulting.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    htdocs/modulebuilder/class/PermissionsBlock.class.php
+ * \ingroup modulebuilder
+ * \brief   Text engine for the BEGIN/END MODULEBUILDER PERMISSIONS section of a module descriptor.
+ */
+
+/**
+ * Text engine for the BEGIN/END MODULEBUILDER PERMISSIONS section of a module descriptor.
+ *
+ * Owns everything that touches the raw text of that section: locating it, deciding whether it is
+ * safe to rewrite, rendering a new one from a rights array, and writing it back in a single pass.
+ */
+final class PermissionsBlock
+{
+	const BEGIN_MARKER = '/* BEGIN MODULEBUILDER PERMISSIONS */';
+	const END_MARKER = '/* END MODULEBUILDER PERMISSIONS */';
+
+	/**
+	 * Variables a rewritable block may mention. Anything else means the block builds its rights
+	 * from data the renderer cannot reproduce.
+	 *
+	 * @var string[]
+	 */
+	private const ALLOWED_VARIABLES = array('$this', '$r', '$o');
+
+	/**
+	 * Identifiers a rewritable block may mention: the two descriptor properties it assigns and
+	 * the single function the generated id expression calls.
+	 *
+	 * @var string[]
+	 */
+	private const ALLOWED_IDENTIFIERS = array('rights', 'numero', 'sprintf');
+
+	/**
+	 * Punctuation a rewritable block may contain.
+	 *
+	 * @var string[]
+	 */
+	private const ALLOWED_PUNCTUATION = array('[', ']', '(', ')', '=', ';', ',', '.', '+', '-', '*');
+
+	/** @var string Path to the descriptor file */
+	private $file;
+
+	/** @var string Full descriptor content as read from disk */
+	private $content;
+
+	/** @var string Content between the two markers, markers excluded */
+	private $innerBlock;
+
+	/**
+	 * @param string $file       Path to the descriptor file
+	 * @param string $content    Full descriptor content
+	 * @param string $innerBlock Content between the markers
+	 */
+	private function __construct(string $file, string $content, string $innerBlock)
+	{
+		$this->file = $file;
+		$this->content = $content;
+		$this->innerBlock = $innerBlock;
+	}
+
+	/**
+	 * Read a descriptor and locate its permissions block.
+	 *
+	 * @param string $file Path to the mod<Module>.class.php descriptor
+	 * @return self
+	 * @throws \RuntimeException When the file is unreadable or the markers are missing or inverted
+	 */
+	public static function fromFile(string $file): self
+	{
+		if (!dol_is_file($file)) {
+			throw new \RuntimeException('Descriptor file not found: '.$file);
+		}
+		$content = file_get_contents($file);
+		if ($content === false) {
+			throw new \RuntimeException('Descriptor file is unreadable: '.$file);
+		}
+
+		$posBegin = strpos($content, self::BEGIN_MARKER);
+		$posEnd = strpos($content, self::END_MARKER);
+		if ($posBegin === false || $posEnd === false || $posEnd < $posBegin) {
+			throw new \RuntimeException('Cannot find the start and/or end comments of the permissions section in '.$file);
+		}
+
+		$start = $posBegin + strlen(self::BEGIN_MARKER);
+		$innerBlock = substr($content, $start, $posEnd - $start);
+
+		return new self($file, $content, $innerBlock);
+	}
+
+	/**
+	 * Raw content between the markers, markers excluded.
+	 *
+	 * @return string
+	 */
+	public function getInnerBlock(): string
+	{
+		return $this->innerBlock;
+	}
+
+	/**
+	 * List the reasons why rewriting this block would destroy something.
+	 *
+	 * Comments are ignored, which is what makes a brand new module — whose block holds the fully
+	 * commented-out template — rewritable. Everything else must belong to the whitelist: a block
+	 * that computes its rights (loop, condition, translation call) cannot be reproduced by
+	 * render() and must never be flattened into static lines.
+	 *
+	 * @return string[] Plain English reasons, empty when the block is safe to rewrite
+	 */
+	public function detectTextConflicts(): array
+	{
+		$conflicts = array();
+		$tokens = token_get_all('<?php '.$this->innerBlock);
+
+		foreach ($tokens as $token) {
+			if (is_string($token)) {
+				if (!in_array($token, self::ALLOWED_PUNCTUATION, true)) {
+					$conflicts[] = 'unexpected "'.$token.'" in the permissions block';
+				}
+				continue;
+			}
+
+			list($id, $text, $line) = $token;
+
+			if (in_array($id, array(T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT, T_INLINE_HTML), true)) {
+				continue;
+			}
+			if (in_array($id, array(T_LNUMBER, T_DNUMBER, T_CONSTANT_ENCAPSED_STRING, T_OBJECT_OPERATOR, T_INC), true)) {
+				continue;
+			}
+			if ($id === T_VARIABLE) {
+				if (!in_array($text, self::ALLOWED_VARIABLES, true)) {
+					$conflicts[] = 'line '.$line.': unexpected variable '.$text.' — the permissions block builds its rights dynamically and cannot be rewritten safely';
+				}
+				continue;
+			}
+			if ($id === T_STRING) {
+				if (!in_array($text, self::ALLOWED_IDENTIFIERS, true)) {
+					$conflicts[] = 'line '.$line.': unexpected identifier "'.$text.'" in the permissions block';
+				}
+				continue;
+			}
+
+			$conflicts[] = 'line '.$line.': unexpected "'.trim($text).'" in the permissions block — the section cannot be rewritten safely';
+		}
+
+		return array_values(array_unique($conflicts));
+	}
+}

--- a/htdocs/modulebuilder/class/PermissionsBlock.class.php
+++ b/htdocs/modulebuilder/class/PermissionsBlock.class.php
@@ -80,21 +80,16 @@ final class PermissionsBlock
 	/** @var string Path to the descriptor file */
 	private $file;
 
-	/** @var string Full descriptor content as read from disk */
-	private $content;
-
 	/** @var string Content between the two markers, markers excluded */
 	private $innerBlock;
 
 	/**
 	 * @param string $file       Path to the descriptor file
-	 * @param string $content    Full descriptor content
 	 * @param string $innerBlock Content between the markers
 	 */
-	private function __construct(string $file, string $content, string $innerBlock)
+	private function __construct(string $file, string $innerBlock)
 	{
 		$this->file = $file;
-		$this->content = $content;
 		$this->innerBlock = $innerBlock;
 	}
 
@@ -127,7 +122,7 @@ final class PermissionsBlock
 		$start = $posBegin + strlen(self::BEGIN_MARKER);
 		$innerBlock = substr($content, $start, $posEnd - $start);
 
-		return new self($file, $content, $innerBlock);
+		return new self($file, $innerBlock);
 	}
 
 	/**
@@ -360,7 +355,6 @@ final class PermissionsBlock
 			return $result < 0 ? $result : -1;
 		}
 
-		$this->content = (string) file_get_contents($this->file);
 		$this->innerBlock = $newInnerBlock;
 
 		return 1;

--- a/htdocs/modulebuilder/class/PermissionsBlock.class.php
+++ b/htdocs/modulebuilder/class/PermissionsBlock.class.php
@@ -41,12 +41,13 @@ final class PermissionsBlock
 	private const ALLOWED_VARIABLES = array('$this', '$r', '$o');
 
 	/**
-	 * Identifiers a rewritable block may mention: the two descriptor properties it assigns and
-	 * the single function the generated id expression calls.
+	 * Identifiers a rewritable block may mention: the two descriptor properties it assigns, the
+	 * single function the generated id expression calls, and the three literals the tokenizer
+	 * reports as T_STRING rather than as a dedicated token.
 	 *
 	 * @var string[]
 	 */
-	private const ALLOWED_IDENTIFIERS = array('rights', 'numero', 'sprintf');
+	private const ALLOWED_IDENTIFIERS = array('rights', 'numero', 'sprintf', 'null', 'true', 'false');
 
 	/**
 	 * Punctuation a rewritable block may contain.
@@ -106,6 +107,9 @@ final class PermissionsBlock
 	 */
 	public static function fromFile(string $file): self
 	{
+		if (strpos($file, '..') !== false) {
+			throw new \RuntimeException('Descriptor path must not contain a parent directory reference: '.$file);
+		}
 		if (!dol_is_file($file)) {
 			throw new \RuntimeException('Descriptor file not found: '.$file);
 		}

--- a/htdocs/modulebuilder/class/PermissionsBlock.class.php
+++ b/htdocs/modulebuilder/class/PermissionsBlock.class.php
@@ -55,6 +55,27 @@ final class PermissionsBlock
 	 */
 	private const ALLOWED_PUNCTUATION = array('[', ']', '(', ')', '=', ';', ',', '.', '+', '-', '*');
 
+	/** @var array<string,int> Canonical numbering offset of the three standard crud codes */
+	private const CRUD_OFFSETS = array('read' => 0, 'write' => 1, 'delete' => 2);
+
+	/** @var int Numbering stride between two objects */
+	private const OBJECT_ID_STRIDE = 10;
+
+	/** @var int Rights array index holding the permission id */
+	private const INDEX_ID = 0;
+
+	/** @var int Rights array index holding the permission label */
+	private const INDEX_LABEL = 1;
+
+	/** @var int Rights array index holding the object name */
+	private const INDEX_OBJECT = 4;
+
+	/** @var int Rights array index holding the crud code */
+	private const INDEX_CRUD = 5;
+
+	/** @var int[] The only rights array indexes the renderer emits */
+	private const SUPPORTED_INDEXES = array(0, 1, 4, 5);
+
 	/** @var string Path to the descriptor file */
 	private $file;
 
@@ -163,5 +184,145 @@ final class PermissionsBlock
 		}
 
 		return array_values(array_unique($conflicts));
+	}
+
+	/**
+	 * List the rights that cannot be rendered at all.
+	 *
+	 * @param array<int,array<int,string>> $permissions Rights array to inspect
+	 * @return string[] Plain English reasons, empty when every right is renderable
+	 */
+	public function detectRightsShapeConflicts(array $permissions): array
+	{
+		$conflicts = array();
+		foreach ($permissions as $i => $right) {
+			if (!is_array($right)) {
+				$conflicts[] = 'right #'.$i.' is not an array';
+				continue;
+			}
+			if (!isset($right[self::INDEX_OBJECT]) || (string) $right[self::INDEX_OBJECT] === '') {
+				$conflicts[] = 'right #'.$i.' declares no object name at index '.self::INDEX_OBJECT;
+			}
+			if (!isset($right[self::INDEX_CRUD]) || (string) $right[self::INDEX_CRUD] === '') {
+				$conflicts[] = 'right #'.$i.' declares no crud code at index '.self::INDEX_CRUD;
+			}
+		}
+
+		return $conflicts;
+	}
+
+	/**
+	 * List the rights carrying indexes the renderer will drop.
+	 *
+	 * Indexes 2 and 3 are obsolete in modern Dolibarr. Dropping them is the correct migration, so
+	 * this is reported as a warning and does not prevent the write.
+	 *
+	 * @param array<int,array<int,string>> $permissions Rights array to inspect
+	 * @return string[] Plain English warnings, empty when every right has a supported shape
+	 */
+	public function detectRightsShapeWarnings(array $permissions): array
+	{
+		$warnings = array();
+		foreach ($permissions as $i => $right) {
+			if (!is_array($right)) {
+				continue;
+			}
+			$unsupported = array_diff(array_keys($right), self::SUPPORTED_INDEXES);
+			if (!empty($unsupported)) {
+				$warnings[] = 'right #'.$i.' carries unsupported index '.implode(', ', $unsupported).', dropped on rewrite';
+			}
+		}
+
+		return $warnings;
+	}
+
+	/**
+	 * Render a rights array as the new content of the permissions block.
+	 *
+	 * Only indexes 0, 1, 4 and 5 are emitted: the historical code rewrote those four but imploded
+	 * the whole row, so a right carrying the obsolete index 2 or 3 had its raw value written into
+	 * the descriptor, which then no longer parsed.
+	 *
+	 * @param array<int,array<int,string>> $permissions Rights array to render
+	 * @return string Block content, markers excluded, one trailing newline
+	 */
+	public function render(array $permissions): string
+	{
+		$grouped = array();
+		foreach ($permissions as $right) {
+			if (!is_array($right) || !isset($right[self::INDEX_OBJECT], $right[self::INDEX_CRUD])) {
+				continue;
+			}
+			$grouped[(string) $right[self::INDEX_OBJECT]][] = $right;
+		}
+
+		$lines = array();
+		$objectIndex = 0;
+		foreach ($grouped as $group) {
+			foreach ($this->assignOffsets($group) as $entry) {
+				$right = $entry['right'];
+				$id = "\$this->numero . sprintf('%02d', (".$objectIndex." * ".self::OBJECT_ID_STRIDE.") + ".$entry['offset']." + 1)";
+
+				$lines[] = "\t\t\$this->rights[\$r][".self::INDEX_ID."] = ".$id.";";
+				$lines[] = "\t\t\$this->rights[\$r][".self::INDEX_LABEL."] = '".$this->escapeForPhpSingleQuotedString((string) ($right[self::INDEX_LABEL] ?? ''))."';";
+				$lines[] = "\t\t\$this->rights[\$r][".self::INDEX_OBJECT."] = '".$this->escapeForPhpSingleQuotedString((string) $right[self::INDEX_OBJECT])."';";
+				$lines[] = "\t\t\$this->rights[\$r][".self::INDEX_CRUD."] = '".$this->escapeForPhpSingleQuotedString((string) $right[self::INDEX_CRUD])."';";
+				$lines[] = "\t\t\$r++;";
+			}
+			$objectIndex++;
+		}
+
+		return empty($lines) ? '' : implode("\n", $lines)."\n";
+	}
+
+	/**
+	 * Give each right of one object its numbering offset.
+	 *
+	 * The three standard crud codes keep their canonical offset. Any other code — or a duplicate
+	 * standard one — takes the next free offset from 3 upwards, so two rights of the same object
+	 * can never collide on the same permission id.
+	 *
+	 * @param array<int,array<int,string>> $group Rights of a single object
+	 * @return array<int,array{offset:int,right:array<int,string>}> Entries sorted by offset
+	 */
+	private function assignOffsets(array $group): array
+	{
+		$assigned = array();
+		$usedOffsets = array();
+		$next = count(self::CRUD_OFFSETS);
+
+		foreach ($group as $right) {
+			$crud = (string) $right[self::INDEX_CRUD];
+			if (isset(self::CRUD_OFFSETS[$crud]) && !isset($usedOffsets[self::CRUD_OFFSETS[$crud]])) {
+				$offset = self::CRUD_OFFSETS[$crud];
+			} else {
+				while (isset($usedOffsets[$next])) {
+					$next++;
+				}
+				$offset = $next;
+			}
+			$usedOffsets[$offset] = true;
+			$assigned[] = array('offset' => $offset, 'right' => $right);
+		}
+
+		usort($assigned, static function (array $a, array $b): int {
+			return $a['offset'] <=> $b['offset'];
+		});
+
+		return $assigned;
+	}
+
+	/**
+	 * Escape a value for inclusion in a single-quoted PHP string literal.
+	 *
+	 * GETPOST(..., 'alpha') keeps the single quote, the semicolon, the dollar sign and
+	 * parentheses, so a label reaches this class able to close the literal it is written into.
+	 *
+	 * @param string $value Raw value
+	 * @return string Value safe to place between single quotes in generated PHP
+	 */
+	private function escapeForPhpSingleQuotedString(string $value): string
+	{
+		return str_replace(array('\\', "'"), array('\\\\', "\\'"), $value);
 	}
 }

--- a/htdocs/modulebuilder/class/PermissionsBlock.class.php
+++ b/htdocs/modulebuilder/class/PermissionsBlock.class.php
@@ -325,4 +325,40 @@ final class PermissionsBlock
 	{
 		return str_replace(array('\\', "'"), array('\\\\', "\\'"), $value);
 	}
+
+	/**
+	 * Replace the whole permissions block, markers included, in a single write.
+	 *
+	 * dolReplaceInFile() already writes to a .tmp file and dol_move()s it into place, so the write
+	 * itself is atomic. What matters here is that there is exactly ONE of them: the historical code
+	 * deleted the block and then inserted the new one, leaving the descriptor without any
+	 * permissions block whenever the second write failed.
+	 *
+	 * Regex mode is mandatory, not a style choice: in plain mode dolReplaceInFile() runs the whole
+	 * file through make_substitutions(), which expands __(Key)__ and __[class:method:id]__ patterns
+	 * anywhere in the descriptor and even instantiates classes to do so.
+	 *
+	 * @param string $newInnerBlock New block content, markers excluded
+	 * @return int 1 if OK, <0 if KO
+	 */
+	public function write(string $newInnerBlock): int
+	{
+		$pattern = '/'.preg_quote(self::BEGIN_MARKER, '/').'.*?'.preg_quote(self::END_MARKER, '/').'/s';
+		$replacement = self::BEGIN_MARKER."\n".$newInnerBlock."\t\t".self::END_MARKER;
+
+		// preg_replace() reads $1 and \1 in the replacement as backreferences, and a permission
+		// label can legitimately contain either.
+		$replacement = str_replace(array('\\', '$'), array('\\\\', '\\$'), $replacement);
+
+		$result = dolReplaceInFile($this->file, array($pattern => $replacement), '', '0', 0, 1);
+		if ($result <= 0) {
+			dol_syslog('PermissionsBlock::write failed on '.$this->file.' with code '.$result, LOG_ERR);
+			return $result < 0 ? $result : -1;
+		}
+
+		$this->content = (string) file_get_contents($this->file);
+		$this->innerBlock = $newInnerBlock;
+
+		return 1;
+	}
 }

--- a/htdocs/modulebuilder/class/RightsSyncCommand.class.php
+++ b/htdocs/modulebuilder/class/RightsSyncCommand.class.php
@@ -1,0 +1,206 @@
+<?php
+/* Copyright (C) 2026 ATM Consulting <support@atm-consulting.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    htdocs/modulebuilder/class/RightsSyncCommand.class.php
+ * \ingroup modulebuilder
+ * \brief   Immutable request describing one permissions sync to perform on a module descriptor.
+ */
+
+/**
+ * Immutable request describing one permissions sync to perform on a module descriptor.
+ *
+ * ModuleBuilder triggers project onto two axes, not one: a scope (the three CRUD rights of an
+ * object, or a single right) and an action. The five real triggers are the five named factories
+ * below; there is no object-scoped update.
+ *
+ * The command deliberately carries the current rights array along with the intent. That keeps
+ * RightsSyncService free of $db, dol_include_once() and globals, so it stays unit-testable
+ * against a throwaway fixture file.
+ */
+final class RightsSyncCommand
+{
+	const ACTION_ADD = 'add';
+	const ACTION_UPDATE = 'update';
+	const ACTION_DELETE = 'delete';
+
+	const SCOPE_OBJECT = 'object';
+	const SCOPE_RIGHT = 'right';
+
+	/** @var string Module name, any casing */
+	public $module;
+
+	/** @var string Path to the mod<Module>.class.php descriptor to patch */
+	public $descriptorFile;
+
+	/** @var array<int,array<int,string>> Rights array read from the instantiated descriptor */
+	public $permissions;
+
+	/** @var string Object the command applies to, compared case-insensitively. Empty for right deletion. */
+	public $objectName;
+
+	/** @var string One of SCOPE_OBJECT, SCOPE_RIGHT */
+	public $scope;
+
+	/** @var string One of ACTION_ADD, ACTION_UPDATE, ACTION_DELETE */
+	public $actionType;
+
+	/** @var int|null Index in $permissions. Required for right-scoped update and delete. */
+	public $rightKey;
+
+	/** @var string|null Permission label. Required for right-scoped add and update. */
+	public $rightLabel;
+
+	/** @var string|null Permission crud code. Required for right-scoped add and update. */
+	public $rightCrud;
+
+	/**
+	 * @param string                       $module         Module name
+	 * @param string                       $descriptorFile Path to the descriptor to patch
+	 * @param array<int,array<int,string>> $permissions    Current rights array
+	 * @param string                       $objectName     Target object, may be empty for right deletion
+	 * @param string                       $scope          One of SCOPE_*
+	 * @param string                       $actionType     One of ACTION_*
+	 * @param int|null                     $rightKey       Index in $permissions
+	 * @param string|null                  $rightLabel     Permission label
+	 * @param string|null                  $rightCrud      Permission crud code
+	 * @throws \InvalidArgumentException When the command is incomplete for its scope and action
+	 */
+	private function __construct(
+		string $module,
+		string $descriptorFile,
+		array $permissions,
+		string $objectName,
+		string $scope,
+		string $actionType,
+		?int $rightKey = null,
+		?string $rightLabel = null,
+		?string $rightCrud = null
+	) {
+		if ($module === '') {
+			throw new \InvalidArgumentException('RightsSyncCommand requires a module name');
+		}
+		if ($descriptorFile === '') {
+			throw new \InvalidArgumentException('RightsSyncCommand requires a descriptor file path');
+		}
+		if (!in_array($scope, array(self::SCOPE_OBJECT, self::SCOPE_RIGHT), true)) {
+			throw new \InvalidArgumentException('RightsSyncCommand got an unknown scope: '.$scope);
+		}
+		if (!in_array($actionType, array(self::ACTION_ADD, self::ACTION_UPDATE, self::ACTION_DELETE), true)) {
+			throw new \InvalidArgumentException('RightsSyncCommand got an unknown action: '.$actionType);
+		}
+		if ($scope === self::SCOPE_OBJECT) {
+			if ($objectName === '') {
+				throw new \InvalidArgumentException('An object-scoped RightsSyncCommand requires an object name');
+			}
+			if ($actionType === self::ACTION_UPDATE) {
+				throw new \InvalidArgumentException('There is no object-scoped update in ModuleBuilder');
+			}
+		}
+		if ($scope === self::SCOPE_RIGHT && $actionType !== self::ACTION_ADD && $rightKey === null) {
+			throw new \InvalidArgumentException('A right-scoped '.$actionType.' requires a right key');
+		}
+		if ($scope === self::SCOPE_RIGHT && $actionType !== self::ACTION_DELETE && ($rightLabel === null || $rightCrud === null)) {
+			throw new \InvalidArgumentException('A right-scoped '.$actionType.' requires a label and a crud code');
+		}
+
+		$this->module = $module;
+		$this->descriptorFile = $descriptorFile;
+		$this->permissions = $permissions;
+		$this->objectName = $objectName;
+		$this->scope = $scope;
+		$this->actionType = $actionType;
+		$this->rightKey = $rightKey;
+		$this->rightLabel = $rightLabel;
+		$this->rightCrud = $rightCrud;
+	}
+
+	/**
+	 * Declare the three CRUD rights of a newly generated object.
+	 *
+	 * @param string                       $module         Module name
+	 * @param string                       $descriptorFile Path to the descriptor to patch
+	 * @param array<int,array<int,string>> $permissions    Current rights array
+	 * @param string                       $objectName     Object being generated
+	 * @return self
+	 */
+	public static function forObjectCreation(string $module, string $descriptorFile, array $permissions, string $objectName): self
+	{
+		return new self($module, $descriptorFile, $permissions, $objectName, self::SCOPE_OBJECT, self::ACTION_ADD);
+	}
+
+	/**
+	 * Drop every right attached to an object being deleted.
+	 *
+	 * @param string                       $module         Module name
+	 * @param string                       $descriptorFile Path to the descriptor to patch
+	 * @param array<int,array<int,string>> $permissions    Current rights array
+	 * @param string                       $objectName     Object being deleted
+	 * @return self
+	 */
+	public static function forObjectDeletion(string $module, string $descriptorFile, array $permissions, string $objectName): self
+	{
+		return new self($module, $descriptorFile, $permissions, $objectName, self::SCOPE_OBJECT, self::ACTION_DELETE);
+	}
+
+	/**
+	 * Append one right to the descriptor.
+	 *
+	 * @param string                       $module         Module name
+	 * @param string                       $descriptorFile Path to the descriptor to patch
+	 * @param array<int,array<int,string>> $permissions    Current rights array
+	 * @param string                       $objectName     Object the right belongs to
+	 * @param string                       $label          Permission label
+	 * @param string                       $crud           Permission crud code
+	 * @return self
+	 */
+	public static function forRightAddition(string $module, string $descriptorFile, array $permissions, string $objectName, string $label, string $crud): self
+	{
+		return new self($module, $descriptorFile, $permissions, $objectName, self::SCOPE_RIGHT, self::ACTION_ADD, null, $label, $crud);
+	}
+
+	/**
+	 * Replace one right, addressed by its index in the rights array.
+	 *
+	 * @param string                       $module         Module name
+	 * @param string                       $descriptorFile Path to the descriptor to patch
+	 * @param array<int,array<int,string>> $permissions    Current rights array
+	 * @param int                          $rightKey       Index of the right to replace
+	 * @param string                       $objectName     Object the right belongs to
+	 * @param string                       $label          New permission label
+	 * @param string                       $crud           New permission crud code
+	 * @return self
+	 */
+	public static function forRightUpdate(string $module, string $descriptorFile, array $permissions, int $rightKey, string $objectName, string $label, string $crud): self
+	{
+		return new self($module, $descriptorFile, $permissions, $objectName, self::SCOPE_RIGHT, self::ACTION_UPDATE, $rightKey, $label, $crud);
+	}
+
+	/**
+	 * Remove one right, addressed by its index in the rights array.
+	 *
+	 * @param string                       $module         Module name
+	 * @param string                       $descriptorFile Path to the descriptor to patch
+	 * @param array<int,array<int,string>> $permissions    Current rights array
+	 * @param int                          $rightKey       Index of the right to remove
+	 * @return self
+	 */
+	public static function forRightDeletion(string $module, string $descriptorFile, array $permissions, int $rightKey): self
+	{
+		return new self($module, $descriptorFile, $permissions, '', self::SCOPE_RIGHT, self::ACTION_DELETE, $rightKey);
+	}
+}

--- a/htdocs/modulebuilder/class/RightsSyncService.class.php
+++ b/htdocs/modulebuilder/class/RightsSyncService.class.php
@@ -1,0 +1,231 @@
+<?php
+/* Copyright (C) 2026 ATM Consulting <support@atm-consulting.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    htdocs/modulebuilder/class/RightsSyncService.class.php
+ * \ingroup modulebuilder
+ * \brief   Keeps the permissions section of a module descriptor in sync with ModuleBuilder actions.
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/modulebuilder/class/RightsSyncCommand.class.php';
+require_once DOL_DOCUMENT_ROOT.'/modulebuilder/class/SyncReport.class.php';
+require_once DOL_DOCUMENT_ROOT.'/modulebuilder/class/PermissionsBlock.class.php';
+
+/**
+ * Keeps the permissions section of a module descriptor in sync with ModuleBuilder actions.
+ */
+interface RightsSyncService
+{
+	/**
+	 * Apply one sync command to a module descriptor.
+	 *
+	 * @param RightsSyncCommand $cmd Command to apply
+	 * @return SyncReport Outcome — a report carrying conflicts means nothing was written
+	 */
+	public function sync(RightsSyncCommand $cmd): SyncReport;
+}
+
+/**
+ * Syncs rights straight into the mod<Module>.class.php descriptor file.
+ *
+ * Error-first: every reason not to write is collected before the rights array is touched, and a
+ * single conflict aborts the whole run without writing. A half-written permissions section is
+ * worse than a stale one.
+ */
+final class DescriptorRightsSyncService implements RightsSyncService
+{
+	/** @var array<string,string> Label template of each standard crud code */
+	private const CRUD_LABELS = array(
+		'read' => 'Read %s object of %s',
+		'write' => 'Create/Update %s object of %s',
+		'delete' => 'Delete %s object of %s',
+	);
+
+	/** @var int Rights array index holding the permission label */
+	private const INDEX_LABEL = 1;
+
+	/** @var int Rights array index holding the object name */
+	private const INDEX_OBJECT = 4;
+
+	/** @var int Rights array index holding the crud code */
+	private const INDEX_CRUD = 5;
+
+	/**
+	 * Apply one sync command to a module descriptor.
+	 *
+	 * @param RightsSyncCommand $cmd Command to apply
+	 * @return SyncReport Outcome — a report carrying conflicts means nothing was written
+	 */
+	public function sync(RightsSyncCommand $cmd): SyncReport
+	{
+		try {
+			$block = PermissionsBlock::fromFile($cmd->descriptorFile);
+		} catch (\RuntimeException $e) {
+			dol_syslog('DescriptorRightsSyncService::sync '.$e->getMessage(), LOG_WARNING);
+			return new SyncReport(0, 0, array($e->getMessage()));
+		}
+
+		$conflicts = array_merge(
+			$block->detectTextConflicts(),
+			$block->detectRightsShapeConflicts($cmd->permissions)
+		);
+		if (!empty($conflicts)) {
+			dol_syslog(
+				'DescriptorRightsSyncService::sync refused to rewrite '.$cmd->descriptorFile.': '
+				.implode('; ', array_slice($conflicts, 0, 3)),
+				LOG_WARNING
+			);
+			return new SyncReport(0, 0, $conflicts);
+		}
+
+		$warnings = $block->detectRightsShapeWarnings($cmd->permissions);
+
+		try {
+			$permissions = $this->applyCommand($cmd);
+		} catch (\InvalidArgumentException $e) {
+			dol_syslog('DescriptorRightsSyncService::sync '.$e->getMessage(), LOG_WARNING);
+			return new SyncReport(0, 0, array($e->getMessage()), $warnings);
+		}
+		if ($permissions === null) {
+			return new SyncReport(0, 1, array(), $warnings);
+		}
+
+		$newBlock = $block->render($permissions);
+		if ($block->write($newBlock) < 0) {
+			return new SyncReport(0, 0, array('Failed to write the permissions section of '.$cmd->descriptorFile), $warnings);
+		}
+
+		return new SyncReport(substr_count($newBlock, "\n"), 0, array(), $warnings);
+	}
+
+	/**
+	 * Produce the rights array the descriptor should now declare.
+	 *
+	 * @param RightsSyncCommand $cmd Command to apply
+	 * @return array<int,array<int,string>>|null New rights array, or null when the command is a no-op
+	 * @throws \InvalidArgumentException When the command targets a right that cannot be addressed
+	 */
+	private function applyCommand(RightsSyncCommand $cmd): ?array
+	{
+		$permissions = array_values($cmd->permissions);
+
+		if ($cmd->scope === RightsSyncCommand::SCOPE_OBJECT) {
+			if ($cmd->actionType === RightsSyncCommand::ACTION_ADD) {
+				return $this->addObjectRights($permissions, $cmd->module, $cmd->objectName);
+			}
+			return $this->removeObjectRights($permissions, $cmd->objectName);
+		}
+
+		if ($cmd->actionType === RightsSyncCommand::ACTION_ADD) {
+			return $this->addRight($permissions, $cmd->objectName, (string) $cmd->rightLabel, (string) $cmd->rightCrud);
+		}
+
+		$key = (int) $cmd->rightKey;
+		if (!array_key_exists($key, $permissions)) {
+			throw new \InvalidArgumentException('No permission found at index '.$key.' of the descriptor rights array');
+		}
+
+		if ($cmd->actionType === RightsSyncCommand::ACTION_UPDATE) {
+			// Addressed by key, never by value: two rights may carry the very same label.
+			$permissions[$key] = array(
+				self::INDEX_LABEL => (string) $cmd->rightLabel,
+				self::INDEX_OBJECT => strtolower($cmd->objectName),
+				self::INDEX_CRUD => (string) $cmd->rightCrud,
+			);
+			return $permissions;
+		}
+
+		unset($permissions[$key]);
+		return array_values($permissions);
+	}
+
+	/**
+	 * Append the three CRUD rights of a freshly generated object.
+	 *
+	 * @param array<int,array<int,string>> $permissions Current rights
+	 * @param string                       $module      Module name
+	 * @param string                       $objectName  Object being generated
+	 * @return array<int,array<int,string>>|null New rights, or null when the object already owns rights
+	 */
+	private function addObjectRights(array $permissions, string $module, string $objectName): ?array
+	{
+		$target = strtolower($objectName);
+		foreach ($permissions as $right) {
+			if (isset($right[self::INDEX_OBJECT]) && strtolower((string) $right[self::INDEX_OBJECT]) === $target) {
+				return null;
+			}
+		}
+
+		foreach (self::CRUD_LABELS as $crud => $template) {
+			$permissions[] = array(
+				self::INDEX_LABEL => sprintf($template, $objectName, ucfirst($module)),
+				self::INDEX_OBJECT => $target,
+				self::INDEX_CRUD => $crud,
+			);
+		}
+
+		return $permissions;
+	}
+
+	/**
+	 * Drop every right attached to an object.
+	 *
+	 * Filtering, not array_splice() inside a foreach over the same array.
+	 *
+	 * @param array<int,array<int,string>> $permissions Current rights
+	 * @param string                       $objectName  Object being deleted
+	 * @return array<int,array<int,string>> Remaining rights
+	 */
+	private function removeObjectRights(array $permissions, string $objectName): array
+	{
+		$target = strtolower($objectName);
+
+		return array_values(array_filter($permissions, static function ($right) use ($target) {
+			return !isset($right[4]) || strtolower((string) $right[4]) !== $target;
+		}));
+	}
+
+	/**
+	 * Append one right, refusing a crud code the object already declares.
+	 *
+	 * @param array<int,array<int,string>> $permissions Current rights
+	 * @param string                       $objectName  Object the right belongs to
+	 * @param string                       $label       Permission label
+	 * @param string                       $crud        Permission crud code
+	 * @return array<int,array<int,string>> New rights
+	 * @throws \InvalidArgumentException When the object already declares that crud code
+	 */
+	private function addRight(array $permissions, string $objectName, string $label, string $crud): array
+	{
+		$target = strtolower($objectName);
+		foreach ($permissions as $right) {
+			if (isset($right[self::INDEX_OBJECT], $right[self::INDEX_CRUD])
+				&& strtolower((string) $right[self::INDEX_OBJECT]) === $target
+				&& (string) $right[self::INDEX_CRUD] === $crud) {
+				throw new \InvalidArgumentException('Permission "'.$crud.'" is already declared for object "'.$objectName.'"');
+			}
+		}
+
+		$permissions[] = array(
+			self::INDEX_LABEL => $label,
+			self::INDEX_OBJECT => $target,
+			self::INDEX_CRUD => $crud,
+		);
+
+		return $permissions;
+	}
+}

--- a/htdocs/modulebuilder/class/RightsSyncService.class.php
+++ b/htdocs/modulebuilder/class/RightsSyncService.class.php
@@ -206,9 +206,16 @@ final class DescriptorRightsSyncService implements RightsSyncService
 	{
 		$target = strtolower($objectName);
 
-		return array_values(array_filter($permissions, static function ($right) use ($target) {
-			return !isset($right[self::INDEX_OBJECT]) || strtolower((string) $right[self::INDEX_OBJECT]) !== $target;
-		}));
+		return array_values(array_filter(
+			$permissions,
+			/**
+			 * @param 	array<int,string> $right Right to keep or drop
+			 * @return 	bool
+			 */
+			static function ($right) use ($target) {
+				return !isset($right[self::INDEX_OBJECT]) || strtolower((string) $right[self::INDEX_OBJECT]) !== $target;
+			}
+		));
 	}
 
 	/**

--- a/htdocs/modulebuilder/class/RightsSyncService.class.php
+++ b/htdocs/modulebuilder/class/RightsSyncService.class.php
@@ -195,7 +195,7 @@ final class DescriptorRightsSyncService implements RightsSyncService
 		$target = strtolower($objectName);
 
 		return array_values(array_filter($permissions, static function ($right) use ($target) {
-			return !isset($right[4]) || strtolower((string) $right[4]) !== $target;
+			return !isset($right[self::INDEX_OBJECT]) || strtolower((string) $right[self::INDEX_OBJECT]) !== $target;
 		}));
 	}
 

--- a/htdocs/modulebuilder/class/RightsSyncService.class.php
+++ b/htdocs/modulebuilder/class/RightsSyncService.class.php
@@ -104,6 +104,18 @@ final class DescriptorRightsSyncService implements RightsSyncService
 			return new SyncReport(0, 1, array(), $warnings);
 		}
 
+		// The shape check above ran on the incoming rights; the command may itself produce an
+		// unusable one, e.g. a right attached to no object, which hasRight() could never match.
+		$producedConflicts = $block->detectRightsShapeConflicts($permissions);
+		if (!empty($producedConflicts)) {
+			dol_syslog(
+				'DescriptorRightsSyncService::sync refused to write an unusable right into '.$cmd->descriptorFile.': '
+				.implode('; ', array_slice($producedConflicts, 0, 3)),
+				LOG_WARNING
+			);
+			return new SyncReport(0, 0, $producedConflicts, $warnings);
+		}
+
 		$newBlock = $block->render($permissions);
 		if ($block->write($newBlock) < 0) {
 			return new SyncReport(0, 0, array('Failed to write the permissions section of '.$cmd->descriptorFile), $warnings);

--- a/htdocs/modulebuilder/class/SyncReport.class.php
+++ b/htdocs/modulebuilder/class/SyncReport.class.php
@@ -1,0 +1,98 @@
+<?php
+/* Copyright (C) 2026 ATM Consulting <support@atm-consulting.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    htdocs/modulebuilder/class/SyncReport.class.php
+ * \ingroup modulebuilder
+ * \brief   Immutable outcome of a permissions sync run.
+ */
+
+/**
+ * Immutable outcome of a permissions sync run.
+ *
+ * Conflicts and warnings are two distinct severities and must not be merged: a non-empty
+ * $conflicts means NO write was performed, while $warnings means the write was performed and
+ * something was normalized on the way.
+ */
+final class SyncReport
+{
+	/** @var int Number of lines written into the permissions block, 0 when no write occurred */
+	public $updatedLines;
+
+	/** @var int Number of sync operations deliberately skipped, e.g. rights already declared */
+	public $skipped;
+
+	/** @var string[] Blocking problems, in plain English — when not empty, no write was performed */
+	public $conflicts;
+
+	/** @var string[] Non-blocking problems, in plain English — the write was performed anyway */
+	public $warnings;
+
+	/**
+	 * @param int      $updatedLines Number of lines written into the permissions block
+	 * @param int      $skipped      Number of operations deliberately skipped
+	 * @param string[] $conflicts    Blocking problems, in plain English
+	 * @param string[] $warnings     Non-blocking problems, in plain English
+	 */
+	public function __construct(int $updatedLines = 0, int $skipped = 0, array $conflicts = array(), array $warnings = array())
+	{
+		$this->updatedLines = $updatedLines;
+		$this->skipped = $skipped;
+		$this->conflicts = $conflicts;
+		$this->warnings = $warnings;
+	}
+
+	/**
+	 * Whether a blocking problem prevented the write.
+	 *
+	 * @return bool True when no write was performed
+	 */
+	public function hasConflicts(): bool
+	{
+		return !empty($this->conflicts);
+	}
+
+	/**
+	 * Whether something was normalized while still writing.
+	 *
+	 * @return bool True when the write happened but something was adjusted
+	 */
+	public function hasWarnings(): bool
+	{
+		return !empty($this->warnings);
+	}
+
+	/**
+	 * Whether the descriptor file was left untouched.
+	 *
+	 * @return bool True when nothing was written
+	 */
+	public function isNoop(): bool
+	{
+		return $this->updatedLines === 0;
+	}
+
+	/**
+	 * Map the report onto the historical reWriteAllPermissions() return code.
+	 *
+	 * @return int<-1,1> 1 if OK, -1 if KO
+	 */
+	public function toLegacyReturnCode(): int
+	{
+		return $this->hasConflicts() ? -1 : 1;
+	}
+}

--- a/htdocs/modulebuilder/class/SyncReport.class.php
+++ b/htdocs/modulebuilder/class/SyncReport.class.php
@@ -77,9 +77,12 @@ final class SyncReport
 	}
 
 	/**
-	 * Whether the descriptor file was left untouched.
+	 * Whether the sync produced no permission line.
 	 *
-	 * @return bool True when nothing was written
+	 * This is not the same as "the file was left untouched": removing the last right of a module
+	 * writes an empty block, which changes the file while producing zero lines.
+	 *
+	 * @return bool True when no permission line was written
 	 */
 	public function isNoop(): bool
 	{

--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -306,42 +306,6 @@ function modulebuilderValidateGeneratedFile(string $destfile, NamingContract $nc
 }
 
 /**
- * Load the rights array declared by a module descriptor.
- *
- * @param string $module         Module name
- * @param string $descriptorFile Path to the mod<Module>.class.php descriptor
- * @param string $relpath        Descriptor path relative to a Dolibarr root, for dol_include_once()
- * @return array<int,array<int,string>>|null Rights array, or null when the descriptor cannot be used
- */
-function modulebuilderLoadDescriptorRights(string $module, string $descriptorFile, string $relpath): ?array
-{
-	global $db, $langs;
-
-	if (checkExistComment($descriptorFile, 1) < 0) {
-		setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
-		return null;
-	}
-
-	dol_include_once($relpath);
-	$class = 'mod'.$module;
-	if (!class_exists($class)) {
-		dol_syslog('modulebuilderLoadDescriptorRights could not load class '.$class, LOG_ERR);
-		return null;
-	}
-
-	try {
-		$moduleobj = new $class($db);
-	} catch (Exception $e) {
-		dol_syslog('modulebuilderLoadDescriptorRights failed to instantiate '.$class.': '.$e->getMessage(), LOG_ERR);
-		return null;
-	}
-	'@phan-var-force DolibarrModules $moduleobj';
-	/** @var DolibarrModules $moduleobj */
-
-	return is_array($moduleobj->rights) ? $moduleobj->rights : array();
-}
-
-/**
  * Run a permissions sync and report its outcome to the user.
  *
  * @param RightsSyncCommand $cmd Sync command to run
@@ -1564,12 +1528,34 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {		// Test on 
 				$filetogenerate[$templateFile] = $ncObj->applyToFilename($templateFile);
 			}
 		}
+		$class = null;
 		if (GETPOST('generatepermissions', 'aZ09')) {
 			$firstobjectname = 'myobject';
+			$pathtofile = $listofmodules[strtolower($module)]['moduledescriptorrelpath'];
+			dol_include_once($pathtofile);
+			$class = 'mod'.$module;
+			$moduleobj = null;
+			if (class_exists($class)) {
+				try {
+					$moduleobj = new $class($db);
+					'@phan-var-force DolibarrModules $moduleobj';
+					/** @var DolibarrModules $moduleobj */
+				} catch (Exception $e) {
+					$error++;
+					dol_print_error($db, $e->getMessage());
+				}
+			}
+			if (is_object($moduleobj)) {
+				$rights = $moduleobj->rights;
+			} else {
+				$rights = [];
+			}
 			$moduledescriptorfile = $destdir.'/core/modules/mod'.$module.'.class.php';
-			$rights = modulebuilderLoadDescriptorRights($module, $moduledescriptorfile, $listofmodules[strtolower($module)]['moduledescriptorrelpath']);
-			if ($rights !== null) {
-				$reportPerms = modulebuilderSyncRights(RightsSyncCommand::forObjectCreation($module, $moduledescriptorfile, $rights, $objectname));
+			$checkComment = checkExistComment($moduledescriptorfile, 1);
+			if ($checkComment < 0) {
+				setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
+			} else {
+				$reportPerms = modulebuilderSyncRights(RightsSyncCommand::forObjectCreation($module, $moduledescriptorfile, is_array($rights) ? $rights : array(), $objectname));
 				if ($reportPerms->skipped > 0) {
 					setEventMessages($langs->trans("WarningPermissionAlreadyExist", $langs->transnoentities($objectname)), null, 'warnings');
 				}

--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -360,7 +360,7 @@ function modulebuilderSyncRights(RightsSyncCommand $cmd): SyncReport
 	}
 	if ($report->hasConflicts()) {
 		$safe = array_map('dol_escape_htmltag', array_slice($report->conflicts, 0, 5));
-		setEventMessages($langs->trans('ModuleBuilderPermissionsBlockNotSafe').'<br>'.implode('<br>', $safe), null, 'errors');
+		setEventMessages($langs->trans('ModuleBuilderPermissionsNotChanged').'<br>'.implode('<br>', $safe), null, 'errors');
 	}
 
 	return $report;

--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -1569,8 +1569,8 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {		// Test on 
 			$moduledescriptorfile = $destdir.'/core/modules/mod'.$module.'.class.php';
 			$rights = modulebuilderLoadDescriptorRights($module, $moduledescriptorfile, $listofmodules[strtolower($module)]['moduledescriptorrelpath']);
 			if ($rights !== null) {
-				$reportperms = modulebuilderSyncRights(RightsSyncCommand::forObjectCreation($module, $moduledescriptorfile, $rights, $objectname));
-				if ($reportperms->skipped > 0) {
+				$reportPerms = modulebuilderSyncRights(RightsSyncCommand::forObjectCreation($module, $moduledescriptorfile, $rights, $objectname));
+				if ($reportPerms->skipped > 0) {
 					setEventMessages($langs->trans("WarningPermissionAlreadyExist", $langs->transnoentities($objectname)), null, 'warnings');
 				}
 			}
@@ -2366,12 +2366,9 @@ if ($dirins && $action == 'confirm_deleteobject' && $objectname /* && $user->has
 		if ($rewritePerms < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forObjectDeletion($module, $moduledescriptorfile, is_array($permissions) ? $permissions : array(), $objectname));
-			if ($reportperms->hasConflicts()) {
-				// The object files are still removed: a rights conflict must not cancel the deletion,
-				// the warning tells the user the leftover rights need a manual cleanup.
-				$rewritePerms = -1;
-			}
+			$reportPerms = modulebuilderSyncRights(RightsSyncCommand::forObjectDeletion($module, $moduledescriptorfile, is_array($permissions) ? $permissions : array(), $objectname));
+			// A rights conflict deliberately does not cancel the object deletion below: the warning
+			// already told the user the leftover rights need a manual cleanup.
 		}
 		if ($rewritePerms && $rewriteMenu) {
 			// check if documentation has been generated
@@ -2730,8 +2727,8 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel) /* && 
 		if ($rewrite < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forRightAddition($module, $moduledescriptorfile, $permissions, $objectForPerms, $label, $crud));
-			if (!$reportperms->hasConflicts()) {
+			$reportPerms = modulebuilderSyncRights(RightsSyncCommand::forRightAddition($module, $moduledescriptorfile, $permissions, $objectForPerms, $label, $crud));
+			if (!$reportPerms->hasConflicts()) {
 				setEventMessages($langs->trans('PermissionAddedSuccesfuly'), null);
 
 				clearstatcache(true);
@@ -2853,8 +2850,8 @@ if ($dirins && GETPOST('action') == 'update_right' && GETPOST('modifyright') && 
 		if ($rewrite < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forRightUpdate($module, $moduledescriptorfile, $permissions, $key, $objectForPerms, $label, $crud));
-			if (!$reportperms->hasConflicts()) {
+			$reportPerms = modulebuilderSyncRights(RightsSyncCommand::forRightUpdate($module, $moduledescriptorfile, $permissions, $key, $objectForPerms, $label, $crud));
+			if (!$reportPerms->hasConflicts()) {
 				setEventMessages($langs->trans('PermissionUpdatedSuccesfuly'), null);
 				clearstatcache(true);
 				if (function_exists('opcache_invalidate')) {
@@ -2907,8 +2904,8 @@ if ($dirins && $action == 'confirm_deleteright' && !empty($module) && GETPOSTINT
 		if ($rewrite < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forRightDeletion($module, $moduledescriptorfile, $permissions, $key));
-			if (!$reportperms->hasConflicts()) {
+			$reportPerms = modulebuilderSyncRights(RightsSyncCommand::forRightDeletion($module, $moduledescriptorfile, $permissions, $key));
+			if (!$reportPerms->hasConflicts()) {
 				setEventMessages($langs->trans('PermissionDeletedSuccesfuly'), null);
 
 				clearstatcache(true);

--- a/htdocs/modulebuilder/index.php
+++ b/htdocs/modulebuilder/index.php
@@ -56,6 +56,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/modulebuilder.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/modulebuilder/class/NamingContractValidator.class.php';
+require_once DOL_DOCUMENT_ROOT.'/modulebuilder/class/RightsSyncService.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/utils.class.php';
 
@@ -302,6 +303,67 @@ function modulebuilderValidateGeneratedFile(string $destfile, NamingContract $nc
 		$safeErrors = array_map('dol_escape_htmltag', array_slice($errors, 0, 5));
 		setEventMessages(implode('<br>', $safeErrors), null, 'warnings');
 	}
+}
+
+/**
+ * Load the rights array declared by a module descriptor.
+ *
+ * @param string $module         Module name
+ * @param string $descriptorFile Path to the mod<Module>.class.php descriptor
+ * @param string $relpath        Descriptor path relative to a Dolibarr root, for dol_include_once()
+ * @return array<int,array<int,string>>|null Rights array, or null when the descriptor cannot be used
+ */
+function modulebuilderLoadDescriptorRights(string $module, string $descriptorFile, string $relpath): ?array
+{
+	global $db, $langs;
+
+	if (checkExistComment($descriptorFile, 1) < 0) {
+		setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
+		return null;
+	}
+
+	dol_include_once($relpath);
+	$class = 'mod'.$module;
+	if (!class_exists($class)) {
+		dol_syslog('modulebuilderLoadDescriptorRights could not load class '.$class, LOG_ERR);
+		return null;
+	}
+
+	try {
+		$moduleobj = new $class($db);
+	} catch (Exception $e) {
+		dol_syslog('modulebuilderLoadDescriptorRights failed to instantiate '.$class.': '.$e->getMessage(), LOG_ERR);
+		return null;
+	}
+	'@phan-var-force DolibarrModules $moduleobj';
+	/** @var DolibarrModules $moduleobj */
+
+	return is_array($moduleobj->rights) ? $moduleobj->rights : array();
+}
+
+/**
+ * Run a permissions sync and report its outcome to the user.
+ *
+ * @param RightsSyncCommand $cmd Sync command to run
+ * @return SyncReport Outcome — check hasConflicts() before claiming success or redirecting
+ */
+function modulebuilderSyncRights(RightsSyncCommand $cmd): SyncReport
+{
+	global $langs;
+
+	$service = new DescriptorRightsSyncService();
+	$report = $service->sync($cmd);
+
+	if ($report->hasWarnings()) {
+		$safe = array_map('dol_escape_htmltag', array_slice($report->warnings, 0, 5));
+		setEventMessages($langs->trans('ModuleBuilderPermissionsNormalized').'<br>'.implode('<br>', $safe), null, 'warnings');
+	}
+	if ($report->hasConflicts()) {
+		$safe = array_map('dol_escape_htmltag', array_slice($report->conflicts, 0, 5));
+		setEventMessages($langs->trans('ModuleBuilderPermissionsBlockNotSafe').'<br>'.implode('<br>', $safe), null, 'errors');
+	}
+
+	return $report;
 }
 
 if ($dirins && $action == 'initmodule' && $modulename) {		// Test on permission already done
@@ -1502,35 +1564,13 @@ if ($dirins && $action == 'initobject' && $module && $objectname) {		// Test on 
 				$filetogenerate[$templateFile] = $ncObj->applyToFilename($templateFile);
 			}
 		}
-		$class = null;
 		if (GETPOST('generatepermissions', 'aZ09')) {
 			$firstobjectname = 'myobject';
-			$pathtofile = $listofmodules[strtolower($module)]['moduledescriptorrelpath'];
-			dol_include_once($pathtofile);
-			$class = 'mod'.$module;
-			$moduleobj = null;
-			if (class_exists($class)) {
-				try {
-					$moduleobj = new $class($db);
-					'@phan-var-force DolibarrModules $moduleobj';
-					/** @var DolibarrModules $moduleobj */
-				} catch (Exception $e) {
-					$error++;
-					dol_print_error($db, $e->getMessage());
-				}
-			}
-			if (is_object($moduleobj)) {
-				$rights = $moduleobj->rights;
-			} else {
-				$rights = [];
-			}
 			$moduledescriptorfile = $destdir.'/core/modules/mod'.$module.'.class.php';
-			$checkComment = checkExistComment($moduledescriptorfile, 1);
-			if ($checkComment < 0) {
-				setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
-			} else {
-				$generatePerms = reWriteAllPermissions($moduledescriptorfile, $rights, null, null, $objectname, $module, -2);
-				if ($generatePerms < 0) {
+			$rights = modulebuilderLoadDescriptorRights($module, $moduledescriptorfile, $listofmodules[strtolower($module)]['moduledescriptorrelpath']);
+			if ($rights !== null) {
+				$reportperms = modulebuilderSyncRights(RightsSyncCommand::forObjectCreation($module, $moduledescriptorfile, $rights, $objectname));
+				if ($reportperms->skipped > 0) {
 					setEventMessages($langs->trans("WarningPermissionAlreadyExist", $langs->transnoentities($objectname)), null, 'warnings');
 				}
 			}
@@ -2326,7 +2366,12 @@ if ($dirins && $action == 'confirm_deleteobject' && $objectname /* && $user->has
 		if ($rewritePerms < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			reWriteAllPermissions($moduledescriptorfile, $permissions, null, null, $objectname, '', -1);
+			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forObjectDeletion($module, $moduledescriptorfile, is_array($permissions) ? $permissions : array(), $objectname));
+			if ($reportperms->hasConflicts()) {
+				// The object files are still removed: a rights conflict must not cancel the deletion,
+				// the warning tells the user the leftover rights need a manual cleanup.
+				$rewritePerms = -1;
+			}
 		}
 		if ($rewritePerms && $rewriteMenu) {
 			// check if documentation has been generated
@@ -2634,7 +2679,6 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel) /* && 
 		setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentities("Rights")), null, 'errors');
 	}
 
-	$id = GETPOST('id', 'alpha');
 	$label = GETPOST('label', 'alpha');
 	$objectForPerms = strtolower(GETPOST('permissionObj', 'alpha'));
 	$crud = GETPOST('crud', 'alpha');
@@ -2670,17 +2714,7 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel) /* && 
 		}
 	}
 
-	$rightToAdd = array();
 	if (!$error) {
-		$key = $countPerms + 1;
-		//prepare right to add
-		$rightToAdd = array(
-			0 => $id,
-			1 => $label,
-			4 => $objectForPerms,
-			5 => $crud
-		);
-
 		if (isModEnabled(strtolower($module))) {
 			$result = unActivateModule(strtolower($module));
 			dolibarr_set_const($db, "MAIN_IHM_PARAMS_REV", getDolGlobalInt('MAIN_IHM_PARAMS_REV') + 1, 'chaine', 0, '', $conf->entity);
@@ -2696,15 +2730,17 @@ if ($dirins && $action == 'addright' && !empty($module) && empty($cancel) /* && 
 		if ($rewrite < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			reWriteAllPermissions($moduledescriptorfile, $permissions, $key, $rightToAdd, '', '', 1);
-			setEventMessages($langs->trans('PermissionAddedSuccesfuly'), null);
+			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forRightAddition($module, $moduledescriptorfile, $permissions, $objectForPerms, $label, $crud));
+			if (!$reportperms->hasConflicts()) {
+				setEventMessages($langs->trans('PermissionAddedSuccesfuly'), null);
 
-			clearstatcache(true);
-			if (function_exists('opcache_invalidate')) {
-				opcache_reset();	// remove the include cache hell !
+				clearstatcache(true);
+				if (function_exists('opcache_invalidate')) {
+					opcache_reset();	// remove the include cache hell !
+				}
+				header("Location: ".DOL_URL_ROOT.'/modulebuilder/index.php?tab=permissions&module='.$module);
+				exit;
 			}
-			header("Location: ".DOL_URL_ROOT.'/modulebuilder/index.php?tab=permissions&module='.$module);
-			exit;
 		}
 	}
 }
@@ -2817,15 +2853,16 @@ if ($dirins && GETPOST('action') == 'update_right' && GETPOST('modifyright') && 
 		if ($rewrite < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			$rightUpdated = null;  // I not set at this point
-			reWriteAllPermissions($moduledescriptorfile, $permissions, $key, $rightUpdated, '', '', 2);
-			setEventMessages($langs->trans('PermissionUpdatedSuccesfuly'), null);
-			clearstatcache(true);
-			if (function_exists('opcache_invalidate')) {
-				opcache_reset();	// remove the include cache hell !
+			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forRightUpdate($module, $moduledescriptorfile, $permissions, $key, $objectForPerms, $label, $crud));
+			if (!$reportperms->hasConflicts()) {
+				setEventMessages($langs->trans('PermissionUpdatedSuccesfuly'), null);
+				clearstatcache(true);
+				if (function_exists('opcache_invalidate')) {
+					opcache_reset();	// remove the include cache hell !
+				}
+				header("Location: ".DOL_URL_ROOT.'/modulebuilder/index.php?tab=permissions&module='.$module);
+				exit;
 			}
-			header("Location: ".DOL_URL_ROOT.'/modulebuilder/index.php?tab=permissions&module='.$module);
-			exit;
 		}
 	}
 }
@@ -2870,16 +2907,18 @@ if ($dirins && $action == 'confirm_deleteright' && !empty($module) && GETPOSTINT
 		if ($rewrite < 0) {
 			setEventMessages($langs->trans("WarningCommentNotFound", $langs->trans("Permissions"), "mod".$module."class.php"), null, 'warnings');
 		} else {
-			reWriteAllPermissions($moduledescriptorfile, $permissions, $key, null, '', '', 0);
-			setEventMessages($langs->trans('PermissionDeletedSuccesfuly'), null);
+			$reportperms = modulebuilderSyncRights(RightsSyncCommand::forRightDeletion($module, $moduledescriptorfile, $permissions, $key));
+			if (!$reportperms->hasConflicts()) {
+				setEventMessages($langs->trans('PermissionDeletedSuccesfuly'), null);
 
-			clearstatcache(true);
-			if (function_exists('opcache_invalidate')) {
-				opcache_reset();	// remove the include cache hell !
+				clearstatcache(true);
+				if (function_exists('opcache_invalidate')) {
+					opcache_reset();	// remove the include cache hell !
+				}
+
+				header("Location: ".DOL_URL_ROOT.'/modulebuilder/index.php?tab=permissions&module='.$module);
+				exit;
 			}
-
-			header("Location: ".DOL_URL_ROOT.'/modulebuilder/index.php?tab=permissions&module='.$module);
-			exit;
 		}
 	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -367,4 +367,114 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		$this->assertSame(count($matches[1]), count(array_unique($matches[1])));
 		$this->assertSame(3, substr_count($rendered, '$r++;'));
 	}
+
+	/**
+	 * Writing replaces the block in one pass and leaves exactly one marker pair.
+	 *
+	 * @return void
+	 */
+	public function testWriteReplacesBlockInOnePass()
+	{
+		$path = $this->makeDescriptorFixture("\t\t// nothing yet\n");
+		$block = PermissionsBlock::fromFile($path);
+		$rendered = $block->render(array(array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read')));
+
+		$this->assertSame(1, $block->write($rendered));
+
+		$after = (string) file_get_contents($path);
+		$this->assertSame(1, substr_count($after, PermissionsBlock::BEGIN_MARKER));
+		$this->assertSame(1, substr_count($after, PermissionsBlock::END_MARKER));
+		$this->assertStringContainsString("\$this->rights[\$r][4] = 'alpha';", $after);
+		$this->assertStringNotContainsString('// nothing yet', $after);
+
+		// The block just written must itself be rewritable
+		$reread = PermissionsBlock::fromFile($path);
+		$this->assertSame(array(), $reread->detectTextConflicts());
+	}
+
+	/**
+	 * A __(Key)__ or __[obj]__ pattern elsewhere in the descriptor must survive the write untouched.
+	 *
+	 * @return void
+	 */
+	public function testWriteDoesNotSubstituteTranslationPatterns()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$original = (string) file_get_contents($path);
+		file_put_contents($path, str_replace(
+			'class modFixture',
+			"// descriptionlong: __(SomeTranslationKey)__\n// object: __[llx_societe:Societe:fetch:1]__\nclass modFixture",
+			$original
+		));
+
+		$block = PermissionsBlock::fromFile($path);
+		$block->write($block->render(array(array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read'))));
+
+		$after = (string) file_get_contents($path);
+		$this->assertStringContainsString('__(SomeTranslationKey)__', $after);
+		$this->assertStringContainsString('__[llx_societe:Societe:fetch:1]__', $after);
+	}
+
+	/**
+	 * Whatever a label contains, reading the written descriptor back yields it verbatim.
+	 *
+	 * @return void
+	 */
+	public function testWrittenLabelsSurviveRoundTrip()
+	{
+		if (!function_exists('exec')) {
+			$this->markTestSkipped('exec() is disabled, cannot lint the generated descriptor');
+		}
+
+		$labels = array(
+			'Cost $1 per unit',
+			"Backref \\1 test",
+			"Read l'objet",
+			'Path C:\\temp',
+			"x'; echo 'pwned",
+		);
+
+		$dir = sys_get_temp_dir().'/mbrightssync'.getmypid();
+		if (!is_dir($dir)) {
+			dol_mkdir($dir);
+		}
+
+		foreach ($labels as $i => $label) {
+			$class = 'modRoundTrip'.getmypid().'x'.$i;
+			$path = $dir.'/'.$class.'.php';
+			$this->fixtures[] = $path;
+			file_put_contents($path, "<?php\nclass ".$class." {\n\tpublic \$rights = array();\n\tpublic \$numero = 500000;\n\tpublic function initRights() {\n\t\t\$r = 0;\n\t\t"
+				.PermissionsBlock::BEGIN_MARKER."\n\t\t".PermissionsBlock::END_MARKER."\n\t}\n}\n");
+
+			$block = PermissionsBlock::fromFile($path);
+			$block->write($block->render(array(array(1 => $label, 4 => 'alpha', 5 => 'read'))));
+
+			$output = array();
+			$code = 0;
+			exec('php -l '.escapeshellarg($path).' 2>&1', $output, $code);
+			$this->assertSame(0, $code, 'Generated descriptor does not parse: '.implode("\n", $output));
+
+			require $path;
+			$descriptor = new $class();
+			$descriptor->initRights();
+			$this->assertSame($label, $descriptor->rights[0][1]);
+		}
+	}
+
+	/**
+	 * Writing an empty block clears the section but keeps its markers.
+	 *
+	 * @return void
+	 */
+	public function testWriteEmptyBlockKeepsMarkers()
+	{
+		$path = $this->makeDescriptorFixture("\t\t\$this->rights[\$r][5] = 'read';\n\t\t\$r++;\n");
+		$block = PermissionsBlock::fromFile($path);
+
+		$this->assertSame(1, $block->write(''));
+
+		$after = (string) file_get_contents($path);
+		$this->assertStringNotContainsString('$this->rights', $after);
+		$this->assertSame(2, substr_count($after, 'MODULEBUILDER PERMISSIONS'));
+	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -24,8 +24,10 @@
 
 global $conf,$user,$langs,$db;
 require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/files.lib.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/SyncReport.class.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/RightsSyncCommand.class.php';
+require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/PermissionsBlock.class.php';
 require_once dirname(__FILE__).'/CommonClassTest.class.php';
 
 /**
@@ -40,6 +42,45 @@ require_once dirname(__FILE__).'/CommonClassTest.class.php';
  */
 class ModuleBuilderRightsSyncTest extends CommonClassTest
 {
+	/** @var string[] Fixture files to remove on tearDown */
+	private $fixtures = array();
+
+	/**
+	 * Build a throwaway descriptor whose permissions block holds $inner.
+	 *
+	 * @param string $inner Raw content to put between the BEGIN and END markers
+	 * @return string Path to the fixture file
+	 */
+	private function makeDescriptorFixture(string $inner): string
+	{
+		$dir = sys_get_temp_dir().'/mbrightssync'.getmypid();
+		if (!is_dir($dir)) {
+			dol_mkdir($dir);
+		}
+		$path = $dir.'/modFixture'.uniqid().'.php';
+		$content = "<?php\nclass modFixture\n{\n\tpublic \$rights = array();\n\tpublic \$numero = 500000;\n\n\tpublic function initRights()\n\t{\n\t\t\$r = 0;\n\t\t"
+			.PermissionsBlock::BEGIN_MARKER."\n".$inner."\t\t".PermissionsBlock::END_MARKER."\n\t}\n}\n";
+		file_put_contents($path, $content);
+		$this->fixtures[] = $path;
+		return $path;
+	}
+
+	/**
+	 * Remove fixture files created by makeDescriptorFixture().
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void
+	{
+		foreach ($this->fixtures as $path) {
+			if (file_exists($path)) {
+				unlink($path);
+			}
+		}
+		$this->fixtures = array();
+		parent::tearDown();
+	}
+
 	/**
 	 * A report with conflicts reports no write and maps to the legacy -1 return code.
 	 *
@@ -104,5 +145,86 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		// An empty module name is never a valid target
 		$this->expectException(\InvalidArgumentException::class);
 		RightsSyncCommand::forRightDeletion('', '/tmp/modMyModule.class.php', $perms, 0);
+	}
+
+	/**
+	 * A descriptor with no permissions markers is never rewritten.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsBlockRefusesFileWithoutMarkers()
+	{
+		$dir = sys_get_temp_dir().'/mbrightssync'.getmypid();
+		if (!is_dir($dir)) {
+			dol_mkdir($dir);
+		}
+		$path = $dir.'/modNoMarkers'.uniqid().'.php';
+		$this->fixtures[] = $path;
+		file_put_contents($path, "<?php\nclass modNoMarkers {}\n");
+
+		$this->expectException(\RuntimeException::class);
+		PermissionsBlock::fromFile($path);
+	}
+
+	/**
+	 * The commented-out template block of a brand new module is not a conflict.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsBlockAcceptsCommentedTemplate()
+	{
+		$inner = "\t\t/*\n\t\t\$o = 1;\n\t\t\$this->rights[\$r][0] = \$this->numero . sprintf(\"%02d\", (\$o * 10) + 1);\n"
+			."\t\t\$this->rights[\$r][1] = 'Read objects of MyModule';\n\t\t\$r++;\n\t\t*/\n";
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
+
+		$this->assertSame(array(), $block->detectTextConflicts());
+	}
+
+	/**
+	 * A generated block made only of rights assignments is rewritable.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsBlockAcceptsGeneratedBlock()
+	{
+		$inner = "\t\t\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', (0 * 10) + 0 + 1);\n"
+			."\t\t\$this->rights[\$r][1] = 'Read myobject object of Mymodule';\n"
+			."\t\t\$this->rights[\$r][4] = 'myobject';\n"
+			."\t\t\$this->rights[\$r][5] = 'read'; // trailing comment is fine\n"
+			."\t\t\$r++;\n";
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
+
+		$this->assertSame(array(), $block->detectTextConflicts());
+	}
+
+	/**
+	 * Dynamically built rights would be flattened into static lines, so the block is refused.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsBlockRefusesDynamicRights()
+	{
+		$inner = "\t\tforeach (array('read', 'write') as \$crud) {\n"
+			."\t\t\t\$this->rights[\$r][5] = \$crud;\n\t\t\t\$r++;\n\t\t}\n";
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
+
+		$conflicts = $block->detectTextConflicts();
+		$this->assertNotEmpty($conflicts);
+		$this->assertStringContainsString('foreach', $conflicts[0]);
+	}
+
+	/**
+	 * A translated label cannot be reproduced by the renderer, so the block is refused.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsBlockRefusesTranslatedLabel()
+	{
+		$inner = "\t\t\$this->rights[\$r][1] = \$langs->trans('ReadMyObject');\n\t\t\$r++;\n";
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
+
+		$conflicts = $block->detectTextConflicts();
+		$this->assertNotEmpty($conflicts);
+		$this->assertStringContainsString('$langs', $conflicts[0]);
 	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -28,6 +28,7 @@ require_once dirname(__FILE__).'/../../htdocs/core/lib/files.lib.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/SyncReport.class.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/RightsSyncCommand.class.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/PermissionsBlock.class.php';
+require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/RightsSyncService.class.php';
 require_once dirname(__FILE__).'/CommonClassTest.class.php';
 
 /**
@@ -63,6 +64,31 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		file_put_contents($path, $content);
 		$this->fixtures[] = $path;
 		return $path;
+	}
+
+	/**
+	 * Read back the rights actually declared by a fixture descriptor block.
+	 *
+	 * @param string $path Fixture path
+	 * @return array<int,array<int,string>> Rights as index => value maps
+	 */
+	private function parseRenderedRights(string $path): array
+	{
+		$content = (string) file_get_contents($path);
+		$matches = array();
+		preg_match_all("/\\\$this->rights\\[\\\$r\\]\\[(\\d+)\\] = '([^']*)'/", $content, $matches, PREG_SET_ORDER);
+
+		$rights = array();
+		$current = array();
+		foreach ($matches as $match) {
+			$current[(int) $match[1]] = $match[2];
+			if ((int) $match[1] === 5) {
+				$rights[] = $current;
+				$current = array();
+			}
+		}
+
+		return $rights;
 	}
 
 	/**
@@ -476,5 +502,226 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		$after = (string) file_get_contents($path);
 		$this->assertStringNotContainsString('$this->rights', $after);
 		$this->assertSame(2, substr_count($after, 'MODULEBUILDER PERMISSIONS'));
+	}
+
+	/**
+	 * Generating an object declares its three CRUD rights.
+	 *
+	 * @return void
+	 */
+	public function testObjectCreationDeclaresThreeRights()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forObjectCreation('MyModule', $path, array(), 'MyObject')
+		);
+
+		$this->assertFalse($report->hasConflicts());
+		$this->assertGreaterThan(0, $report->updatedLines);
+
+		$rights = $this->parseRenderedRights($path);
+		$this->assertCount(3, $rights);
+		$this->assertSame('myobject', $rights[0][4]);
+		$this->assertSame(array('read', 'write', 'delete'), array($rights[0][5], $rights[1][5], $rights[2][5]));
+		$this->assertSame('Read MyObject object of MyModule', $rights[0][1]);
+	}
+
+	/**
+	 * An object that already owns rights is skipped instead of duplicated.
+	 *
+	 * @return void
+	 */
+	public function testObjectCreationSkipsAlreadyDeclaredObject()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$existing = array(array(1 => 'Read myobject', 4 => 'myobject', 5 => 'read'));
+		$before = (string) file_get_contents($path);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forObjectCreation('MyModule', $path, $existing, 'MyObject')
+		);
+
+		$this->assertSame(1, $report->skipped);
+		$this->assertFalse($report->hasConflicts());
+		$this->assertSame($before, (string) file_get_contents($path));
+	}
+
+	/**
+	 * Deleting an object drops its rights and keeps every other object's.
+	 *
+	 * @return void
+	 */
+	public function testObjectDeletionKeepsOtherObjectsRights()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$existing = array(
+			array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read'),
+			array(1 => 'Read beta', 4 => 'beta', 5 => 'read'),
+			array(1 => 'Write beta', 4 => 'beta', 5 => 'write'),
+		);
+
+		(new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forObjectDeletion('MyModule', $path, $existing, 'Alpha')
+		);
+
+		$rights = $this->parseRenderedRights($path);
+		$this->assertCount(2, $rights);
+		$this->assertSame('beta', $rights[0][4]);
+		$this->assertSame('beta', $rights[1][4]);
+	}
+
+	/**
+	 * Updating a right actually rewrites it — this is what never worked before.
+	 *
+	 * @return void
+	 */
+	public function testRightUpdateActuallyWritesTheNewValue()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$existing = array(
+			array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read'),
+			array(1 => 'Write alpha', 4 => 'alpha', 5 => 'write'),
+		);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightUpdate('MyModule', $path, $existing, 1, 'alpha', 'Edit alpha entries', 'write')
+		);
+
+		$this->assertFalse($report->hasConflicts());
+
+		$rights = $this->parseRenderedRights($path);
+		$this->assertCount(2, $rights);
+		$this->assertSame('Edit alpha entries', $rights[1][1]);
+		$this->assertSame('Read alpha', $rights[0][1]);
+	}
+
+	/**
+	 * Update and deletion address the right by key, so identical labels cannot mislead them.
+	 *
+	 * @return void
+	 */
+	public function testRightOperationsAddressByKeyNotByValue()
+	{
+		$twins = array(
+			array(1 => 'Same label', 4 => 'alpha', 5 => 'read'),
+			array(1 => 'Same label', 4 => 'alpha', 5 => 'write'),
+		);
+
+		$path = $this->makeDescriptorFixture('');
+		(new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightDeletion('MyModule', $path, $twins, 1)
+		);
+		$rights = $this->parseRenderedRights($path);
+		$this->assertCount(1, $rights);
+		$this->assertSame('read', $rights[0][5]);
+
+		$path = $this->makeDescriptorFixture('');
+		(new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightUpdate('MyModule', $path, $twins, 1, 'alpha', 'Renamed second', 'write')
+		);
+		$rights = $this->parseRenderedRights($path);
+		$this->assertSame('Renamed second', $rights[1][1]);
+		$this->assertSame('Same label', $rights[0][1]);
+	}
+
+	/**
+	 * An out-of-range key is a conflict, and a conflict never writes.
+	 *
+	 * @return void
+	 */
+	public function testOutOfRangeKeyIsAConflictAndWritesNothing()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$existing = array(array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read'));
+		$before = (string) file_get_contents($path);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightDeletion('MyModule', $path, $existing, 42)
+		);
+
+		$this->assertTrue($report->hasConflicts());
+		$this->assertSame($before, (string) file_get_contents($path));
+	}
+
+	/**
+	 * A descriptor with a dynamic permissions block is left byte-identical.
+	 *
+	 * @return void
+	 */
+	public function testDynamicBlockIsLeftUntouched()
+	{
+		$inner = "\t\tforeach (array('read', 'write') as \$crud) {\n\t\t\t\$this->rights[\$r][5] = \$crud;\n\t\t\t\$r++;\n\t\t}\n";
+		$path = $this->makeDescriptorFixture($inner);
+		$before = (string) file_get_contents($path);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightAddition('MyModule', $path, array(), 'alpha', 'Read alpha', 'read')
+		);
+
+		$this->assertTrue($report->hasConflicts());
+		$this->assertSame($before, (string) file_get_contents($path));
+	}
+
+	/**
+	 * A missing permissions block is reported and never written to.
+	 *
+	 * @return void
+	 */
+	public function testMissingBlockIsReportedWithoutWriting()
+	{
+		$dir = sys_get_temp_dir().'/mbrightssync'.getmypid();
+		if (!is_dir($dir)) {
+			dol_mkdir($dir);
+		}
+		$path = $dir.'/modNoBlock'.uniqid().'.php';
+		$this->fixtures[] = $path;
+		file_put_contents($path, "<?php\nclass modNoBlock {}\n");
+		$before = (string) file_get_contents($path);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightAddition('MyModule', $path, array(), 'alpha', 'Read alpha', 'read')
+		);
+
+		$this->assertTrue($report->hasConflicts());
+		$this->assertSame($before, (string) file_get_contents($path));
+	}
+
+	/**
+	 * Adding a right that already exists for the object is refused.
+	 *
+	 * @return void
+	 */
+	public function testRightAdditionRefusesDuplicateCrud()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$existing = array(array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read'));
+		$before = (string) file_get_contents($path);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightAddition('MyModule', $path, $existing, 'alpha', 'Read alpha again', 'read')
+		);
+
+		$this->assertTrue($report->hasConflicts());
+		$this->assertSame($before, (string) file_get_contents($path));
+	}
+
+	/**
+	 * A legacy index warns but does not block the write.
+	 *
+	 * @return void
+	 */
+	public function testLegacyIndexWarnsButStillWrites()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$existing = array(array(1 => 'Read alpha', 2 => 'r', 3 => 0, 4 => 'alpha', 5 => 'read'));
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightAddition('MyModule', $path, $existing, 'alpha', 'Write alpha', 'write')
+		);
+
+		$this->assertFalse($report->hasConflicts());
+		$this->assertTrue($report->hasWarnings());
+		$this->assertCount(2, $this->parseRenderedRights($path));
+		$this->assertStringNotContainsString('[2]', (string) file_get_contents($path));
 	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -1,0 +1,70 @@
+<?php
+/* Copyright (C) 2026 ATM Consulting <support@atm-consulting.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *      \file       test/phpunit/ModuleBuilderRightsSyncTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the ModuleBuilder permissions sync service
+ *      \remarks    To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db;
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/SyncReport.class.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks backupGlobals must be disabled to have db,conf,user and lang not erased.
+ * @phan-file-suppress PhanUndeclaredClass
+ * @phan-file-suppress PhanUndeclaredExtendedClass
+ * @phan-file-suppress PhanUndeclaredMethod
+ */
+class ModuleBuilderRightsSyncTest extends CommonClassTest
+{
+	/**
+	 * A report with conflicts reports no write and maps to the legacy -1 return code.
+	 *
+	 * @return void
+	 */
+	public function testSyncReportConflictSemantics()
+	{
+		$clean = new SyncReport(12, 0, array(), array());
+		$this->assertFalse($clean->hasConflicts());
+		$this->assertFalse($clean->hasWarnings());
+		$this->assertFalse($clean->isNoop());
+		$this->assertSame(1, $clean->toLegacyReturnCode());
+
+		$blocked = new SyncReport(0, 0, array('dynamic code detected'), array());
+		$this->assertTrue($blocked->hasConflicts());
+		$this->assertTrue($blocked->isNoop());
+		$this->assertSame(-1, $blocked->toLegacyReturnCode());
+
+		// A warning is non-blocking: the write happened, the legacy code stays 1
+		$warned = new SyncReport(12, 0, array(), array('right #0 carries unsupported index 2'));
+		$this->assertTrue($warned->hasWarnings());
+		$this->assertFalse($warned->hasConflicts());
+		$this->assertSame(1, $warned->toLegacyReturnCode());
+
+		$skippedReport = new SyncReport(0, 1, array(), array());
+		$this->assertSame(1, $skippedReport->skipped);
+		$this->assertTrue($skippedReport->isNoop());
+	}
+}

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -229,8 +229,7 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 	 */
 	public function testPermissionsBlockAcceptsCommentedTemplate()
 	{
-		$inner = "\t\t/*\n\t\t\$o = 1;\n\t\t\$this->rights[\$r][0] = \$this->numero . sprintf(\"%02d\", (\$o * 10) + 1);\n"
-			."\t\t\$this->rights[\$r][1] = 'Read objects of MyModule';\n\t\t\$r++;\n\t\t*/\n";
+		$inner = "\t\t/*\n\t\t\$o = 1;\n\t\t\$this->rights[\$r][0] = \$this->numero . sprintf(\"%02d\", (\$o * 10) + 1);\n\t\t\$this->rights[\$r][1] = 'Read objects of MyModule';\n\t\t\$r++;\n\t\t*/\n";
 		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
 
 		$this->assertSame(array(), $block->detectTextConflicts());
@@ -243,11 +242,7 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 	 */
 	public function testPermissionsBlockAcceptsGeneratedBlock()
 	{
-		$inner = "\t\t\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', (0 * 10) + 0 + 1);\n"
-			."\t\t\$this->rights[\$r][1] = 'Read myobject object of Mymodule';\n"
-			."\t\t\$this->rights[\$r][4] = 'myobject';\n"
-			."\t\t\$this->rights[\$r][5] = 'read'; // trailing comment is fine\n"
-			."\t\t\$r++;\n";
+		$inner = "\t\t\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', (0 * 10) + 0 + 1);\n\t\t\$this->rights[\$r][1] = 'Read myobject object of Mymodule';\n\t\t\$this->rights[\$r][4] = 'myobject';\n\t\t\$this->rights[\$r][5] = 'read'; // trailing comment is fine\n\t\t\$r++;\n";
 		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
 
 		$this->assertSame(array(), $block->detectTextConflicts());
@@ -260,8 +255,7 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 	 */
 	public function testPermissionsBlockRefusesDynamicRights()
 	{
-		$inner = "\t\tforeach (array('read', 'write') as \$crud) {\n"
-			."\t\t\t\$this->rights[\$r][5] = \$crud;\n\t\t\t\$r++;\n\t\t}\n";
+		$inner = "\t\tforeach (array('read', 'write') as \$crud) {\n\t\t\t\$this->rights[\$r][5] = \$crud;\n\t\t\t\$r++;\n\t\t}\n";
 		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
 
 		$conflicts = $block->detectTextConflicts();
@@ -270,18 +264,33 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 	}
 
 	/**
-	 * A translated label cannot be reproduced by the renderer, so the block is refused.
+	 * A label read from a variable cannot be reproduced by the renderer, so the block is refused.
 	 *
 	 * @return void
 	 */
-	public function testPermissionsBlockRefusesTranslatedLabel()
+	public function testPermissionsBlockRefusesComputedLabel()
 	{
-		$inner = "\t\t\$this->rights[\$r][1] = \$langs->trans('ReadMyObject');\n\t\t\$r++;\n";
+		$inner = "\t\t\$this->rights[\$r][1] = \$computedLabel;\n\t\t\$r++;\n";
 		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
 
 		$conflicts = $block->detectTextConflicts();
 		$this->assertNotEmpty($conflicts);
-		$this->assertStringContainsString('$langs', $conflicts[0]);
+		$this->assertStringContainsString('$computedLabel', $conflicts[0]);
+	}
+
+	/**
+	 * Rights guarded by a global constant cannot be reproduced either.
+	 *
+	 * @return void
+	 */
+	public function testPermissionsBlockRefusesConditionalRights()
+	{
+		$inner = "\t\tif (getDolGlobalString('SOME_SETUP_KEY')) {\n\t\t\t\$this->rights[\$r][5] = 'read';\n\t\t\t\$r++;\n\t\t}\n";
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
+
+		$conflicts = $block->detectTextConflicts();
+		$this->assertNotEmpty($conflicts);
+		$this->assertStringContainsString('if', $conflicts[0]);
 	}
 
 	/**
@@ -805,10 +814,7 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 	 */
 	public function testLiteralsAreNotMistakenForDynamicCode()
 	{
-		$inner = "\t\t\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', 1);\n"
-			."\t\t\$this->rights[\$r][3] = null;\n"
-			."\t\t\$this->rights[\$r][2] = true;\n"
-			."\t\t\$this->rights[\$r][5] = 'read';\n\t\t\$r++;\n";
+		$inner = "\t\t\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', 1);\n\t\t\$this->rights[\$r][3] = null;\n\t\t\$this->rights[\$r][2] = true;\n\t\t\$this->rights[\$r][5] = 'read';\n\t\t\$r++;\n";
 		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
 
 		$this->assertSame(array(), $block->detectTextConflicts());

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -797,4 +797,59 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		file_put_contents($truncated, "<?php\nclass modTruncated { function f() { ".PermissionsBlock::BEGIN_MARKER." } }\n");
 		$this->assertSame(-1, deletePerms($truncated));
 	}
+
+	/**
+	 * null, true and false are T_STRING for the tokenizer and must not be read as dynamic code.
+	 *
+	 * @return void
+	 */
+	public function testLiteralsAreNotMistakenForDynamicCode()
+	{
+		$inner = "\t\t\$this->rights[\$r][0] = \$this->numero . sprintf('%02d', 1);\n"
+			."\t\t\$this->rights[\$r][3] = null;\n"
+			."\t\t\$this->rights[\$r][2] = true;\n"
+			."\t\t\$this->rights[\$r][5] = 'read';\n\t\t\$r++;\n";
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture($inner));
+
+		$this->assertSame(array(), $block->detectTextConflicts());
+	}
+
+	/**
+	 * A descriptor path carrying a parent directory reference is refused before any read.
+	 *
+	 * @return void
+	 */
+	public function testParentDirectoryReferenceInPathIsRefused()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$traversal = dirname($path).'/../'.basename(dirname($path)).'/'.basename($path);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forObjectCreation('Acme', $traversal, array(), 'Invoice')
+		);
+
+		$this->assertTrue($report->hasConflicts());
+		$this->assertStringContainsString('parent directory', $report->conflicts[0]);
+	}
+
+	/**
+	 * Removing the last right writes an empty block: no line written, yet the file did change.
+	 *
+	 * @return void
+	 */
+	public function testRemovingLastRightWritesAnEmptyBlock()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$service = new DescriptorRightsSyncService();
+		$service->sync(RightsSyncCommand::forObjectCreation('Acme', $path, array(), 'Invoice'));
+
+		$before = md5_file($path);
+		$report = $service->sync(
+			RightsSyncCommand::forRightDeletion('Acme', $path, array(array(1 => 'Read invoice', 4 => 'invoice', 5 => 'read')), 0)
+		);
+
+		$this->assertTrue($report->isNoop());
+		$this->assertNotSame($before, md5_file($path));
+		$this->assertSame(array(), $this->parseRenderedRights($path));
+	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -25,6 +25,7 @@
 global $conf,$user,$langs,$db;
 require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
 require_once dirname(__FILE__).'/../../htdocs/core/lib/files.lib.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/modulebuilder.lib.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/SyncReport.class.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/RightsSyncCommand.class.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/PermissionsBlock.class.php';
@@ -723,5 +724,77 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		$this->assertTrue($report->hasWarnings());
 		$this->assertCount(2, $this->parseRenderedRights($path));
 		$this->assertStringNotContainsString('[2]', (string) file_get_contents($path));
+	}
+
+	/**
+	 * The legacy entry point keeps its signature and its 1/-1 contract for every action.
+	 *
+	 * @return void
+	 */
+	public function testLegacyReWriteAllPermissionsStillWorks()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$this->assertSame(1, reWriteAllPermissions($path, array(), null, null, 'MyObject', 'MyModule', -2));
+		$this->assertCount(3, $this->parseRenderedRights($path));
+
+		// The object already owns rights: the legacy contract reports that as -1
+		$existing = array(array(1 => 'Read myobject', 4 => 'myobject', 5 => 'read'));
+		$this->assertSame(-1, reWriteAllPermissions($path, $existing, null, null, 'MyObject', 'MyModule', -2));
+
+		// Unknown action is refused
+		$this->assertSame(-1, reWriteAllPermissions($path, $existing, null, null, '', '', 7));
+
+		// action 2 really applies its change now
+		$path = $this->makeDescriptorFixture('');
+		$this->assertSame(1, reWriteAllPermissions(
+			$path,
+			array(array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read')),
+			0,
+			array(1 => 'Renamed', 4 => 'alpha', 5 => 'read'),
+			'',
+			'MyModule',
+			2
+		));
+		$this->assertStringContainsString('Renamed', (string) file_get_contents($path));
+	}
+
+	/**
+	 * A block that cannot be rewritten keeps the legacy -1 code and leaves the file alone.
+	 *
+	 * @return void
+	 */
+	public function testLegacyReWriteAllPermissionsRefusesDynamicBlock()
+	{
+		$inner = "\t\tforeach (array('read') as \$crud) {\n\t\t\t\$r++;\n\t\t}\n";
+		$path = $this->makeDescriptorFixture($inner);
+		$before = (string) file_get_contents($path);
+
+		$this->assertSame(-1, reWriteAllPermissions($path, array(), null, null, 'MyObject', 'MyModule', -2));
+		$this->assertSame($before, (string) file_get_contents($path));
+	}
+
+	/**
+	 * deletePerms() empties the block, reports its status, and never loops on a truncated file.
+	 *
+	 * @return void
+	 */
+	public function testDeletePermsEmptiesBlockAndReportsStatus()
+	{
+		$path = $this->makeDescriptorFixture("\t\t\$this->rights[\$r][5] = 'read';\n\t\t\$r++;\n");
+		$this->assertSame(1, deletePerms($path));
+
+		$after = (string) file_get_contents($path);
+		$this->assertStringNotContainsString('$this->rights', $after);
+		$this->assertSame(1, substr_count($after, PermissionsBlock::BEGIN_MARKER));
+
+		// A descriptor without the END marker is reported, not looped over
+		$dir = sys_get_temp_dir().'/mbrightssync'.getmypid();
+		if (!is_dir($dir)) {
+			dol_mkdir($dir);
+		}
+		$truncated = $dir.'/modTruncated'.uniqid().'.php';
+		$this->fixtures[] = $truncated;
+		file_put_contents($truncated, "<?php\nclass modTruncated { function f() { ".PermissionsBlock::BEGIN_MARKER." } }\n");
+		$this->assertSame(-1, deletePerms($truncated));
 	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -25,6 +25,7 @@
 global $conf,$user,$langs,$db;
 require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
 require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/SyncReport.class.php';
+require_once dirname(__FILE__).'/../../htdocs/modulebuilder/class/RightsSyncCommand.class.php';
 require_once dirname(__FILE__).'/CommonClassTest.class.php';
 
 /**
@@ -66,5 +67,42 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		$skippedReport = new SyncReport(0, 1, array(), array());
 		$this->assertSame(1, $skippedReport->skipped);
 		$this->assertTrue($skippedReport->isNoop());
+	}
+
+	/**
+	 * Each factory pins one scope/action pair, and the constructor refuses an incomplete command.
+	 *
+	 * @return void
+	 */
+	public function testRightsSyncCommandFactories()
+	{
+		$perms = array(array(1 => 'Read', 4 => 'myobject', 5 => 'read'));
+
+		$cmd = RightsSyncCommand::forObjectCreation('MyModule', '/tmp/modMyModule.class.php', $perms, 'MyObject');
+		$this->assertSame(RightsSyncCommand::SCOPE_OBJECT, $cmd->scope);
+		$this->assertSame(RightsSyncCommand::ACTION_ADD, $cmd->actionType);
+		$this->assertSame('MyObject', $cmd->objectName);
+		$this->assertNull($cmd->rightKey);
+
+		$cmd = RightsSyncCommand::forObjectDeletion('MyModule', '/tmp/modMyModule.class.php', $perms, 'MyObject');
+		$this->assertSame(RightsSyncCommand::SCOPE_OBJECT, $cmd->scope);
+		$this->assertSame(RightsSyncCommand::ACTION_DELETE, $cmd->actionType);
+
+		$cmd = RightsSyncCommand::forRightAddition('MyModule', '/tmp/modMyModule.class.php', $perms, 'myobject', 'Export MyObject', 'export');
+		$this->assertSame(RightsSyncCommand::SCOPE_RIGHT, $cmd->scope);
+		$this->assertSame(RightsSyncCommand::ACTION_ADD, $cmd->actionType);
+		$this->assertSame('export', $cmd->rightCrud);
+
+		$cmd = RightsSyncCommand::forRightUpdate('MyModule', '/tmp/modMyModule.class.php', $perms, 0, 'myobject', 'Read it', 'read');
+		$this->assertSame(RightsSyncCommand::ACTION_UPDATE, $cmd->actionType);
+		$this->assertSame(0, $cmd->rightKey);
+
+		$cmd = RightsSyncCommand::forRightDeletion('MyModule', '/tmp/modMyModule.class.php', $perms, 0);
+		$this->assertSame(RightsSyncCommand::ACTION_DELETE, $cmd->actionType);
+		$this->assertSame('', $cmd->objectName);
+
+		// An empty module name is never a valid target
+		$this->expectException(\InvalidArgumentException::class);
+		RightsSyncCommand::forRightDeletion('', '/tmp/modMyModule.class.php', $perms, 0);
 	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -852,4 +852,23 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		$this->assertNotSame($before, md5_file($path));
 		$this->assertSame(array(), $this->parseRenderedRights($path));
 	}
+
+	/**
+	 * A right attached to no object could never be matched by hasRight(), so it is refused.
+	 *
+	 * @return void
+	 */
+	public function testRightWithoutObjectIsRefusedBeforeWriting()
+	{
+		$path = $this->makeDescriptorFixture('');
+		$before = (string) file_get_contents($path);
+
+		$report = (new DescriptorRightsSyncService())->sync(
+			RightsSyncCommand::forRightAddition('Acme', $path, array(), '', 'Orphan right', 'read')
+		);
+
+		$this->assertTrue($report->hasConflicts());
+		$this->assertSame(0, $report->updatedLines);
+		$this->assertSame($before, (string) file_get_contents($path));
+	}
 }

--- a/test/phpunit/ModuleBuilderRightsSyncTest.php
+++ b/test/phpunit/ModuleBuilderRightsSyncTest.php
@@ -66,6 +66,35 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 	}
 
 	/**
+	 * Check that a rendered permissions block is valid PHP.
+	 *
+	 * @param string $renderedBlock Block content produced by PermissionsBlock::render()
+	 * @return int 0 when the block parses
+	 */
+	private function lintRenderedBlock(string $renderedBlock): int
+	{
+		if (!function_exists('exec')) {
+			$this->markTestSkipped('exec() is disabled, cannot lint the generated block');
+		}
+		$dir = sys_get_temp_dir().'/mbrightssync'.getmypid();
+		if (!is_dir($dir)) {
+			dol_mkdir($dir);
+		}
+		$tmp = $dir.'/rendered'.uniqid().'.php';
+		$this->fixtures[] = $tmp;
+		file_put_contents($tmp, "<?php\nclass T { public \$rights = array(); public \$numero = 500000; function f() { \$r = 0;\n".$renderedBlock."} }\n");
+
+		$output = array();
+		$code = 0;
+		exec('php -l '.escapeshellarg($tmp).' 2>&1', $output, $code);
+		if ($code !== 0) {
+			$this->fail('Rendered block does not parse: '.implode("\n", $output));
+		}
+
+		return $code;
+	}
+
+	/**
 	 * Remove fixture files created by makeDescriptorFixture().
 	 *
 	 * @return void
@@ -226,5 +255,116 @@ class ModuleBuilderRightsSyncTest extends CommonClassTest
 		$conflicts = $block->detectTextConflicts();
 		$this->assertNotEmpty($conflicts);
 		$this->assertStringContainsString('$langs', $conflicts[0]);
+	}
+
+	/**
+	 * Rendering groups rights per object and numbers them read/write/delete within each group.
+	 *
+	 * @return void
+	 */
+	public function testRenderNumbersRightsPerObject()
+	{
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture(''));
+		$rendered = $block->render(array(
+			array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read'),
+			array(1 => 'Delete alpha', 4 => 'alpha', 5 => 'delete'),
+			array(1 => 'Read beta', 4 => 'beta', 5 => 'read'),
+		));
+
+		// First object gets stride 0, second gets stride 1
+		$this->assertStringContainsString("sprintf('%02d', (0 * 10) + 0 + 1)", $rendered);
+		$this->assertStringContainsString("sprintf('%02d', (0 * 10) + 2 + 1)", $rendered);
+		$this->assertStringContainsString("sprintf('%02d', (1 * 10) + 0 + 1)", $rendered);
+		// read comes before delete inside a group
+		$this->assertLessThan(strpos($rendered, 'Delete alpha'), strpos($rendered, 'Read alpha'));
+		$this->assertSame(3, substr_count($rendered, '$r++;'));
+	}
+
+	/**
+	 * A label carrying an apostrophe must not break the generated descriptor.
+	 *
+	 * @return void
+	 */
+	public function testRenderEscapesLabels()
+	{
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture(''));
+		$rendered = $block->render(array(
+			array(1 => "Read l'objet", 4 => 'alpha', 5 => 'read'),
+		));
+
+		$this->assertStringContainsString("Read l\\'objet", $rendered);
+		$this->assertSame(0, $this->lintRenderedBlock($rendered));
+	}
+
+	/**
+	 * A label crafted to close the string literal stays inert data.
+	 *
+	 * @return void
+	 */
+	public function testRenderKeepsCraftedLabelInert()
+	{
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture(''));
+		$rendered = $block->render(array(
+			array(1 => "x'; echo 'pwned", 4 => 'alpha', 5 => 'read'),
+		));
+
+		$this->assertSame(0, $this->lintRenderedBlock($rendered));
+		$this->assertStringNotContainsString("= 'x'; echo 'pwned';", $rendered);
+	}
+
+	/**
+	 * Legacy indexes 2 and 3 are dropped with a warning instead of corrupting the descriptor.
+	 *
+	 * @return void
+	 */
+	public function testLegacyIndexesAreNormalizedWithAWarning()
+	{
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture(''));
+		$permissions = array(
+			array(1 => 'Read alpha', 2 => 'r', 3 => 0, 4 => 'alpha', 5 => 'read'),
+		);
+
+		$warnings = $block->detectRightsShapeWarnings($permissions);
+		$this->assertNotEmpty($warnings);
+		$this->assertStringContainsString('2', $warnings[0]);
+
+		$rendered = $block->render($permissions);
+		$this->assertStringNotContainsString('[2]', $rendered);
+		$this->assertStringNotContainsString('[3]', $rendered);
+		$this->assertSame(1, substr_count($rendered, '$r++;'));
+		$this->assertSame(0, $this->lintRenderedBlock($rendered));
+	}
+
+	/**
+	 * A right missing its object or crud cannot be rendered at all.
+	 *
+	 * @return void
+	 */
+	public function testRightMissingObjectOrCrudIsAConflict()
+	{
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture(''));
+
+		$this->assertNotEmpty($block->detectRightsShapeConflicts(array(array(1 => 'Orphan'))));
+		$this->assertSame(array(), $block->detectRightsShapeConflicts(array(array(1 => 'Ok', 4 => 'alpha', 5 => 'read'))));
+	}
+
+	/**
+	 * Two rights of one object never collide on the same permission id.
+	 *
+	 * @return void
+	 */
+	public function testOffsetsStayUniqueWithCustomAndDuplicateCruds()
+	{
+		$block = PermissionsBlock::fromFile($this->makeDescriptorFixture(''));
+		$rendered = $block->render(array(
+			array(1 => 'Read alpha', 4 => 'alpha', 5 => 'read'),
+			array(1 => 'Export alpha', 4 => 'alpha', 5 => 'export'),
+			array(1 => 'Read alpha again', 4 => 'alpha', 5 => 'read'),
+		));
+
+		$matches = array();
+		preg_match_all('/\+ (\d+) \+ 1\)/', $rendered, $matches);
+		$this->assertSame(count($matches[1]), count(array_unique($matches[1])));
+		$this->assertSame(3, substr_count($rendered, '$r++;'));
 	}
 }


### PR DESCRIPTION
## What this fixes

The permissions section of a module descriptor is rewritten by ModuleBuilder on five different
actions. That rewrite was not transactional, silently discarded its own failures, and one of the
five actions had never worked at all.

Nine defects are addressed:

| # | Defect | Where |
|---|---|---|
| 1 | **"Update a permission" was a no-op that reported success.** `$rightUpdated` was hardcoded to `null`, so `reWriteAllPermissions()` fell into its `else { $error++; }` branch and returned `-1`. The return value was ignored and `PermissionUpdatedSuccesfuly` was displayed. Broken since b0087aaf612 (2024-08-18). | `modulebuilder/index.php` |
| 2 | Return value of `reWriteAllPermissions()` ignored on 4 of its 5 call sites — every failure was reported to the user as a success. | `modulebuilder/index.php` |
| 3 | A right carrying the obsolete index `[2]` or `[3]` had its raw value written into the descriptor: only indexes 0/1/4/5 were rewritten, but the whole row was `implode()`d. Result: a descriptor that no longer parses. | `core/lib/modulebuilder.lib.php` |
| 4 | Rights were deleted and updated **by value** (`array_splice($p, array_search($p[$key], $p), 1)`) instead of by key: with two identical rows, the wrong one was touched. | `core/lib/modulebuilder.lib.php` |
| 5 | `array_splice()` called inside a `foreach` over the same array when deleting an object's rights. | `core/lib/modulebuilder.lib.php` |
| 6 | `$permissions[$key]` read without checking the key exists. | `core/lib/modulebuilder.lib.php` |
| 7 | `deletePerms()` looped forever when the END marker was missing (`while (($line = $lines[++$i]) !== false)` runs past the end of the array, and `null !== false`), and returned `void` so no caller could detect failure. | `core/lib/modulebuilder.lib.php` |
| 8 | `dolReplaceInFile()` was called in plain mode, which runs the **whole descriptor** through `make_substitutions()`. That expands `__(Key)__` and `__[table:class:method:id]__` patterns anywhere in the file, and even instantiates classes to do so. | `core/lib/modulebuilder.lib.php` |
| 9 | Permission labels were concatenated into generated PHP without escaping. `GETPOST(..., 'alpha')` strips the double quote but keeps the single quote, the semicolon, `$` and parentheses, so a label with an apostrophe produced an unparsable descriptor. | `core/lib/modulebuilder.lib.php` |

## Approach

A new `htdocs/modulebuilder/class/` set, following the conventions introduced by #38370
(`NamingContract` / `StrictNamingContractValidator`): no namespace, `.class.php`, explicit
`require_once`, typed parameters and returns.

- **`RightsSyncCommand`** — immutable request. ModuleBuilder's triggers project onto two axes,
  a scope (an object's three CRUD rights, or a single right) and an action, so the five real
  triggers are five named factories with a private constructor.
- **`PermissionsBlock`** — everything touching the raw text of the `BEGIN`/`END MODULEBUILDER
  PERMISSIONS` section: locating it, deciding whether it is safe to rewrite, rendering, writing.
- **`RightsSyncService`** — orchestration, error-first: every reason not to write is collected
  before the rights array is touched, and a single conflict aborts the run without writing.
- **`SyncReport`** — outcome. `conflicts` means nothing was written; `warnings` means the write
  happened and something was normalized.

`reWriteAllPermissions()` keeps its signature and its `1`/`-1` contract — it is a public core
function that external modules may call — and now delegates to the service, so third-party
callers get all nine fixes without touching their code.

### Two behaviours worth reviewing

**Rewriting is refused rather than attempted when the section cannot be reproduced.** A descriptor
that builds its rights dynamically (a loop, a condition on `getDolGlobalString()`, a
`$langs->trans()` label) would be flattened into static lines and its logic silently destroyed.
The block is analysed with `token_get_all()` against a whitelist of what a rewritable section may
contain. Comments are ignored, which is what keeps a brand-new module rewritable: the shipped
template ships its permissions block fully commented out. When the section cannot be rewritten
safely, the user gets a warning naming the offending line and **the file is not touched**.

**The whole section is replaced in a single write.** `dolReplaceInFile()` already writes to a
`.tmp` file and `dol_move()`s it into place, so the write itself was already atomic — the problem
was that there were *two* of them (`deletePerms()` then the insertion), leaving the descriptor
with no permissions block whenever the second failed.

## Note for reviewers

The `id` field of the "add a permission" form is no longer read. It was **already** ignored before
this PR: index 0 is unconditionally recomputed from `$this->numero`, so the value the user typed
was overwritten on every rewrite.

`compareFirstValue()` is removed; ordering is now handled by the renderer. It had no other caller.

## Tests

34 PHPUnit methods in `test/phpunit/ModuleBuilderRightsSyncTest.php`, covering each defect above
plus the cases that make this delicate:

- a brand-new module, whose block is the fully commented-out template, is rewritable;
- a descriptor with a missing marker pair is left byte-for-byte identical;
- a dynamically built block is refused, and the conflict names the offending line;
- labels containing `'`, `\`, `$1` or `\1` survive a full round-trip — written, parsed back by
  PHP, and compared to the original value;
- a `__(Key)__` pattern elsewhere in the descriptor is untouched by a sync;
- a right attached to no object is refused before any write.

Verified end-to-end against the shipped `modulebuilder/template/core/modules/modMyModule.class.php`
over a full lifecycle (create object, second object, custom right, update, delete object): the
content outside the `BEGIN`/`END` markers stays byte-for-byte identical, and the descriptor passes
`php -l` at every step.
