### PR TITLE
FIX Stock movement origin never displayed for objects declared as Class@module/path

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -1058,6 +1058,12 @@ class MouvementStock extends CommonObject
 					$modulename = empty($origin_type_array[1]) ? strtolower($classname) : $origin_type_array[1];
 
 					$result = dol_include_once('/'.$modulename.'/class/'.$classname.'.class.php');
+					if (!$result) {
+						// Dolibarr names its class files in lowercase, so a CamelCase class name gives a path
+						// that does not exist on a case sensitive filesystem. Retry with a lowercase file name
+						// (class names themselves are case insensitive in PHP).
+						$result = dol_include_once('/'.$modulename.'/class/'.strtolower($classname).'.class.php');
+					}
 
 					if ($result) {
 						$classname = ucfirst($classname);

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -1058,13 +1058,9 @@ class MouvementStock extends CommonObject
 					$classname = $origin_type_array[0];
 					$modulename = empty($origin_type_array[1]) ? strtolower($classname) : $origin_type_array[1];
 
-					$result = dol_include_once('/'.$modulename.'/class/'.$classname.'.class.php');
-					if (!$result) {
-						// Dolibarr names its class files in lowercase, so a CamelCase class name gives a path
-						// that does not exist on a case sensitive filesystem. Retry with a lowercase file name
-						// (class names themselves are case insensitive in PHP).
-						$result = dol_include_once('/'.$modulename.'/class/'.strtolower($classname).'.class.php');
-					}
+					// Dolibarr names its class files in lowercase, so use a lowercase file name whatever
+					// the case of the class name (class names themselves are case insensitive in PHP).
+					$result = dol_include_once('/'.$modulename.'/class/'.strtolower($classname).'.class.php');
 
 					if ($result) {
 						$classname = ucfirst($classname);

--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2014	   Cedric GROSS	        <c.gross@kreiz-it.fr>
  * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Problem

`MouvementStock::get_origin()` resolves an origin whose type is not one of its hardcoded cases by including the class file, and it builds the path from the class name exactly as written:

```php
$origin_type_array = explode('@', $origin_type);
$classname = $origin_type_array[0];
$modulename = empty($origin_type_array[1]) ? strtolower($classname) : $origin_type_array[1];

$result = dol_include_once('/'.$modulename.'/class/'.$classname.'.class.php');

if ($result) {
    $classname = ucfirst($classname);   // applied after the path was built
    $origin = new $classname($this->db);
}
```

Dolibarr names its class files in **lowercase**, so a CamelCase class name produces a path that does not exist on a case sensitive filesystem. `dol_include_once()` then returns false (it does a plain `file_exists()`, no case normalisation), `$origin` stays empty and `get_origin()` silently returns an empty string.

## Where it shows

Stock transfers. `StockTransfer::__construct()` sets:

```php
$this->origin_type = 'StockTransfer@product/stock/stocktransfer';
```

and `StockTransferLine::createMouvementStock()` copies it onto the movement, so `origintype` and `fk_origin` **are stored correctly**. But the path built by `get_origin()` is `product/stock/stocktransfer/class/StockTransfer.class.php` while the file on disk is `stocktransfer.class.php`.

Result: the **Origin column of the stock movement list is empty for every stock transfer**, even though the link is present in the database. The same applies to any module declaring its origin with the documented `Class@module/path` syntax and a CamelCase class name.

## Fix

Retry with a lowercase file name when the first include fails.

The original path is still attempted first, so a module that does use a CamelCase file name keeps working. Nothing is stored differently, so **movements already recorded are fixed too** — the origin simply starts resolving.

## How to test

1. Enable the Stock Transfer module, create a transfer between two warehouses and validate it.
2. Go to Products/Services > Stock > Movements.
3. Before: the Origin column is empty for the two movements. After: it shows a link to the stock transfer.

## Note on the target branch

Retargeted to **23.0**: the flawed code is identical in 22.0, 23.0, 24.0 and develop, and fixes on the maintenance branch propagate upward. The branch has been rebased onto 23.0 (same three commits, same diff).
