### PR TITLE
NEW Discriminating default inventory codes for stock corrections and transfers

### DIFF
--- a/htdocs/product/stock/massstockmove.php
+++ b/htdocs/product/stock/massstockmove.php
@@ -780,7 +780,7 @@ if (count($listofdata)) {
 	print '<input type="hidden" name="action" value="createmovements">';
 
 	// Button to record mass movement
-	$codemove = (GETPOSTISSET("codemove") ? GETPOST("codemove", 'alpha') : dol_print_date(dol_now(), '%Y%m%d%H%M%S'));
+	$codemove = (GETPOSTISSET("codemove") ? GETPOST("codemove", 'alpha') : getDolGlobalString('STOCK_MASSSTOCKMOVE_CODE_PREFIX', 'MSM-').dol_print_date(dol_now(), '%Y%m%d%H%M%S'));
 	$labelmovement = GETPOST("label") ? GETPOST('label') : $langs->trans("MassStockTransferShort").' '.dol_print_date($now, '%Y-%m-%d %H:%M');
 
 	print '<div class="center">';

--- a/htdocs/product/stock/massstockmove.php
+++ b/htdocs/product/stock/massstockmove.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2014	    Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/stock/tpl/stockcorrection.tpl.php
+++ b/htdocs/product/stock/tpl/stockcorrection.tpl.php
@@ -265,7 +265,8 @@ print '<input type="text" name="label" class="minwidth400" value="'.dol_escape_h
 print '</td>';
 print '<td>'.$langs->trans("InventoryCode").'</td>';
 print '<td>';
-print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventorycode" value="'.(GETPOSTISSET("inventorycode") ? GETPOST("inventorycode", 'alpha') : dol_print_date(dol_now(), '%Y%m%d%H%M%S')).'">';
+// Prefix the default inventory code so corrections can be told apart from other movement batches
+print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventorycode" value="'.(GETPOSTISSET("inventorycode") ? GETPOST("inventorycode", 'alpha') : getDolGlobalString('STOCK_CORRECTION_CODE_PREFIX', 'COR-').dol_print_date(dol_now(), '%Y%m%d%H%M%S')).'">';
 print '</td>';
 print '</tr>';
 

--- a/htdocs/product/stock/tpl/stockcorrection.tpl.php
+++ b/htdocs/product/stock/tpl/stockcorrection.tpl.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2010-2017  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/stock/tpl/stocktransfer.tpl.php
+++ b/htdocs/product/stock/tpl/stocktransfer.tpl.php
@@ -154,7 +154,8 @@ print '<input type="text" name="label" class="minwidth300" value="'.dol_escape_h
 print '</td>';
 print '<td>'.$langs->trans("InventoryCode").'</td>';
 print '<td>';
-print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventorycode" value="'.(GETPOSTISSET("inventorycode") ? GETPOST("inventorycode", 'alpha') : dol_print_date(dol_now(), '%Y%m%d%H%M%S')).'">';
+// Prefix the default inventory code so transfers can be told apart from other movement batches
+print '<input class="maxwidth100onsmartphone" name="inventorycode" id="inventorycode" value="'.(GETPOSTISSET("inventorycode") ? GETPOST("inventorycode", 'alpha') : getDolGlobalString('STOCK_TRANSFER_CODE_PREFIX', 'TRA-').dol_print_date(dol_now(), '%Y%m%d%H%M%S')).'">';
 print '</td>';
 print '</tr>';
 

--- a/htdocs/product/stock/tpl/stocktransfer.tpl.php
+++ b/htdocs/product/stock/tpl/stocktransfer.tpl.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2010-2017  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Problem

The three manual stock screens all prefill their inventory code with the same bare timestamp (`%Y%m%d%H%M%S`):

| Screen | File | Prefilled code |
|---|---|---|
| Stock correction | `product/stock/tpl/stockcorrection.tpl.php` | `20260828113045` |
| Stock transfer (product card / movement list) | `product/stock/tpl/stocktransfer.tpl.php` | `20260828113045` |
| Mass stock transfer | `product/stock/massstockmove.php` | `20260828113045` |

The inventory code correctly **groups** each batch of movements, but it does not say **what** the batch is. Once recorded, there is no way to answer "show me every manual stock correction" from the movement list: corrections, transfers and mass transfers all look alike, and none of them carries an origin document either.

The Inventory module already solved this for itself by stamping `INV-<ref>`, and the SOAP endpoint stamps `WS<timestamp>`. Only the three manual screens produce anonymous codes.

## What this PR does

Prefixes the **prefilled default** by screen, following that existing idiom:

- stock correction → `COR-<timestamp>` (constant `STOCK_CORRECTION_CODE_PREFIX`)
- stock transfer → `TRA-<timestamp>` (constant `STOCK_TRANSFER_CODE_PREFIX`)
- mass stock transfer → `MSM-<timestamp>` (constant `STOCK_MASSSTOCKMOVE_CODE_PREFIX`)

Filtering the movement list on `COR` (the *Inventory code* filter already exists) then returns every manual correction.

## Notes

- The code remains a plain editable input: a user who types their own code is unaffected — only the **default** changes.
- The three hidden constants let anyone change or empty the prefixes without touching code.
- 3 files, +5/−3, no schema change, no behaviour change beyond the prefilled string.
