### PR TITLE
FIX #39396 - Reject enclosing leave requests

### DIFF
--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -1235,6 +1235,11 @@ class Holiday extends CommonObject
 			//var_dump("old: ".dol_print_date($infos_CP['date_debut'],'dayhour').' '.dol_print_date($infos_CP['date_fin'],'dayhour').' '.$infos_CP['halfday']);
 			//var_dump("new: ".dol_print_date($dateStart,'dayhour').' '.dol_print_date($dateEnd,'dayhour').' '.$halfday);
 
+			// A new leave can fully contain an existing leave, so neither endpoint is inside the existing range.
+			if ($dateStart < $infos_CP['date_debut'] && $dateEnd > $infos_CP['date_fin']) {
+				return false;
+			}
+
 			if ($halfday == 0) {
 				if ($dateStart >= $infos_CP['date_debut'] && $dateStart <= $infos_CP['date_fin']) {
 					return false;

--- a/test/phpunit/HolidayTest.php
+++ b/test/phpunit/HolidayTest.php
@@ -278,6 +278,13 @@ class HolidayTest extends CommonClassTest
 
 		$result = $localobjectc->verifDateHolidayCP($user->id, $date_debut, $date_fin, 2);	// start afternoon and end morning
 		$this->assertTrue($result, 'result should be true, there is no overlapping');
+
+		$date_start_enclosing = dol_mktime(0, 0, 0, 12, 31, 2019);
+		$date_end_enclosing = dol_mktime(0, 0, 0, 1, 3, 2020);
+		foreach (array(0, -1, 1, 2) as $halfday) {
+			$result = $localobjectc->verifDateHolidayCP($user->id, $date_start_enclosing, $date_end_enclosing, $halfday);
+			$this->assertFalse($result, 'result should be false, an enclosing leave overlaps existing leave requests.');
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- reject leave requests that completely enclose an existing request
- cover the full-day and all valid half-day forms

## Tests
- `git diff --check`
- `php -l htdocs/holiday/class/holiday.class.php`
- `php -l test/phpunit/HolidayTest.php`
- standalone overlap regression proof for halfday `0`, `-1`, `1`, and `2`

Fixes #39396