### PR TITLE
NEW Inventory card Documents generation - ModuleBuilder scaffolding

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3675,6 +3675,17 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 		if (isModEnabled('stock')) {
 			$original_file = $conf->stock->multidir_output[$entity].'/movement/'.$original_file;
 		}
+	} elseif ($modulepart == 'inventory') {
+		// Wrapping for stock inventories
+		if (empty($entity) || empty($conf->stock->multidir_output[$entity])) {
+			return array('accessallowed' => 0, 'error' => 'Value entity must be provided');
+		}
+		if ($fuser->hasRight('stock', $lire) || preg_match('/^specimen/i', $original_file)) {
+			$accessallowed = 1;
+		}
+		if (isModEnabled('stock')) {
+			$original_file = $conf->stock->multidir_output[$entity].'/inventory/'.$original_file;
+		}
 	} elseif ($modulepart == 'entrepot') {
 		// Wrapping for stock warehouse
 		if (empty($entity) || empty($conf->stock->multidir_output[$entity])) {

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2023       Lenin Rivas         <lenin.rivas777@gmail.com>
  * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		William Mead		<william@m34d.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/core/modules/inventory/modules_inventory.php
+++ b/htdocs/core/modules/inventory/modules_inventory.php
@@ -1,0 +1,91 @@
+<?php
+/* Copyright (C) 2026	Jose MARTINEZ	<jose.martinez@pichinov.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *  \file			htdocs/core/modules/inventory/modules_inventory.php
+ *  \ingroup		stock
+ *  \brief			File that contains parent class for inventory document models and parent class for inventory numbering models
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/class/commondocgenerator.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/commonnumrefgenerator.class.php';
+
+
+/**
+ *	Parent class for documents models
+ */
+abstract class ModelePDFInventory extends CommonDocGenerator
+{
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *  Return list of active generation modules
+	 *
+	 *  @param  DoliDB  	$db                 Database handler
+	 *  @param  int<0,max>	$maxfilenamelength  Max length of value to show
+	 *  @return string[]|int<-1,0>				List of templates
+	 */
+	public static function liste_modeles($db, $maxfilenamelength = 0)
+	{
+		// phpcs:enable
+		$type = 'inventory';
+		$list = array();
+
+		include_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
+		$list = getListOfModels($db, $type, $maxfilenamelength);
+
+		return $list;
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *	Function to build document onto disk
+	 *
+	 *	@param		Inventory		$object				Object Inventory to generate
+	 *	@param		Translate		$outputlangs		Lang output object
+	 *  @param		string			$srctemplatepath	Full path of source filename for generator using a template file
+	 *  @param		int<0,1>		$hidedetails		Do not show line details
+	 *  @param		int<0,1>		$hidedesc			Do not show desc
+	 *  @param		int<0,1>		$hideref			Do not show ref
+	 *  @return     int<-1,1>      	    				1=OK, 0=KO
+	 */
+	abstract public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0);
+	// phpcs:enable
+}
+
+
+
+/**
+ *  Parent class to manage numbering of Inventory
+ */
+abstract class ModeleNumRefInventory extends CommonNumRefGenerator
+{
+	/**
+	 * 	Return next free value
+	 *
+	 *  @param  Inventory	$object		Object we need next value for
+	 *  @return string|int<-1,0>		Value if OK, 0 if KO
+	 */
+	abstract public function getNextValue($object);
+
+	/**
+	 *  Return an example of numbering
+	 *
+	 *  @return     string      Example
+	 */
+	abstract public function getExample();
+}

--- a/htdocs/product/inventory/card.php
+++ b/htdocs/product/inventory/card.php
@@ -65,7 +65,6 @@ if (!getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
 $object = new Inventory($db);
 $extrafields = new ExtraFields($db);
 // no inventory docs yet
-$includedocgeneration = false;
 $diroutputmassaction = null;
 // $diroutputmassaction = $conf->stock->dir_output.'/temp/massgeneration/'.$user->id;
 
@@ -93,7 +92,6 @@ include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'inclu
 // Security check - Protection if external user
 //if ($user->socid > 0) accessforbidden();
 //if ($user->socid > 0) $socid = $user->socid;
-//restrictedArea($user, 'mymodule', $id);
 
 if (!getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
 	$permissiontoread = $user->hasRight('stock', 'lire');
@@ -457,15 +455,13 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		print '<a name="builddoc"></a>'; // ancre
 
 		// Documents
-		if ($includedocgeneration) {
-			$objref = dol_sanitizeFileName($object->ref);
-			$relativepath = $objref.'/'.$objref.'.pdf';
-			$filedir = $conf->mymodule->dir_output.'/'.$object->element.'/'.$objref;
-			$urlsource = $_SERVER["PHP_SELF"]."?id=".$object->id;
-			$genallowed = $user->hasRight('mymodule', 'myobject', 'read'); // If you can read, you can build the PDF to read content
-			$delallowed = $user->hasRight('mymodule', 'myobject', 'write'); // If you can create/edit, you can remove a file on card
-			print $formfile->showdocuments('mymodule:MyObject', $object->element.'/'.$objref, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 28, 0, '', '', '', $langs->defaultlang);
-		}
+		$objref = dol_sanitizeFileName($object->ref);
+		$relativepath = $objref.'/'.$objref.'.pdf';
+		$filedir = $conf->stock->multidir_output[$conf->entity].'/inventory/'.$objref;
+		$urlsource = $_SERVER["PHP_SELF"]."?id=".$object->id;
+		$genallowed = $user->hasRight('stock', 'lire'); // If you can read, you can build the PDF to read content
+		$delallowed = $user->hasRight('stock', 'creer'); // If you can create/edit, you can remove a file on card
+		print $formfile->showdocuments('inventory:Inventory', $objref, $filedir, $urlsource, $genallowed, $delallowed, $object->model_pdf, 1, 0, 0, 28, 0, '', '', '', $langs->defaultlang, '', $object);
 
 		// Show links to link elements
 		$tmparray = $form->showLinkToObjectBlock($object, array(), array('inventory'), 1);

--- a/htdocs/product/inventory/card.php
+++ b/htdocs/product/inventory/card.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2007-2017 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2015       Raphaël Doursenaud  <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/inventory/class/inventory.class.php
+++ b/htdocs/product/inventory/class/inventory.class.php
@@ -775,6 +775,42 @@ class Inventory extends CommonObject
 			return -1;
 		}
 	}
+
+	/**
+	 *  Create a document onto disk according to template module.
+	 *
+	 *  @param	string		$modele			Force template to use ('' to not force)
+	 *  @param	Translate	$outputlangs	Object lang to use for translations
+	 *  @param  int<0,1>	$hidedetails    Hide details of lines
+	 *  @param  int<0,1>	$hidedesc       Hide description
+	 *  @param  int<0,1>	$hideref        Hide ref
+	 *  @param  ?array<string,mixed>	$moreparams		Array to provide more information
+	 *  @return int<-1,1>				0 if KO, 1 if OK
+	 */
+	public function generateDocument($modele, $outputlangs, $hidedetails = 0, $hidedesc = 0, $hideref = 0, $moreparams = null)
+	{
+		global $langs;
+
+		$langs->load("stocks");
+
+		if (!dol_strlen($modele)) {
+			$modele = ''; // Remove this once a pdf_standard.php exists.
+
+			if ($this->model_pdf) {
+				$modele = $this->model_pdf;
+			} elseif (getDolGlobalString('INVENTORY_ADDON_PDF')) {
+				$modele = getDolGlobalString('INVENTORY_ADDON_PDF');
+			}
+		}
+
+		$modelpath = "core/modules/inventory/doc/";
+
+		if (empty($modele)) {
+			return 1; // Remove this once a pdf_standard.php exists.
+		}
+
+		return $this->commonGenerateDocument($modelpath, $modele, $outputlangs, $hidedetails, $hidedesc, $hideref, $moreparams);
+	}
 }
 
 /**

--- a/htdocs/product/inventory/inventory_document.php
+++ b/htdocs/product/inventory/inventory_document.php
@@ -1,0 +1,159 @@
+<?php
+/* Copyright (C) 2026	Jose MARTINEZ	<jose.martinez@pichinov.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ *  \file       htdocs/product/inventory/inventory_document.php
+ *  \ingroup    stock
+ *  \brief      Tab for documents linked to an inventory
+ */
+
+// Load Dolibarr environment
+require '../../main.inc.php';
+/**
+ * @var Conf $conf
+ * @var DoliDB $db
+ * @var ExtraFields $extrafields
+ * @var HookManager $hookmanager
+ * @var Translate $langs
+ * @var User $user
+ */
+require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/images.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.formfile.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/inventory/class/inventory.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/inventory/lib/inventory.lib.php';
+
+// Load translation files required by the page
+$langs->loadLangs(array("stocks", "other", "mails"));
+
+$action = GETPOST('action', 'aZ09');
+$confirm = GETPOST('confirm');
+$id = GETPOSTINT('id');
+$ref = GETPOST('ref', 'alpha');
+
+// Get parameters
+$limit = GETPOSTINT('limit') ? GETPOSTINT('limit') : $conf->liste_limit;
+$sortfield = GETPOST('sortfield', 'aZ09comma');
+$sortorder = GETPOST('sortorder', 'aZ09comma');
+$page = GETPOSTISSET('pageplusone') ? (GETPOSTINT('pageplusone') - 1) : GETPOSTINT("page");
+if (empty($page) || $page == -1) {
+	$page = 0;
+}     // If $page is not defined, or '' or -1
+$offset = $limit * $page;
+$pageprev = $page - 1;
+$pagenext = $page + 1;
+if (!$sortorder) {
+	$sortorder = "ASC";
+}
+if (!$sortfield) {
+	$sortfield = "name";
+}
+
+// Initialize a technical objects
+$object = new Inventory($db);
+$hookmanager->initHooks(array('inventorydocument', 'globalcard')); // Note that conf->hooks_modules contains array
+
+// Fetch optionals attributes and labels
+$extrafields->fetch_name_optionals_label($object->table_element);
+
+// Load object
+include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'include', not 'include_once'. Include fetch and fetch_thirdparty but not fetch_optionals
+
+$upload_dir = null;
+if ($id > 0 || !empty($ref)) {
+	$upload_dir = $conf->stock->multidir_output[$object->entity ? $object->entity : $conf->entity].'/inventory/'.dol_sanitizeFileName((string) $object->ref);
+}
+
+// Security check
+if ($user->socid > 0) {
+	accessforbidden();
+}
+$result = restrictedArea($user, 'stock', $object->id, 'inventory&stock');
+
+$permissiontoadd = $user->hasRight('stock', 'creer'); // Used by the include of actions_linkedfiles.inc.php
+
+
+/*
+ * Actions
+ */
+
+include DOL_DOCUMENT_ROOT.'/core/actions_linkedfiles.inc.php';
+
+
+/*
+ * View
+ */
+
+$form = new Form($db);
+
+$title = $langs->trans("Inventory").' - '.$langs->trans("Files");
+$help_url = 'EN:Module_Stocks_En|FR:Module_Stock|DE:Modul_Lager';
+
+llxHeader('', $title, $help_url, '', 0, 0, '', '', '', 'mod-product page-inventory_document');
+
+if ($object->id && $upload_dir !== null) {
+	/*
+	 * Show tabs
+	 */
+	$head = inventoryPrepareHead($object);
+
+	print dol_get_fiche_head($head, 'document', $langs->trans("Inventory"), -1, 'stock');
+
+	// Build file list
+	$filearray = dol_dir_list($upload_dir, "files", 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ? SORT_DESC : SORT_ASC), 1);
+	$totalsize = 0;
+	foreach ($filearray as $key => $file) {
+		$totalsize += $file['size'];
+	}
+
+	// Object card
+	// ------------------------------------------------------------
+	$linkback = '<a href="'.dol_buildpath('/product/inventory/list.php', 1).'?restore_lastsearch_values=1">'.$langs->trans("BackToList").'</a>';
+
+	dol_banner_tab($object, 'ref', $linkback, 1, 'ref', 'ref');
+
+	print '<div class="fichecenter">';
+
+	print '<div class="underbanner clearboth"></div>';
+	print '<table class="border centpercent tableforfield">';
+
+	// Number of files
+	print '<tr><td class="titlefield">'.$langs->trans("NbOfAttachedFiles").'</td><td colspan="3">'.count($filearray).'</td></tr>';
+
+	// Total size
+	print '<tr><td>'.$langs->trans("TotalSizeOfAttachedFiles").'</td><td colspan="3">'.$totalsize.' '.$langs->trans("bytes").'</td></tr>';
+
+	print '</table>';
+
+	print '</div>';
+
+	print dol_get_fiche_end();
+
+	$modulepart = 'inventory';
+	$permtoedit = $user->hasRight('stock', 'creer');
+	$param = '&id='.$object->id;
+
+	$relativepathwithnofile = dol_sanitizeFileName((string) $object->ref).'/';
+
+	include DOL_DOCUMENT_ROOT.'/core/tpl/document_actions_post_headers.tpl.php';
+} else {
+	accessforbidden('', 0, 1);
+}
+
+// End of page
+llxFooter();
+$db->close();

--- a/htdocs/product/inventory/lib/inventory.lib.php
+++ b/htdocs/product/inventory/lib/inventory.lib.php
@@ -78,6 +78,17 @@ function inventoryPrepareHead(&$inventory, $title = 'Inventory', $get = '')
 
 	$h = 2;
 
+	require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
+	$upload_dir = $conf->stock->multidir_output[$inventory->entity ? $inventory->entity : $conf->entity].'/inventory/'.dol_sanitizeFileName((string) $inventory->ref);
+	$nbFiles = count(dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));
+	$head[$h][0] = dol_buildpath('/product/inventory/inventory_document.php?id='.$inventory->id.$get, 1);
+	$head[$h][1] = $langs->trans('Documents');
+	if ($nbFiles > 0) {
+		$head[$h][1] .= '<span class="badge marginleftonlyshort">'.$nbFiles.'</span>';
+	}
+	$head[$h][2] = 'document';
+	$h++;
+
 	complete_head_from_modules($conf, $langs, $inventory, $head, $h, 'inventory');
 	complete_head_from_modules($conf, $langs, $inventory, $head, $h, 'inventory', 'remove');
 

--- a/htdocs/product/inventory/lib/inventory.lib.php
+++ b/htdocs/product/inventory/lib/inventory.lib.php
@@ -2,6 +2,7 @@
 /* <one line to give the program's name and a brief idea of what it does.>
  * Copyright (C) 2015 ATM Consulting <support@atm-consulting.fr>
  * Copyright (C) 2024		MDW				<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Problem

The Documents section of the inventory card (`product/inventory/card.php`) shipped as raw ModuleBuilder scaffolding, never adapted to the object, and disabled:

```php
$includedocgeneration = false;
...
$filedir = $conf->mymodule->dir_output.'/'.$object->element.'/'.$objref;
$genallowed = $user->hasRight('mymodule', 'myobject', 'read');
print $formfile->showdocuments('mymodule:MyObject', ...);
```

Inventory is thus the only stock document with no working Documents box: there is no way to attach a signed count sheet to an inventory, and no plug point for a future PDF model — while stock movements (`pdf_standard_movementstock`), warehouses (`pdf_standard_stock`) and stock transfers (`pdf_eagle`) all have one, and stock transfers also have numbering models. Inventory also had **no Documents tab at all**, so nothing could be attached either.

## What this PR does — wiring only, following existing core patterns

| Change | Modeled on |
|---|---|
| `card.php`: enable the section, `stock` lire/creer permissions, files under `<stock>/inventory/<ref>`, modulepart `inventory:Inventory` | the MO card documents block |
| **New** `inventory_document.php`: Documents tab so files can actually be attached, + tab entry with file-count badge in `inventory.lib.php` | `mrp/mo_document.php` |
| **New** `core/modules/inventory/modules_inventory.php`: parent classes `ModelePDFInventory` **and** `ModeleNumRefInventory` | `modules_stocktransfer.php` (same file bundles both parents) |
| `inventory.class.php`: minimal `generateDocument()` — returns 1 while no model exists, constant `INVENTORY_ADDON_PDF` | `Mo::generateDocument()`, including its "Remove this once a pdf_standard.php exists" pattern |
| `files.lib.php`: `inventory` download wrapping (stock read permission) | the `movement` wrapping just above it |

The parent classes file is required (the generic branch of `showdocuments()` calls `ModelePDF<Object>::liste_modeles()` and errors if the class is missing) and deliberately includes the numbering parent as well, exactly like stocktransfer's, so numbering models can follow.

## Behaviour change

The Documents box appears on the inventory card and works for **attachments** (e.g. the signed paper count sheet). PDF generation stays inactive until a `pdf_standard_inventory` exists — planned as a follow-up NEW PR, along with numbering models (free / single counter / masks).

6 files, +313/−6, no schema change.
