### PR TITLE
NEW Enter multiple serial numbers at once on supplier order / reception dispatch

### DIFF
--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -1031,6 +1031,10 @@ if ($id > 0 || !empty($ref)) {
 						if (isModEnabled('productbatch') && $objp->tobatch > 0) {
 							$type = 'batch';
 							print img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" onClick="addDispatchLine('.$i.', \''.$type.'\')"');
+							if ($objp->tobatch == 2) {
+								// Product managed with unique serial numbers: allow to enter several serial numbers at once (one line per serial)
+								print img_picto($langs->trans('EnterMultipleSerialNumbers'), 'barcode', 'class="splitbutton marginleftonly" onClick="addDispatchLinesFromSerialList('.$i.', \''.$type.'\')"');
+							}
 						} else {
 							$type = 'dispatch';
 							print img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" onClick="addDispatchLine('.$i.', \''.$type.'\')"');

--- a/htdocs/fourn/js/lib_dispatch.js.php
+++ b/htdocs/fourn/js/lib_dispatch.js.php
@@ -46,6 +46,12 @@ if (!defined('NOREQUIREAJAX')) {
 session_cache_limiter('public');
 
 require_once '../../main.inc.php';
+/**
+ * @var Translate $langs
+ */
+
+// Load translation files required by the page
+$langs->loadLangs(array("productbatch"));
 
 // Define javascript type
 top_httphead('text/javascript; charset=UTF-8');
@@ -60,9 +66,11 @@ header('Cache-Control: max-age=10800, public, must-revalidate');
  * @param	index	int		index of product line. 0 = first product line
  * @param	type	string	type of dispatch ('batch' = batch dispatch, 'dispatch' = non batch dispatch)
  * @param	mode	string	'qtymissing' will create new line with qty missing, 'lessone' will keep 1 in old line and the rest in new one
+ * @param	lotnumber	string	If set, the new line is created with this lot/serial number and qty 1, and the qty of the previous line is kept unchanged
  */
-function addDispatchLine(index, type, mode) {
+function addDispatchLine(index, type, mode, lotnumber) {
 	mode = mode || 'qtymissing'
+	lotnumber = lotnumber || ''
 
 	console.log("fourn/js/lib_dispatch.js.php addDispatchLine Split line type="+type+" index="+index+" mode="+mode);
 
@@ -87,19 +95,21 @@ function addDispatchLine(index, type, mode) {
 	else {
 		qtyDispatched = parseFloat($("#qty_dispatched_0_" + index).val()) + qty;
 		// If user did not reduced the qty to dispatch on old line, we keep only 1 on old line and the rest on new line
-		if (qtyDispatched == qtyOrdered && qtyDispatched > 1) {
+		if (lotnumber === '' && qtyDispatched == qtyOrdered && qtyDispatched > 1) {
 			qtyDispatched = parseFloat($("#qty_dispatched_0_" + index).val()) + 1;
 			mode = 'lessone';
 		}
 	}
 	console.log("qtyDispatched=" + qtyDispatched + " qtyOrdered=" + qtyOrdered+ " qty=" + qty);
 
-	if (qty <= 1) {
+	if (qty <= 1 && lotnumber === '') {
 		window.alert("Remain quantity to dispatch is too low to be split");
 	} else {
 		var oldlineqty = qtyDispatched;
 		var newlineqty = qtyOrdered - qtyDispatched;
-		if (newlineqty <= 0) {
+		if (lotnumber !== '') {
+			newlineqty = 1;		// One serial number = one unit, previous line is kept unchanged
+		} else if (newlineqty <= 0) {
 			newlineqty = qty - 1;
 			oldlineqty = 1;
 			$("#qty_"+(nbrTrs - 1)+"_"+index).val(oldlineqty);
@@ -177,11 +187,87 @@ function addDispatchLine(index, type, mode) {
 		$("#lot_number_" + (nbrTrs) + "_" + index).focus();
 		//Clean bad values
 		$("tr[name^='" + type + "_'][name$='_" + index + "']:last").data("remove", "remove");
-		$("#lot_number_" + (nbrTrs) + "_" + index).val("")
+		$("#lot_number_" + (nbrTrs) + "_" + index).val(lotnumber)
 		$("#idline_" + (nbrTrs) + "_" + index).val("-1")
 		$("#qty_" + (nbrTrs) + "_" + index).data('expected', "0");
 		$("#lot_number_" + (nbrTrs) + "_" + index).removeAttr("disabled");
 	}
+}
+
+/**
+ * addDispatchLinesFromSerialList
+ * Open a dialog to enter several unique serial numbers at once (typed, pasted or scanned, one per line),
+ * then create one dispatch line with qty 1 for each of them using addDispatchLine().
+ * If the last line of the product is still empty, it is used for the first serial number.
+ *
+ * @param	index	int		index of product line. 0 = first product line
+ * @param	type	string	type of dispatch (always 'batch' for a product with unique serial numbers)
+ */
+function addDispatchLinesFromSerialList(index, type) {
+	console.log("fourn/js/lib_dispatch.js.php addDispatchLinesFromSerialList type="+type+" index="+index);
+
+	var $dialog = jQuery("#dialogforpopup");
+	var html = '<textarea id="seriallist" class="centpercent" rows="10" placeholder="<?php echo dol_escape_js(dol_escape_htmltag($langs->transnoentitiesnoconv("EnterOneSerialNumberPerLine"))); ?>"></textarea>';
+	html += '<div id="seriallistmessage" class="opacitymedium paddingtop"></div>';
+	$dialog.html(html);
+
+	// Return the list of non empty trimmed lines
+	var getSerialList = function() {
+		return jQuery("#seriallist").val().split(/\r\n|\r|\n/).map(function(s) { return s.trim(); }).filter(function(s) { return s !== ''; });
+	};
+
+	jQuery("#seriallist").on("input", function() {
+		jQuery("#seriallistmessage").removeClass("error").text('<?php echo dol_escape_js($langs->transnoentitiesnoconv("NbOfSerialNumbersDetected", "%s")); ?>'.replace('%s', getSerialList().length));
+	});
+
+	$dialog.dialog({
+		title: '<?php echo dol_escape_js($langs->transnoentitiesnoconv("EnterMultipleSerialNumbers")); ?>',
+		modal: true,
+		resizable: false,
+		width: 'auto',
+		buttons: [
+			{
+				text: '<?php echo dol_escape_js($langs->transnoentitiesnoconv("Apply")); ?>',
+				click: function() {
+					var serials = getSerialList();
+					if (serials.length == 0) {
+						return;
+					}
+					// Cheap early check of duplicates inside the list. Uniqueness in stock is still checked by MouvementStock.
+					var seen = {};
+					for (var n = 0; n < serials.length; n++) {
+						if (seen[serials[n]]) {
+							jQuery("#seriallistmessage").addClass("error").text('<?php echo dol_escape_js($langs->transnoentitiesnoconv("ErrorDuplicateSerialNumberInList", "%s")); ?>'.replace('%s', serials[n]));
+							return;
+						}
+						seen[serials[n]] = true;
+					}
+
+					var nbrTrs = $("tr[name^='"+type+"_'][name$='_"+index+"']").length;
+					var $lastlot = $("#lot_number_"+(nbrTrs - 1)+"_"+index);
+					var k = 0;
+					// Reuse the last line if it is still empty (not a saved line and no lot/serial entered yet)
+					if (!$lastlot.prop('disabled') && $lastlot.val().trim() === '') {
+						$lastlot.val(serials[0]);
+						$("#qty_"+(nbrTrs - 1)+"_"+index).val(1);
+						k = 1;
+					}
+					for (; k < serials.length; k++) {
+						addDispatchLine(index, type, 'qtymissing', serials[k]);
+					}
+
+					jQuery(this).dialog("close");
+				}
+			},
+			{
+				text: '<?php echo dol_escape_js($langs->transnoentitiesnoconv("Cancel")); ?>',
+				click: function() {
+					jQuery(this).dialog("close");
+				}
+			}
+		]
+	});
+	jQuery("#seriallist").focus();
 }
 
 /**

--- a/htdocs/langs/en_US/productbatch.lang
+++ b/htdocs/langs/en_US/productbatch.lang
@@ -53,3 +53,7 @@ IlligalQtyForSerialNumbers= Stock correction required because unique serial numb
 ErrorBatchesNeedStockManagement=Error. A product with batch/lot management must also be managed in stock.
 ForceBatchesNeedStockManagement=A product with batch/lot management must be managed in stock (stock management force to yes)
 BatchInformationNotfound=Batch information not found
+EnterMultipleSerialNumbers=Enter multiple serial numbers
+EnterOneSerialNumberPerLine=Type, paste or scan the serial numbers, one per line
+NbOfSerialNumbersDetected=%s serial number(s) detected
+ErrorDuplicateSerialNumberInList=Serial number %s is present several times in the list

--- a/htdocs/reception/dispatch.php
+++ b/htdocs/reception/dispatch.php
@@ -824,6 +824,10 @@ if ($id > 0 || !empty($ref)) {
 								if (isModEnabled('productbatch') && $objp->tobatch > 0) {
 									$type = 'batch';
 									print img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" '.($numd != $j + 1 ? 'style="display:none"' : '').' onClick="addDispatchLine('.$i.', \''.$type.'\')"');
+									if ($objp->tobatch == 2) {
+										// Product managed with unique serial numbers: allow to enter several serial numbers at once (one line per serial)
+										print img_picto($langs->trans('EnterMultipleSerialNumbers'), 'barcode', 'class="splitbutton marginleftonly" '.($numd != $j + 1 ? 'style="display:none"' : '').' onClick="addDispatchLinesFromSerialList('.$i.', \''.$type.'\')"');
+									}
 								} else {
 									$type = 'dispatch';
 									print img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" '.($numd != $j + 1 ? 'style="display:none"' : '').' onClick="addDispatchLine('.$i.', \''.$type.'\')"');
@@ -997,6 +1001,10 @@ if ($id > 0 || !empty($ref)) {
 							if (isModEnabled('productbatch') && $objp->tobatch > 0) {
 								$type = 'batch';
 								print img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" onClick="addDispatchLine('.$i.', \''.$type.'\')"');
+								if ($objp->tobatch == 2) {
+									// Product managed with unique serial numbers: allow to enter several serial numbers at once (one line per serial)
+									print img_picto($langs->trans('EnterMultipleSerialNumbers'), 'barcode', 'class="splitbutton marginleftonly" onClick="addDispatchLinesFromSerialList('.$i.', \''.$type.'\')"');
+								}
 							} else {
 								$type = 'dispatch';
 								print img_picto($langs->trans('AddStockLocationLine'), 'split', 'class="splitbutton" onClick="addDispatchLine('.$i.', \''.$type.'\')"');


### PR DESCRIPTION
# NEW Enter multiple serial numbers at once on supplier order / reception dispatch

Related to #18229 and #23957 (both ask for a faster way to enter several lot/serial numbers when receiving a supplier order). This PR intentionally covers the narrower, unambiguous case: **products managed with unique serial numbers** (`tobatch = 2`), where one serial always means one unit.

## Why

Receiving a supplier order that contains products managed with unique serial numbers (e.g. 20 devices, each with its own serial) currently means splitting the line 20 times and typing each serial in its own row. Users at our company asked for a faster way (they typically have the serials in a delivery note or scan them one after the other), and the same need has been raised several times upstream (#18229 in 2021 — closed by the stale bot without implementation, #23957, older PRs #16975 / #19571). A contributor on #18229 suggested adapting the inventory bulk-scan idea to receptions: this PR does that in the smallest possible form, reusing the existing split-row mechanism instead of adding a new entry screen.

## What it does

On the "Item receipts" tab of a supplier order (`fourn/commande/dispatch.php`) and on the draft reception dispatch page (`reception/dispatch.php`), a new picto is shown next to the existing "split line" picto, only for products configured with *unique serial number* management:

- click it → a small dialog opens with a textarea: **one serial number per line** (typed, pasted, or scanned — a barcode scanner sends `SERIAL` + `ENTER`);
- the number of detected serials is shown live; duplicates inside the list are refused;
- **Apply** creates the same rows the user would create manually with the split button: one row per serial, qty 1, warehouse inherited from the previous row. If the current last row is still empty, it is used for the first serial.

The user then reviews the rows and submits the form as usual.

## What it does NOT do

This change adds a bulk-input convenience for unique serial-number products. The entered serials are converted into the same dispatch/reception rows already created by the existing manual split-row workflow (`addDispatchLine()`). Existing reception persistence (`ReceptionLineBatch`), stock movements (`MouvementStock`) and the unique-serial validation (`TooManyQtyForSerialNumber`) remain unchanged and stay authoritative.

- no database change
- no new configuration constant (gated by the product's own "unique serial number" setting)
- no external dependency (jQuery UI dialog already used by `#dialogforpopup`)
- no new server-side code, no new endpoint: the textarea lives in the dialog and is not posted; only the usual `product_batch_<j>_<i>` / `lot_number_<j>_<i>` / `qty_<j>_<i>` / `entrepot_<j>_<i>` fields reach the server
- no new stock logic, no new serial model
- regular lot products (`tobatch = 1`) and products without lot management are untouched: the picto is not displayed, the split button behaves exactly as before
- manual entry (one row, one serial) still works exactly as before
- serials containing `,` `;` `|` are kept as-is (no splitting on punctuation): only line breaks (LF / CRLF) separate serials, blank lines are ignored, values are trimmed like `ReceptionLineBatch` does

## Why a dialog and not `FormOther::getHTMLScannerForm()`

The inventory/shipment scanner panel is page-level: it needs a page reload (`action=updatebyscaning`), which would drop unsaved split rows, relies on an inventory-specific AJAX barcode lookup, and cannot target one order line. Here the need is per line ("these N serials belong to this product line"), so a small jQuery UI dialog on the already existing `#dialogforpopup` container, calling the existing `addDispatchLine()`, keeps the change local and the diff small (4 files, ~100 lines, no server-side code).

## Screenshots

Dialog opened from the new picto on a unique-serial product line:

![bulk serial dialog](https://raw.githubusercontent.com/guiltekmdion/dolibarr/screenshots-bulk-serial/dolibarr_bulk_serial_dialog.png)

Result after Apply: one native row per serial, qty 1, warehouse inherited (lot and non-batch lines unchanged):

![generated rows](https://raw.githubusercontent.com/guiltekmdion/dolibarr/screenshots-bulk-serial/dolibarr_bulk_serial_result.png)

## Implementation

- `htdocs/fourn/js/lib_dispatch.js.php`: `addDispatchLine()` gets an optional 4th argument `lotnumber`; when set, the cloned row is initialised with that lot/serial and qty 1 and the previous row quantity is left unchanged (all existing callers pass 3 arguments and are unaffected). New function `addDispatchLinesFromSerialList(index, type)` opens the dialog and calls `addDispatchLine()` once per serial.
- `htdocs/fourn/commande/dispatch.php`, `htdocs/reception/dispatch.php`: display the picto when `$objp->tobatch == 2`.
- `htdocs/langs/en_US/productbatch.lang`: 4 new keys.

## Tested

Local instance (develop, PHP 8.4, MySQL 5.7), product with unique serial numbers, supplier order of 10 units:
1. Item receipts → picto → pasted `SER0001`, blank line, ` SER0002 ` (CRLF), `SER0003`, `ABC,123`, `DEF;456` → "5 serial number(s) detected" → Apply → 5 rows qty 1 / Warehouse A → Create reception → Validate: 5 `receptiondet_batch` rows, 5 stock movements, 5 `product_lot`, stock 5, order "partially received".
2. Pasting `SER0001 / SER0002 / SER0001` is refused with "Serial number SER0001 is present several times in the list".
3. Second reception of the remaining 5 (3 from the order page, 2 added on the draft reception dispatch page where saved rows are read-only): validated, stock 10, 10 serials with qty 1 each. Lot product (`LOT001` qty 5) and non-batch product received in the same reception behave as before.

phpcs (Dolibarr ruleset), phpstan (level of `phpstan.neon.dist`), `php -l`, `git diff --check`, `ReceptionTest` and `MouvementStockTest` pass.