### PR TITLE
NEW Tags/categories column in the source documents export

### DIFF
--- a/htdocs/compta/accounting-files.php
+++ b/htdocs/compta/accounting-files.php
@@ -538,10 +538,10 @@ if ($result && $action == "dl" && !$error) {	// Test on permission not required 
 				continue;
 			}
 
-			$sqltags = "SELECT ct.fk_".$tablefortags." as fk_object, c.label";
-			$sqltags .= " FROM ".MAIN_DB_PREFIX."categorie_".$tablefortags." as ct, ".MAIN_DB_PREFIX."categorie as c";
+			$sqltags = "SELECT ct.fk_".$db->sanitize($tablefortags)." as fk_object, c.label";
+			$sqltags .= " FROM ".MAIN_DB_PREFIX."categorie_".$db->sanitize($tablefortags)." as ct, ".MAIN_DB_PREFIX."categorie as c";
 			$sqltags .= " WHERE ct.fk_categorie = c.rowid";
-			$sqltags .= " AND ct.fk_".$tablefortags." IN (".$db->sanitize(implode(',', $idsfortags)).")";
+			$sqltags .= " AND ct.fk_".$db->sanitize($tablefortags)." IN (".$db->sanitize(implode(',', $idsfortags)).")";
 			$sqltags .= " AND c.entity IN (".getEntity('category').")";
 			$sqltags .= " ORDER BY c.label";
 

--- a/htdocs/compta/accounting-files.php
+++ b/htdocs/compta/accounting-files.php
@@ -520,6 +520,46 @@ if ($result && $action == "dl" && !$error) {	// Test on permission not required 
 	} else {
 		dol_mkdir($dirfortmpfile);
 
+		// Tags of the exported documents, read with one query per document type for the whole
+		// batch: a month of activity holds hundreds of documents and one query per document
+		// would make the export crawl. Only customer and supplier invoices can carry tags,
+		// the other items of the export (various payments, expense reports, salaries,
+		// donations, social contributions, loan payments) have no category type in Dolibarr
+		// and keep an empty column.
+		$tagsofdocuments = array();
+		foreach (array('Invoice' => 'invoice', 'SupplierInvoice' => 'supplier_invoice') as $itemfortags => $tablefortags) {
+			$idsfortags = array();
+			foreach ($filesarray as $filefortags) {
+				if ($filefortags['item'] == $itemfortags) {
+					$idsfortags[] = (int) $filefortags['id'];
+				}
+			}
+			if (empty($idsfortags)) {
+				continue;
+			}
+
+			$sqltags = "SELECT ct.fk_".$tablefortags." as fk_object, c.label";
+			$sqltags .= " FROM ".MAIN_DB_PREFIX."categorie_".$tablefortags." as ct, ".MAIN_DB_PREFIX."categorie as c";
+			$sqltags .= " WHERE ct.fk_categorie = c.rowid";
+			$sqltags .= " AND ct.fk_".$tablefortags." IN (".$db->sanitize(implode(',', $idsfortags)).")";
+			$sqltags .= " AND c.entity IN (".getEntity('category').")";
+			$sqltags .= " ORDER BY c.label";
+
+			$resqltags = $db->query($sqltags);
+			if ($resqltags) {
+				while ($objtags = $db->fetch_object($resqltags)) {
+					$keyfortags = $itemfortags.'_'.$objtags->fk_object;
+					if (empty($tagsofdocuments[$keyfortags])) {
+						$tagsofdocuments[$keyfortags] = array();
+					}
+					$tagsofdocuments[$keyfortags][] = $objtags->label;
+				}
+				$db->free($resqltags);
+			} else {
+				dol_print_error($db);
+			}
+		}
+
 		$log = $langs->transnoentitiesnoconv("Type");
 		if (isModEnabled('multicompany') && isset($mc) && is_object($mc)) {
 			$log .= ','.$langs->transnoentitiesnoconv("Entity");
@@ -540,7 +580,8 @@ if ($result && $action == "dl" && !$error) {	// Test on permission not required 
 		$log .= ','.$langs->transnoentitiesnoconv("Code");
 		$log .= ','.$langs->transnoentitiesnoconv("Country");
 		$log .= ','.$langs->transnoentitiesnoconv("VATIntra");
-		$log .= ','.$langs->transnoentitiesnoconv("Sens")."\n";
+		$log .= ','.$langs->transnoentitiesnoconv("Sens");
+		$log .= ','.$langs->transnoentitiesnoconv("Categories")."\n";
 		$zipname = $dirfortmpfile.'/'.dol_print_date($date_start, 'dayrfc', 'tzuserrel')."-".dol_print_date($date_stop, 'dayrfc', 'tzuserrel');
 		if (!empty($projectid)) {
 			$project = new Project($db);
@@ -586,6 +627,8 @@ if ($result && $action == "dl" && !$error) {	// Test on permission not required 
 				$log .= ',"'.$file['country_code'].'"';
 				$log .= ',"'.$file['vatnum'].'"';
 				$log .= ',"'.$file['sens'].'"';
+				$keyfortags = $file['item'].'_'.$file['id'];
+				$log .= ',"'.(empty($tagsofdocuments[$keyfortags]) ? '' : implode(',', $tagsofdocuments[$keyfortags])).'"';
 				$log .= "\n";
 			}
 			$zip->addFromString('transactions.csv', $log);


### PR DESCRIPTION
# NEW Tags/categories column in the source documents export

The accountancy export of source documents (Accounting > Export source documents) builds a zip holding the PDF files and a `transactions.csv` file.

Companies that split their flows (per country, per brand, per entity) tag their invoices, but the CSV does not carry those tags, so the column has to be added by hand after every export.

**What this PR does**

Adds a `Tags/categories` column at the end of each line of `transactions.csv`, filled with the tags of the document, comma separated in a single column, which is the convention already used by the product export.

The column is appended at the end of the line so existing columns keep their position for people who already post-process this file.

**Implementation notes**

* Tags are read with one query per document type for the whole batch, not one query per document: a month of activity holds hundreds of documents.
* Only customer and supplier invoices can carry tags in Dolibarr. The other exported items (various payments, expense reports, salaries, donations, social contributions, loan payments) have no category type and keep an empty column.
* The page declares hooks (`comptafileslist`, `globallist`) but the `executeHooks` call is commented out in the core, so an external module cannot add such a column today.

**Sample output**

```
Type,Date,...,VAT ID,Direction,Tags/categories
"Invoice",2025-01-05,...,"FR00000000000","1","TAG1,TAG2"
"Invoice",2025-01-08,...,"","1","TAG1"
"Vendor invoice",2025-01-12,...,"FR00000000000","0","TAG2"
"Invoice",2025-01-20,...,"","1",""
```

Tested on 23.0.3 with customer invoices carrying one tag, two tags and no tag, plus a supplier invoice carrying one tag. Sample above is anonymised.
