### PR TITLE
Qual: Translate French permission comments to English in module descriptors

### DIFF
--- a/htdocs/core/modules/modBanque.class.php
+++ b/htdocs/core/modules/modBanque.class.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2004       Benoit Mortier              <benoit.mortier@opensides.be>
  * Copyright (C) 2008-2011  Regis Houssin               <regis.houssin@inodbox.com>
  * Copyright (C) 2026       Solution Libre SAS          <contact@solution-libre.fr>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -85,49 +86,49 @@ class modBanque extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = 111; // id de la permission
+		$this->rights[$r][0] = 111; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read bank account and transactions';
 		$this->rights[$r][2] = 'r';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
-		$this->rights[$r][0] = 112; // id de la permission
+		$this->rights[$r][0] = 112; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Creer/modifier montant/supprimer ecriture bancaire';
 		$this->rights[$r][2] = 'w';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'modifier';
 
 		$r++;
-		$this->rights[$r][0] = 113; // id de la permission
+		$this->rights[$r][0] = 113; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Configurer les comptes bancaires (creer, gerer categories)';
 		$this->rights[$r][2] = 'a';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'configurer';
 
 		$r++;
-		$this->rights[$r][0] = 114; // id de la permission
+		$this->rights[$r][0] = 114; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Rapprocher les ecritures bancaires';
 		$this->rights[$r][2] = 'w';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'consolidate';
 
 		$r++;
-		$this->rights[$r][0] = 115; // id de la permission
+		$this->rights[$r][0] = 115; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Exporter transactions et releves';
 		$this->rights[$r][2] = 'r';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'export';
 
 		$r++;
-		$this->rights[$r][0] = 116; // id de la permission
+		$this->rights[$r][0] = 116; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Virements entre comptes';
 		$this->rights[$r][2] = 'w';
 		$this->rights[$r][3] = 0;
 		$this->rights[$r][4] = 'transfer';
 
 		$r++;
-		$this->rights[$r][0] = 117; // id de la permission
+		$this->rights[$r][0] = 117; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Gerer les envois de cheques';
 		$this->rights[$r][2] = 'w';
 		$this->rights[$r][3] = 0;

--- a/htdocs/core/modules/modBarcode.class.php
+++ b/htdocs/core/modules/modBarcode.class.php
@@ -79,23 +79,23 @@ class modBarcode extends DolibarrModules
 		$this->rights_class = 'barcode';
 		$r = 0;
 
-		$this->rights[$r][0] = 301; // id de la permission
+		$this->rights[$r][0] = 301; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Generate PDF sheets of barcodes'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 		$r++;
 
-		$this->rights[$r][0] = 304; // id de la permission
+		$this->rights[$r][0] = 304; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read barcodes'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire_advance';
 		$r++;
 
-		$this->rights[$r][0] = 305; // id de la permission
+		$this->rights[$r][0] = 305; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create/modify barcodes'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer_advance';
 		$r++;

--- a/htdocs/core/modules/modBarcode.class.php
+++ b/htdocs/core/modules/modBarcode.class.php
@@ -80,21 +80,21 @@ class modBarcode extends DolibarrModules
 		$r = 0;
 
 		$this->rights[$r][0] = 301; // id de la permission
-		$this->rights[$r][1] = 'Generate PDF sheets of barcodes'; // libelle de la permission
+		$this->rights[$r][1] = 'Generate PDF sheets of barcodes'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 		$r++;
 
 		$this->rights[$r][0] = 304; // id de la permission
-		$this->rights[$r][1] = 'Read barcodes'; // libelle de la permission
+		$this->rights[$r][1] = 'Read barcodes'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire_advance';
 		$r++;
 
 		$this->rights[$r][0] = 305; // id de la permission
-		$this->rights[$r][1] = 'Create/modify barcodes'; // libelle de la permission
+		$this->rights[$r][1] = 'Create/modify barcodes'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer_advance';

--- a/htdocs/core/modules/modBarcode.class.php
+++ b/htdocs/core/modules/modBarcode.class.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2005-2008 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2015      Juanjo Menent        <jmenent@2byte.es>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -81,21 +82,21 @@ class modBarcode extends DolibarrModules
 		$this->rights[$r][0] = 301; // id de la permission
 		$this->rights[$r][1] = 'Generate PDF sheets of barcodes'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 		$r++;
 
 		$this->rights[$r][0] = 304; // id de la permission
 		$this->rights[$r][1] = 'Read barcodes'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire_advance';
 		$r++;
 
 		$this->rights[$r][0] = 305; // id de la permission
 		$this->rights[$r][1] = 'Create/modify barcodes'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer_advance';
 		$r++;
 

--- a/htdocs/core/modules/modBookmark.class.php
+++ b/htdocs/core/modules/modBookmark.class.php
@@ -80,21 +80,21 @@ class modBookmark extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 331; // id de la permission
-		$this->rights[$r][1] = 'Lire les bookmarks'; // libelle de la permission
+		$this->rights[$r][1] = 'Lire les bookmarks'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 332; // id de la permission
-		$this->rights[$r][1] = 'Creer/modifier les bookmarks'; // libelle de la permission
+		$this->rights[$r][1] = 'Creer/modifier les bookmarks'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 333; // id de la permission
-		$this->rights[$r][1] = 'Supprimer les bookmarks'; // libelle de la permission
+		$this->rights[$r][1] = 'Supprimer les bookmarks'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';

--- a/htdocs/core/modules/modBookmark.class.php
+++ b/htdocs/core/modules/modBookmark.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2005      Rodolphe Quiedeville <rodolphe@quiedeville.org>
  * Copyright (C) 2005-2007 Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -81,21 +82,21 @@ class modBookmark extends DolibarrModules
 		$this->rights[$r][0] = 331; // id de la permission
 		$this->rights[$r][1] = 'Lire les bookmarks'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 332; // id de la permission
 		$this->rights[$r][1] = 'Creer/modifier les bookmarks'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 333; // id de la permission
 		$this->rights[$r][1] = 'Supprimer les bookmarks'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 

--- a/htdocs/core/modules/modBookmark.class.php
+++ b/htdocs/core/modules/modBookmark.class.php
@@ -79,23 +79,23 @@ class modBookmark extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = 331; // id de la permission
+		$this->rights[$r][0] = 331; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Lire les bookmarks'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
-		$this->rights[$r][0] = 332; // id de la permission
+		$this->rights[$r][0] = 332; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Creer/modifier les bookmarks'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = 333; // id de la permission
+		$this->rights[$r][0] = 333; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Supprimer les bookmarks'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 

--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -93,23 +93,23 @@ class modCategorie extends DolibarrModules
 
 		$r = 0;
 
-		$this->rights[$r][0] = 241; // id de la permission
+		$this->rights[$r][0] = 241; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Lire les categories'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
-		$this->rights[$r][0] = 242; // id de la permission
+		$this->rights[$r][0] = 242; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Creer/modifier les categories'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
-		$this->rights[$r][0] = 243; // id de la permission
+		$this->rights[$r][0] = 243; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Supprimer les categories'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 		$r++;

--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -94,21 +94,21 @@ class modCategorie extends DolibarrModules
 		$r = 0;
 
 		$this->rights[$r][0] = 241; // id de la permission
-		$this->rights[$r][1] = 'Lire les categories'; // libelle de la permission
+		$this->rights[$r][1] = 'Lire les categories'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
 		$this->rights[$r][0] = 242; // id de la permission
-		$this->rights[$r][1] = 'Creer/modifier les categories'; // libelle de la permission
+		$this->rights[$r][1] = 'Creer/modifier les categories'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
 		$this->rights[$r][0] = 243; // id de la permission
-		$this->rights[$r][1] = 'Supprimer les categories'; // libelle de la permission
+		$this->rights[$r][1] = 'Supprimer les categories'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';

--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2020		Stéphane Lesage			<stephane.lesage@ateis.com>
  * Copyright (C) 2022-2025	Solution Libre SAS		<contact@solution-libre.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2025		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2025-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2025		Alexandre Spangaro		<alexandre@inovea-conseil.com>
  * Copyright (C) 2025		Charlene Benke		    <charlene@patas-monkey.com>
  *
@@ -96,21 +96,21 @@ class modCategorie extends DolibarrModules
 		$this->rights[$r][0] = 241; // id de la permission
 		$this->rights[$r][1] = 'Lire les categories'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
 		$this->rights[$r][0] = 242; // id de la permission
 		$this->rights[$r][1] = 'Creer/modifier les categories'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
 		$this->rights[$r][0] = 243; // id de la permission
 		$this->rights[$r][1] = 'Supprimer les categories'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 		$r++;
 

--- a/htdocs/core/modules/modDebugBar.class.php
+++ b/htdocs/core/modules/modDebugBar.class.php
@@ -80,7 +80,7 @@ class modDebugBar extends DolibarrModules
 		$this->rights = array();
 
 		$this->rights[1][0] = 431; // id de la permission
-		$this->rights[1][1] = 'Use Debug Bar'; // libelle de la permission
+		$this->rights[1][1] = 'Use Debug Bar'; // Permission label
 		$this->rights[1][2] = 'u'; // type de la permission (deprecated)
 		$this->rights[1][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[1][4] = 'read';

--- a/htdocs/core/modules/modDebugBar.class.php
+++ b/htdocs/core/modules/modDebugBar.class.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2019-2020 AXeL-dev <contact.axel.dev@gmail.com>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -81,7 +82,7 @@ class modDebugBar extends DolibarrModules
 		$this->rights[1][0] = 431; // id de la permission
 		$this->rights[1][1] = 'Use Debug Bar'; // libelle de la permission
 		$this->rights[1][2] = 'u'; // type de la permission (deprecated)
-		$this->rights[1][3] = 0; // La permission est-elle une permission par default
+		$this->rights[1][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[1][4] = 'read';
 	}
 

--- a/htdocs/core/modules/modDebugBar.class.php
+++ b/htdocs/core/modules/modDebugBar.class.php
@@ -79,9 +79,9 @@ class modDebugBar extends DolibarrModules
 		// Permissions
 		$this->rights = array();
 
-		$this->rights[1][0] = 431; // id de la permission
+		$this->rights[1][0] = 431; // Permission id (must not be already used)
 		$this->rights[1][1] = 'Use Debug Bar'; // Permission label
-		$this->rights[1][2] = 'u'; // type de la permission (deprecated)
+		$this->rights[1][2] = 'u'; // Permission type (deprecated)
 		$this->rights[1][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[1][4] = 'read';
 	}

--- a/htdocs/core/modules/modExpedition.class.php
+++ b/htdocs/core/modules/modExpedition.class.php
@@ -169,7 +169,7 @@ class modExpedition extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 105; // id de la permission
-		$this->rights[$r][1] = 'Send shipments by email to customers'; // libelle de la permission
+		$this->rights[$r][1] = 'Send shipments by email to customers'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'shipping_advance';

--- a/htdocs/core/modules/modExpedition.class.php
+++ b/htdocs/core/modules/modExpedition.class.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2005-2011 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2011      Juanjo Menent	    <jmenent@2byte.es>
  * Copyright (C) 2013	   Philippe Grand	    <philippe.grand@atoo-net.com>
- * Copyright (C) 2024-2025  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -171,7 +171,7 @@ class modExpedition extends DolibarrModules
 		$this->rights[$r][0] = 105; // id de la permission
 		$this->rights[$r][1] = 'Send shipments by email to customers'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'shipping_advance';
 		$this->rights[$r][5] = 'send';
 

--- a/htdocs/core/modules/modExpedition.class.php
+++ b/htdocs/core/modules/modExpedition.class.php
@@ -168,9 +168,9 @@ class modExpedition extends DolibarrModules
 		$this->rights[$r][5] = 'validate';
 
 		$r++;
-		$this->rights[$r][0] = 105; // id de la permission
+		$this->rights[$r][0] = 105; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Send shipments by email to customers'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'shipping_advance';
 		$this->rights[$r][5] = 'send';

--- a/htdocs/core/modules/modLabel.class.php
+++ b/htdocs/core/modules/modLabel.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2007-2009 Regis Houssin       <regis.houssin@inodbox.com>
  * Copyright (C) 2008      Laurent Destailleur <eldy@users.sourceforge.net>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -77,17 +78,17 @@ class modLabel extends DolibarrModules
 
 		$this->rights[1][0] = 601; // id de la permission
 		$this->rights[1][1] = 'Read stickers';
-		$this->rights[1][3] = 0; // La permission est-elle une permission par default
+		$this->rights[1][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[1][4] = 'lire';
 
 		$this->rights[2][0] = 602; // id de la permission
 		$this->rights[2][1] = 'Create/modify stickers';
-		$this->rights[2][3] = 0; // La permission est-elle une permission par default
+		$this->rights[2][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[2][4] = 'creer';
 
 		$this->rights[4][0] = 609; // id de la permission
 		$this->rights[4][1] = 'Delete stickers';
-		$this->rights[4][3] = 0; // La permission est-elle une permission par default
+		$this->rights[4][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[4][4] = 'supprimer';
 	}
 

--- a/htdocs/core/modules/modLabel.class.php
+++ b/htdocs/core/modules/modLabel.class.php
@@ -76,17 +76,17 @@ class modLabel extends DolibarrModules
 		$this->rights = array();
 		$this->rights_class = 'label';
 
-		$this->rights[1][0] = 601; // id de la permission
+		$this->rights[1][0] = 601; // Permission id (must not be already used)
 		$this->rights[1][1] = 'Read stickers';
 		$this->rights[1][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[1][4] = 'lire';
 
-		$this->rights[2][0] = 602; // id de la permission
+		$this->rights[2][0] = 602; // Permission id (must not be already used)
 		$this->rights[2][1] = 'Create/modify stickers';
 		$this->rights[2][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[2][4] = 'creer';
 
-		$this->rights[4][0] = 609; // id de la permission
+		$this->rights[4][0] = 609; // Permission id (must not be already used)
 		$this->rights[4][1] = 'Delete stickers';
 		$this->rights[4][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[4][4] = 'supprimer';

--- a/htdocs/core/modules/modMailing.class.php
+++ b/htdocs/core/modules/modMailing.class.php
@@ -94,7 +94,7 @@ class modMailing extends DolibarrModules
 		$this->rights[$r][0] = 221; // id de la permission
 		$this->rights[$r][1] = 'Consulter les mailings'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;

--- a/htdocs/core/modules/modMailing.class.php
+++ b/htdocs/core/modules/modMailing.class.php
@@ -91,9 +91,9 @@ class modMailing extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = 221; // id de la permission
+		$this->rights[$r][0] = 221; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Consulter les mailings'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 

--- a/htdocs/core/modules/modMailing.class.php
+++ b/htdocs/core/modules/modMailing.class.php
@@ -92,7 +92,7 @@ class modMailing extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 221; // id de la permission
-		$this->rights[$r][1] = 'Consulter les mailings'; // libelle de la permission
+		$this->rights[$r][1] = 'Consulter les mailings'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';

--- a/htdocs/core/modules/modMargin.class.php
+++ b/htdocs/core/modules/modMargin.class.php
@@ -127,21 +127,21 @@ class modMargin extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 59001; // id de la permission
-		$this->rights[$r][1] = 'Visualiser les marges'; // libelle de la permission
+		$this->rights[$r][1] = 'Visualiser les marges'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'liretous';
 
 		$r++;
 		$this->rights[$r][0] = 59002; // id de la permission
-		$this->rights[$r][1] = 'Définir les marges'; // libelle de la permission
+		$this->rights[$r][1] = 'Définir les marges'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 59003; // id de la permission
-		$this->rights[$r][1] = 'Read every user margin'; // libelle de la permission
+		$this->rights[$r][1] = 'Read every user margin'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';

--- a/htdocs/core/modules/modMargin.class.php
+++ b/htdocs/core/modules/modMargin.class.php
@@ -126,23 +126,23 @@ class modMargin extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = 59001; // id de la permission
+		$this->rights[$r][0] = 59001; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Visualiser les marges'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'liretous';
 
 		$r++;
-		$this->rights[$r][0] = 59002; // id de la permission
+		$this->rights[$r][0] = 59002; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Définir les marges'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = 59003; // id de la permission
+		$this->rights[$r][0] = 59003; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read every user margin'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 		$this->rights[$r][5] = 'all';

--- a/htdocs/core/modules/modMargin.class.php
+++ b/htdocs/core/modules/modMargin.class.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2012	    Christophe Battarel	    <christophe.battarel@altairis.fr>
  * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -129,21 +129,21 @@ class modMargin extends DolibarrModules
 		$this->rights[$r][0] = 59001; // id de la permission
 		$this->rights[$r][1] = 'Visualiser les marges'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'liretous';
 
 		$r++;
 		$this->rights[$r][0] = 59002; // id de la permission
 		$this->rights[$r][1] = 'Définir les marges'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 59003; // id de la permission
 		$this->rights[$r][1] = 'Read every user margin'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 		$this->rights[$r][5] = 'all';
 	}

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -118,21 +118,21 @@ class modProduct extends DolibarrModules
 		$r = 0;
 
 		$this->rights[$r][0] = 31; // id de la permission
-		$this->rights[$r][1] = 'Read products'; // libelle de la permission
+		$this->rights[$r][1] = 'Read products'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
 		$this->rights[$r][0] = 32; // id de la permission
-		$this->rights[$r][1] = 'Create/modify products'; // libelle de la permission
+		$this->rights[$r][1] = 'Create/modify products'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
 		$this->rights[$r][0] = 33; // id de la permission
-		$this->rights[$r][1] = 'Read prices products'; // libelle de la permission
+		$this->rights[$r][1] = 'Read prices products'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
@@ -140,7 +140,7 @@ class modProduct extends DolibarrModules
 		$r++;
 
 		$this->rights[$r][0] = 35; // id de la permission
-		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
+		$this->rights[$r][1] = 'Read supplier prices'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
@@ -149,7 +149,7 @@ class modProduct extends DolibarrModules
 
 		// EN: Advanced permission to write supplier prices
 		$this->rights[$r][0] = 36; // id de la permission
-		$this->rights[$r][1] = 'Write supplier prices'; // libelle de la permission
+		$this->rights[$r][1] = 'Write supplier prices'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
@@ -157,7 +157,7 @@ class modProduct extends DolibarrModules
 		$r++;
 
 		$this->rights[$r][0] = 34; // id de la permission
-		$this->rights[$r][1] = 'Delete products'; // libelle de la permission
+		$this->rights[$r][1] = 'Delete products'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -120,21 +120,21 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][0] = 31; // id de la permission
 		$this->rights[$r][1] = 'Read products'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
 		$this->rights[$r][0] = 32; // id de la permission
 		$this->rights[$r][1] = 'Create/modify products'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
 		$this->rights[$r][0] = 33; // id de la permission
 		$this->rights[$r][1] = 'Read prices products'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
 		$this->rights[$r][5] = 'read_prices';
 		$r++;
@@ -142,7 +142,7 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][0] = 35; // id de la permission
 		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
 		$this->rights[$r][5] = 'read_supplier_prices';
 		$r++;
@@ -151,7 +151,7 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][0] = 36; // id de la permission
 		$this->rights[$r][1] = 'Write supplier prices'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
 		$this->rights[$r][5] = 'write_supplier_prices';
 		$r++;
@@ -159,7 +159,7 @@ class modProduct extends DolibarrModules
 		$this->rights[$r][0] = 34; // id de la permission
 		$this->rights[$r][1] = 'Delete products'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 		$r++;
 

--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -117,48 +117,48 @@ class modProduct extends DolibarrModules
 		$this->rights_class = 'produit';
 		$r = 0;
 
-		$this->rights[$r][0] = 31; // id de la permission
+		$this->rights[$r][0] = 31; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read products'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
-		$this->rights[$r][0] = 32; // id de la permission
+		$this->rights[$r][0] = 32; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create/modify products'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
-		$this->rights[$r][0] = 33; // id de la permission
+		$this->rights[$r][0] = 33; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read prices products'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
 		$this->rights[$r][5] = 'read_prices';
 		$r++;
 
-		$this->rights[$r][0] = 35; // id de la permission
+		$this->rights[$r][0] = 35; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read supplier prices'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
 		$this->rights[$r][5] = 'read_supplier_prices';
 		$r++;
 
 		// EN: Advanced permission to write supplier prices
-		$this->rights[$r][0] = 36; // id de la permission
+		$this->rights[$r][0] = 36; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Write supplier prices'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'product_advance';
 		$this->rights[$r][5] = 'write_supplier_prices';
 		$r++;
 
-		$this->rights[$r][0] = 34; // id de la permission
+		$this->rights[$r][0] = 34; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Delete products'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 		$r++;

--- a/htdocs/core/modules/modProjet.class.php
+++ b/htdocs/core/modules/modProjet.class.php
@@ -155,61 +155,61 @@ class modProjet extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = 41; // id de la permission
+		$this->rights[$r][0] = 41; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Read projects and tasks (shared projects or projects I am contact for)"; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
-		$this->rights[$r][0] = 42; // id de la permission
+		$this->rights[$r][0] = 42; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Create/modify projects and tasks (shared projects or projects I am contact for)"; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = 44; // id de la permission
+		$this->rights[$r][0] = 44; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Delete project and tasks (shared projects or projects I am contact for)"; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
-		$this->rights[$r][0] = 45; // id de la permission
+		$this->rights[$r][0] = 45; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Export projects"; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		$r++;
-		$this->rights[$r][0] = 141; // id de la permission
+		$this->rights[$r][0] = 141; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Read all projects and tasks (also private projects I am not contact for)"; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
 		$this->rights[$r][5] = 'lire';
 
 		$r++;
-		$this->rights[$r][0] = 142; // id de la permission
+		$this->rights[$r][0] = 142; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Create/modify all projects and tasks (also private projects I am not contact for)"; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
 		$this->rights[$r][5] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = 144; // id de la permission
+		$this->rights[$r][0] = 144; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Delete all projects and tasks (also private projects I am not contact for)"; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
 		$this->rights[$r][5] = 'supprimer';
 
 		$r++;
-		$this->rights[$r][0] = 145; // id de la permission
+		$this->rights[$r][0] = 145; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Can enter time consumed on assigned tasks (timesheet)"; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'time';
 

--- a/htdocs/core/modules/modProjet.class.php
+++ b/htdocs/core/modules/modProjet.class.php
@@ -156,35 +156,35 @@ class modProjet extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 41; // id de la permission
-		$this->rights[$r][1] = "Read projects and tasks (shared projects or projects I am contact for)"; // libelle de la permission
+		$this->rights[$r][1] = "Read projects and tasks (shared projects or projects I am contact for)"; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 42; // id de la permission
-		$this->rights[$r][1] = "Create/modify projects and tasks (shared projects or projects I am contact for)"; // libelle de la permission
+		$this->rights[$r][1] = "Create/modify projects and tasks (shared projects or projects I am contact for)"; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 44; // id de la permission
-		$this->rights[$r][1] = "Delete project and tasks (shared projects or projects I am contact for)"; // libelle de la permission
+		$this->rights[$r][1] = "Delete project and tasks (shared projects or projects I am contact for)"; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = 45; // id de la permission
-		$this->rights[$r][1] = "Export projects"; // libelle de la permission
+		$this->rights[$r][1] = "Export projects"; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		$r++;
 		$this->rights[$r][0] = 141; // id de la permission
-		$this->rights[$r][1] = "Read all projects and tasks (also private projects I am not contact for)"; // libelle de la permission
+		$this->rights[$r][1] = "Read all projects and tasks (also private projects I am not contact for)"; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
@@ -192,7 +192,7 @@ class modProjet extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 142; // id de la permission
-		$this->rights[$r][1] = "Create/modify all projects and tasks (also private projects I am not contact for)"; // libelle de la permission
+		$this->rights[$r][1] = "Create/modify all projects and tasks (also private projects I am not contact for)"; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
@@ -200,7 +200,7 @@ class modProjet extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 144; // id de la permission
-		$this->rights[$r][1] = "Delete all projects and tasks (also private projects I am not contact for)"; // libelle de la permission
+		$this->rights[$r][1] = "Delete all projects and tasks (also private projects I am not contact for)"; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
@@ -208,7 +208,7 @@ class modProjet extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 145; // id de la permission
-		$this->rights[$r][1] = "Can enter time consumed on assigned tasks (timesheet)"; // libelle de la permission
+		$this->rights[$r][1] = "Can enter time consumed on assigned tasks (timesheet)"; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'time';

--- a/htdocs/core/modules/modProjet.class.php
+++ b/htdocs/core/modules/modProjet.class.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2013	    Florian Henry           <florian.henry@open-concept.pro>
  * Copyright (C) 2014	    Charles-Fr BENKE		<charles.fr@benke.fr>
  * Copyright (C) 2023       Gauthier VERDOL         <gauthier.verdol@atm-consulting.fr>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -158,35 +158,35 @@ class modProjet extends DolibarrModules
 		$this->rights[$r][0] = 41; // id de la permission
 		$this->rights[$r][1] = "Read projects and tasks (shared projects or projects I am contact for)"; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 42; // id de la permission
 		$this->rights[$r][1] = "Create/modify projects and tasks (shared projects or projects I am contact for)"; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 44; // id de la permission
 		$this->rights[$r][1] = "Delete project and tasks (shared projects or projects I am contact for)"; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = 45; // id de la permission
 		$this->rights[$r][1] = "Export projects"; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		$r++;
 		$this->rights[$r][0] = 141; // id de la permission
 		$this->rights[$r][1] = "Read all projects and tasks (also private projects I am not contact for)"; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
 		$this->rights[$r][5] = 'lire';
 
@@ -194,7 +194,7 @@ class modProjet extends DolibarrModules
 		$this->rights[$r][0] = 142; // id de la permission
 		$this->rights[$r][1] = "Create/modify all projects and tasks (also private projects I am not contact for)"; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
 		$this->rights[$r][5] = 'creer';
 
@@ -202,7 +202,7 @@ class modProjet extends DolibarrModules
 		$this->rights[$r][0] = 144; // id de la permission
 		$this->rights[$r][1] = "Delete all projects and tasks (also private projects I am not contact for)"; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'all';
 		$this->rights[$r][5] = 'supprimer';
 
@@ -210,7 +210,7 @@ class modProjet extends DolibarrModules
 		$this->rights[$r][0] = 145; // id de la permission
 		$this->rights[$r][1] = "Can enter time consumed on assigned tasks (timesheet)"; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'time';
 
 		// Menus

--- a/htdocs/core/modules/modPropale.class.php
+++ b/htdocs/core/modules/modPropale.class.php
@@ -141,14 +141,14 @@ class modPropale extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 21; // id de la permission
-		$this->rights[$r][1] = 'Read commercial proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Read commercial proposals'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 22; // id de la permission
-		$this->rights[$r][1] = 'Create and update commercial proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Create and update commercial proposals'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
@@ -163,7 +163,7 @@ class modPropale extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 25; // id de la permission
-		$this->rights[$r][1] = 'Send commercial proposals to customers'; // libelle de la permission
+		$this->rights[$r][1] = 'Send commercial proposals to customers'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
@@ -179,14 +179,14 @@ class modPropale extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 27; // id de la permission
-		$this->rights[$r][1] = 'Delete commercial proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Delete commercial proposals'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = 28; // id de la permission
-		$this->rights[$r][1] = 'Exporting commercial proposals and attributes'; // libelle de la permission
+		$this->rights[$r][1] = 'Exporting commercial proposals and attributes'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';

--- a/htdocs/core/modules/modPropale.class.php
+++ b/htdocs/core/modules/modPropale.class.php
@@ -143,21 +143,21 @@ class modPropale extends DolibarrModules
 		$this->rights[$r][0] = 21; // id de la permission
 		$this->rights[$r][1] = 'Read commercial proposals'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = 22; // id de la permission
 		$this->rights[$r][1] = 'Create and update commercial proposals'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = 24; // id de la permission
 		$this->rights[$r][1] = 'Validate commercial proposals'; // Validate proposal
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'validate';
 
@@ -165,7 +165,7 @@ class modPropale extends DolibarrModules
 		$this->rights[$r][0] = 25; // id de la permission
 		$this->rights[$r][1] = 'Send commercial proposals to customers'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'send';
 
@@ -173,7 +173,7 @@ class modPropale extends DolibarrModules
 		$this->rights[$r][0] = 26; // id de la permission
 		$this->rights[$r][1] = 'Close commercial proposals'; // Set proposal to signed or refused
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'close';
 
@@ -181,21 +181,21 @@ class modPropale extends DolibarrModules
 		$this->rights[$r][0] = 27; // id de la permission
 		$this->rights[$r][1] = 'Delete commercial proposals'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = 28; // id de la permission
 		$this->rights[$r][1] = 'Exporting commercial proposals and attributes'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		$r++;
 		$this->rights[$r][0] = 29; // id de la permission
 		$this->rights[$r][1] = 'Reopen commercial proposals'; // Set proposal to signed or refused
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecie a ce jour)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'reopen';
 

--- a/htdocs/core/modules/modPropale.class.php
+++ b/htdocs/core/modules/modPropale.class.php
@@ -140,61 +140,61 @@ class modPropale extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = 21; // id de la permission
+		$this->rights[$r][0] = 21; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read commercial proposals'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
-		$this->rights[$r][0] = 22; // id de la permission
+		$this->rights[$r][0] = 22; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create and update commercial proposals'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = 24; // id de la permission
+		$this->rights[$r][0] = 24; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Validate commercial proposals'; // Validate proposal
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'validate';
 
 		$r++;
-		$this->rights[$r][0] = 25; // id de la permission
+		$this->rights[$r][0] = 25; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Send commercial proposals to customers'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'send';
 
 		$r++;
-		$this->rights[$r][0] = 26; // id de la permission
+		$this->rights[$r][0] = 26; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Close commercial proposals'; // Set proposal to signed or refused
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'close';
 
 		$r++;
-		$this->rights[$r][0] = 27; // id de la permission
+		$this->rights[$r][0] = 27; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Delete commercial proposals'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
-		$this->rights[$r][0] = 28; // id de la permission
+		$this->rights[$r][0] = 28; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Exporting commercial proposals and attributes'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		$r++;
-		$this->rights[$r][0] = 29; // id de la permission
+		$this->rights[$r][0] = 29; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Reopen commercial proposals'; // Set proposal to signed or refused
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecie a ce jour)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'propal_advance';
 		$this->rights[$r][5] = 'reopen';

--- a/htdocs/core/modules/modReception.class.php
+++ b/htdocs/core/modules/modReception.class.php
@@ -137,7 +137,7 @@ class modReception extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = $this->numero.$r; // id de la permission
-		$this->rights[$r][1] = 'Send receptions to customers'; // libelle de la permission
+		$this->rights[$r][1] = 'Send receptions to customers'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'reception_advance';

--- a/htdocs/core/modules/modReception.class.php
+++ b/htdocs/core/modules/modReception.class.php
@@ -136,9 +136,9 @@ class modReception extends DolibarrModules
 		$this->rights[$r][5] = 'validate';
 
 		$r++;
-		$this->rights[$r][0] = $this->numero.$r; // id de la permission
+		$this->rights[$r][0] = $this->numero.$r; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Send receptions to customers'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'reception_advance';
 		$this->rights[$r][5] = 'send';

--- a/htdocs/core/modules/modReception.class.php
+++ b/htdocs/core/modules/modReception.class.php
@@ -139,7 +139,7 @@ class modReception extends DolibarrModules
 		$this->rights[$r][0] = $this->numero.$r; // id de la permission
 		$this->rights[$r][1] = 'Send receptions to customers'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'reception_advance';
 		$this->rights[$r][5] = 'send';
 

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -89,39 +89,39 @@ class modService extends DolibarrModules
 		$this->rights_class = 'service';
 		$r = 0;
 
-		$this->rights[$r][0] = 531; // id de la permission
+		$this->rights[$r][0] = 531; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read services'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
-		$this->rights[$r][0] = 532; // id de la permission
+		$this->rights[$r][0] = 532; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create/modify services'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
-		$this->rights[$r][0] = 533; // id de la permission
+		$this->rights[$r][0] = 533; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read prices services'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'service_advance';
 		$this->rights[$r][5] = 'read_prices';
 		$r++;
 
-		$this->rights[$r][0] = 535; // id de la permission
+		$this->rights[$r][0] = 535; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read supplier prices'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'service_advance';
 		$this->rights[$r][5] = 'read_supplier_prices';
 		$r++;
 
-		$this->rights[$r][0] = 534; // id de la permission
+		$this->rights[$r][0] = 534; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Delete les services'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 		$r++;

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -90,21 +90,21 @@ class modService extends DolibarrModules
 		$r = 0;
 
 		$this->rights[$r][0] = 531; // id de la permission
-		$this->rights[$r][1] = 'Read services'; // libelle de la permission
+		$this->rights[$r][1] = 'Read services'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
 		$this->rights[$r][0] = 532; // id de la permission
-		$this->rights[$r][1] = 'Create/modify services'; // libelle de la permission
+		$this->rights[$r][1] = 'Create/modify services'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
 		$this->rights[$r][0] = 533; // id de la permission
-		$this->rights[$r][1] = 'Read prices services'; // libelle de la permission
+		$this->rights[$r][1] = 'Read prices services'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'service_advance';
@@ -112,7 +112,7 @@ class modService extends DolibarrModules
 		$r++;
 
 		$this->rights[$r][0] = 535; // id de la permission
-		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
+		$this->rights[$r][1] = 'Read supplier prices'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'service_advance';
@@ -120,7 +120,7 @@ class modService extends DolibarrModules
 		$r++;
 
 		$this->rights[$r][0] = 534; // id de la permission
-		$this->rights[$r][1] = 'Delete les services'; // libelle de la permission
+		$this->rights[$r][1] = 'Delete les services'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';

--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -6,6 +6,7 @@
  * Copyright (C) 2005-2012	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2020-2021	Alexandre Spangaro		<aspangaro@open-dsi.fr>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -91,21 +92,21 @@ class modService extends DolibarrModules
 		$this->rights[$r][0] = 531; // id de la permission
 		$this->rights[$r][1] = 'Read services'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 		$r++;
 
 		$this->rights[$r][0] = 532; // id de la permission
 		$this->rights[$r][1] = 'Create/modify services'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 		$r++;
 
 		$this->rights[$r][0] = 533; // id de la permission
 		$this->rights[$r][1] = 'Read prices services'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'service_advance';
 		$this->rights[$r][5] = 'read_prices';
 		$r++;
@@ -113,7 +114,7 @@ class modService extends DolibarrModules
 		$this->rights[$r][0] = 535; // id de la permission
 		$this->rights[$r][1] = 'Read supplier prices'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'service_advance';
 		$this->rights[$r][5] = 'read_supplier_prices';
 		$r++;
@@ -121,7 +122,7 @@ class modService extends DolibarrModules
 		$this->rights[$r][0] = 534; // id de la permission
 		$this->rights[$r][1] = 'Delete les services'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 		$r++;
 

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -138,7 +138,7 @@ class modSociete extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 121; // id de la permission
-		$this->rights[$r][1] = 'Read third parties'; // libelle de la permission
+		$this->rights[$r][1] = 'Read third parties'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
@@ -162,7 +162,7 @@ class modSociete extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 122; // id de la permission
-		$this->rights[$r][1] = 'Create and update third parties'; // libelle de la permission
+		$this->rights[$r][1] = 'Create and update third parties'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
@@ -186,14 +186,14 @@ class modSociete extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 125; // id de la permission
-		$this->rights[$r][1] = 'Delete third parties'; // libelle de la permission
+		$this->rights[$r][1] = 'Delete third parties'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = 126; // id de la permission
-		$this->rights[$r][1] = 'Export third parties'; // libelle de la permission
+		$this->rights[$r][1] = 'Export third parties'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
@@ -226,7 +226,7 @@ class modSociete extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 281; // id de la permission
-		$this->rights[$r][1] = 'Read contacts'; // libelle de la permission
+		$this->rights[$r][1] = 'Read contacts'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
@@ -234,7 +234,7 @@ class modSociete extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 282; // id de la permission
-		$this->rights[$r][1] = 'Create and update contact'; // libelle de la permission
+		$this->rights[$r][1] = 'Create and update contact'; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
@@ -242,7 +242,7 @@ class modSociete extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 283; // id de la permission
-		$this->rights[$r][1] = 'Delete contacts'; // libelle de la permission
+		$this->rights[$r][1] = 'Delete contacts'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
@@ -250,7 +250,7 @@ class modSociete extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = 286; // id de la permission
-		$this->rights[$r][1] = 'Export contacts'; // libelle de la permission
+		$this->rights[$r][1] = 'Export contacts'; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -140,7 +140,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 121; // id de la permission
 		$this->rights[$r][1] = 'Read third parties'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		/*$r++;
@@ -164,7 +164,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 122; // id de la permission
 		$this->rights[$r][1] = 'Create and update third parties'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		/* $r++;
@@ -188,14 +188,14 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 125; // id de la permission
 		$this->rights[$r][1] = 'Delete third parties'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = 126; // id de la permission
 		$this->rights[$r][1] = 'Export third parties'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		$r++;
@@ -228,7 +228,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 281; // id de la permission
 		$this->rights[$r][1] = 'Read contacts'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'lire';
 
@@ -236,7 +236,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 282; // id de la permission
 		$this->rights[$r][1] = 'Create and update contact'; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'creer';
 
@@ -244,7 +244,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 283; // id de la permission
 		$this->rights[$r][1] = 'Delete contacts'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'supprimer';
 
@@ -252,7 +252,7 @@ class modSociete extends DolibarrModules
 		$this->rights[$r][0] = 286; // id de la permission
 		$this->rights[$r][1] = 'Export contacts'; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'export';
 

--- a/htdocs/core/modules/modSociete.class.php
+++ b/htdocs/core/modules/modSociete.class.php
@@ -137,9 +137,9 @@ class modSociete extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = 121; // id de la permission
+		$this->rights[$r][0] = 121; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read third parties'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
@@ -161,9 +161,9 @@ class modSociete extends DolibarrModules
 		 */
 
 		$r++;
-		$this->rights[$r][0] = 122; // id de la permission
+		$this->rights[$r][0] = 122; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create and update third parties'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
@@ -185,16 +185,16 @@ class modSociete extends DolibarrModules
 		 */
 
 		$r++;
-		$this->rights[$r][0] = 125; // id de la permission
+		$this->rights[$r][0] = 125; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Delete third parties'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
-		$this->rights[$r][0] = 126; // id de la permission
+		$this->rights[$r][0] = 126; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Export third parties'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
@@ -225,33 +225,33 @@ class modSociete extends DolibarrModules
 		 */
 
 		$r++;
-		$this->rights[$r][0] = 281; // id de la permission
+		$this->rights[$r][0] = 281; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read contacts'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'lire';
 
 		$r++;
-		$this->rights[$r][0] = 282; // id de la permission
+		$this->rights[$r][0] = 282; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create and update contact'; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = 283; // id de la permission
+		$this->rights[$r][0] = 283; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Delete contacts'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'supprimer';
 
 		$r++;
-		$this->rights[$r][0] = 286; // id de la permission
+		$this->rights[$r][0] = 286; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Export contacts'; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'contact';
 		$this->rights[$r][5] = 'export';

--- a/htdocs/core/modules/modSupplierProposal.class.php
+++ b/htdocs/core/modules/modSupplierProposal.class.php
@@ -112,37 +112,37 @@ class modSupplierProposal extends DolibarrModules
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Read supplier proposals'; // libelle de la permission
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Create/modify supplier proposals'; // libelle de la permission
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Validate supplier proposals'; // libelle de la permission
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'validate_advance';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Send supplier proposals'; // libelle de la permission
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'send_advance';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Delete supplier proposals'; // libelle de la permission
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
 		$this->rights[$r][1] = 'Close supplier price requests'; // libelle de la permission
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'cloturer';
 
 		// Main menu entries

--- a/htdocs/core/modules/modSupplierProposal.class.php
+++ b/htdocs/core/modules/modSupplierProposal.class.php
@@ -110,37 +110,37 @@ class modSupplierProposal extends DolibarrModules
 		$r = 0;
 
 		$r++;
-		$this->rights[$r][0] = $this->numero + $r; // id de la permission
+		$this->rights[$r][0] = $this->numero + $r; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Read supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
-		$this->rights[$r][0] = $this->numero + $r; // id de la permission
+		$this->rights[$r][0] = $this->numero + $r; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Create/modify supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
-		$this->rights[$r][0] = $this->numero + $r; // id de la permission
+		$this->rights[$r][0] = $this->numero + $r; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Validate supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'validate_advance';
 
 		$r++;
-		$this->rights[$r][0] = $this->numero + $r; // id de la permission
+		$this->rights[$r][0] = $this->numero + $r; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Send supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'send_advance';
 
 		$r++;
-		$this->rights[$r][0] = $this->numero + $r; // id de la permission
+		$this->rights[$r][0] = $this->numero + $r; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Delete supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
-		$this->rights[$r][0] = $this->numero + $r; // id de la permission
+		$this->rights[$r][0] = $this->numero + $r; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'Close supplier price requests'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'cloturer';

--- a/htdocs/core/modules/modSupplierProposal.class.php
+++ b/htdocs/core/modules/modSupplierProposal.class.php
@@ -111,37 +111,37 @@ class modSupplierProposal extends DolibarrModules
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
-		$this->rights[$r][1] = 'Read supplier proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Read supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'lire';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
-		$this->rights[$r][1] = 'Create/modify supplier proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Create/modify supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'creer';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
-		$this->rights[$r][1] = 'Validate supplier proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Validate supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'validate_advance';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
-		$this->rights[$r][1] = 'Send supplier proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Send supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'send_advance';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
-		$this->rights[$r][1] = 'Delete supplier proposals'; // libelle de la permission
+		$this->rights[$r][1] = 'Delete supplier proposals'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'supprimer';
 
 		$r++;
 		$this->rights[$r][0] = $this->numero + $r; // id de la permission
-		$this->rights[$r][1] = 'Close supplier price requests'; // libelle de la permission
+		$this->rights[$r][1] = 'Close supplier price requests'; // Permission label
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'cloturer';
 

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -226,45 +226,45 @@ class modTicket extends DolibarrModules
 		$this->rights = []; // Permission array used by this module
 
 		$r = 0;
-		$this->rights[$r][0] = 56001; // id de la permission
+		$this->rights[$r][0] = 56001; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Read ticket"; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 
 		$r++;
-		$this->rights[$r][0] = 56002; // id de la permission
+		$this->rights[$r][0] = 56002; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Create les tickets"; // Permission label
-		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'w'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'write';
 
 		$r++;
-		$this->rights[$r][0] = 56003; // id de la permission
+		$this->rights[$r][0] = 56003; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Delete les tickets"; // Permission label
-		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'delete';
 
 		$r++;
-		$this->rights[$r][0] = 56004; // id de la permission
+		$this->rights[$r][0] = 56004; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Manage tickets"; // Permission label
-		//$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		//$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'manage_advance';
 
 		$r++;
-		$this->rights[$r][0] = 56006; // id de la permission
+		$this->rights[$r][0] = 56006; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Export ticket"; // Permission label
-		//$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
+		//$this->rights[$r][2] = 'd'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		/* Seems not used and in conflict with societe->client->voir (see all thirdparties)
 		$r++;
-		$this->rights[$r][0] = 56005; // id de la permission
+		$this->rights[$r][0] = 56005; // Permission id (must not be already used)
 		$this->rights[$r][1] = 'See all tickets, even if not assigned to (not effective for external users, always restricted to the thirdpardy they depends on)'; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'view';
 		$this->rights[$r][5] = 'all';

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -227,35 +227,35 @@ class modTicket extends DolibarrModules
 
 		$r = 0;
 		$this->rights[$r][0] = 56001; // id de la permission
-		$this->rights[$r][1] = "Read ticket"; // libelle de la permission
+		$this->rights[$r][1] = "Read ticket"; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 
 		$r++;
 		$this->rights[$r][0] = 56002; // id de la permission
-		$this->rights[$r][1] = "Create les tickets"; // libelle de la permission
+		$this->rights[$r][1] = "Create les tickets"; // Permission label
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'write';
 
 		$r++;
 		$this->rights[$r][0] = 56003; // id de la permission
-		$this->rights[$r][1] = "Delete les tickets"; // libelle de la permission
+		$this->rights[$r][1] = "Delete les tickets"; // Permission label
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'delete';
 
 		$r++;
 		$this->rights[$r][0] = 56004; // id de la permission
-		$this->rights[$r][1] = "Manage tickets"; // libelle de la permission
+		$this->rights[$r][1] = "Manage tickets"; // Permission label
 		//$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'manage_advance';
 
 		$r++;
 		$this->rights[$r][0] = 56006; // id de la permission
-		$this->rights[$r][1] = "Export ticket"; // libelle de la permission
+		$this->rights[$r][1] = "Export ticket"; // Permission label
 		//$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
@@ -263,7 +263,7 @@ class modTicket extends DolibarrModules
 		/* Seems not used and in conflict with societe->client->voir (see all thirdparties)
 		$r++;
 		$this->rights[$r][0] = 56005; // id de la permission
-		$this->rights[$r][1] = 'See all tickets, even if not assigned to (not effective for external users, always restricted to the thirdpardy they depends on)'; // libelle de la permission
+		$this->rights[$r][1] = 'See all tickets, even if not assigned to (not effective for external users, always restricted to the thirdpardy they depends on)'; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'view';

--- a/htdocs/core/modules/modTicket.class.php
+++ b/htdocs/core/modules/modTicket.class.php
@@ -229,35 +229,35 @@ class modTicket extends DolibarrModules
 		$this->rights[$r][0] = 56001; // id de la permission
 		$this->rights[$r][1] = "Read ticket"; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 
 		$r++;
 		$this->rights[$r][0] = 56002; // id de la permission
 		$this->rights[$r][1] = "Create les tickets"; // libelle de la permission
 		$this->rights[$r][2] = 'w'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'write';
 
 		$r++;
 		$this->rights[$r][0] = 56003; // id de la permission
 		$this->rights[$r][1] = "Delete les tickets"; // libelle de la permission
 		$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'delete';
 
 		$r++;
 		$this->rights[$r][0] = 56004; // id de la permission
 		$this->rights[$r][1] = "Manage tickets"; // libelle de la permission
 		//$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'manage_advance';
 
 		$r++;
 		$this->rights[$r][0] = 56006; // id de la permission
 		$this->rights[$r][1] = "Export ticket"; // libelle de la permission
 		//$this->rights[$r][2] = 'd'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'export';
 
 		/* Seems not used and in conflict with societe->client->voir (see all thirdparties)
@@ -265,7 +265,7 @@ class modTicket extends DolibarrModules
 		$this->rights[$r][0] = 56005; // id de la permission
 		$this->rights[$r][1] = 'See all tickets, even if not assigned to (not effective for external users, always restricted to the thirdpardy they depends on)'; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'view';
 		$this->rights[$r][5] = 'all';
 		*/

--- a/htdocs/core/modules/modWorkflow.class.php
+++ b/htdocs/core/modules/modWorkflow.class.php
@@ -110,7 +110,7 @@ class modWorkflow extends DolibarrModules
 		/*
 		$r++;
 		$this->rights[$r][0] = 6001; // id de la permission
-		$this->rights[$r][1] = "Lire les workflow"; // libelle de la permission
+		$this->rights[$r][1] = "Lire les workflow"; // Permission label
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';

--- a/htdocs/core/modules/modWorkflow.class.php
+++ b/htdocs/core/modules/modWorkflow.class.php
@@ -109,9 +109,9 @@ class modWorkflow extends DolibarrModules
 
 		/*
 		$r++;
-		$this->rights[$r][0] = 6001; // id de la permission
+		$this->rights[$r][0] = 6001; // Permission id (must not be already used)
 		$this->rights[$r][1] = "Lire les workflow"; // Permission label
-		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
+		$this->rights[$r][2] = 'r'; // Permission type (deprecated)
 		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 		*/

--- a/htdocs/core/modules/modWorkflow.class.php
+++ b/htdocs/core/modules/modWorkflow.class.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2010-2012	Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2010		Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -111,7 +112,7 @@ class modWorkflow extends DolibarrModules
 		$this->rights[$r][0] = 6001; // id de la permission
 		$this->rights[$r][1] = "Lire les workflow"; // libelle de la permission
 		$this->rights[$r][2] = 'r'; // type de la permission (deprecated)
-		$this->rights[$r][3] = 0; // La permission est-elle une permission par default
+		$this->rights[$r][3] = 0; // Permission by default for new user (0/1)
 		$this->rights[$r][4] = 'read';
 		*/
 


### PR DESCRIPTION
## Description

Leftover French comments (one with an English typo) on the `$this->rights[$r][...]` lines of `htdocs/core/modules/modXxx.class.php`, replaced with the English forms already used elsewhere in the same directory / the module skeleton. Comment-only changes (plus the automatic copyright-year bump from the pre-commit hook), no behaviour change.

| French comment | English | Occurrences |
|---|---|---|
| `// id de la permission` | `// Permission id (must not be already used)` | 74 |
| `// La permission est-elle une permission par default` | `// Permission by default for new user (0/1)` | 67 |
| `// libelle de la permission` | `// Permission label` | 61 |
| `// type de la permission (deprecated)` / `(deprecie a ce jour)` | `// Permission type (deprecated)` | 58 |