### PR TITLE
FIX Prevent empty subprice_ttc from breaking line insert/update SQL

### DIFF
--- a/htdocs/comm/propal/class/propaleligne.class.php
+++ b/htdocs/comm/propal/class/propaleligne.class.php
@@ -511,6 +511,9 @@ class PropaleLigne extends CommonObjectLine
 		if (empty($this->total_localtax2)) {
 			$this->total_localtax2 = 0;
 		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
+		}
 		if (empty($this->rang)) {
 			$this->rang = 0;
 		}
@@ -762,6 +765,9 @@ class PropaleLigne extends CommonObjectLine
 		}
 		if (empty($this->subprice)) {
 			$this->subprice = 0;
+		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
 		}
 		if (empty($this->pa_ht)) {
 			$this->pa_ht = 0;

--- a/htdocs/commande/class/orderline.class.php
+++ b/htdocs/commande/class/orderline.class.php
@@ -449,6 +449,9 @@ class OrderLine extends CommonOrderLine
 		if (empty($this->remise_percent)) {
 			$this->remise_percent = 0;
 		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
+		}
 		if (empty($this->info_bits)) {
 			$this->info_bits = 0;
 		}
@@ -598,6 +601,9 @@ class OrderLine extends CommonOrderLine
 		}
 		if (empty($this->qty)) {
 			$this->qty = 0;
+		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
 		}
 		if (empty($this->total_localtax1)) {
 			$this->total_localtax1 = 0;

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -438,6 +438,9 @@ class FactureLigne extends CommonInvoiceLine
 		if (empty($this->subprice)) {
 			$this->subprice = 0;
 		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
+		}
 		if (empty($this->ref_ext)) {
 			$this->ref_ext = '';
 		}
@@ -652,6 +655,9 @@ class FactureLigne extends CommonInvoiceLine
 		$this->desc = trim($this->desc);
 		if (empty($this->ref_ext)) {
 			$this->ref_ext = '';
+		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
 		}
 		if (empty($this->tva_tx)) {
 			$this->tva_tx = 0;

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -1619,7 +1619,7 @@ class Contrat extends CommonObject
 			$sql .= " '".$this->db->escape($localtax2_type)."',";
 			$sql .= " ".price2num($remise_percent).",";
 			$sql .= " ".price2num($pu_ht).",";
-			$sql .= " ".($price_base_type === 'TTC' ? price2num($pu_ttc) : "0").",";
+			$sql .= " ".($price_base_type === 'TTC' ? (float) price2num($pu_ttc) : 0).",";
 			$sql .= " ".price2num($total_ht).",".price2num($total_tva).",".price2num($total_localtax1).",".price2num($total_localtax2).",".price2num($total_ttc).",";
 			$sql .= " ".((int) $info_bits).",";
 			if (isset($fk_fournprice)) {

--- a/htdocs/contrat/class/contratligne.class.php
+++ b/htdocs/contrat/class/contratligne.class.php
@@ -850,7 +850,7 @@ class ContratLigne extends CommonObjectLine
 		$sql .= " '".$this->db->escape($this->localtax2_tx)."',";
 		$sql .= " '".$this->db->escape($this->localtax1_type)."',";
 		$sql .= " '".$this->db->escape($this->localtax2_type)."',";
-		$sql .= " ".price2num($this->remise_percent).",".price2num($this->subprice).",".price2num($this->subprice_ttc).",";
+		$sql .= " ".price2num($this->remise_percent).",".price2num($this->subprice).",".((float) price2num($this->subprice_ttc)).",";
 		$sql .= " ".price2num($this->total_ht).",".price2num($this->total_tva).",".price2num($this->total_localtax1).",".price2num($this->total_localtax2).",".price2num($this->total_ttc).",";
 		$sql .= " '".$this->db->escape((string) $this->info_bits)."',";
 		$sql .= " ".(empty($this->rang) ? '0' : (int) $this->rang).",";

--- a/htdocs/fourn/class/fournisseur.facture.ligne.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.ligne.class.php
@@ -482,6 +482,9 @@ class SupplierInvoiceLine extends CommonObjectLine
 		}
 
 		// Clean parameters
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
+		}
 		if (empty($this->remise_percent)) {
 			$this->remise_percent = 0;
 		}
@@ -647,6 +650,9 @@ class SupplierInvoiceLine extends CommonObjectLine
 		}
 		if (empty($this->subprice)) {
 			$this->subprice = 0;
+		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
 		}
 		if (empty($this->special_code)) {
 			$this->special_code = 0;

--- a/htdocs/fourn/class/fournisseur.orderline.class.php
+++ b/htdocs/fourn/class/fournisseur.orderline.class.php
@@ -316,6 +316,9 @@ class CommandeFournisseurLigne extends CommonOrderLine
 		if (empty($this->remise_percent)) {
 			$this->remise_percent = 0;
 		}
+		if (empty($this->subprice_ttc)) {
+			$this->subprice_ttc = 0;
+		}
 		if (empty($this->info_bits)) {
 			$this->info_bits = 0;
 		}

--- a/test/phpunit/TtcRoundingTest.php
+++ b/test/phpunit/TtcRoundingTest.php
@@ -1837,4 +1837,121 @@ class TtcRoundingTest extends CommonClassTest
 		$this->assertMixedSubpriceTtc($afterRemise, 'Supplier invoice ROT discount');
 		print __METHOD__." id=".$id." clone=".$clonedId."\n";
 	}
+
+	/**
+	 * Customer invoice - applying a deposit/absolute discount inserts a FactureLigne through
+	 * insert_discount() which never sets subprice_ttc.
+	 * The line must be inserted with subprice_ttc defaulting to 0.
+	 *
+	 * @return void
+	 */
+	public function testCustomerInvoiceApplyDepositTtc()
+	{
+		global $user,$db;
+		$this->restoreGlobals();
+		if (!isModEnabled('invoice')) {
+			$this->markTestSkipped('Module invoice disabled');
+			return;
+		}
+
+		require_once DOL_DOCUMENT_ROOT.'/core/class/discount.class.php';
+
+		$socid = self::$socid;
+		$pid = self::$productid;
+
+		// Final invoice with one TTC line.
+		$object = new Facture($db);
+		$object->initAsSpecimen();
+		$object->socid = $socid;
+		$object->lines = array();
+		$id = $object->create($user);
+		$this->assertGreaterThan(0, $id, 'Invoice create for deposit');
+		$object->addline('Product TTC', 0, self::QTY, self::VAT, 0, 0, $pid, 0, '', '', 0, 0, 0, 'TTC', self::PU_TTC);
+
+		// A deposit/absolute discount available for the thirdparty (not yet linked to any invoice).
+		$discount = new DiscountAbsolute($db);
+		$discount->socid = $socid;
+		$discount->fk_soc = $socid;
+		$discount->description = 'Deposit TTC';
+		$discount->amount_ht = 100;
+		$discount->amount_tva = 20;
+		$discount->amount_ttc = 120;
+		$discount->tva_tx = self::VAT;
+		$discountid = $discount->create($user);
+		$this->assertGreaterThan(0, $discountid, 'DiscountAbsolute create: '.$discount->error);
+
+		// Apply the deposit on the final invoice: this is the path that used to crash.
+		$reloaded = new Facture($db);
+		$reloaded->fetch($id);
+		$res = $reloaded->insert_discount($discountid);
+		$this->assertGreaterThan(0, $res, 'insert_discount must not fail with an SQL error: '.$reloaded->error);
+
+		// The discount line is persisted with subprice_ttc = 0 (HT-entered, not a TTC entry marker).
+		$after = new Facture($db);
+		$after->fetch($id);
+		$after->fetch_lines();
+		$found = null;
+		foreach ($after->lines as $line) {
+			if (!empty($line->fk_remise_except)) {
+				$found = $line;
+				break;
+			}
+		}
+		$this->assertNotNull($found, 'Deposit line must exist on the invoice');
+		$this->assertEquals(0, (float) ($found->subprice_ttc ?? 0), 'Deposit line subprice_ttc must default to 0');
+		$this->assertEquals(-100, (float) $found->subprice, 'Deposit line subprice = -amount_ht');
+		print __METHOD__." id=".$id." discount=".$discountid."\n";
+	}
+
+	/**
+	 * Customer invoice - a line created before subprice_ttc existed has NULL in DB.
+	 * After fetch() (subprice_ttc = null), a plain update() must not break the SQL: the guard defaults it to 0.
+	 *
+	 * @return void
+	 */
+	public function testCustomerInvoiceLineUpdateLegacyNullSubpriceTtc()
+	{
+		global $user,$db;
+		$this->restoreGlobals();
+		if (!isModEnabled('invoice')) {
+			$this->markTestSkipped('Module invoice disabled');
+			return;
+		}
+
+		require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/factureligne.class.php';
+
+		$socid = self::$socid;
+		$pid = self::$productid;
+
+		$object = new Facture($db);
+		$object->initAsSpecimen();
+		$object->socid = $socid;
+		$object->lines = array();
+		$id = $object->create($user);
+		$this->assertGreaterThan(0, $id, 'Invoice create for legacy NULL subprice_ttc');
+		$object->addline('Product TTC', 0, self::QTY, self::VAT, 0, 0, $pid, 0, '', '', 0, 0, 0, 'TTC', self::PU_TTC);
+
+		$reloaded = new Facture($db);
+		$reloaded->fetch($id);
+		$reloaded->fetch_lines();
+		$priced = $this->pricedLines($reloaded);
+		$lineid = $priced[0]->id;
+
+		// Simulate a line created before subprice_ttc existed: force NULL in DB.
+		$sql = "UPDATE ".$db->prefix()."facturedet SET subprice_ttc = NULL WHERE rowid = ".((int) $lineid);
+		$this->assertNotFalse($db->query($sql), 'Force subprice_ttc = NULL in DB');
+
+		// Fetch (subprice_ttc becomes null) then update(): must not break the SQL.
+		$line = new FactureLigne($db);
+		$line->fetch($lineid);
+		$this->assertEmpty($line->subprice_ttc, 'subprice_ttc is empty/null after fetch of a legacy line');
+		$res = $line->update($user);
+		$this->assertGreaterThan(0, $res, 'update() must not fail on a legacy NULL subprice_ttc line: '.$line->error);
+
+		// After the update the guard persisted a 0 (never an empty SQL value).
+		$afterLine = new FactureLigne($db);
+		$afterLine->fetch($lineid);
+		$this->assertEquals(0, (float) ($afterLine->subprice_ttc ?? 0), 'subprice_ttc persisted as 0 after update');
+		print __METHOD__." id=".$id." line=".$lineid."\n";
+	}
 }


### PR DESCRIPTION
FIX Prevent empty subprice_ttc from breaking line insert/update SQL

price2num(null) returns an empty string, so writing subprice_ttc without a guard
produced a hole in the INSERT/UPDATE SQL - e.g. applying a deposit via
insert_discount(), or editing a line created before subprice_ttc existed and
stored as NULL.

Guard subprice_ttc (empty() default to 0) in the line insert()/update() of
customer invoice, proposal and order and supplier invoice/order lines; add the
missing (float) cast in Contrat::addline() and ContratLigne::insert() where a
local variable is written. Supplier proposal and the cast-protected update
paths were already safe.

Add non-regression tests (deposit application and legacy NULL subprice_ttc line
update) to TtcRoundingTest.