### PR TITLE
FIX #39802 Webhook trigger closes shared PostgreSQL connection, causing 500 error

### DIFF
--- a/htdocs/core/db/Database.interface.php
+++ b/htdocs/core/db/Database.interface.php
@@ -264,10 +264,11 @@ interface Database
 	 * @param   string 			$passwd 					Password
 	 * @param   string 			$name 						Name of database (not used for mysql, used for pgsql)
 	 * @param   int    			$port 						Port of database server
+	 * @param   bool			$forcenew					Force opening of a genuinely new connection instead of reusing one already opened to the same server/database in this process (relevant for pgsql only, see DoliDBPgsql::connect())
 	 * @return  false|resource|mysqli|mysqliDoli|PgSql\Connection|SQLite3    Database access handler
 	 * @see     close()
 	 */
-	public function connect($host, $login, $passwd, $name, $port = 0);
+	public function connect($host, $login, $passwd, $name, $port = 0, $forcenew = false);
 
 	/**
 	 *    Define limits and offset of request

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -58,8 +58,9 @@ class DoliDBMysqli extends DoliDB
 	 *	@param	    string	$pass		Password of database user
 	 *	@param	    string	$name		Name of database
 	 *	@param	    int		$port		Port of database server
+	 *	@param	    bool	$forcenew	Not used by this driver: mysqli always opens a genuinely new connection. Kept for signature parity with the Database interface.
 	 */
-	public function __construct($type, $host, $user, $pass, $name = '', $port = 0)
+	public function __construct($type, $host, $user, $pass, $name = '', $port = 0, $forcenew = false)
 	{
 		global $conf, $langs;
 
@@ -251,10 +252,11 @@ class DoliDBMysqli extends DoliDB
 	 * @param   string          $passwd         Password
 	 * @param   string          $name           Name of database (not used for mysql, used for pgsql)
 	 * @param   integer         $port           Port of database server
+	 * @param   bool            $forcenew       Not used by this driver: mysqli always opens a genuinely new connection. Kept for signature parity with the Database interface.
 	 * @return  mysqli|mysqliDoli|false         Database access object
 	 * @see close()
 	 */
-	public function connect($host, $login, $passwd, $name, $port = 0)
+	public function connect($host, $login, $passwd, $name, $port = 0, $forcenew = false)
 	{
 		dol_syslog(get_class($this)."::connect host=$host, port=$port, login=$login, passwd=--hidden--, name=$name", LOG_DEBUG);
 

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -77,8 +77,9 @@ class DoliDBPgsql extends DoliDB
 	 *	@param	    string	$pass		Password
 	 *	@param	    string	$name		Nom de la database
 	 *	@param	    int		$port		Port of database server
+	 *	@param	    bool	$forcenew	Force opening of a genuinely new connection instead of reusing one already opened to the same server/database in this process (see connect())
 	 */
-	public function __construct($type, $host, $user, $pass, $name = '', $port = 0)
+	public function __construct($type, $host, $user, $pass, $name = '', $port = 0, $forcenew = false)
 	{
 		global $conf, $langs;
 
@@ -116,7 +117,7 @@ class DoliDBPgsql extends DoliDB
 
 		// Essai connection serveur
 		//print "$host, $user, $pass, $name, $port";
-		$this->db = $this->connect($host, $user, $pass, $name, $port);
+		$this->db = $this->connect($host, $user, $pass, $name, $port, $forcenew);
 
 		if ($this->db) {
 			$this->connected = true;
@@ -405,10 +406,16 @@ class DoliDBPgsql extends DoliDB
 	 *	@param	    string		$passwd		Password
 	 *	@param		string		$name		Name of database (not used for mysql, used for pgsql)
 	 *	@param		integer		$port		Port of database server
+	 *	@param		bool		$forcenew	Force opening of a genuinely new connection instead of reusing one already opened to the same connection string in this process.
+	 *										By default, pg_connect() silently returns an existing connection resource when called again with an identical connection string within
+	 *										the same PHP process. This is dangerous whenever code intentionally opens a second, independent DoliDB instance to the same database
+	 *										(for example to run a piece of work on its own transaction) and later closes it: without $forcenew, that close() would actually close
+	 *										the shared underlying connection still in use by the original DoliDB instance, causing later queries on it to fail with
+	 *										"PostgreSQL connection has already been closed". Pass true whenever the caller needs a truly independent connection.
 	 *	@return		false|resource			Database access handler
 	 *	@see		close()
 	 */
-	public function connect($host, $login, $passwd, $name, $port = 0)
+	public function connect($host, $login, $passwd, $name, $port = 0, $forcenew = false)
 	{
 		// use pg_pconnect() instead of pg_connect() if you want to use persistent connection costing 1ms, instead of 30ms for non persistent
 
@@ -425,11 +432,13 @@ class DoliDBPgsql extends DoliDB
 			$name = "postgres"; // When try to connect using admin user
 		}
 
+		$connectflags = $forcenew ? PGSQL_CONNECT_FORCE_NEW : 0;
+
 		// try first Unix domain socket (local)
 		if ((!empty($host) && $host == "socket") && !defined('NOLOCALSOCKETPGCONNECT')) {
 			$con_string = "dbname='".$name."' user='".$login."' password='".$passwd."'"; // $name may be empty
 			try {
-				$this->db = @pg_connect($con_string);
+				$this->db = @pg_connect($con_string, $connectflags);
 			} catch (Exception $e) {
 				// No message
 			}
@@ -446,7 +455,7 @@ class DoliDBPgsql extends DoliDB
 
 			$con_string = "host='".$host."' port='".$port."' dbname='".$name."' user='".$login."' password='".$passwd."'";
 			try {
-				$this->db = @pg_connect($con_string);
+				$this->db = @pg_connect($con_string, $connectflags);
 			} catch (Exception $e) {
 				print $e->getMessage();
 			}

--- a/htdocs/core/db/sqlite3.class.php
+++ b/htdocs/core/db/sqlite3.class.php
@@ -66,8 +66,9 @@ class DoliDBSqlite3 extends DoliDB
 	 *  @param	    string	$pass		Password
 	 *  @param	    string	$name		Nom de la database
 	 *  @param	    int		$port		Port of database server
+	 *  @param	    bool	$forcenew	Not used by this driver: sqlite3 always opens a genuinely new connection. Kept for signature parity with the Database interface.
 	 */
-	public function __construct($type, $host, $user, $pass, $name = '', $port = 0)
+	public function __construct($type, $host, $user, $pass, $name = '', $port = 0, $forcenew = false)
 	{
 		global $conf;
 
@@ -321,10 +322,11 @@ class DoliDBSqlite3 extends DoliDB
 	 *	@param	    string			$passwd		password
 	 *	@param		string			$name		name of database (not used for mysql, used for pgsql)
 	 *	@param		integer			$port		Port of database server
+	 *	@param		bool			$forcenew	Not used by this driver: sqlite3 always opens a genuinely new connection. Kept for signature parity with the Database interface.
 	 *	@return		SQLite3|false				Database access handler
 	 *	@see		close()
 	 */
-	public function connect($host, $login, $passwd, $name, $port = 0)
+	public function connect($host, $login, $passwd, $name, $port = 0, $forcenew = false)
 	{
 		global $main_data_dir;
 

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -537,14 +537,15 @@ function isDolTms($timestamp)
  * @param	string	$pass		Password (clear)
  * @param	string	$name		Name of database
  * @param	int		$port		Port of database server
+ * @param	bool	$forcenew	Force opening of a genuinely new connection instead of reusing one already opened to the same server/database in this process (only meaningful for drivers, like pgsql, that may otherwise transparently reuse a matching connection)
  * @return	DoliDB				A DoliDB instance
  */
-function getDoliDBInstance($type, $host, $user, $pass, $name, $port)
+function getDoliDBInstance($type, $host, $user, $pass, $name, $port, $forcenew = false)
 {
 	require_once DOL_DOCUMENT_ROOT . "/core/db/" . $type . '.class.php';
 
 	$class = 'DoliDB' . ucfirst($type);
-	$db = new $class($type, $host, $user, $pass, $name, $port);
+	$db = new $class($type, $host, $user, $pass, $name, $port, $forcenew);
 	return $db;
 }
 

--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -157,7 +157,10 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 				}
 
 				if (empty($dbhistory)) {
-					$dbhistory = getDoliDBInstance($conf->db->type, $conf->db->host, (string) $conf->db->user, $dolibarr_main_db_pass, $conf->db->name, (int) $conf->db->port);
+					// Force a genuinely new connection (not one silently reused/shared with the main $db, as pg_connect() would otherwise do for
+					// an identical connection string): $dbhistory is closed independently below, and closing a connection shared with $this->db
+					// would break any later query on $this->db (e.g. the caller's pending commit) with "PostgreSQL connection has already been closed".
+					$dbhistory = getDoliDBInstance($conf->db->type, $conf->db->host, (string) $conf->db->user, $dolibarr_main_db_pass, $conf->db->name, (int) $conf->db->port, true);
 				}
 
 				$dbhistory->begin();

--- a/htdocs/debugbar/class/TraceableDB.php
+++ b/htdocs/debugbar/class/TraceableDB.php
@@ -409,12 +409,13 @@ class TraceableDB extends DoliDB
 	 * @param   string $passwd password
 	 * @param   string $name name of database (not used for mysql, used for pgsql)
 	 * @param   int    $port Port of database server
+	 * @param   bool   $forcenew Force opening of a genuinely new connection instead of reusing one already opened to the same server/database in this process (relevant for pgsql only)
 	 * @return  resource            Database access handler
 	 * @see     close()
 	 */
-	public function connect($host, $login, $passwd, $name, $port = 0)
+	public function connect($host, $login, $passwd, $name, $port = 0, $forcenew = false)
 	{
-		return $this->db->connect($host, $login, $passwd, $name, $port);
+		return $this->db->connect($host, $login, $passwd, $name, $port, $forcenew);
 	}
 
 	/**


### PR DESCRIPTION
  The webhook trigger opens a second DoliDB instance (getDoliDBInstance)
  with the same connection parameters as the main , purely to save a
  TriggerHistory audit record, then closes it at the end of runTrigger().

  On PostgreSQL, pg_connect() reuses/caches a connection by connection
  string within a process, so that second handle is actually the SAME
  underlying connection as the main . Closing it there closes the
  connection the caller (e.g. Product::correct_stock()) is still using,
  mid-transaction. The caller's next query (COMMIT) then hits PHP 8.1+'s
  pg_query() throwing an uncaught Error on an already-closed connection,
  producing an HTTP 500 even though the underlying business action
  (product create/update, stock movement) already succeeded.

  Add an optional  parameter, threaded through
  getDoliDBInstance() and DoliDBPgsql::connect()/__construct(), that
  passes PGSQL_CONNECT_FORCE_NEW to pg_connect() so a genuinely
  independent connection is opened instead of an aliased one. Defaults
  to false everywhere, so no other caller changes behavior. mysqli and
  sqlite3 drivers accept the same parameter for interface parity only
  (they already always open a new connection, so it has no effect
  there). The webhook trigger now requests  = true for its
  history connection.
