### PR TITLE
FIX missing entity field in supplier recurring invoice list SQL query

### DIFF
--- a/htdocs/fourn/facture/list-rec.php
+++ b/htdocs/fourn/facture/list-rec.php
@@ -292,7 +292,7 @@ $today = dol_mktime(23, 59, 59, $tmparray['mon'], $tmparray['mday'], $tmparray['
 // Build and execute select
 // --------------------------------------------------------------------
 
-$sql = "SELECT s.nom as name, s.rowid as socid, f.rowid as facid, f.titre as title, f.total_ht, f.total_tva, f.total_ttc, f.frequency, f.unit_frequency,";
+$sql = "SELECT s.nom as name, s.rowid as socid, f.rowid as facid, f.entity, f.titre as title, f.total_ht, f.total_tva, f.total_ttc, f.frequency, f.unit_frequency,";
 $sql .= " f.nb_gen_done, f.nb_gen_max, f.date_last_gen, f.date_when, f.suspended,";
 $sql .= " f.datec, f.fk_user_author, f.tms, f.fk_user_modif,";
 $sql .= " f.fk_cond_reglement, f.fk_mode_reglement";


### PR DESCRIPTION
Atomic split of #39784. `f.entity` was missing from the SELECT in `htdocs/fourn/facture/list-rec.php`, so the entity of each recurring supplier invoice was never available on the list results.