### PR TITLE
FIX updateline() stored (int) cast of the User object instead of $user->id

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -1274,7 +1274,7 @@ class FactureFournisseurRec extends CommonInvoice
 		$sql .= ', special_code = ' . (int) $special_code;
 		$sql .= ', rang = ' . (int) $rang;
 		$sql .= ', fk_unit = ' . ($fk_unit ? "'" . $this->db->escape($fk_unit) . "'" : 'null');
-		$sql .= ', fk_user_modif = ' . (int) $user;
+		$sql .= ', fk_user_modif = ' . (int) $user->id;
 		$sql .= ', multicurrency_subprice = '.price2num($pu_ht_devise);
 		$sql .= ', multicurrency_total_ht = '.price2num($multicurrency_total_ht);
 		$sql .= ', multicurrency_total_tva = '.price2num($multicurrency_total_tva);


### PR DESCRIPTION
Atomic split of #39784. In `FactureFournisseurRec::updateline()`, `fk_user_modif` was set from `(int) $user` (casting the whole User object, which PHP coerces to 1) instead of `(int) $user->id`. The correct pattern is already used a few lines above in `update()` (line 602).