### PR TITLE
FIX fetch_lines() wrongly ran date_start/date_end through jdate()

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -863,8 +863,8 @@ class FactureFournisseurRec extends CommonInvoice
 				$line->total_localtax2          = $objp->total_localtax2;
 				$line->total_ttc                = $objp->total_ttc;
 				$line->product_type             = $objp->product_type;
-				$line->date_start               = $objp->date_start; // Not a SQL datetime string, jdate() would corrupt it
-				$line->date_end                 = $objp->date_end; // Not a SQL datetime string, jdate() would corrupt it
+				$line->date_start               = $objp->date_start; // Not a SQL datetime string, but a boolean 0 or 1, jdate() would corrupt it
+				$line->date_end                 = $objp->date_end; // Not a SQL datetime string, but a boolean 0 or 1, jdate() would corrupt it
 				$line->info_bits                = $objp->info_bits	;
 				$line->special_code             = $objp->special_code;
 				$line->rang                     = $objp->rang;

--- a/htdocs/fourn/class/fournisseur.facture-rec.class.php
+++ b/htdocs/fourn/class/fournisseur.facture-rec.class.php
@@ -863,8 +863,8 @@ class FactureFournisseurRec extends CommonInvoice
 				$line->total_localtax2          = $objp->total_localtax2;
 				$line->total_ttc                = $objp->total_ttc;
 				$line->product_type             = $objp->product_type;
-				$line->date_start               = $this->db->jdate($objp->date_start);
-				$line->date_end                 = $this->db->jdate($objp->date_end);
+				$line->date_start               = $objp->date_start; // Not a SQL datetime string, jdate() would corrupt it
+				$line->date_end                 = $objp->date_end; // Not a SQL datetime string, jdate() would corrupt it
 				$line->info_bits                = $objp->info_bits	;
 				$line->special_code             = $objp->special_code;
 				$line->rang                     = $objp->rang;


### PR DESCRIPTION
Atomic split of #39784. `DoliDB::jdate()` expects a SQL datetime string (`YYYYMMDDHHMMSS`); it strips non-digit characters and reparses them as a date. `facture_fourn_det_rec.date_start`/`date_end` are not SQL datetime values, so passing them through `jdate()` in `fetch_lines()` corrupts the value instead of leaving it untouched.