### PR TITLE
NEW Send reminder by email before a contract service expires

### DIFF
--- a/htdocs/admin/contract.php
+++ b/htdocs/admin/contract.php
@@ -563,6 +563,14 @@ print '<td class="right">';
 print ajax_constantonoff('CONTRACT_ALLOW_EXTERNAL_DOWNLOAD', array(), null, 0, 0, 0, 2, 0, 1);
 print '</td>';
 print '</tr>';
+
+// Reminder by email before a contract service expires
+print '<tr class="oddeven">';
+print '<td>'.$langs->trans("CONTRACT_REMINDER_EMAIL", $langs->transnoentitiesnoconv("Contract")).'</td>';
+print '<td class="right">';
+print ajax_constantonoff('CONTRACT_REMINDER_EMAIL', array(), null, 0, 0, 0, 2, 0, 1, '', '', 'inline-block', 0, $langs->trans("CONTRACT_REMINDER_EMAILHelp", $langs->transnoentitiesnoconv("Contract")));
+print '</td>';
+print '</tr>';
 print '</table>';
 print '</div>';
 

--- a/htdocs/admin/contract.php
+++ b/htdocs/admin/contract.php
@@ -569,7 +569,7 @@ if (isModEnabled('cron')) {
 	print '<tr class="oddeven">';
 	print '<td>'.$langs->trans("SendReminderForExpiredServicesTitle").'</td>';
 	print '<td class="right">';
-	print '<a href="'.dol_buildpath('/cron/list.php', 1).'?search_label=SendReminderForExpiredServicesTitle&status=-1">'.$langs->trans("ConfigureContractReminderCronjobToSetFrequency").'</a>';
+	print '<a href="'.DOL_URL_ROOT.'cron/list.php?search_label=SendReminderForExpiredServicesTitle&status=-1">'.$langs->trans("ConfigureContractReminderCronjobToSetFrequency").'</a>';
 	print '</td>';
 	print '</tr>';
 }

--- a/htdocs/admin/contract.php
+++ b/htdocs/admin/contract.php
@@ -565,12 +565,14 @@ print '</td>';
 print '</tr>';
 
 // Reminder by email before a contract service expires
-print '<tr class="oddeven">';
-print '<td>'.$langs->trans("CONTRACT_REMINDER_EMAIL", $langs->transnoentitiesnoconv("Contract")).'</td>';
-print '<td class="right">';
-print ajax_constantonoff('CONTRACT_REMINDER_EMAIL', array(), null, 0, 0, 0, 2, 0, 1, '', '', 'inline-block', 0, $langs->trans("CONTRACT_REMINDER_EMAILHelp", $langs->transnoentitiesnoconv("Contract")));
-print '</td>';
-print '</tr>';
+if (isModEnabled('cron')) {
+	print '<tr class="oddeven">';
+	print '<td>'.$langs->trans("SendReminderForExpiredServicesTitle").'</td>';
+	print '<td class="right">';
+	print '<a href="'.dol_buildpath('/cron/list.php', 1).'?search_label=SendReminderForExpiredServicesTitle&status=-1">'.$langs->trans("ConfigureContractReminderCronjobToSetFrequency").'</a>';
+	print '</td>';
+	print '</tr>';
+}
 print '</table>';
 print '</div>';
 

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3020,4 +3020,203 @@ class Contrat extends CommonObject
 	{
 		return $this->setSignedStatusCommon($user, $status, $notrigger, $triggercode);
 	}
+
+	/**
+	 * Send reminders by email before a running contract service expires.
+	 * CAN BE A CRON TASK
+	 *
+	 * Modeled on Adherent::sendReminderForExpiredSubscription(): for each requested delay, it looks
+	 * for contract lines whose end date falls on that one exact day (today + delay), so a line is
+	 * only ever matched once per delay value and running the job daily does not resend the same
+	 * reminder. Each successful send is logged as an agenda event on the contract, same as other
+	 * automated reminder emails in the application.
+	 *
+	 * @param	string		$daysbeforeendlist		Nb of days before end of service (negative number = after end). Can be a list of delays, separated by a semicolon, for example '10;5;0;-5'
+	 * @param	int			$fk_product				Restrict to lines of this product/service (0 = no restriction)
+	 * @return	int									0 if OK, <>0 if KO (this function is used also by cron so only 0 is OK)
+	 */
+	public function sendReminderForExpiredServices($daysbeforeendlist = '10', $fk_product = 0)
+	{
+		global $conf, $langs, $mysoc, $user;
+
+		$error = 0;
+		$this->output = '';
+		$this->error = '';
+
+		$blockingerrormsg = '';
+
+		if (!isModEnabled('contrat')) { // Should not happen. If module disabled, cron job should not be visible.
+			$langs->load("agenda");
+			$this->output = $langs->trans('ModuleNotEnabled', $langs->transnoentitiesnoconv("Contrat"));
+			return 0;
+		}
+		if (!getDolGlobalString('CONTRACT_REMINDER_EMAIL')) {
+			$langs->load("agenda");
+			$this->output = $langs->trans('EventRemindersByEmailNotEnabled', $langs->transnoentitiesnoconv("Contrat"));
+			return 0;
+		}
+
+		$now = dol_now();
+		$nbok = 0;
+		$nbko = 0;
+
+		$listoflinesok = array();
+		$listoflinesko = array();
+
+		$arraydaysbeforeend = explode(';', $daysbeforeendlist);
+		foreach ($arraydaysbeforeend as $daysbeforeend) { // Loop on each delay
+			dol_syslog(__METHOD__.' - Process delta = '.$daysbeforeend, LOG_DEBUG);
+
+			if (!is_numeric($daysbeforeend)) {
+				$blockingerrormsg = "Value for delta is not a numeric value";
+				$nbko++;
+				break;
+			}
+
+			$tmp = dol_getdate($now);
+			$datetosearchfor = dol_time_plus_duree(dol_mktime(0, 0, 0, $tmp['mon'], $tmp['mday'], $tmp['year'], 'tzserver'), (int) $daysbeforeend, 'd');
+			$datetosearchforend = dol_time_plus_duree(dol_mktime(23, 59, 59, $tmp['mon'], $tmp['mday'], $tmp['year'], 'tzserver'), (int) $daysbeforeend, 'd');
+
+			$sql = "SELECT cd.rowid, cd.fk_contrat";
+			$sql .= " FROM ".MAIN_DB_PREFIX."contratdet as cd";
+			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."contrat as c ON c.rowid = cd.fk_contrat";
+			$sql .= " WHERE c.entity = ".((int) $conf->entity); // Do not use getEntity('contract') here, we want the batch to be on its entity only
+			$sql .= " AND cd.statut = ".((int) ContratLigne::STATUS_OPEN);
+			$sql .= " AND cd.date_fin_validite >= '".$this->db->idate($datetosearchfor)."'";
+			$sql .= " AND cd.date_fin_validite <= '".$this->db->idate($datetosearchforend)."'";
+			if ((int) $fk_product > 0) {
+				$sql .= " AND cd.fk_product = ".((int) $fk_product);
+			}
+
+			$resql = $this->db->query($sql);
+			if ($resql) {
+				$num_rows = $this->db->num_rows($resql);
+
+				include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
+				include_once DOL_DOCUMENT_ROOT.'/contrat/class/contratligne.class.php';
+				$formmail = new FormMail($this->db);
+
+				$i = 0;
+				while ($i < $num_rows) {
+					$obj = $this->db->fetch_object($resql);
+
+					$contractline = new ContratLigne($this->db);
+					$contractline->fetch($obj->rowid);
+
+					$contractstatic = new Contrat($this->db);
+					$contractstatic->fetch($obj->fk_contrat);
+					$thirdpartyres = $contractstatic->fetch_thirdparty();
+
+					if ($thirdpartyres <= 0 || empty($contractstatic->thirdparty->email)) {
+						$nbko++;
+						$listoflinesko[$contractline->id] = $contractline->id;
+					} else {
+						$languagefromcountrycode = getLanguageCodeFromCountryCode($contractstatic->thirdparty->country_code);
+						$languagecodetouse = (empty($contractstatic->thirdparty->default_lang) ? ($languagefromcountrycode ? $languagefromcountrycode : $mysoc->default_lang) : $contractstatic->thirdparty->default_lang);
+
+						$outputlangs = new Translate('', $conf);
+						$outputlangs->setDefaultLang($languagecodetouse);
+						$outputlangs->loadLangs(array("main", "contracts"));
+						dol_syslog("sendReminderForExpiredServices Language for thirdparty id ".$contractstatic->thirdparty->id." set to ".$outputlangs->defaultlang." mysoc->default_lang=".$mysoc->default_lang);
+
+						$arraydefaultmessage = null;
+						$labeltouse = getDolGlobalString('CONTRACT_EMAIL_TEMPLATE_REMIND_EXPIRATION');
+
+						if (!empty($labeltouse)) {
+							$arraydefaultmessage = $formmail->getEMailTemplate($this->db, 'contrat', $user, $outputlangs, 0, 1, $labeltouse);
+						}
+
+						if (!empty($labeltouse) && is_object($arraydefaultmessage) && $arraydefaultmessage->id > 0) {
+							$substitutionarray = getCommonSubstitutionArray($outputlangs, 0, null, $contractstatic);
+							complete_substitutions_array($substitutionarray, $outputlangs, $contractstatic);
+							$substitutionarray['__CONTRACT_LINE_LABEL__'] = ($contractline->label ? $contractline->label : $contractline->description);
+							$substitutionarray['__CONTRACT_LINE_DATE_END__'] = dol_print_date($contractline->date_end, 'day', 'tzuserrel', $outputlangs);
+
+							$subject = make_substitutions($arraydefaultmessage->topic, $substitutionarray, $outputlangs);
+							$msg = make_substitutions($arraydefaultmessage->content, $substitutionarray, $outputlangs);
+							$email_from = getDolGlobalString('CONTRACT_MAIL_FROM', $conf->email_from);
+							$to = $contractstatic->thirdparty->email;
+							$cc = getDolGlobalString('CONTRACT_CC_MAIL_FROM');
+
+							$trackid = 'con'.$contractstatic->id;
+							$moreinheader = 'X-Dolibarr-Info: sendReminderForExpiredServices'."\r\n";
+
+							include_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+							$cmail = new CMailFile($subject, $to, $email_from, $msg, array(), array(), array(), $cc, '', 0, 1, '', '', $trackid, $moreinheader);
+							$result = $cmail->sendfile();
+							if (!$result) {
+								$error++;
+								$this->error .= $cmail->error.' ';
+								if (!is_null($cmail->errors)) {
+									$this->errors = array_merge($this->errors, $cmail->errors);
+								}
+								$nbko++;
+								$listoflinesko[$contractline->id] = $contractline->id;
+							} else {
+								$nbok++;
+								$listoflinesok[$contractline->id] = $contractline->id;
+
+								// Insert record of email sent, as an agenda event on the contract (same convention as other automated reminder emails)
+								require_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
+
+								$actioncomm = new ActionComm($this->db);
+								$actioncomm->type_code = 'AC_OTH_AUTO';
+								$actioncomm->code = 'AC_EMAIL';
+								$actioncomm->label = $langs->transnoentities('MailSentByTo', CMailFile::getValidAddress($email_from, 4, 0, 1), CMailFile::getValidAddress($to, 4, 0, 1));
+								$actioncomm->note_private = $msg;
+								$actioncomm->fk_project = 0;
+								$actioncomm->datep = $now;
+								$actioncomm->datef = $now;
+								$actioncomm->percentage = -1; // Not applicable
+								$actioncomm->socid = $contractstatic->thirdparty->id;
+								$actioncomm->contact_id = 0;
+								$actioncomm->authorid = $user->id;
+								$actioncomm->userownerid = $user->id;
+								$actioncomm->email_msgid = $cmail->msgid;
+								$actioncomm->email_from = $email_from;
+								$actioncomm->email_sender = '';
+								$actioncomm->email_to = $to;
+								$actioncomm->email_subject = $subject;
+
+								$actioncomm->fk_element = $contractstatic->id;
+								$actioncomm->elementid = $contractstatic->id;
+								$actioncomm->elementtype = $contractstatic->element;
+
+								$actioncomm->create($user);
+							}
+						} else {
+							$error++;
+							$this->error .= "Can't find email template with label=".$labeltouse.", to use for the reminding email ";
+
+							$nbko++;
+							$listoflinesko[$contractline->id] = $contractline->id;
+
+							break;
+						}
+					}
+
+					$i++;
+				}
+			} else {
+				$this->error = $this->db->lasterror();
+				return 1;
+			}
+		}
+
+		if ($blockingerrormsg) {
+			$this->error = $blockingerrormsg;
+			return 1;
+		} else {
+			$this->output = 'Found '.($nbok + $nbko).' contract lines to send reminder for.';
+			$this->output .= ' Sent email successfully for '.$nbok.' lines';
+			if ($nbko) {
+				$this->output .= ' - Canceled for '.$nbko.' line(s) (no thirdparty email, missing template, or send error)';
+			}
+		}
+
+		if ($error) {
+			return 1;
+		}
+		return 0;
+	}
 }

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3050,11 +3050,6 @@ class Contrat extends CommonObject
 			$this->output = $langs->trans('ModuleNotEnabled', $langs->transnoentitiesnoconv("Contract"));
 			return 0;
 		}
-		if (!getDolGlobalString('CONTRACT_REMINDER_EMAIL')) {
-			$langs->load("agenda");
-			$this->output = $langs->trans('EventRemindersByEmailNotEnabled', $langs->transnoentitiesnoconv("Contract"));
-			return 0;
-		}
 
 		$now = dol_now();
 		$nbok = 0;
@@ -3135,7 +3130,7 @@ class Contrat extends CommonObject
 							$subject = make_substitutions($arraydefaultmessage->topic, $substitutionarray, $outputlangs);
 							$msg = make_substitutions($arraydefaultmessage->content, $substitutionarray, $outputlangs);
 							$email_from = getDolGlobalString('CONTRACT_MAIL_FROM', $conf->email_from);
-							$to = $contractstatic->thirdparty->email;
+							$to = (string) $contractstatic->thirdparty->email;
 							$cc = getDolGlobalString('CONTRACT_CC_MAIL_FROM');
 
 							$trackid = 'con'.$contractstatic->id;

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3045,14 +3045,14 @@ class Contrat extends CommonObject
 
 		$blockingerrormsg = '';
 
-		if (!isModEnabled('contrat')) { // Should not happen. If module disabled, cron job should not be visible.
+		if (!isModEnabled('contract')) { // Should not happen. If module disabled, cron job should not be visible.
 			$langs->load("agenda");
-			$this->output = $langs->trans('ModuleNotEnabled', $langs->transnoentitiesnoconv("Contrat"));
+			$this->output = $langs->trans('ModuleNotEnabled', $langs->transnoentitiesnoconv("Contract"));
 			return 0;
 		}
 		if (!getDolGlobalString('CONTRACT_REMINDER_EMAIL')) {
 			$langs->load("agenda");
-			$this->output = $langs->trans('EventRemindersByEmailNotEnabled', $langs->transnoentitiesnoconv("Contrat"));
+			$this->output = $langs->trans('EventRemindersByEmailNotEnabled', $langs->transnoentitiesnoconv("Contract"));
 			return 0;
 		}
 

--- a/htdocs/core/modules/modContrat.class.php
+++ b/htdocs/core/modules/modContrat.class.php
@@ -114,7 +114,7 @@ class modContrat extends DolibarrModules
 				'unitfrequency' => 3600 * 24,
 				'priority' => 50,
 				'status' => 1,
-				'test' => 'isModEnabled("contrat")',
+				'test' => 'isModEnabled("contract")',
 				'datestart' => $datestart
 			),
 		);

--- a/htdocs/core/modules/modContrat.class.php
+++ b/htdocs/core/modules/modContrat.class.php
@@ -99,6 +99,26 @@ class modContrat extends DolibarrModules
 			1=>array('file'=>'box_services_expired.php', 'enabledbydefaulton'=>'Home')
 		);
 
+		// Cronjobs
+		$arraydate = dol_getdate(dol_now());
+		$datestart = dol_mktime(22, 0, 0, $arraydate['mon'], $arraydate['mday'], $arraydate['year']);
+		$this->cronjobs = array(
+			0 => array(
+				'label' => 'SendReminderForExpiredServicesTitle',
+				'jobtype' => 'method', 'class' => 'contrat/class/contrat.class.php',
+				'objectname' => 'Contrat',
+				'method' => 'sendReminderForExpiredServices',
+				'parameters' => '10;0',
+				'comment' => 'SendReminderForExpiredServices',
+				'frequency' => 1,
+				'unitfrequency' => 3600 * 24,
+				'priority' => 50,
+				'status' => 1,
+				'test' => 'isModEnabled("contrat")',
+				'datestart' => $datestart
+			),
+		);
+
 		// Permissions
 		$this->rights = array();
 		$this->rights_class = 'contrat';

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1642,6 +1642,8 @@ MemberCreateAnExternalUserForSubscriptionValidated=Create automatically an exter
 VisitorCanChooseItsPaymentMode=Visitor can choose from any available payment modes
 MEMBER_REMINDER_EMAIL=Enable automatic reminder <b>by email</b> of expired subscriptions.
 MEMBER_REMINDER_EMAILHelp=Note: The module <strong>%s</strong> must be enabled and correctly setup to send reminders.
+CONTRACT_REMINDER_EMAIL=Enable automatic reminder <b>by email</b> of contract services about to expire.
+CONTRACT_REMINDER_EMAILHelp=Note: The module <strong>%s</strong> must be enabled and correctly setup to send reminders.
 MembersDocModules=Document templates for documents generated from member record
 ##### LDAP setup #####
 LDAPSetup=LDAP Setup

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1642,8 +1642,7 @@ MemberCreateAnExternalUserForSubscriptionValidated=Create automatically an exter
 VisitorCanChooseItsPaymentMode=Visitor can choose from any available payment modes
 MEMBER_REMINDER_EMAIL=Enable automatic reminder <b>by email</b> of expired subscriptions.
 MEMBER_REMINDER_EMAILHelp=Note: The module <strong>%s</strong> must be enabled and correctly setup to send reminders.
-CONTRACT_REMINDER_EMAIL=Enable automatic reminder <b>by email</b> of contract services about to expire.
-CONTRACT_REMINDER_EMAILHelp=Note: The module <strong>%s</strong> must be enabled and correctly setup to send reminders.
+ConfigureContractReminderCronjobToSetFrequency=Configure the scheduled job to enable it and set its frequency
 MembersDocModules=Document templates for documents generated from member record
 ##### LDAP setup #####
 LDAPSetup=LDAP Setup

--- a/htdocs/langs/en_US/contracts.lang
+++ b/htdocs/langs/en_US/contracts.lang
@@ -120,3 +120,6 @@ ShowClosedServices=Show Closed Services
 HideClosedServices=Hide Closed Services
 UserStartingService=User starting service
 UserClosingService=User closing service
+SendReminderForExpiredServicesTitle=Send reminder by email for expiring contract services
+SendReminderForExpiredServices=Send reminder by email to the customer when a running contract service is about to expire (parameter is number of days before end of service to send the reminder. It can be a list of days separated by a semicolon, for example '10;5;0;-5'). The template of email to send is defined in setup of contract module.
+DescCONTRACT_EMAIL_TEMPLATE_REMIND_EXPIRATION=Email template to use to send email reminder when a contract service is about to expire


### PR DESCRIPTION
Add Contrat::sendReminderForExpiredServices(), modeled on Adherent::sendReminderForExpiredSubscription(): for each requested delay (days before/after end of service), find contract lines whose end date falls in that exact day window and send an email reminder to the thirdparty using the email template configured for the 'contrat' module. Each successful send is logged as an agenda event on the contract, matching the existing pattern used for other automated reminder emails.

Register it as a cron job (disabled by default via the CONTRACT_REMINDER_EMAIL setup constant, matching the member module's reminder toggle) and add an on/off switch on the contract module setup page.

The email template to use is set via the
CONTRACT_EMAIL_TEMPLATE_REMIND_EXPIRATION constant (Setup > Other), same as other module reminder features that don't have a dedicated template picker UI yet.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# UIUX|Uiux [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

