### PR TITLE
FIX #39816 Fix donation table creation

### DIFF
--- a/htdocs/install/mysql/tables/llx_don-don.sql
+++ b/htdocs/install/mysql/tables/llx_don-don.sql
@@ -55,5 +55,5 @@ create table llx_don
   model_pdf       varchar(255),
   import_key      varchar(14),
   extraparams	    varchar(255),							-- for other parameters with json format
-  ip              varchar(250)              --ip used to create record (for public submission page)
+  ip              varchar(250)              -- ip used to create record (for public submission page)
 )ENGINE=innodb;


### PR DESCRIPTION
## Summary
- add the required whitespace after the SQL double-dash comment marker
- allow `run_sql()` to remove the inline comment before creating `llx_don`

## Tests
- `git diff --check`
- standalone preprocessing proof using the exact inline-comment regex from `run_sql()`
- targeted scan confirms no malformed inline comment remains in `llx_don-don.sql`

Fixes #39816