### PR TITLE
NEW TakePOS action buttons accept a custom class, colorful theme stops defeating module styles

### DIFF
--- a/htdocs/takepos/css/colorful.css
+++ b/htdocs/takepos/css/colorful.css
@@ -1,3 +1,5 @@
+/* Copyright (C) 2026	Jose Martinez	<jose.martinez@pichinov.com> */
+
 button.calcbutton {
     background-color: #008000 !important;
 }
@@ -15,8 +17,11 @@ button.calcbutton2.poscolordelete {
 	color: #FFFFFF !important;
 }
 
+/* Loaded after pos.css.php, so the cascade is enough to override its color.
+   No !important here: it would also defeat the inline style a module can set
+   on its own button through the ActionButtons hook. */
 button.actionbutton {
-    background: #FFB100 !important;
+    background: #FFB100;
 }
 
 tr.selected, tr.selected td {

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -1607,6 +1607,7 @@ if (getDolGlobalString('TAKEPOS_WEIGHING_SCALE')) {
 	$menus[$r++] = array('title' => '<span class="fa fa-balance-scale pictofixedwidth"></span><div class="trunc">'.$langs->trans("WeighingScale").'</div>', 'action' => 'WeighingScale();');
 }
 
+// Each menu entry supports: 'title' (html), 'action' (js), 'style' (inline css) and 'class' (extra css class on the button).
 $parameters = array('menus' => $menus);
 $reshook = $hookmanager->executeHooks('ActionButtons', $parameters);
 if ($reshook == 0) {  //add buttons
@@ -1656,12 +1657,12 @@ if ($reshook == 0) {  //add buttons
 			if (count($menus) > 12 and $i == 12) {
 				echo '<button style="'.(empty($menu['style']) ? '' : $menu['style']).'" type="button" id="actionnext" class="actionbutton" onclick="MoreActions('.count($menus).')">'.$langs->trans("Next").'</button>';
 				echo '<button style="display: none;" type="button" id="actionprevious" class="actionbutton" onclick="MoreActions('.count($menus).')">'.$langs->trans("Previous").'</button>';
-				echo '<button style="display: none;" type="button" id="action'.$i.'" class="actionbutton" onclick="'.(empty($menu['action']) ? '' : $menu['action']).'">'.$menu['title'].'</button>';
+				echo '<button style="display: none;" type="button" id="action'.$i.'" class="actionbutton'.(empty($menu['class']) ? '' : ' '.dol_escape_htmltag($menu['class'])).'" onclick="'.(empty($menu['action']) ? '' : $menu['action']).'">'.$menu['title'].'</button>';
 			} elseif ($i > 12) {
-				echo '<button style="display: none;" type="button" id="action'.$i.'" class="actionbutton" onclick="'.(empty($menu['action']) ? '' : $menu['action']).'">'.$menu['title'].'</button>';
+				echo '<button style="display: none;" type="button" id="action'.$i.'" class="actionbutton'.(empty($menu['class']) ? '' : ' '.dol_escape_htmltag($menu['class'])).'" onclick="'.(empty($menu['action']) ? '' : $menu['action']).'">'.$menu['title'].'</button>';
 				// TODO keep style but hide button
 			} else {
-				echo '<button style="'.(empty($menu['style']) ? '' : $menu['style']).'" type="button" id="action'.$i.'" class="actionbutton" onclick="'.(empty($menu['action']) ? '' : $menu['action']).'">'.$menu['title'].'</button>';
+				echo '<button style="'.(empty($menu['style']) ? '' : $menu['style']).'" type="button" id="action'.$i.'" class="actionbutton'.(empty($menu['class']) ? '' : ' '.dol_escape_htmltag($menu['class'])).'" onclick="'.(empty($menu['action']) ? '' : $menu['action']).'">'.$menu['title'].'</button>';
 			}
 		}
 


### PR DESCRIPTION
## Problem

A module adding a button to the TakePOS action bar through the `ActionButtons` hook can pass a `'style'` entry, rendered as an inline style. But:

- the button class is hardcoded to `actionbutton`, so a module cannot attach its own CSS class;
- the optional colorful theme (`TAKEPOS_COLOR_THEME=1`) ships `button.actionbutton { background: #FFB100 !important; }` — a stylesheet `!important` beats plain inline styles, so whatever background the module chose is silently replaced by orange. The only workaround today is an inline `!important`, which is a hack.

## Changes

- **`htdocs/takepos/index.php`**: menu entries now support an optional `'class'` key, appended (escaped) to the hardcoded `actionbutton` class, and the supported keys are documented above the hook call. Modules can style their buttons with a semantic class, and themes can restyle those classes coherently.
- **`htdocs/takepos/css/colorful.css`**: drop the `!important` on `button.actionbutton`. The file is loaded after `pos.css.php` ($arrayofcss order), so the cascade already overrides the default color; the `!important` brought nothing except defeating module inline styles.

## Impact

No visual change for core buttons, in the default and colorful themes (checked: same specificity, colorful.css still wins by source order). Modules using the documented `'style'` key now get what they asked for under the colorful theme too.