### PR TITLE
FIX: Malformed inline SQL comments break migration/repair dedup steps

### DIFF
--- a/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
+++ b/htdocs/install/mysql/migration/10.0.0-11.0.0.sql
@@ -432,8 +432,8 @@ create table llx_expedition_package
 (
   rowid             integer AUTO_INCREMENT PRIMARY KEY,
   fk_expedition     integer NOT NULL,
-  description       varchar(255),    --Description of goods in the package (required by the custom)
-  value             double(24,8)     DEFAULT 0, --Value (Price of the content, for insurance & custom)
+  description       varchar(255),    -- Description of goods in the package (required by the custom)
+  value             double(24,8)     DEFAULT 0, -- Value (Price of the content, for insurance & custom)
   fk_parcel_type    integer,           -- Type or package, linked to llx_c_shipment_parcel_type (eg: 1=enveloppe, 2=package, 3=palette, 4=other)
   height            float,	       -- height
   width             float,	       -- width

--- a/htdocs/install/mysql/migration/4.0.0-5.0.0.sql
+++ b/htdocs/install/mysql/migration/4.0.0-5.0.0.sql
@@ -251,7 +251,7 @@ DROP TABLE tmp_links_double;
 --select objectid, label, max(rowid) as max_rowid, count(rowid) as count_rowid from llx_links where label is not null group by objectid, label having count(rowid) >= 2;
 CREATE TABLE tmp_links_double AS (SELECT objectid, label, MAX(rowid) AS max_rowid, COUNT(rowid) AS count_rowid FROM llx_links WHERE label IS NOT NULL GROUP BY objectid, label HAVING COUNT(rowid) >= 2);
 --select * from tmp_links_double;
-DELETE FROM llx_links WHERE (rowid, label) IN (SELECT max_rowid, label FROM tmp_links_double);	--update to avoid duplicate, delete to delete
+DELETE FROM llx_links WHERE (rowid, label) IN (SELECT max_rowid, label FROM tmp_links_double);	-- update to avoid duplicate, delete to delete
 DROP TABLE tmp_links_double;
 
 ALTER TABLE llx_links ADD UNIQUE INDEX uk_links (objectid,label);

--- a/htdocs/install/mysql/migration/repair.sql
+++ b/htdocs/install/mysql/migration/repair.sql
@@ -296,7 +296,7 @@ drop table tmp_links_double;
 --select objectid, label, max(rowid) as max_rowid, count(rowid) as count_rowid from llx_links where label is not null group by objectid, label having count(rowid) >= 2;
 create table tmp_links_double as (select objectid, label, MAX(rowid) as max_rowid, COUNT(rowid) as count_rowid from llx_links where label is not null group by objectid, label having COUNT(rowid) >= 2);
 --select * from tmp_links_double;
-delete from llx_links where (rowid, label) in (select max_rowid, label from tmp_links_double);	--update to avoid duplicate, delete to delete
+delete from llx_links where (rowid, label) in (select max_rowid, label from tmp_links_double);	-- update to avoid duplicate, delete to delete
 drop table tmp_links_double;
 
 
@@ -305,7 +305,7 @@ drop table tmp_product_double;
 --select barcode, max(rowid) as max_rowid, count(rowid) as count_rowid from llx_product where barcode is not null group by barcode having count(rowid) >= 2;
 create table tmp_product_double as (select barcode, MAX(rowid) as max_rowid, COUNT(rowid) as count_rowid from llx_product where barcode is not null group by barcode having COUNT(rowid) >= 2);
 --select * from tmp_product_double;
-update llx_product set barcode = null where (rowid, barcode) in (select max_rowid, barcode from tmp_product_double);	--update to avoid duplicate, delete to delete
+update llx_product set barcode = null where (rowid, barcode) in (select max_rowid, barcode from tmp_product_double);	-- update to avoid duplicate, delete to delete
 drop table tmp_product_double;
 
 
@@ -334,7 +334,7 @@ drop table tmp_commande_extrafields_double;
 --select fk_object, max(rowid) as max_rowid, count(rowid) as count_rowid from llx_links where label is not null group by fk_object having count(rowid) >= 2;
 create table tmp_commande_extrafields_double as (select fk_object, MAX(rowid) as max_rowid, COUNT(rowid) as count_rowid from llx_commande_extrafields group by fk_object having COUNT(rowid) >= 2);
 --select * from tmp_commande_extrafields_double;
-delete from llx_commande_extrafields where (rowid) in (select max_rowid from tmp_commande_extrafields_double);	--update to avoid duplicate, delete to delete
+delete from llx_commande_extrafields where (rowid) in (select max_rowid from tmp_commande_extrafields_double);	-- update to avoid duplicate, delete to delete
 drop table tmp_commande_extrafields_double;
 
 


### PR DESCRIPTION
## Problem

`run_sql()` (`htdocs/core/lib/admin.lib.php`) only removes an inline SQL comment when the `--` is followed by a space. Six lines in the migration scripts use `--word` glued with no space, which the loader cannot strip:

| File | Lines | Effect (verified against MariaDB via `mysqli::query()`) |
|------|-------|--------|
| `migration/repair.sql` | 299, 308, 337 | The three duplicate-cleanup `DELETE`/`UPDATE` end with `;<tab>--update to avoid duplicate, delete to delete`. Since `;` is not at end of line the buffer never flushes and the comment is not stripped, so the statement **and the following `DROP TABLE`** are concatenated and sent as one query → `ERROR 1064`. The three dedup sequences (`llx_links`, `llx_product.barcode`, `llx_commande_extrafields`) were silently no-ops and left their temp tables behind. This file is run live from **Home → System tools → Repair → “Execute”** (`install/repair.php`). |
| `migration/4.0.0-5.0.0.sql` | 254 | Same pattern on the `llx_links` dedup (only affects pre-5.0 upgrade paths). |
| `migration/10.0.0-11.0.0.sql` | 435-436 | `--Description` / `--Value` glued in the `CREATE TABLE llx_expedition_package` column list → `ERROR 1064`, table not created by the migration (only affects pre-11.0 upgrade paths). Adjacent lines already use the correct `, -- Type …` form. |

## Fix

Add the required space after `--` on the six lines. `run_sql()` then strips the comment and each statement executes on its own.

## Test

Replayed the affected blocks through a faithful copy of the `run_sql()` line/buffer loop and executed via `mysqli` against MariaDB 11.5: before the change the `repair.sql` `DELETE`s and the `CREATE TABLE llx_expedition_package` raise `ERROR 1064`; after the change every statement (dedup `DELETE`/`UPDATE` + its `DROP TABLE`, and the `CREATE TABLE`) runs successfully. Pure comment change, no schema/logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)