### PR TITLE
FIX #39757 Use absolute BlockedLog URL

### DIFF
--- a/htdocs/takepos/ajax/ajax.php
+++ b/htdocs/takepos/ajax/ajax.php
@@ -239,7 +239,7 @@ if ($action == 'getProducts' && $user->hasRight('takepos', 'run')) {
 
 						$ig = '../public/theme/common/nophoto.png';
 						if (!getDolGlobalString('TAKEPOS_HIDE_PRODUCT_IMAGES')) {
-							$image = $objProd->show_photos('product', $conf->product->multidir_output[$objProd->entity], 'small', 1);
+							$image = $objProd->show_photos('product', $conf->product->multidir_output[(int) $objProd->entity], 'small', 1);
 
 							$match = array();
 							preg_match('@src="([^"]+)"@', $image, $match);
@@ -357,7 +357,7 @@ if ($action == 'getProducts' && $user->hasRight('takepos', 'run')) {
 		while ($obj = $db->fetch_object($resql)) {
 			$objProd = new Product($db);
 			$objProd->fetch($obj->rowid);
-			$image = $objProd->show_photos('product', $conf->product->multidir_output[$objProd->entity], 'small', 1);
+			$image = $objProd->show_photos('product', $conf->product->multidir_output[(int) $objProd->entity], 'small', 1);
 
 			$match = array();
 			preg_match('@src="([^"]+)"@', $image, $match);

--- a/htdocs/takepos/ajax/ajax.php
+++ b/htdocs/takepos/ajax/ajax.php
@@ -449,7 +449,7 @@ if ($action == 'getProducts' && $user->hasRight('takepos', 'run')) {
 		$resultinccounter = 0;
 		$templateidtouse = 0;
 
-		$url = DOL_URL_ROOT."/blockedlog/ajax/block-add.php?id=".((int) $object->id).'&element='.urlencode($object->element)."&action=DOC_PREVIEW&token=".newToken();
+		$url = DOL_MAIN_URL_ROOT."/blockedlog/ajax/block-add.php?id=".((int) $object->id).'&element='.urlencode($object->element)."&action=DOC_PREVIEW&token=".newToken();
 
 		$result = getURLContent($url, 'GET', '', 1, array(), array('http', 'https'), 2);
 


### PR DESCRIPTION
## Summary
- build the server-side BlockedLog request with the absolute Dolibarr URL root
- allow TakePOS receipt printing to continue after the BlockedLog counter update

## Tests
- `git diff --check`
- `php -l htdocs/takepos/ajax/ajax.php`
- standalone URL construction proof confirms `DOL_URL_ROOT` produces a relative path while `DOL_MAIN_URL_ROOT` produces a valid absolute URL

Fixes #39757