### PR TITLE
Use right_position in the rights ORDER BY of every permission editor

### DIFF
--- a/htdocs/admin/perms.php
+++ b/htdocs/admin/perms.php
@@ -153,7 +153,7 @@ $sql .= " AND r.entity = ".((int) $entity);
 if (!getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
 	$sql .= " AND r.perms NOT LIKE '%_advance'"; // Hide advanced perms if option is not enabled
 }
-$sql .= " ORDER BY r.family_position, r.module_position, r.module, r.id";
+$sql .= " ORDER BY r.family_position, r.module_position, r.right_position, r.module, r.id";
 
 $result = $db->query($sql);
 if ($result) {

--- a/htdocs/user/group/perms.php
+++ b/htdocs/user/group/perms.php
@@ -359,7 +359,7 @@ $sql .= " AND r.entity = ".((int) $entity);
 if (!getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
 	$sql .= " AND r.perms NOT LIKE '%_advance'"; // Hide advanced perms if option is not enabled
 }
-$sql .= " ORDER BY r.family_position, r.module_position, r.module, r.id";
+$sql .= " ORDER BY r.family_position, r.module_position, r.right_position, r.module, r.id";
 
 $familyinfo = array(
 	'hr' => array('position' => '001', 'label' => $langs->trans("ModuleFamilyHr")),

--- a/htdocs/user/perms.php
+++ b/htdocs/user/perms.php
@@ -224,7 +224,7 @@ $sql = "SELECT r.id, r.libelle as label, r.module, r.perms, r.subperms, r.module
 $sql .= " FROM ".MAIN_DB_PREFIX."rights_def as r";
 $sql .= " WHERE r.libelle NOT LIKE 'tou%'"; // We ignore permission "tous les tiers". Why ?
 $sql .= " AND r.entity = ".((int) $entity);
-$sql .= " ORDER BY r.family, r.family_position, r.module_position, r.module, r.id";
+$sql .= " ORDER BY r.family, r.family_position, r.module_position, r.right_position, r.module, r.id";
 
 $result = $db->query($sql);
 if ($result) {
@@ -494,7 +494,7 @@ $sql .= " AND r.entity = ".((int) $entity);
 if (!getDolGlobalString('MAIN_USE_ADVANCED_PERMS')) {
 	$sql .= " AND r.perms NOT LIKE '%_advance'"; // Hide advanced perms if option is not enabled
 }
-$sql .= " ORDER BY r.family_position, r.module_position, r.module, r.id";
+$sql .= " ORDER BY r.family_position, r.module_position, r.right_position, r.module, r.id";
 
 $familyinfo = array(
 	'hr' => array('position' => '001', 'label' => $langs->trans("ModuleFamilyHr")),


### PR DESCRIPTION
Follow-up to #39787. As discussed there with @eldy, now that `right_position` exists on `llx_rights_def`, this adds it as a tie-breaker (after `family_position`/`module_position`, before `module`/`id`) in the `ORDER BY` of every place that lists rights in this hierarchy: `admin/perms.php` (the one referenced in the review comment), plus `user/perms.php` (both queries) and `user/group/perms.php`, for consistency across all the permission editors.