### PR TITLE
Product mass VAT change tool: support rates without a VAT code

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -470,3 +470,5 @@ UseBarCodeForProducts=Use barcode for products
 UseBarCodeForThirdParties=Use barcode for third parties
 NotSupportedOnKits=Not supported on kits
 ProductLangExtrafieldsSetup=Product translations Extrafields
+
+WithoutVATCode=Without VAT code

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -470,3 +470,5 @@ UseBarCodeForProducts=Utilisez code-barre pour produits
 UseBarCodeForThirdParties=Utilisez code-barre pour les tiers
 NotSupportedOnKits=Non pris en charge sur les kits
 ProductLangExtrafieldsSetup=produit traductions Champs supplémentaires
+
+WithoutVATCode=Sans code de TVA

--- a/htdocs/product/admin/product_tools.php
+++ b/htdocs/product/admin/product_tools.php
@@ -3,6 +3,7 @@
  * Copyright (C) 2013-2015 Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2025		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/product/admin/product_tools.php
+++ b/htdocs/product/admin/product_tools.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2013-2015 Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2025		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
+ * Copyright (C) 2026		Jose Martinez		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -208,9 +208,10 @@ if ($action == 'convert') {
 			} else {
 				$sweepwhere .= " AND (default_vat_code IS NULL OR default_vat_code = '')";
 			}
-			$newcodesql = ($vat_src_code_new ? "'".$db->escape($vat_src_code_new)."'" : "null");
-			$db->query("UPDATE ".MAIN_DB_PREFIX."product SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = ".$newcodesql." WHERE entity IN (".getEntity('product').")".$sweepwhere);
-			$db->query("UPDATE ".MAIN_DB_PREFIX."product_price SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = ".$newcodesql." WHERE 1 = 1".$sweepwhere);
+			$sweepproductsql = "UPDATE ".MAIN_DB_PREFIX."product SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = '".$db->escape($vat_src_code_new)."' WHERE entity IN (".getEntity('product').")".$sweepwhere;
+			$db->query($sweepproductsql);
+			$sweeppricesql = "UPDATE ".MAIN_DB_PREFIX."product_price SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = '".$db->escape($vat_src_code_new)."' WHERE 1 = 1".$sweepwhere;
+			$db->query($sweeppricesql);
 		}
 
 		$fourn = new Fournisseur($db);

--- a/htdocs/product/admin/product_tools.php
+++ b/htdocs/product/admin/product_tools.php
@@ -107,7 +107,7 @@ if ($action == 'convert') {
 			if ($vat_src_code_old) {
 				$sql .= " AND default_vat_code = '".$db->escape($vat_src_code_old)."'";
 			} else {
-				$sql .= " AND default_vat_code IS NULL";
+				$sql .= " AND (default_vat_code IS NULL OR default_vat_code = '')";
 			}
 
 			$resql = $db->query($sql);
@@ -197,6 +197,19 @@ if ($action == 'convert') {
 			} else {
 				dol_print_error($db);
 			}
+
+			// Sweep: updatePrice() above only reaches products that have a defined price. Set the target
+			// rate and VAT code directly on any product/price row still matching the old value (products
+			// without a price, and historical price rows), so the mass change is complete.
+			$sweepwhere = " AND tva_tx = '".$db->escape($oldvatrateclean)."'";
+			if ($vat_src_code_old) {
+				$sweepwhere .= " AND default_vat_code = '".$db->escape($vat_src_code_old)."'";
+			} else {
+				$sweepwhere .= " AND (default_vat_code IS NULL OR default_vat_code = '')";
+			}
+			$newcodesql = ($vat_src_code_new ? "'".$db->escape($vat_src_code_new)."'" : "null");
+			$db->query("UPDATE ".MAIN_DB_PREFIX."product SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = ".$newcodesql." WHERE entity IN (".getEntity('product').")".$sweepwhere);
+			$db->query("UPDATE ".MAIN_DB_PREFIX."product_price SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = ".$newcodesql." WHERE 1 = 1".$sweepwhere);
 		}
 
 		$fourn = new Fournisseur($db);
@@ -209,7 +222,7 @@ if ($action == 'convert') {
 		if ($vat_src_code_old) {
 			$sql .= " AND default_vat_code = '".$db->escape($vat_src_code_old)."'";
 		} else {
-			$sql .= " AND default_vat_code IS NULL";
+			$sql .= " AND (default_vat_code IS NULL OR default_vat_code = '')";
 		}
 		$sql .= " AND s.fk_pays = ".((int) $country_id);
 
@@ -335,7 +348,21 @@ if (empty($mysoc->country_code)) {
 	print '<tr class="oddeven">'."\n";
 	print '<td>'.$langs->trans("OldVATRates").'</td>'."\n";
 	print '<td width="60" class="right">'."\n";
-	print $form->load_tva('oldvatrate', $oldvatrate, $mysoc, null, 0, 0, '', false, 1);
+	// Old VAT rate: distinct (rate, code) pairs present on products, with the count of products for
+	// each -- so the source to convert (including rates without a VAT code) is visible and quantified.
+	print '<select class="flat" name="oldvatrate" id="oldvatrate">';
+	$sqloldvat = "SELECT tva_tx, default_vat_code, COUNT(*) as nb FROM ".MAIN_DB_PREFIX."product";
+	$sqloldvat .= " WHERE entity IN (".getEntity('product').") AND tva_tx IS NOT NULL";
+	$sqloldvat .= " GROUP BY tva_tx, default_vat_code ORDER BY tva_tx DESC, default_vat_code";
+	$resqloldvat = $db->query($sqloldvat);
+	while ($resqloldvat && $objoldvat = $db->fetch_object($resqloldvat)) {
+		$rateclean = price2num($objoldvat->tva_tx);
+		$hascode = !empty($objoldvat->default_vat_code);
+		$optval = $rateclean.($hascode ? ' ('.$objoldvat->default_vat_code.')' : '');
+		$optlbl = vatrate($rateclean, true).($hascode ? ' ('.$objoldvat->default_vat_code.')' : ' ('.$langs->trans("WithoutVATCode").')').' ('.$objoldvat->nb.')';
+		print '<option value="'.dol_escape_htmltag($optval).'"'.((string) $oldvatrate === (string) $optval ? ' selected' : '').'>'.$optlbl.'</option>';
+	}
+	print '</select>';
 	print '</td>'."\n";
 	print '</tr>'."\n";
 

--- a/htdocs/product/admin/product_tools.php
+++ b/htdocs/product/admin/product_tools.php
@@ -208,10 +208,8 @@ if ($action == 'convert') {
 			} else {
 				$sweepwhere .= " AND (default_vat_code IS NULL OR default_vat_code = '')";
 			}
-			$sweepproductsql = "UPDATE ".MAIN_DB_PREFIX."product SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = '".$db->escape($vat_src_code_new)."' WHERE entity IN (".getEntity('product').")".$sweepwhere;
-			$db->query($sweepproductsql);
-			$sweeppricesql = "UPDATE ".MAIN_DB_PREFIX."product_price SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = '".$db->escape($vat_src_code_new)."' WHERE 1 = 1".$sweepwhere;
-			$db->query($sweeppricesql);
+			$db->query("UPDATE ".MAIN_DB_PREFIX."product SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = '".$db->escape($vat_src_code_new)."' WHERE entity IN (".getEntity('product').")".$sweepwhere);
+			$db->query("UPDATE ".MAIN_DB_PREFIX."product_price SET tva_tx = '".$db->escape($newvatrateclean)."', default_vat_code = '".$db->escape($vat_src_code_new)."' WHERE 1 = 1".$sweepwhere);
 		}
 
 		$fourn = new Fournisseur($db);


### PR DESCRIPTION
## Summary
Three improvements to the mass VAT change tool (`htdocs/product/admin/product_tools.php`) so it can also handle products/prices that have a VAT **rate** but no VAT **code** (`default_vat_code`), which the current tool cannot select nor reliably update.

1. **"Old VAT rate" select** now lists the distinct `(rate, code)` pairs actually present on products, each with the number of products, e.g. `20% (TVAFR20) (37)` and `20% (Without VAT code) (16)`.
2. **Empty string as well as NULL** in the matching: `(default_vat_code IS NULL OR default_vat_code = '')`.
3. **Sweep** update after the price loop, to reach products that have no defined price (and historical price rows).

## Background — how a product ends up with a rate but no code
Dolibarr's reference VAT dictionary does not ship a `code` for the standard rates (e.g. the France reference row is `insert into llx_c_tva(fk_pays,taux,recuperableonly,note,active,entity) values (1,'20','0','VAT rate - standard ...',1,...)` — no `code`). Coded entries (`TVAFR20`, …) are added afterwards (manually in *Setup > Dictionaries > VAT rates*, by a module, or by importing a dictionary that has them).

So on a database where coded rates exist, products can still carry a rate **without** a code, because they were created before the code was added, imported, or synced from an e-commerce connector that sets `tva_tx` but not `default_vat_code`. This becomes visible because the VAT drop-down on document lines matches on the full `rate (code)` string: a product with a rate but no code is only auto-filled if an active **code-less** entry for that rate still exists as a fallback; if the dictionary only keeps the coded entry, the line VAT is left empty. Either way such products are inconsistent (they matter e.g. for Factur-X / e-invoicing, where the VAT category is derived from the code).

## What the tool could not do before
- The two selects were built from the dictionary via `load_tva(..., $mode = 1)`, so they only offered **coded** rates (`20 (TVAFR20)`). A rate **without** a code could not be chosen as the *source* of a conversion, so those products were unreachable.
- The no-code branch used an invalid comparison in some releases and, more importantly, only matched `IS NULL`, missing an empty-string code.
- The update is performed through `updatePrice()`, which is skipped for products that have no defined price (`if (empty($price_base_type)) { continue; }`), so price-less products were never updated, and historical `product_price` rows kept the old value.

## Changes in detail
### 1. Source select built from the products themselves (+ counts)
```php
$sqloldvat = "SELECT tva_tx, default_vat_code, COUNT(*) as nb FROM ".MAIN_DB_PREFIX."product
  WHERE entity IN (".getEntity('product').") AND tva_tx IS NOT NULL
  GROUP BY tva_tx, default_vat_code ORDER BY tva_tx DESC, default_vat_code";
```
Each distinct pair becomes an option whose value is `rate` (code-less) or `rate (code)`, labelled `20% (TVAFR20) (37)` / `20% (Without VAT code) (16)`. The admin sees exactly which combinations exist and how many products each holds, and can pick the code-less one as the conversion source.

### 2. Match empty string as well as NULL
`AND (default_vat_code IS NULL OR default_vat_code = '')` in both the product and supplier-price selection, since a missing code can be stored either way.

### 3. Sweep to complete the change
Since `updatePrice()` only reaches products that have a defined price, a direct `UPDATE` sets the target rate + code on any remaining matching rows in `product` and `product_price` (products without a price, and historical price rows), so the conversion is complete.

## Example
On a French database whose 20% products lost their code, the admin selects **Old = `20% (Without VAT code)`**, **New = `20% (TVAFR20)`**, and every 20% product without a code is migrated (including price-less ones), instead of only the subset that had a price.

## New label
`WithoutVATCode` in `htdocs/langs/en_US/products.lang` and `htdocs/langs/fr_FR/products.lang`.

## Backward compatibility
- The *New VAT rate* select is unchanged.
- Existing conversions between coded rates keep working; the new options only add code-less sources.
- The sweep uses the same old/new values already parsed by the action, so it only touches rows that match the chosen source.

_Draft for review._
