### PR TITLE
FIX #39766 Avoid duplicate OAuth root

### DIFF
--- a/htdocs/core/login/functions_googleoauth.php
+++ b/htdocs/core/login/functions_googleoauth.php
@@ -82,7 +82,8 @@ function check_user_password_googleoauth($usertotest, $passwordtotest, $entityto
 
 			$oauthstateanticsrf = bin2hex(random_bytes(128/8));
 			$_SESSION['oauthstateanticsrf'] = $shortscope.'-'.$oauthstateanticsrf;
-			$backtourl = $_SERVER['REQUEST_URI'];	// Here we are using a relative URL.
+			// Convert the server-root URI to the Dolibarr-root-relative URL expected by the callback.
+			$backtourl = preg_replace('/^'.preg_quote(DOL_URL_ROOT, '/').'/', '', $_SERVER['REQUEST_URI']);
 
 			// Clean the backtourl we can use after an OAuth authentication
 			$backtourl = preg_replace('/token=[^&]+/', '', $backtourl);	// We remove any token into url so we are sure only url with no action are qualified as call back urls.


### PR DESCRIPTION
## Summary
- normalize the saved Google OAuth return URL against `DOL_URL_ROOT`
- prevent subfolder installations from duplicating the Dolibarr path after OAuth login

## Root cause
`REQUEST_URI` already includes the Dolibarr subfolder, while the OAuth callback later prefixes the saved value with `DOL_MAIN_URL_ROOT`.

## Tests
- `git diff --check`
- `php -l htdocs/core/login/functions_googleoauth.php`
- standalone redirect construction proof for root, `/dolibarr`, and nested-subfolder installations (3 cases)

Fixes #39766