### PR TITLE
FIX Fix #39831 Wrong hardcoded 'llx_' prefix in API token list and ticket contact check

### DIFF
--- a/htdocs/api/admin/token_list.php
+++ b/htdocs/api/admin/token_list.php
@@ -207,7 +207,7 @@ $sql = "SELECT oat.rowid, oat.tokenstring, oat.entity, oat.state as rights, oat.
 $sql .= " oat.lastaccess, oat.apicount_total";
 $sql .= " FROM ".MAIN_DB_PREFIX."oauth_token as oat";
 $sql .= " WHERE service = 'dolibarr_rest_api'";
-$sql .= " AND EXISTS(SELECT 'exist' FROM llx_user as u WHERE u.api_key IS NOT NULL AND u.rowid = oat.fk_user)";
+$sql .= " AND EXISTS(SELECT 'exist' FROM ".MAIN_DB_PREFIX."user as u WHERE u.api_key IS NOT NULL AND u.rowid = oat.fk_user)";
 if ($search_user) {
 	$sql .= " AND EXISTS (SELECT 'exist' FROM ".MAIN_DB_PREFIX."user u";
 	$sql .= " WHERE (u.lastname LIKE '%".$db->escape($search_user)."%'";

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -816,7 +816,7 @@ class Tickets extends DolibarrApi
 		if ($source == "external") {
 			// Check external contact exists
 			$sqlCheckExternalContact = "SELECT 1 as exist";
-			$sqlCheckExternalContact .= " FROM llx_socpeople";
+			$sqlCheckExternalContact .= " FROM ".MAIN_DB_PREFIX."socpeople";
 			$sqlCheckExternalContact .= " WHERE rowid = " . intval($contactid);
 			$result = $this->db->query($sqlCheckExternalContact);
 
@@ -826,7 +826,7 @@ class Tickets extends DolibarrApi
 		} else {
 			// Check internal contact exists
 			$sqlCheckInternalContact = "SELECT 1 as exist";
-			$sqlCheckInternalContact .= " FROM llx_user";
+			$sqlCheckInternalContact .= " FROM ".MAIN_DB_PREFIX."user";
 			$sqlCheckInternalContact .= " WHERE rowid = " . intval($contactid);
 			$result = $this->db->query($sqlCheckInternalContact);
 


### PR DESCRIPTION
# FIX Fix #39831 Wrong hardcoded 'llx_' prefix in API token list and ticket contact check

Two executed SQL queries used a **hardcoded `llx_`** table prefix, failing with `DB_ERROR_NOSUCHTABLE` on installs whose prefix is not `llx_`:

- `htdocs/api/admin/token_list.php` — `EXISTS(SELECT 'exist' FROM llx_user as u …)` → `".MAIN_DB_PREFIX."user`. Breaks the **API tokens admin list**.
- `htdocs/ticket/class/api_tickets.class.php` (contact-existence check, lines 819 & 829) — `FROM llx_socpeople` and `FROM llx_user` → `".MAIN_DB_PREFIX."…`.

Both surrounding queries otherwise rely on `MAIN_DB_PREFIX`, so this is an oversight.

`token_list.php` is affected since 23.0 and `api_tickets.class.php` since 24.0; both are grouped here against **24.0** (the common branch where both bugs are present).

Fixes #39831