### PR TITLE
Fix expense report payments on multiple reports

### DIFF
--- a/htdocs/accountancy/journal/bankjournal.php
+++ b/htdocs/accountancy/journal/bankjournal.php
@@ -1661,8 +1661,10 @@ function getSourceDocRef($val, $typerecord)
 		$ref = $langs->transnoentitiesnoconv("SupplierInvoice");
 	} elseif ($typerecord == 'payment_expensereport') {
 		$sqlmid = 'SELECT e.rowid as id, e.ref';
-		$sqlmid .= " FROM ".MAIN_DB_PREFIX."payment_expensereport as pe, ".MAIN_DB_PREFIX."expensereport as e";
-		$sqlmid .= " WHERE pe.rowid=".((int) $val["paymentexpensereport"])." AND pe.fk_expensereport = e.rowid";
+		$sqlmid .= " FROM ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per";
+		$sqlmid .= " INNER JOIN ".MAIN_DB_PREFIX."expensereport as e ON e.rowid = per.fk_expensereport";
+		$sqlmid .= " WHERE per.fk_payment=".((int) $val["paymentexpensereport"]);
+		$sqlmid .= " ORDER BY per.rowid";
 		$ref = $langs->transnoentitiesnoconv("ExpenseReport");
 	} elseif ($typerecord == 'payment_salary') {
 		$sqlmid = 'SELECT s.rowid as ref';

--- a/htdocs/accountancy/journal/treasuryjournal.php
+++ b/htdocs/accountancy/journal/treasuryjournal.php
@@ -438,14 +438,15 @@ if ($resql) {
 				// Expense reports
 				//------------------------------------------
 				$sql = "SELECT er.rowid, er.ref, er.total_ht AS expense_report_total_ht, er.total_ttc AS expense_report_total_ttc,";
-				$sql .= " per.amount AS amount_payment,";
+				$sql .= " perer.amount AS amount_payment,";
 				$sql .= " erf.rowid AS row_id, erf.total_ht, erf.total_tva, erf.total_localtax1, erf.total_localtax2, erf.tva_tx, erf.total_ttc, erf.vat_src_code,";
 				$sql .= " ctf.accountancy_code,";
 				$sql .= " aa.label as accountancy_code_label,";
 				$sql .= " bu.fk_bank, bu.url_id AS bu_url_id, bu.type AS bu_type";
 				$sql .= " FROM ".$db->prefix()."expensereport_det as erf";
 				$sql .= " INNER JOIN ".$db->prefix()."expensereport as er ON er.rowid = erf.fk_expensereport";
-				$sql .= " INNER JOIN ".$db->prefix()."payment_expensereport as per ON per.fk_expensereport = er.rowid";
+				$sql .= " INNER JOIN ".$db->prefix()."paymentexpensereport_expensereport as perer ON perer.fk_expensereport = er.rowid";
+				$sql .= " INNER JOIN ".$db->prefix()."payment_expensereport as per ON per.rowid = perer.fk_payment";
 				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.url_id = per.rowid AND bu.type = '".$db->escape($type)."'";
 				$sql .= " LEFT JOIN ".$db->prefix()."c_type_fees as ctf ON ctf.id = erf.fk_c_type_fees";
 				$sql .= " LEFT JOIN ".$db->prefix()."accounting_account as aa ON aa.account_number = ctf.accountancy_code";

--- a/htdocs/compta/resultat/clientfourn.php
+++ b/htdocs/compta/resultat/clientfourn.php
@@ -1075,10 +1075,11 @@ if ($modecompta == 'BOOKKEEPING') {
 
 				$column = 'p.date_valid';
 			} else {
-				$sql = "SELECT p.rowid, p.ref, u.rowid as userid, u.firstname, u.lastname, date_format(pe.datep,'%Y-%m') as dm, sum(pe.amount) as amount_ht, sum(pe.amount) as amount_ttc";
+				$sql = "SELECT p.rowid, p.ref, u.rowid as userid, u.firstname, u.lastname, date_format(pe.datep,'%Y-%m') as dm, sum(per.amount) as amount_ht, sum(per.amount) as amount_ttc";
 				$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as p";
 				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."user as u ON u.rowid=p.fk_user_author";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as pe ON pe.fk_expensereport = p.rowid";
+				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per ON per.fk_expensereport = p.rowid";
+				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as pe ON pe.rowid = per.fk_payment";
 				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_paiement as c ON pe.fk_typepayment = c.id";
 				$sql .= " WHERE p.entity IN (".getEntity('expensereport').")";
 				$sql .= " AND p.fk_statut>=5";

--- a/htdocs/compta/resultat/index.php
+++ b/htdocs/compta/resultat/index.php
@@ -707,10 +707,11 @@ if (isModEnabled('expensereport') && ($modecompta == 'CREANCES-DETTES' || $modec
 			$sql .= " AND ".$db->sanitize($column)." >= '".$db->idate($date_start)."' AND ".$db->sanitize($column)." <= '".$db->idate($date_end)."'";
 		}
 	} elseif ($modecompta == 'RECETTES-DEPENSES') {
-		$sql = "SELECT date_format(pe.datep,'%Y-%m') as dm, sum(p.total_ht) as amount_ht,sum(p.total_ttc) as amount_ttc";
+		$sql = "SELECT date_format(pe.datep,'%Y-%m') as dm, sum(per.amount) as amount_ht,sum(per.amount) as amount_ttc";
 		$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as p";
 		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."user as u ON u.rowid=p.fk_user_author";
-		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as pe ON pe.fk_expensereport = p.rowid";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per ON per.fk_expensereport = p.rowid";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as pe ON pe.rowid = per.fk_payment";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_paiement as c ON pe.fk_typepayment = c.id";
 		$sql .= " WHERE p.entity IN (".getEntity('expensereport').")";
 		$sql .= " AND p.fk_statut >= 5";

--- a/htdocs/compta/resultat/projects.php
+++ b/htdocs/compta/resultat/projects.php
@@ -756,16 +756,22 @@ if (isModEnabled('invoice') && ($modecompta == 'CREANCES-DETTES' || $modecompta 
 			$sql .= " AND e.fk_statut >= 5";
 
 			$column = 'e.date_valid';
+			$groupby = " GROUP BY ed.rowid, ed.fk_projet, p.rowid, p.ref";
 		} else {
-			$sql = "SELECT ed.rowid as rowid, ed.fk_projet, p.rowid as project_rowid, p.ref as project_ref, sum(DISTINCT pe.amount) as amount_ht, sum(DISTINCT pe.amount) as amount_ttc";
+			// Distribute each payment proportionally between the expense report lines/projects.
+			$sql = "SELECT p.rowid as rowid, p.rowid as project_rowid, p.ref as project_ref,";
+			$sql .= " SUM(CASE WHEN e.total_ttc <> 0 THEN per.amount * ed.total_ttc / e.total_ttc ELSE 0 END) as amount_ht,";
+			$sql .= " SUM(CASE WHEN e.total_ttc <> 0 THEN per.amount * ed.total_ttc / e.total_ttc ELSE 0 END) as amount_ttc";
 			$sql .= " FROM ".MAIN_DB_PREFIX."expensereport_det as ed";
 			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."expensereport as e ON ed.fk_expensereport = e.rowid";
-			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as pe ON pe.fk_expensereport = e.rowid";
+			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per ON per.fk_expensereport = e.rowid";
+			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as pe ON pe.rowid = per.fk_payment";
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."projet as p ON ed.fk_projet = p.rowid";
 			$sql .= " WHERE e.entity IN (".getEntity('expensereport').")";
 			$sql .= " AND e.fk_statut >= 5";
 
 			$column = 'pe.datep';
+			$groupby = " GROUP BY p.rowid, p.ref";
 		}
 		if (!empty($date_start)) {
 			$sql .= " AND ".$db->sanitize($column)." >= '".$db->idate($date_start)."'";
@@ -774,7 +780,7 @@ if (isModEnabled('invoice') && ($modecompta == 'CREANCES-DETTES' || $modecompta 
 			$sql .= " AND ".$db->sanitize($column)." <= '".$db->idate($date_end)."'";
 		}
 
-		$sql .= " GROUP BY ed.rowid, ed.fk_projet, p.rowid, p.ref";
+		$sql .= $groupby;
 		$sqlNewSortField = $sortfield;  // @phan-suppress-current-line SqlInjection
 		if ($sqlNewSortField == 's.nom, s.rowid') {
 			$sqlNewSortField = 'project_ref';

--- a/htdocs/core/lib/tax.lib.php
+++ b/htdocs/core/lib/tax.lib.php
@@ -546,10 +546,11 @@ function tax_by_thirdparty($type, $db, $y, $date_start, $date_end, $modetax, $di
 		$sql .= " d.total_localtax1 as total_localtax1, d.total_localtax2 as total_localtax2, ";
 		$sql .= " e.date_debut as date_start, e.date_fin as date_end, e.fk_user_author,";
 		$sql .= " e.ref as facnum, e.total_ttc as ftotal_ttc, e.date_create, d.fk_c_type_fees as type,";
-		$sql .= " p.fk_bank as payment_id, p.amount as payment_amount, p.rowid as pid, e.ref as pref";
+		$sql .= " p.fk_bank as payment_id, per.amount as payment_amount, p.rowid as pid, e.ref as pref";
 		$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as e";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."expensereport_det as d ON d.fk_expensereport = e.rowid ";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."payment_expensereport as p ON p.fk_expensereport = e.rowid ";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per ON per.fk_expensereport = e.rowid ";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."payment_expensereport as p ON p.rowid = per.fk_payment ";
 		$sql .= " WHERE e.entity = ".((int) $conf->entity);
 		$sql .= " AND e.fk_statut IN (" . ExpenseReport::STATUS_CLOSED . ")";
 		if ($y && $m) {
@@ -571,7 +572,7 @@ function tax_by_thirdparty($type, $db, $y, $date_start, $date_end, $modetax, $di
 		if (getDolGlobalString('MAIN_NOT_INCLUDE_ZERO_VAT_IN_REPORTS')) {
 			$sql .= " AND (d.".$db->sanitize($f_rate)." <> 0 OR d.total_tva <> 0)";
 		}
-		$sql .= " ORDER BY e.rowid";
+		$sql .= " ORDER BY e.rowid, d.rowid, p.rowid";
 
 		dol_syslog("Tax.lib.php::tax_by_thirdparty", LOG_DEBUG);
 		$resql = $db->query($sql);
@@ -1083,10 +1084,11 @@ function tax_by_rate($type, $db, $y, $q, $date_start, $date_end, $modetax, $dire
 		$sql .= " d.total_localtax1 as total_localtax1, d.total_localtax2 as total_localtax2, ";
 		$sql .= " e.date_debut as date_start, e.date_fin as date_end, e.fk_user_author,";
 		$sql .= " e.ref as facnum, e.ref as pref, e.total_ttc as ftotal_ttc, e.date_create, d.fk_c_type_fees as type,";
-		$sql .= " p.fk_bank as payment_id, p.amount as payment_amount, p.rowid as pid";
+		$sql .= " p.fk_bank as payment_id, per.amount as payment_amount, p.rowid as pid";
 		$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as e";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."expensereport_det as d ON d.fk_expensereport = e.rowid";
-		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."payment_expensereport as p ON p.fk_expensereport = e.rowid";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per ON per.fk_expensereport = e.rowid";
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."payment_expensereport as p ON p.rowid = per.fk_payment";
 		$sql .= " WHERE e.entity = ".((int) $conf->entity);
 		$sql .= " AND e.fk_statut IN (" . ExpenseReport::STATUS_CLOSED . ")";
 		if ($y && $m) {
@@ -1108,7 +1110,7 @@ function tax_by_rate($type, $db, $y, $q, $date_start, $date_end, $modetax, $dire
 		if (getDolGlobalString('MAIN_NOT_INCLUDE_ZERO_VAT_IN_REPORTS')) {
 			$sql .= " AND (d.".$db->sanitize($f_rate)." <> 0 OR d.total_tva <> 0)";
 		}
-		$sql .= " ORDER BY e.rowid";
+		$sql .= " ORDER BY e.rowid, d.rowid, p.rowid";
 
 		dol_syslog("Tax.lib.php::tax_by_rate", LOG_DEBUG);
 		$resql = $db->query($sql);

--- a/htdocs/core/modules/expensereport/doc/pdf_standard_expensereport.modules.php
+++ b/htdocs/core/modules/expensereport/doc/pdf_standard_expensereport.modules.php
@@ -1069,15 +1069,16 @@ class pdf_standard_expensereport extends ModeleExpenseReport
 		// Loop on each payment
 		// TODO create method on expensereport class to get payments
 		// Payments already done (from payment on this expensereport)
-		$sql = "SELECT p.rowid, p.num_payment, p.datep as dp, p.amount, p.fk_bank,";
+		$sql = "SELECT p.rowid, p.num_payment, p.datep as dp, per.amount, p.fk_bank,";
 		$sql .= "c.code as p_code, c.libelle as payment_type,";
 		$sql .= "ba.rowid as baid, ba.ref as baref, ba.label, ba.number as banumber, ba.account_number, ba.fk_accountancy_journal";
-		$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as e, ".MAIN_DB_PREFIX."payment_expensereport as p";
+		$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as e";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per ON per.fk_expensereport = e.rowid";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as p ON p.rowid = per.fk_payment";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_paiement as c ON p.fk_typepayment = c.id";
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bank as b ON p.fk_bank = b.rowid';
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bank_account as ba ON b.fk_account = ba.rowid';
 		$sql .= " WHERE e.rowid = ".((int) $object->id);
-		$sql .= " AND p.fk_expensereport = e.rowid";
 		$sql .= ' AND e.entity IN ('.getEntity('expensereport').')';
 		$sql .= " ORDER BY dp";
 

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -2007,15 +2007,16 @@ if ($action == 'create') {
 			print '</tr>';
 
 			// Payments already done (from payment on this expensereport)
-			$sql = "SELECT p.rowid, p.num_payment, p.datep as dp, p.amount, p.fk_bank,";
+			$sql = "SELECT p.rowid, p.num_payment, p.datep as dp, per.amount, p.fk_bank,";
 			$sql .= "c.code as payment_code, c.libelle as payment_type,";
 			$sql .= "ba.rowid as baid, ba.ref as baref, ba.label, ba.number as banumber, ba.account_number, ba.fk_accountancy_journal";
-			$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as e, ".MAIN_DB_PREFIX."payment_expensereport as p";
+			$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as e";
+			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per ON per.fk_expensereport = e.rowid";
+			$sql .= " INNER JOIN ".MAIN_DB_PREFIX."payment_expensereport as p ON p.rowid = per.fk_payment";
 			$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."c_paiement as c ON p.fk_typepayment = c.id";
 			$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bank as b ON p.fk_bank = b.rowid';
 			$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bank_account as ba ON b.fk_account = ba.rowid';
 			$sql .= " WHERE e.rowid = ".((int) $id);
-			$sql .= " AND p.fk_expensereport = e.rowid";
 			$sql .= ' AND e.entity IN ('.getEntity('expensereport').')';
 			$sql .= " ORDER BY dp";
 

--- a/htdocs/expensereport/class/api_expensereports.class.php
+++ b/htdocs/expensereport/class/api_expensereports.class.php
@@ -881,9 +881,13 @@ class ExpenseReports extends DolibarrApi
 			throw new RestException(403);
 		}
 
-		$sql = "SELECT t.rowid FROM " . MAIN_DB_PREFIX . "payment_expensereport as t, ".MAIN_DB_PREFIX."expensereport as e";
-		$sql .= " WHERE e.rowid = t.fk_expensereport";
-		$sql .= ' AND e.entity IN ('.getEntity('expensereport').')';
+		$sql = "SELECT DISTINCT t.rowid";
+		$sql .= " FROM ".MAIN_DB_PREFIX."payment_expensereport as t";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per";
+		$sql .= " ON per.fk_payment = t.rowid";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."expensereport as e";
+		$sql .= " ON e.rowid = per.fk_expensereport";
+		$sql .= " WHERE e.entity IN (".getEntity('expensereport').")";
 
 		$sql .= $this->db->order($sortfield, $sortorder);
 		if ($limit) {
@@ -961,18 +965,59 @@ class ExpenseReports extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('expensereport', 'creer')) {
 			throw new RestException(403);
 		}
+
 		// Check mandatory fields
 		$result = $this->_validatepayment($request_data);
 
+		if (!is_array($request_data['amounts'])) {
+			throw new RestException(400, 'amounts field must be an array');
+		}
+
+		/*
+		 * Historically amounts was indexed by user ID.
+		 *
+		 * This endpoint creates a payment for one expense report,
+		 * so preserve the total amount while converting the internal
+		 * representation to:
+		 *
+		 *     expense_report_id => amount
+		 */
+		$totalamount = 0;
+
+		foreach ($request_data['amounts'] as $amount) {
+			$totalamount += (float) price2num($amount, 'MT');
+		}
+
 		$paymentExpenseReport = new PaymentExpenseReport($this->db);
-		$paymentExpenseReport->fk_expensereport = $id;
+		$paymentExpenseReport->fk_expensereport = (int) $id;
+		$paymentExpenseReport->amounts = array(
+			(int) $id => $totalamount
+		);
+
 		foreach ($request_data as $field => $value) {
-			$paymentExpenseReport->$field = $this->_checkValForAPI($field, $value, $paymentExpenseReport);
+			// Already normalized above.
+			if ($field === 'amounts' || $field === 'fk_expensereport') {
+				continue;
+			}
+
+			$paymentExpenseReport->$field = $this->_checkValForAPI(
+				$field,
+				$value,
+				$paymentExpenseReport
+			);
 		}
 
 		if ($paymentExpenseReport->create(DolibarrApiAccess::$user) < 0) {
-			throw new RestException(500, 'Error creating paymentExpenseReport', array_merge(array($paymentExpenseReport->error), $paymentExpenseReport->errors));
+			throw new RestException(
+				500,
+				'Error creating paymentExpenseReport',
+				array_merge(
+					array($paymentExpenseReport->error),
+					$paymentExpenseReport->errors
+				)
+			);
 		}
+
 		if (isModEnabled("bank")) {
 			$paymentExpenseReport->addPaymentToBank(
 				DolibarrApiAccess::$user,
@@ -1009,6 +1054,7 @@ class ExpenseReports extends DolibarrApi
 
 		$paymentExpenseReport = new PaymentExpenseReport($this->db);
 		$result = $paymentExpenseReport->fetch($id);
+
 		if (!$result) {
 			throw new RestException(404, 'payment of expense report not found');
 		}
@@ -1017,7 +1063,24 @@ class ExpenseReports extends DolibarrApi
 			if ($field == 'id') {
 				continue;
 			}
-			$paymentExpenseReport->$field = $this->_checkValForAPI($field, $value, $paymentExpenseReport);
+
+			/*
+			 * These fields define the expense-report allocation.
+			 * Updating only the legacy payment row would make it
+			 * inconsistent with paymentexpensereport_expensereport.
+			 */
+			if (in_array($field, array('fk_expensereport', 'amount', 'amounts'), true)) {
+				throw new RestException(
+					400,
+					'Field "'.$field.'" cannot be modified on an existing expense report payment'
+				);
+			}
+
+			$paymentExpenseReport->$field = $this->_checkValForAPI(
+				$field,
+				$value,
+				$paymentExpenseReport
+			);
 		}
 
 		if ($paymentExpenseReport->update(DolibarrApiAccess::$user) > 0) {

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -2704,12 +2704,9 @@ class ExpenseReport extends CommonObject
 	 */
 	public function getSumPayments()
 	{
-		$table = 'payment_expensereport';
-		$field = 'fk_expensereport';
-
-		$sql = 'SELECT sum(amount) as amount';
-		$sql .= ' FROM '.MAIN_DB_PREFIX.$table;
-		$sql .= " WHERE ".$this->db->sanitize($field)." = ".((int) $this->id);
+		$sql = 'SELECT SUM(amount) as amount';
+		$sql .= ' FROM '.MAIN_DB_PREFIX.'paymentexpensereport_expensereport';
+		$sql .= ' WHERE fk_expensereport = '.((int) $this->id);
 
 		dol_syslog(get_class($this)."::getSumPayments", LOG_DEBUG);
 		$resql = $this->db->query($sql);

--- a/htdocs/expensereport/class/paymentexpensereport.class.php
+++ b/htdocs/expensereport/class/paymentexpensereport.class.php
@@ -26,6 +26,7 @@
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
 require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
+require_once DOL_DOCUMENT_ROOT.'/expensereport/class/expensereport.class.php';
 
 
 /**
@@ -54,7 +55,7 @@ class PaymentExpenseReport extends CommonObject
 	public $rowid;
 
 	/**
-	 * @var int ID
+	 * @var int Legacy expense report ID kept for backward compatibility
 	 */
 	public $fk_expensereport;
 
@@ -72,9 +73,9 @@ class PaymentExpenseReport extends CommonObject
 	 */
 	public $amount; // Total amount of payment
 	/**
-	 * @var array<float|int>
+	 * @var array<int,float|int> Array of amounts indexed by expense report ID
 	 */
-	public $amounts = array(); // Array of amounts
+	public $amounts = array();
 
 	/**
 	 * @var int ID
@@ -139,8 +140,8 @@ class PaymentExpenseReport extends CommonObject
 	}
 
 	/**
-	 *  Create payment of expense report into database.
-	 *  Use this->amounts to have list of lines for the payment
+	 *  Create an expense report payment in database.
+	 *  Uses $this->amounts as an array indexed by expense report ID.
 	 *
 	 *  @param      User		$user   User making payment
 	 *  @return     int     			Return integer <0 if KO, id of payment if OK
@@ -189,7 +190,7 @@ class PaymentExpenseReport extends CommonObject
 		}
 
 		$totalamount = 0;
-		foreach ($this->amounts as $key => $value) {  // How payment is dispatch
+		foreach ($this->amounts as $key => $value) {  // Amount allocated to each expense report
 			$newvalue = (float) price2num($value, 'MT');
 			$this->amounts[$key] = $newvalue;
 			$totalamount += $newvalue;
@@ -217,6 +218,47 @@ class PaymentExpenseReport extends CommonObject
 			$resql = $this->db->query($sql);
 			if ($resql) {
 				$this->id = $this->db->last_insert_id(MAIN_DB_PREFIX."payment_expensereport");
+
+				// Insert links between this payment and each expense report.
+				foreach ($this->amounts as $expensereportid => $amount) {
+					$expensereportid = (int) $expensereportid;
+					$amount = (float) price2num($amount, 'MT');
+
+					if ($amount == 0) {
+						continue;
+					}
+
+					if ($expensereportid <= 0) {
+						$this->error = 'ErrorBadExpenseReportId';
+						$error++;
+						break;
+					}
+
+					$sql = "INSERT INTO ".MAIN_DB_PREFIX."paymentexpensereport_expensereport";
+					$sql .= " (fk_payment, fk_expensereport, amount,";
+					$sql .= " multicurrency_code, multicurrency_tx, multicurrency_amount)";
+					$sql .= " VALUES (";
+					$sql .= ((int) $this->id).",";
+					$sql .= ((int) $expensereportid).",";
+					$sql .= price2num($amount).",";
+					$sql .= " NULL,";
+					$sql .= " 1,";
+					$sql .= price2num($amount);
+					$sql .= ")";
+
+					dol_syslog(
+						get_class($this)."::create link payment ".$this->id.
+						" to expense report ".$expensereportid,
+						LOG_DEBUG
+					);
+
+					$resql2 = $this->db->query($sql);
+					if (!$resql2) {
+						$this->error = $this->db->lasterror();
+						$error++;
+						break;
+					}
+				}
 			} else {
 				$error++;
 			}
@@ -227,7 +269,9 @@ class PaymentExpenseReport extends CommonObject
 			$this->db->commit();
 			return $this->id;
 		} else {
-			$this->error = $this->db->error();
+			if (empty($this->error)) {
+				$this->error = $this->db->error();
+			}
 			$this->db->rollback();
 			return -1;
 		}
@@ -405,6 +449,18 @@ class PaymentExpenseReport extends CommonObject
 		if (!$error) {
 			$sql = "DELETE FROM ".MAIN_DB_PREFIX."bank_url";
 			$sql .= " WHERE type='payment_expensereport' AND url_id=".((int) $this->id);
+
+			dol_syslog(get_class($this)."::delete", LOG_DEBUG);
+			$resql = $this->db->query($sql);
+			if (!$resql) {
+				$error++;
+				$this->errors[] = "Error ".$this->db->lasterror();
+			}
+		}
+
+		if (!$error) {
+			$sql = "DELETE FROM ".MAIN_DB_PREFIX."paymentexpensereport_expensereport";
+			$sql .= " WHERE fk_payment=".((int) $this->id);
 
 			dol_syslog(get_class($this)."::delete", LOG_DEBUG);
 			$resql = $this->db->query($sql);
@@ -611,13 +667,29 @@ class PaymentExpenseReport extends CommonObject
 					}
 				}
 
-				// Add link 'user' in bank_url between user and bank transaction
-				if (!$error) {
-					foreach ($this->amounts as $key => $value) {  // We should have always same user but we loop in case of.
-						if ($mode == 'payment_expensereport') {
-							$fuser = new User($this->db);
-							$fuser->fetch($key);
+				// Add links to related users in bank_url.
+				if (!$error && $mode == 'payment_expensereport') {
+					$linkaddedforuser = array();
 
+					foreach ($this->amounts as $expensereportid => $value) {
+						$expensereport = new ExpenseReport($this->db);
+						$result = $expensereport->fetch((int) $expensereportid);
+						if ($result <= 0) {
+							$this->error = $expensereport->error;
+							$error++;
+							break;
+						}
+
+						$fuser = new User($this->db);
+						$result = $fuser->fetch((int) $expensereport->fk_user_author);
+						if ($result <= 0) {
+							$this->error = $fuser->error;
+							$error++;
+							break;
+						}
+
+						// Several expense reports may belong to the same user.
+						if (!isset($linkaddedforuser[$fuser->id])) {
 							$result = $acc->add_url_line(
 								$bank_line_id,
 								$fuser->id,
@@ -627,9 +699,12 @@ class PaymentExpenseReport extends CommonObject
 							);
 							if ($result <= 0) {
 								$this->error = $this->db->lasterror();
-								dol_syslog(get_class($this).'::addPaymentToBank '.$this->error);
+								dol_syslog(get_class($this).'::addPaymentToBank '.$this->error, LOG_ERR);
 								$error++;
+								break;
 							}
+
+							$linkaddedforuser[$fuser->id] = true;
 						}
 					}
 				}

--- a/htdocs/expensereport/payment/card.php
+++ b/htdocs/expensereport/payment/card.php
@@ -166,14 +166,16 @@ print dol_get_fiche_end();
 
 
 /*
- * List of expense report paid
+ * List of expense reports paid
  */
 
 $sql = 'SELECT er.rowid as eid, er.paid, er.total_ttc, per.amount';
-$sql .= ' FROM '.MAIN_DB_PREFIX.'payment_expensereport as per,'.MAIN_DB_PREFIX.'expensereport as er';
-$sql .= ' WHERE per.fk_expensereport = er.rowid';
+$sql .= ' FROM '.MAIN_DB_PREFIX.'paymentexpensereport_expensereport as per';
+$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'expensereport as er';
+$sql .= ' ON er.rowid = per.fk_expensereport';
+$sql .= ' WHERE per.fk_payment = '.((int) $id);
 $sql .= ' AND er.entity IN ('.getEntity('expensereport').')';
-$sql .= ' AND per.rowid = '.((int) $id);
+$sql .= ' ORDER BY per.rowid';
 
 dol_syslog("expensereport/payment/card.php", LOG_DEBUG);
 $resql = $db->query($sql);
@@ -216,7 +218,14 @@ if ($resql) {
 			print '<td class="right">'.price($objp->amount).'</td>';
 
 			// Remain to pay
-			print '<td class="right">'.price($objp->total_ttc - $objp->amount).'</td>';
+			$totalpaidonexpensereport = $expensereport->getSumPayments();
+
+			$remaintopay = price2num(
+				$objp->total_ttc - $totalpaidonexpensereport,
+				'MT'
+			);
+
+			print '<td class="right">'.price($remaintopay).'</td>';
 
 			// Status
 			print '<td class="center">'.$expensereport->getLibStatut(4).'</td>';

--- a/htdocs/expensereport/payment/list.php
+++ b/htdocs/expensereport/payment/list.php
@@ -197,7 +197,6 @@ $sql = 'SELECT pndf.rowid, pndf.rowid as ref, pndf.datep, pndf.amount as pamount
 $sql .= ', u.rowid as userid, u.login, u.email, u.lastname, u.firstname, u.photo';
 $sql .= ', c.code as paiement_type, c.libelle as paiement_libelle';
 $sql .= ', ba.rowid as bid, ba.ref as bref, ba.label as blabel, ba.number, ba.account_number as account_number, ba.iban_prefix, ba.bic, ba.currency_code, ba.fk_accountancy_journal as accountancy_journal';
-$sql .= ', SUM(pndf.amount)';
 // Add fields from hooks
 $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListSelect', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
@@ -207,7 +206,10 @@ $sql = preg_replace('/,\s*$/', '', $sql);
 $sqlfields = $sql; // $sql fields to remove for count total
 
 $sql .= ' FROM '.MAIN_DB_PREFIX.'payment_expensereport AS pndf';
-$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'expensereport AS ndf ON ndf.rowid=pndf.fk_expensereport';
+$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'paymentexpensereport_expensereport AS per';
+$sql .= ' ON per.fk_payment = pndf.rowid';
+$sql .= ' INNER JOIN '.MAIN_DB_PREFIX.'expensereport AS ndf';
+$sql .= ' ON ndf.rowid = per.fk_expensereport';
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_paiement AS c ON pndf.fk_typepayment = c.id';
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'user AS u ON u.rowid = ndf.fk_user_author';
 $sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'bank as b ON pndf.fk_bank = b.rowid';
@@ -263,7 +265,7 @@ $sql .= ' ba.rowid, ba.ref, ba.label, ba.number, ba.account_number, ba.iban_pref
 $nbtotalofrecords = '';
 if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {
 	/* The fast and low memory method to get and count full list converts the sql into a sql count */
-	$sqlforcount = preg_replace('/^'.preg_quote($sqlfields, '/').'/', 'SELECT COUNT(*) as nbtotalofrecords', $sql);
+	$sqlforcount = preg_replace('/^'.preg_quote($sqlfields, '/').'/', 'SELECT COUNT(DISTINCT pndf.rowid) as nbtotalofrecords', $sql);
 	$sqlforcount = preg_replace('/GROUP BY .*$/', '', $sqlforcount);
 
 	$resql = $db->query($sqlforcount);

--- a/htdocs/expensereport/payment/payment.php
+++ b/htdocs/expensereport/payment/payment.php
@@ -107,12 +107,30 @@ if ($action == 'add_payment' && $permissiontoadd) {
 		$paymentid = 0;
 		// $total = 0;
 
-		// Read possible payments
-		foreach ($_POST as $key => $value) {
-			if (substr($key, 0, 7) == 'amount_') {
-				if (GETPOST($key)) {
-					$amounts[$expensereport->fk_user_author] = (float) price2num(GETPOST($key));
-					// $total += price2num(GETPOST($key));
+		// Read possible payments.
+		// The key of $amounts is the expense report ID.
+		foreach ($_POST as $postkey => $value) {
+			if (preg_match('/^amount_([0-9]+)$/', $postkey, $matches)) {
+				$expensereportid = (int) $matches[1];
+
+				if (GETPOST($postkey) === '') {
+					continue;
+				}
+
+				$amount = (float) price2num(GETPOST($postkey), 'MT');
+
+				if ($amount < 0) {
+					$error++;
+					setEventMessages(
+						$langs->trans("ErrorBadValueForParameter", $postkey),
+						null,
+						'errors'
+					);
+					continue;
+				}
+
+				if ($amount != 0) {
+					$amounts[$expensereportid] = $amount;
 				}
 			}
 		}
@@ -120,6 +138,104 @@ if ($action == 'add_payment' && $permissiontoadd) {
 		if (count($amounts) <= 0) {
 			$error++;
 			setEventMessages('ErrorNoPaymentDefined', null, 'errors');
+		}
+
+		$expensereportsToPay = array();
+
+		/*
+		 * Server-side validation of every expense report submitted.
+		 */
+		if (!$error) {
+			foreach ($amounts as $expensereportid => $amount) {
+				$tmpExpenseReport = new ExpenseReport($db);
+
+				$result = $tmpExpenseReport->fetch((int) $expensereportid);
+
+				if ($result <= 0) {
+					$error++;
+					setEventMessages(
+						'Expense report '.$expensereportid.' not found',
+						null,
+						'errors'
+					);
+					break;
+				}
+
+				// All reports of one payment must belong to the same user.
+				if ((int) $tmpExpenseReport->fk_user_author !== (int) $expensereport->fk_user_author) {
+					$error++;
+					setEventMessages(
+						'Expense report '.$tmpExpenseReport->ref.' belongs to another user',
+						null,
+						'errors'
+					);
+					break;
+				}
+
+				// Keep the payment inside the same entity.
+				if ((int) $tmpExpenseReport->entity !== (int) $expensereport->entity) {
+					$error++;
+					setEventMessages(
+						'Expense report '.$tmpExpenseReport->ref.' belongs to another entity',
+						null,
+						'errors'
+					);
+					break;
+				}
+
+				// Only approved, unpaid reports can receive a payment here.
+				if (
+					(int) $tmpExpenseReport->status !== ExpenseReport::STATUS_APPROVED
+					|| !empty($tmpExpenseReport->paid)
+				) {
+					$error++;
+					setEventMessages(
+						'Expense report '.$tmpExpenseReport->ref.' is not available for payment',
+						null,
+						'errors'
+					);
+					break;
+				}
+
+				$sumpaidtmp = $tmpExpenseReport->getSumPayments();
+
+				if ($sumpaidtmp < 0) {
+					$error++;
+					setEventMessages(
+						$tmpExpenseReport->error,
+						$tmpExpenseReport->errors,
+						'errors'
+					);
+					break;
+				}
+
+				$remaintopay = price2num(
+					$tmpExpenseReport->total_ttc - $sumpaidtmp,
+					'MT'
+				);
+
+				if ($remaintopay <= 0) {
+					$error++;
+					setEventMessages(
+						'Expense report '.$tmpExpenseReport->ref.' has no amount remaining to pay',
+						null,
+						'errors'
+					);
+					break;
+				}
+
+				if ((float) $amount > (float) $remaintopay) {
+					$error++;
+					setEventMessages(
+						$langs->trans("PaymentHigherThanReminderToPay"),
+						null,
+						'errors'
+					);
+					break;
+				}
+
+				$expensereportsToPay[$expensereportid] = $tmpExpenseReport;
+			}
 		}
 
 		if (!$error) {
@@ -154,12 +270,40 @@ if ($action == 'add_payment' && $permissiontoadd) {
 			}
 
 			if (!$error) {
-				$payment->fetch($paymentid);
-				if ($expensereport->total_ttc - $payment->amount == 0) {
-					$result = $expensereport->setPaid($expensereport->id, $user);
-					if (!($result > 0)) {
-						setEventMessages($payment->error, $payment->errors, 'errors');
+				foreach ($expensereportsToPay as $expensereportid => $tmpExpenseReport) {
+					// Recalculate after inserting the new payment relation.
+					$sumpaidtmp = $tmpExpenseReport->getSumPayments();
+
+					if ($sumpaidtmp < 0) {
+						setEventMessages(
+							$tmpExpenseReport->error,
+							$tmpExpenseReport->errors,
+							'errors'
+						);
 						$error++;
+						break;
+					}
+
+					$remaintopay = price2num(
+						$tmpExpenseReport->total_ttc - $sumpaidtmp,
+						'MT'
+					);
+
+					if ($remaintopay == 0) {
+						$result = $tmpExpenseReport->setPaid(
+							$tmpExpenseReport->id,
+							$user
+						);
+
+						if ($result <= 0) {
+							setEventMessages(
+								$tmpExpenseReport->error,
+								$tmpExpenseReport->errors,
+								'errors'
+							);
+							$error++;
+							break;
+						}
 					}
 				}
 			}
@@ -231,17 +375,14 @@ if ($action == 'create' || empty($action)) {
 	print '<tr><td class="titlefield">'.$langs->trans("Period").'</td><td>'.get_date_range($expensereport->date_debut, $expensereport->date_fin, "", $langs, 0).'</td></tr>';
 	print '<tr><td>'.$langs->trans("Amount").'</td><td><span class="amount">'.price($expensereport->total_ttc, 0, $langs, 1, -1, -1, $conf->currency).'</span></td></tr>';
 
-	$sql = "SELECT sum(p.amount) as total";
-	$sql .= " FROM ".MAIN_DB_PREFIX."payment_expensereport as p, ".MAIN_DB_PREFIX."expensereport as e";
-	$sql .= " WHERE p.fk_expensereport = e.rowid AND p.fk_expensereport = ".((int) $id);
-	$sql .= ' AND e.entity IN ('.getEntity('expensereport').')';
-	$sumpaid = 0;
-	$resql = $db->query($sql);
-	if ($resql) {
-		$obj = $db->fetch_object($resql);
-		$sumpaid = $obj->total;
-		$db->free($resql);
+
+	$sumpaid = $expensereport->getSumPayments();
+
+	if ($sumpaid < 0) {
+		dol_print_error($db, $expensereport->error);
+		$sumpaid = 0;
 	}
+
 	print '<tr><td>'.$langs->trans("AlreadyPaid").'</td><td><span class="amount">'.price($sumpaid, 0, $langs, 1, -1, -1, $conf->currency).'</span></td></tr>';
 	print '<tr><td class="tdtop">'.$langs->trans("RemainderToPay").'</td><td><span class="amount">'.price($total - $sumpaid, 0, $langs, 1, -1, -1, $conf->currency).'</span></td></tr>';
 
@@ -295,8 +436,7 @@ if ($action == 'create' || empty($action)) {
 
 	print '<br>';
 
-	// List of expenses ereport not already paid completely
-	$num = 1;
+	// List of expense reports of the same user not already paid completely
 	$i = 0;
 
 	print '<table class="noborder centpercent">';
@@ -311,48 +451,101 @@ if ($action == 'create' || empty($action)) {
 	$total_ttc = 0;
 	$totalrecu = 0;
 
-	while ($i < $num) {
-		$objp = $expensereport;
+	/*
+	 * Get all approved and unpaid expense reports for the same user.
+	 *
+	 * The expense report used to enter this page is shown first.
+	 */
+	$sql = "SELECT";
+	$sql .= " e.rowid,";
+	$sql .= " e.ref,";
+	$sql .= " e.total_ttc,";
+	$sql .= " e.date_debut,";
+	$sql .= " COALESCE(SUM(per.amount), 0) as total_paid";
+	$sql .= " FROM ".MAIN_DB_PREFIX."expensereport as e";
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."paymentexpensereport_expensereport as per";
+	$sql .= " ON per.fk_expensereport = e.rowid";
+	$sql .= " WHERE e.fk_user_author = ".((int) $expensereport->fk_user_author);
+	$sql .= " AND e.entity = ".((int) $expensereport->entity);
+	$sql .= " AND e.fk_statut = ".ExpenseReport::STATUS_APPROVED;
+	$sql .= " AND e.paid = 0";
+	$sql .= " GROUP BY e.rowid, e.ref, e.total_ttc, e.date_debut";
+	$sql .= " HAVING (e.total_ttc - COALESCE(SUM(per.amount), 0)) > 0";
+	$sql .= " ORDER BY";
+	$sql .= " CASE WHEN e.rowid = ".((int) $expensereport->id)." THEN 0 ELSE 1 END,";
+	$sql .= " e.date_debut DESC,";
+	$sql .= " e.rowid DESC";
 
-		print '<tr class="oddeven">';
+	$resql = $db->query($sql);
 
-		print '<td>'.$expensereport->getNomUrl(1)."</td>";
-		print '<td class="right">'.price($objp->total_ttc)."</td>";
-		print '<td class="right">'.price($sumpaid)."</td>";
-		print '<td class="right">'.price($objp->total_ttc - $sumpaid)."</td>";
-		print '<td class="center">';
-		if ($sumpaid < $objp->total_ttc) {
-			$namef = "amount_".$objp->id;
-			$nameRemain = "remain_".$objp->id; // autofill remainder amount
-			if (!empty($conf->use_javascript_ajax)) { // autofill remainder amount
-				print img_picto("Auto fill", 'rightarrow.png', "class='AutoFillAmount' data-rowid='".$namef."' data-value='".($objp->total_ttc - $sumpaid)."'"); // autofill remainder amount
+	if ($resql) {
+		while ($objp = $db->fetch_object($resql)) {
+			$tmpExpenseReport = new ExpenseReport($db);
+			$tmpExpenseReport->id = $objp->rowid;
+			$tmpExpenseReport->ref = $objp->ref;
+
+			$sumpaidrow = (float) $objp->total_paid;
+			$remaintopay = price2num($objp->total_ttc - $sumpaidrow, 'MT');
+
+			print '<tr class="oddeven'.($objp->rowid == $expensereport->id ? ' highlight' : '').'">';
+
+			print '<td>'.$tmpExpenseReport->getNomUrl(1).'</td>';
+
+			print '<td class="right">'.price($objp->total_ttc).'</td>';
+
+			print '<td class="right">'.price($sumpaidrow).'</td>';
+
+			print '<td class="right">'.price($remaintopay).'</td>';
+
+			print '<td class="center nowraponall">';
+
+			$namef = 'amount_'.$objp->rowid;
+			$nameRemain = 'remain_'.$objp->rowid;
+
+			if ($remaintopay > 0) {
+				if (!empty($conf->use_javascript_ajax)) {
+					print img_picto(
+						"Auto fill",
+						'rightarrow.png',
+						"class='AutoFillAmount' data-rowid='".$namef."' data-value='".$remaintopay."'"
+					);
+				}
+
+				print '<input type="hidden" class="sum_remain" name="'.$nameRemain.'" value="'.$remaintopay.'">';
+
+				print '<input type="text" class="width75"';
+				print ' name="'.$namef.'"';
+				print ' id="'.$namef.'"';
+				print ' value="'.dol_escape_htmltag(GETPOST($namef)).'">';
+			} else {
+				print '-';
 			}
-			$remaintopay = $objp->total_ttc - $sumpaid; // autofill remainder amount
-			print '<input type=hidden class="sum_remain" name="'.$nameRemain.'" value="'.$remaintopay.'">'; // autofill remainder amount
-			print '<input type="text" class="width75" name="'.$namef.'" id="'.$namef.'" value="'.GETPOST($namef).'">';
-		} else {
-			print '-';
+
+			print '</td>';
+
+			print "</tr>\n";
+
+			$total_ttc += (float) $objp->total_ttc;
+			$totalrecu += $sumpaidrow;
+			$i++;
 		}
-		print "</td>";
 
-		print "</tr>\n";
-
-		$total_ttc += $objp->total_ttc;
-		$totalrecu += $sumpaid;
-		$i++;
+		$db->free($resql);
+	} else {
+		dol_print_error($db);
 	}
+
 	if ($i > 1) {
-		// Print total
-		print '<tr class="oddeven">';
-		print '<td colspan="2" class="left">'.$langs->trans("Total").':</td>';
+		print '<tr class="liste_total">';
+		print '<td>'.$langs->trans("Total").'</td>';
 		print '<td class="right"><b>'.price($total_ttc).'</b></td>';
 		print '<td class="right"><b>'.price($totalrecu).'</b></td>';
 		print '<td class="right"><b>'.price($total_ttc - $totalrecu).'</b></td>';
-		print '<td class="center">&nbsp;</td>';
-		print "</tr>\n";
+		print '<td>&nbsp;</td>';
+		print '</tr>';
 	}
 
-	print "</table>";
+	print '</table>';
 
 	print $form->buttonsSaveCancel();
 

--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -564,6 +564,26 @@ ALTER TABLE llx_actioncomm ADD INDEX idx_actioncomm_max_participants (max_partic
 ALTER TABLE llx_c_tva ADD COLUMN einvoice_vatex	varchar(32);
 
 
+-- Backfill n-n links for existing expense report payments
+INSERT INTO llx_paymentexpensereport_expensereport
+	(fk_payment, fk_expensereport, amount, multicurrency_code, multicurrency_tx, multicurrency_amount)
+SELECT
+	pe.rowid AS fk_payment,
+	pe.fk_expensereport,
+	pe.amount,
+	NULL AS multicurrency_code,
+	1 AS multicurrency_tx,
+	pe.amount AS multicurrency_amount
+FROM llx_payment_expensereport AS pe
+WHERE pe.fk_expensereport IS NOT NULL
+	AND pe.fk_expensereport > 0
+	AND NOT EXISTS (
+		SELECT 1
+		FROM llx_paymentexpensereport_expensereport AS per
+		WHERE per.fk_payment = pe.rowid
+			AND per.fk_expensereport = pe.fk_expensereport
+	);
+
 -- SQL with disabled check must be at end
 --noqa:disable=PRS
 DELETE FROM llx_const WHERE __DECRYPT('name')__ = 'MAIN_MENU_BARRETOP';


### PR DESCRIPTION
# FIX | Fix expense report payments on multiple reports

Complete support for using a single expense report payment to pay multiple expense reports.

The existing `paymentexpensereport_expensereport` N-N table is now used consistently as the relation between payments and expense reports, while the legacy `payment_expensereport.fk_expensereport` field is still populated for backward compatibility.

## Related work

This continues previous work around supporting payments covering multiple expense reports:

- #24884 introduced the `paymentexpensereport_expensereport` N-N table and prepared the database model for this functionality.
- #24885 and #30920 explored functional support for payments involving multiple expense reports.
- #36001 was a more recent attempt to implement this support but was closed without being merged.
- #39951 handles the historical data backfill into the existing N-N relation.

This PR contains the functional code changes only.

## Changes

- Allow the expense report payment page to select and pay several approved expense reports belonging to the same user.
- Create one payment and one bank transaction for the selected expense reports.
- Store the amount assigned to each expense report in `paymentexpensereport_expensereport`.
- Calculate paid and remaining amounts from the N-N relation.
- Update expense report payment cards, lists and PDF output to use the N-N relation.
- Update tax calculations, accounting journals and cash accounting reports to use the amount assigned to each expense report.
- Allocate expense report payments proportionally by project in cash accounting mode.
- Update Expense Report API payment handling to populate the N-N relation.
- Keep `payment_expensereport.fk_expensereport` populated for backward compatibility.

## Validation

Checked with:

- PHP syntax validation
- Phan 5.5.2
- PHPStan 2.1.12
- PHP_CodeSniffer 4.0.4
- `git diff --check`