### PR TITLE
FIX Install SQL scripts that never created their table

### DIFF
--- a/htdocs/install/mysql/tables/llx_don-don.sql
+++ b/htdocs/install/mysql/tables/llx_don-don.sql
@@ -55,5 +55,5 @@ create table llx_don
   model_pdf       varchar(255),
   import_key      varchar(14),
   extraparams	    varchar(255),							-- for other parameters with json format
-  ip              varchar(250)              --ip used to create record (for public submission page)
+  ip              varchar(250)              -- ip used to create record (for public submission page)
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.sql
+++ b/htdocs/install/mysql/tables/llx_eventorganization_conferenceorboothattendee.sql
@@ -35,7 +35,7 @@ CREATE TABLE llx_eventorganization_conferenceorboothattendee(
 	fk_user_creat integer,
 	fk_user_modif integer,
 	last_main_doc varchar(255),
-	ip varchar(250),              --ip used to create record (for public submission page)
+	ip varchar(250),              -- ip used to create record (for public submission page)
 	import_key varchar(14),
 	model_pdf varchar(255),
 	status smallint NOT NULL,

--- a/htdocs/install/mysql/tables/llx_expedition_package.sql
+++ b/htdocs/install/mysql/tables/llx_expedition_package.sql
@@ -3,8 +3,8 @@ create table llx_expedition_package
 (
   rowid             integer AUTO_INCREMENT PRIMARY KEY,
   fk_expedition     integer NOT NULL,
-  description       varchar(255),    --Description of goods in the package (required by the custom)
-  value             double(24,8)     DEFAULT 0, --Value (Price of the content, for insurance & custom)
+  description       varchar(255),    -- Description of goods in the package (required by the custom)
+  value             double(24,8)     DEFAULT 0, -- Value (Price of the content, for insurance & custom)
   fk_package_type    integer,           -- Type or package, linked to llx_c_shipment_parcel_type (eg: 1=enveloppe, 2=package, 3=palette, 4=other)
   height            float,	       -- height
   width             float,	       -- width

--- a/htdocs/install/mysql/tables/llx_facture.sql
+++ b/htdocs/install/mysql/tables/llx_facture.sql
@@ -120,5 +120,5 @@ create table llx_facture
   multicurrency_total_ht	double(24,8) DEFAULT 0,
   multicurrency_total_tva	double(24,8) DEFAULT 0,
   multicurrency_total_ttc	double(24,8) DEFAULT 0,
-  ip  varchar(250) --ip used to create record (for public submission page)
+  ip  varchar(250) -- ip used to create record (for public submission page)
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_opensurvey_comments-opensurvey.sql
+++ b/htdocs/install/mysql/tables/llx_opensurvey_comments-opensurvey.sql
@@ -22,5 +22,5 @@ CREATE TABLE llx_opensurvey_comments (
     tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     usercomment text,
     date_creation datetime NOT NULL,
-    ip varchar(250)              --ip used to create record (for public submission page)
+    ip varchar(250)              -- ip used to create record (for public submission page)
 ) ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_opensurvey_user_studs-opensurvey.sql
+++ b/htdocs/install/mysql/tables/llx_opensurvey_user_studs-opensurvey.sql
@@ -22,5 +22,5 @@ CREATE TABLE llx_opensurvey_user_studs (
     reponses VARCHAR(200) NOT NULL,		-- Not used for 'F' surveys
     tms timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     date_creation datetime NOT NULL,
-    ip varchar(250)              --ip used to create record (for public submission page)
+    ip varchar(250)              -- ip used to create record (for public submission page)
 ) ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_quickmemo_memo_user-quickmemo.key.sql
+++ b/htdocs/install/mysql/tables/llx_quickmemo_memo_user-quickmemo.key.sql
@@ -14,4 +14,4 @@
 -- along with this program.  If not, see https://www.gnu.org/licenses/.
 
 ALTER TABLE llx_quickmemo_memo_user ADD INDEX idx_quickmemo_memo_rowid (fk_memo);
-ALTER TABLE llx_quickmemo_memo_user ADD UNIQUE KEY uk_memo_user (fk_memo, fk_user);
+ALTER TABLE llx_quickmemo_memo_user ADD UNIQUE INDEX uk_memo_user (fk_memo, fk_user);

--- a/htdocs/install/mysql/tables/llx_recruitment_recruitmentcandidature-recruitment.sql
+++ b/htdocs/install/mysql/tables/llx_recruitment_recruitmentcandidature-recruitment.sql
@@ -41,6 +41,6 @@ CREATE TABLE llx_recruitment_recruitmentcandidature(
 	email_msgid varchar(175),				-- Do not use a too large value, it generates trouble with unique index
 	email_date datetime,
 	fk_recruitment_origin INTEGER NULL,
-  	ip varchar(250)                              --ip used to create record (for public submission page)
+  	ip varchar(250)                              -- ip used to create record (for public submission page)
 	-- END MODULEBUILDER FIELDS
 ) ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_socpeople.sql
+++ b/htdocs/install/mysql/tables/llx_socpeople.sql
@@ -69,5 +69,5 @@ create table llx_socpeople
   canvas			varchar(32),			-- type of canvas if used (null by default)
   import_key		varchar(14),
   statut			tinyint DEFAULT 1 NOT NULL,
-  ip    varchar(250)    --ip used to create record (for public submission page)
+  ip    varchar(250)    -- ip used to create record (for public submission page)
 )ENGINE=innodb;

--- a/htdocs/install/mysql/tables/llx_website-website.sql
+++ b/htdocs/install/mysql/tables/llx_website-website.sql
@@ -44,5 +44,5 @@ CREATE TABLE llx_website
     pageviews_total BIGINT UNSIGNED DEFAULT 0,			-- increased by 1 at each page access, no reset
 	tms           timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     import_key    varchar(14),      -- import key
-	name_template varchar(255) NULL   --name of template imported
+	name_template varchar(255) NULL   -- name of template imported
 ) ENGINE=innodb;


### PR DESCRIPTION
## Problem

Several `install/mysql/tables/*.sql` files contain SQL that fails to run,
so the table (or its constraint) is silently **never created** on a fresh
install where these files are applied by `run_sql()` (module activation /
`DolibarrModules::_load_tables()`), i.e. anything not loaded by
`step2.php`.

### 1. Inline comments glued to the double dash

9 files use `--word` (no space after `--`) for an inline comment, e.g.:

```sql
ip varchar(250)              --ip used to create record (for public submission page)
```

MySQL/MariaDB only treat `-- ` (dash-dash-space) as a comment, so `--ip`
is parsed as SQL. `step2.php` strips it anyway
(`preg_replace('/--(.+)*/', '', ...)`), but `run_sql()` only strips
`-- ` with a space, so the `CREATE TABLE` errors out and is swallowed.

Affected: `llx_don-don.sql`, `llx_website-website.sql`,
`llx_opensurvey_comments-opensurvey.sql`,
`llx_opensurvey_user_studs-opensurvey.sql`,
`llx_recruitment_recruitmentcandidature-recruitment.sql`,
`llx_socpeople.sql`, `llx_facture.sql`, `llx_expedition_package.sql`,
`llx_eventorganization_conferenceorboothattendee.sql`.

### 2. `ADD UNIQUE KEY` instead of `ADD UNIQUE INDEX`

`llx_quickmemo_memo_user-quickmemo.key.sql` is the only `*.key.sql` file
using `ALTER TABLE ... ADD UNIQUE KEY` (239 others use
`ADD UNIQUE INDEX`). `convertSQLFromMysql()` only rewrites the `INDEX`
form, so the unique constraint was never created on PostgreSQL. `KEY`
and `INDEX` are synonyms in MySQL, so MariaDB is unaffected.

## Fix

Add the missing space in the 9 comment lines, and use `ADD UNIQUE INDEX`
in the quickmemo key file. Pure formatting / keyword change, no schema
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
