### PR TITLE
FIX Salary: fk_projet NULL, and set a payment type in the tests

### DIFF
--- a/htdocs/salaries/class/salary.class.php
+++ b/htdocs/salaries/class/salary.class.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2011-2022  Alexandre Spangaro      <aspangaro@open-dsi.fr>
  * Copyright (C) 2014       Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2021       Gauthier VERDOL         <gauthier.verdol@atm-consulting.fr>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -301,7 +301,7 @@ class Salary extends CommonObject
 		/*$sql .= " datep='".$this->db->idate($this->datep)."',";
 		$sql .= " datev='".$this->db->idate($this->datev)."',";*/
 		$sql .= " amount=".price2num($this->amount).",";
-		$sql .= " fk_projet=".((int) $this->fk_project).",";
+		$sql .= " fk_projet=".($this->fk_project > 0 ? ((int) $this->fk_project) : "null").",";
 		$sql .= " fk_typepayment=".((int) $this->type_payment).",";
 		$sql .= " label='".$this->db->escape($this->label)."',";
 		$sql .= " datesp='".$this->db->idate($this->datesp)."',";
@@ -527,7 +527,7 @@ class Salary extends CommonObject
 		//$sql .= ", '".$this->db->idate($this->datep)."'";
 		//$sql .= ", '".$this->db->idate($this->datev)."'";
 		$sql .= ", ".((float) $this->amount);
-		$sql .= ", ".($this->fk_project > 0 ? ((int) $this->fk_project) : 0);
+		$sql .= ", ".($this->fk_project > 0 ? ((int) $this->fk_project) : "null");
 		$sql .= ", ".($this->salary > 0 ? ((float) $this->salary) : "null");
 		$sql .= ", ".($this->type_payment > 0 ? ((int) $this->type_payment) : 0);
 		$sql .= ", ".($this->accountid > 0 ? ((int) $this->accountid) : "null");

--- a/test/phpunit/PaymentSalaryTest.php
+++ b/test/phpunit/PaymentSalaryTest.php
@@ -98,6 +98,7 @@ class PaymentSalaryTest extends CommonClassTest
 		$salary->amount = 100;
 		$salary->datesp = dol_now();
 		$salary->dateep = dol_now() + (3600 * 24 * 30);
+		$salary->type_payment = dol_getIdFromCode($db, 'VIR', 'c_paiement', 'code', 'id', 1);
 		$salaryid = $salary->create($user);
 		$this->assertGreaterThan(0, $salaryid, $salary->errorsToString());
 

--- a/test/phpunit/SalaryTest.php
+++ b/test/phpunit/SalaryTest.php
@@ -94,6 +94,7 @@ class SalaryTest extends CommonClassTest
 		$localobject->amount = 2000;
 		$localobject->datesp = dol_now();
 		$localobject->dateep = dol_now() + (3600 * 24 * 30);
+		$localobject->type_payment = dol_getIdFromCode($db, 'VIR', 'c_paiement', 'code', 'id', 1);
 		$result = $localobject->create($user);
 
 		$this->assertGreaterThan(0, $result, $localobject->errorsToString());


### PR DESCRIPTION
## Problem

On a fresh install (no demo data), `SalaryTest::testSalaryCreate` and
`PaymentSalaryTest::testPaymentSalaryCreate` fail on foreign key
constraints of `llx_salary`:

1. `Salary::create()` / `Salary::update()` write `fk_projet = 0` when no
   project is set, which violates `fk_salary_fk_projet`
   (`llx_projet(rowid)`). The column is `DEFAULT NULL`, like `fk_bank`
   and `fk_account` which the code already handles with `"null"`.
2. The two tests create a `Salary` without a payment type;
   `llx_salary.fk_typepayment` is `NOT NULL` with a FK to
   `llx_c_paiement(id)` (constraint added 2026-03-14), so `fk_typepayment
   = 0` violates it.

These are hidden today because the CI always starts from a demo dump that
has no such FKs (older schema) and only runs MySQL.

## Fix

- `Salary::create()` / `update()`: insert `NULL` (not `0`) for
  `fk_projet` when there is no project.
- `SalaryTest` / `PaymentSalaryTest`: set `type_payment` to the `VIR`
  code id, like `PaymentSalaryTest` already does for the payment itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
