### PR TITLE
Fix expense report payment bank transaction deletion

### DIFF
--- a/htdocs/expensereport/class/paymentexpensereport.class.php
+++ b/htdocs/expensereport/class/paymentexpensereport.class.php
@@ -25,6 +25,7 @@
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT.'/compta/bank/class/account.class.php';
 
 
 /**
@@ -388,6 +389,18 @@ class PaymentExpenseReport extends CommonObject
 		$error = 0;
 
 		$this->db->begin();
+
+		if ($this->bank_line > 0) {
+			$accline = new AccountLine($this->db);
+			$result = $accline->fetch($this->bank_line);
+			if ($result > 0) {
+				$result = $accline->delete($user);
+				if ($result < 0) {
+					$this->errors[] = $accline->error;
+					$error++;
+				}
+			}
+		}
 
 		if (!$error) {
 			$sql = "DELETE FROM ".MAIN_DB_PREFIX."bank_url";


### PR DESCRIPTION
# FIX | Fix expense report payment bank transaction deletion

Deleting an expense report payment currently removes the payment record and its `bank_url` link, but leaves the associated bank transaction in `bank`.

This change deletes the associated bank transaction through `AccountLine::delete()` before deleting the expense report payment, following the same pattern already used by other Dolibarr payment classes.

The existing explicit cleanup of `bank_url` is kept so stale payment links are still removed when the referenced bank line no longer exists.

## Changes

- Load the bank account class required by `AccountLine`.
- Delete the associated bank transaction when deleting an expense report payment.
- Abort and roll back the payment deletion if the bank transaction cannot be deleted.
- Keep the existing `bank_url` cleanup and payment record deletion in the same transaction.

## Validation

Checked with:

- PHP syntax validation
- Phan 5.5.2
- PHPStan 2.1.12
- PHP_CodeSniffer 4.0.4
- `git diff --check`

The deletion behavior was also functionally validated in the local implementation.