### PR TITLE
FIX CommonInvoiceTest: markTestSkipped() on non-MySQL instead of doing nothing

### DIFF
--- a/test/phpunit/CommonInvoiceTest.php
+++ b/test/phpunit/CommonInvoiceTest.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -143,6 +143,8 @@ class CommonInvoiceTest extends CommonClassTest
 			print __METHOD__." date=".dol_print_date($localobject->date, 'standard', 'gmt')."\n";
 			print __METHOD__." result=".dol_print_date($result, 'standard', 'gmt')."\n";
 			$this->assertEquals('2010-06-15 00:00:00', dol_print_date($result, 'standard', 'gmt'));
+		} else {
+			$this->markTestSkipped('This test is only implemented for MySQL/MariaDB.');
 		}
 
 		return $result;


### PR DESCRIPTION
The whole body of `CommonInvoiceTest::testCalculateDateLimReglement` is
wrapped in:

```php
if (in_array($db->type, array('mysql', 'mysqli'))) {
    ...
}
```

so on a PostgreSQL run the test does nothing and PHPUnit reports it as
**risky** ("This test did not perform any assertions"). Add an `else`
branch calling `markTestSkipped()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
