### PR TITLE
NEW Extract ActionComm::checkResourceConflicts() / formatResourceConflicts()

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1265,8 +1265,9 @@ if (empty($reshook) && $action == 'confirm_delete' && GETPOST("confirm") == 'yes
 }
 
 /*
- * Action move update, used when user move an event in calendar by drag'n drop
- * TODO Move this into page comm/action/index that trigger this call by the drag and drop of event.
+ * Action move update, used when user moves an event in calendar by drag'n drop.
+ * The agenda calendar UI now calls comm/action/ajax/ajaxmoveevent.php instead (Ajax, no
+ * page reload); this handler is kept as a standalone POST entry point for any other caller.
  */
 if (empty($reshook) && GETPOST('actionmove', 'alpha') == 'mupdate' && $usercancreate) {
 	$error = 0;
@@ -1290,61 +1291,16 @@ if (empty($reshook) && GETPOST('actionmove', 'alpha') == 'mupdate' && $usercancr
 		$object->datep = $datep;
 
 		if (!$error) {
-			// check if an event resource is already in use
-			if (getDolGlobalString('RESOURCE_USED_IN_EVENT_CHECK') && $object->element == 'action') {
-				$eventDateStart = $object->datep;
-				$eventDateEnd = $object->datef;
-
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($object->element)."'";
-				$sql .= " WHERE ac.id <> ".((int) $object->id);
-				$sql .= " AND er.resource_id IN (";
-				$sql .= " SELECT resource_id FROM ".MAIN_DB_PREFIX."element_resources";
-				$sql .= " WHERE element_id = ".((int) $object->id);
-				$sql .= " AND element_type = '".$db->escape($object->element)."'";
-				$sql .= " AND busy = 1";
-				$sql .= ")";
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
-
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
-					$error++;
-					$object->error = $db->lasterror();
-					$object->errors[] = $object->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$object->errors[] = $object->error;
-					}
-					$db->free($resql);
-				}
-
-				if ($error) {
-					setEventMessages($object->error, $object->errors, 'errors');
-				}
+			$conflicts = $object->checkResourceConflicts($object->datep, $object->datef);
+			if ($conflicts === -1) {
+				$error++;
+				$object->errors[] = $object->error;
+				setEventMessages($object->error, $object->errors, 'errors');
+			} elseif (!empty($conflicts)) {
+				$error++;
+				$object->error = $object->formatResourceConflicts($conflicts, $langs);
+				$object->errors[] = $object->error;
+				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
 

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2011-2017  Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2015	    Marcos García		    <marcosgdf@gmail.com>
  * Copyright (C) 2018	    Nicolas ZABOURI	        <info@inovea-conseil.com>
- * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  *
@@ -1396,6 +1396,79 @@ class ActionComm extends CommonObject
 			$this->error = $this->db->lasterror();
 			return -1;
 		}
+	}
+
+	/**
+	 *  Check if any resource attached to this event would become double-booked if the
+	 *  event's dates were changed to the given range. Only checks when the
+	 *  RESOURCE_USED_IN_EVENT_CHECK option is enabled and $this->element is 'action';
+	 *  returns no conflict otherwise.
+	 *
+	 *  @param	int		$newdatep	New start date to check (Unix timestamp)
+	 *  @param	int		$newdatef	New end date to check (Unix timestamp), 0 if none
+	 *  @return	array<int,array{r_ref:string,ac_id:int,ac_label:string}>|int<-1,-1>	Array of conflicting resource/event pairs (empty array = no conflict), -1 if a DB error occurred (check $this->error)
+	 */
+	public function checkResourceConflicts($newdatep, $newdatef)
+	{
+		if (!getDolGlobalString('RESOURCE_USED_IN_EVENT_CHECK') || $this->element != 'action') {
+			return array();
+		}
+
+		$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
+		$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
+		$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$this->db->escape($this->element)."'";
+		$sql .= " WHERE ac.id <> ".((int) $this->id);
+		$sql .= " AND er.resource_id IN (";
+		$sql .= " SELECT resource_id FROM ".MAIN_DB_PREFIX."element_resources";
+		$sql .= " WHERE element_id = ".((int) $this->id);
+		$sql .= " AND element_type = '".$this->db->escape($this->element)."'";
+		$sql .= " AND busy = 1";
+		$sql .= ")";
+		$sql .= " AND er.busy = 1";
+		$sql .= " AND (";
+		$sql .= " (ac.datep <= '".$this->db->idate($newdatep)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$this->db->idate($newdatep)."'))";
+		if (!empty($newdatef)) {
+			$sql .= " OR (ac.datep <= '".$this->db->idate($newdatef)."' AND (ac.datep2 >= '".$this->db->idate($newdatef)."'))";
+		}
+		$sql .= " OR (";
+		$sql .= "ac.datep >= '".$this->db->idate($newdatep)."'";
+		if (!empty($newdatef)) {
+			$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$this->db->idate($newdatef)."')";
+		}
+		$sql .= ")";
+		$sql .= ")";
+
+		$resql = $this->db->query($sql);
+		if (!$resql) {
+			$this->error = $this->db->lasterror();
+			return -1;
+		}
+
+		$conflicts = array();
+		while ($obj = $this->db->fetch_object($resql)) {
+			$conflicts[] = array('r_ref' => $obj->r_ref, 'ac_id' => (int) $obj->ac_id, 'ac_label' => $obj->ac_label);
+		}
+		$this->db->free($resql);
+
+		return $conflicts;
+	}
+
+	/**
+	 *  Format an array of resource conflicts (as returned by checkResourceConflicts()) into a
+	 *  translated, HTML-formatted error message.
+	 *
+	 *  @param	array<int,array{r_ref:string,ac_id:int,ac_label:string}>	$conflicts	Conflicts array
+	 *  @param	Translate	$langs	Translate object to use for translation
+	 *  @return	string	Translated HTML message listing the conflicts
+	 */
+	public function formatResourceConflicts($conflicts, $langs)
+	{
+		$message = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
+		foreach ($conflicts as $conflict) {
+			$message .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $conflict['r_ref'], $conflict['ac_label'].' ['.$conflict['ac_id'].']');
+		}
+		return $message;
 	}
 
 	/**


### PR DESCRIPTION
`htdocs/comm/action/card.php` carries an inline SQL block that detects
resource (user) booking conflicts when an event is moved, plus the code
that builds the warning message from the result.

Move both into reusable `ActionComm` methods:

- **`checkResourceConflicts($newdatep, $newdatef)`** - returns the list
  of events that overlap the new time slot for the same assigned
  resources.
- **`formatResourceConflicts($conflicts, $langs)`** - builds the warning
  text from that list.

`card.php` now just calls them. No behaviour change; this is preparation
for reusing the same check from the agenda drag&drop Ajax endpoints
(#39381).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
