### PR TITLE
QUAL Use ActionComm::checkResourceConflicts() in the event update path

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1102,61 +1102,17 @@ if (empty($reshook) && $action == 'update' && $usercancreate) {
 		}
 
 		if (!$error) {
-			// check if an event resource is already in use
-			if (getDolGlobalString('RESOURCE_USED_IN_EVENT_CHECK') && $object->element == 'action') {
-				$eventDateStart = $object->datep;
-				$eventDateEnd = $object->datef;
-
-				$sql  = "SELECT er.rowid, r.ref as r_ref, ac.id as ac_id, ac.label as ac_label";
-				$sql .= " FROM ".MAIN_DB_PREFIX."element_resources as er";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."resource as r ON r.rowid = er.resource_id AND er.resource_type = 'dolresource'";
-				$sql .= " INNER JOIN ".MAIN_DB_PREFIX."actioncomm as ac ON ac.id = er.element_id AND er.element_type = '".$db->escape($object->element)."'";
-				$sql .= " WHERE ac.id <> ".((int) $object->id);
-				$sql .= " AND er.resource_id IN (";
-				$sql .= " SELECT resource_id FROM ".MAIN_DB_PREFIX."element_resources";
-				$sql .= " WHERE element_id = ".((int) $object->id);
-				$sql .= " AND element_type = '".$db->escape($object->element)."'";
-				$sql .= " AND busy = 1";
-				$sql .= ")";
-				$sql .= " AND er.busy = 1";
-				$sql .= " AND (";
-
-				// event date start between ac.datep and ac.datep2 (if datep2 is null we consider there is no end)
-				$sql .= " (ac.datep <= '".$db->idate($eventDateStart)."' AND (ac.datep2 IS NULL OR ac.datep2 >= '".$db->idate($eventDateStart)."'))";
-				// event date end between ac.datep and ac.datep2
-				if (!empty($eventDateEnd)) {
-					$sql .= " OR (ac.datep <= '".$db->idate($eventDateEnd)."' AND (ac.datep2 >= '".$db->idate($eventDateEnd)."'))";
-				}
-				// event date start before ac.datep and event date end after ac.datep2
-				$sql .= " OR (";
-				$sql .= "ac.datep >= '".$db->idate($eventDateStart)."'";
-				if (!empty($eventDateEnd)) {
-					$sql .= " AND (ac.datep2 IS NOT NULL AND ac.datep2 <= '".$db->idate($eventDateEnd)."')";
-				}
-				$sql .= ")";
-
-				$sql .= ")";
-				$resql = $db->query($sql);
-				if (!$resql) {
-					$error++;
-					$object->error = $db->lasterror();
-					$object->errors[] = $object->error;
-				} else {
-					if ($db->num_rows($resql) > 0) {
-						// Resource already in use
-						$error++;
-						$object->error = $langs->trans('ErrorResourcesAlreadyInUse').' : ';
-						while ($obj = $db->fetch_object($resql)) {
-							$object->error .= '<br> - '.$langs->trans('ErrorResourceUseInEvent', $obj->r_ref, $obj->ac_label.' ['.$obj->ac_id.']');
-						}
-						$object->errors[] = $object->error;
-					}
-					$db->free($resql);
-				}
-
-				if ($error) {
-					setEventMessages($object->error, $object->errors, 'errors');
-				}
+			// Check that no resource attached to this event is already booked on the same slot
+			$conflicts = $object->checkResourceConflicts($object->datep, $object->datef);
+			if ($conflicts === -1) {
+				$error++;
+				$object->errors[] = $object->error;
+				setEventMessages($object->error, $object->errors, 'errors');
+			} elseif (!empty($conflicts)) {
+				$error++;
+				$object->error = $object->formatResourceConflicts($conflicts, $langs);
+				$object->errors[] = $object->error;
+				setEventMessages($object->error, $object->errors, 'errors');
 			}
 		}
 


### PR DESCRIPTION
## Follow-up of #39849

#39849 extracted the inline resource double-booking check from `htdocs/comm/action/card.php` into `ActionComm::checkResourceConflicts()` / `formatResourceConflicts()`, but only converted the **actionmove** (`mupdate`) path.

The `$action == 'update'` handler still carried a **byte-for-byte copy** of the same `element_resources` SELECT and the same message-building loop (`ErrorResourcesAlreadyInUse` / `ErrorResourceUseInEvent`).

This PR replaces that copy with the exact same call the move path now uses:

```php
$conflicts = $object->checkResourceConflicts($object->datep, $object->datef);
if ($conflicts === -1) { ... }
elseif (!empty($conflicts)) { $object->error = $object->formatResourceConflicts($conflicts, $langs); ... }
```

- No behaviour change (same SQL, same option gate `RESOURCE_USED_IN_EVENT_CHECK`, same `$object->element == 'action'` guard — both now enforced inside the method).
- `card.php`: 55 lines removed, 11 added.
- The `$action == 'add'` handler keeps its own variant on purpose: it checks each newly-attached resource **individually** (`er.resource_id = X` from the association loop) with full-day date bounds, before the event is persisted. Left untouched here.