### PR TITLE
QUAL Mutualize the agenda birthday-events query into agenda.lib.php

### DIFF
--- a/htdocs/comm/action/index.php
+++ b/htdocs/comm/action/index.php
@@ -1087,78 +1087,7 @@ if ($resql) {
 // BIRTHDATES CALENDAR
 // Complete $eventarray with birthdates
 if ($check_birthday) {
-	// Add events in array
-	$sql = 'SELECT sp.rowid, sp.lastname, sp.firstname, sp.birthday';
-	$sql .= ' FROM '.MAIN_DB_PREFIX.'socpeople as sp';
-	$sql .= ' WHERE (priv=0 OR (priv=1 AND fk_user_creat='.((int) $user->id).'))';
-	$sql .= " AND sp.entity IN (".getEntity('contact').")";
-	if ($mode == 'show_day') {
-		$sql .= ' AND MONTH(birthday) = '.((int) $month);
-		$sql .= ' AND DAY(birthday) = '.((int) $day);
-	} else {
-		$sql .= ' AND MONTH(birthday) = '.((int) $month);
-	}
-	$sql .= ' ORDER BY birthday';
-
-	dol_syslog("comm/action/index.php", LOG_DEBUG);
-	$resql = $db->query($sql);
-	if ($resql) {
-		$num = $db->num_rows($resql);
-		$nbevents += $num;
-
-		$i = 0;
-		while ($i < $num) {
-			$obj = $db->fetch_object($resql);
-
-			$event = new ActionComm($db);
-
-			$event->id = $obj->rowid; // We put contact id in action id for birthdays events
-			$event->ref = (string) $event->id;
-
-			$datebirth = dol_stringtotime($obj->birthday, 1);
-			//print 'ee'.$obj->birthday.'-'.$datebirth;
-			$datearray = dol_getdate($datebirth, true);
-			$event->datep = dol_mktime(0, 0, 0, $datearray['mon'], $datearray['mday'], $year, true); // For full day events, date are also GMT but they won't but converted during output
-			$event->datef = $event->datep;
-
-			$event->type_code = 'BIRTHDAY';
-			$event->type_label = '';
-			$event->type_color = '';
-			$event->type = 'birthdate';
-			$event->type_picto = 'birthdate';
-
-			$event->label = $langs->trans("Birthday").' '.dolGetFirstLastname($obj->firstname, $obj->lastname);
-			$event->percentage = 100;
-			$event->fulldayevent = 1;
-
-			$event->contact_id = $obj->rowid;
-
-			$event->date_start_in_calendar = $event->datep;
-			$event->date_end_in_calendar = $event->datef;
-
-			// Add an entry in eventarray for each day
-			$daycursor = $event->datep;
-			$annee = (int) dol_print_date($daycursor, '%Y', 'tzuserrel');
-			$mois = (int) dol_print_date($daycursor, '%m', 'tzuserrel');
-			$jour = (int) dol_print_date($daycursor, '%d', 'tzuserrel');
-
-			$daykey = dol_mktime(0, 0, 0, $mois, $jour, $annee, 'gmt');
-
-			$eventarray[$daykey][] = $event;
-
-			/*$loop = true;
-			 $daykey = dol_mktime(0, 0, 0, $mois, $jour, $annee);
-			 do {
-			 $eventarray[$daykey][] = $event;
-			 $daykey += 60 * 60 * 24;
-			 if ($daykey > $event->date_end_in_calendar) $loop = false;
-			 } while ($loop);
-			 */
-			$i++;
-		}
-	} else {
-		dol_print_error($db);
-	}
+	agenda_get_birthday_events($db, $langs, $user, $mode, $month, $day, $year, $eventarray, $nbevents);
 }
 
 // LEAVE-HOLIDAY CALENDAR

--- a/htdocs/comm/action/peruser.php
+++ b/htdocs/comm/action/peruser.php
@@ -1048,76 +1048,7 @@ if ($resql) {
 // BIRTHDATES CALENDAR
 // Complete $eventarray with birthdates
 if ($showbirthday) {  // always false @phpstan-ignore-line
-	// Add events in array
-	$sql = 'SELECT sp.rowid, sp.lastname, sp.firstname, sp.birthday';
-	$sql .= ' FROM '.MAIN_DB_PREFIX.'socpeople as sp';
-	$sql .= ' WHERE (priv=0 OR (priv=1 AND fk_user_creat='.((int) $user->id).'))';
-	$sql .= " AND sp.entity IN (".getEntity('contact').")";
-	if ($mode == 'show_day') {
-		$sql .= ' AND MONTH(birthday) = '.((int) $month);
-		$sql .= ' AND DAY(birthday) = '.((int) $day);
-	} else {
-		$sql .= ' AND MONTH(birthday) = '.((int) $month);
-	}
-	$sql .= ' ORDER BY birthday';
-
-	dol_syslog("comm/action/index.php", LOG_DEBUG);
-	$resql = $db->query($sql);
-	if ($resql) {
-		$num = $db->num_rows($resql);
-		$i = 0;
-		while ($i < $num) {
-			$obj = $db->fetch_object($resql);
-
-			$event = new ActionComm($db);
-
-			$event->id = $obj->rowid; // We put contact id in action id for birthdays events
-			$event->ref = (string) $event->id;
-
-			$datebirth = dol_stringtotime($obj->birthday, 1);
-			//print 'ee'.$obj->birthday.'-'.$datebirth;
-			$datearray = dol_getdate($datebirth, true);
-			$event->datep = dol_mktime(0, 0, 0, $datearray['mon'], $datearray['mday'], $year, true); // For full day events, date are also GMT but they won't but converted during output
-			$event->datef = $event->datep;
-
-			$event->type_code = 'BIRTHDAY';
-			$event->type_label = '';
-			$event->type_color = '';
-			$event->type = 'birthdate';
-			$event->type_picto = 'birthdate';
-
-			$event->label = $langs->trans("Birthday").' '.dolGetFirstLastname($obj->firstname, $obj->lastname);
-			$event->percentage = 100;
-			$event->fulldayevent = 1;
-
-			$event->contact_id = $obj->rowid;
-
-			$event->date_start_in_calendar = $db->jdate($event->datep);
-			$event->date_end_in_calendar = $db->jdate($event->datef);
-
-			// Add an entry in eventarray for each day
-			$daycursor = $event->datep;
-			$annee = (int) dol_print_date($daycursor, '%Y', 'tzuserrel');
-			$mois = (int) dol_print_date($daycursor, '%m', 'tzuserrel');
-			$jour = (int) dol_print_date($daycursor, '%d', 'tzuserrel');
-
-			$daykey = dol_mktime(0, 0, 0, $mois, $jour, $annee, 'gmt');
-
-			$eventarray[$daykey][] = $event;
-
-			/*$loop = true;
-			 $daykey = dol_mktime(0, 0, 0, $mois, $jour, $annee);
-			 do {
-			 $eventarray[$daykey][] = $event;
-			 $daykey += 60 * 60 * 24;
-			 if ($daykey > $event->date_end_in_calendar) $loop = false;
-			 } while ($loop);
-			 */
-			$i++;
-		}
-	} else {
-		dol_print_error($db);
-	}
+	agenda_get_birthday_events($db, $langs, $user, $mode, $month, $day, $year, $eventarray, $nbevents);
 }
 
 // LEAVE-HOLIDAY CALENDAR

--- a/htdocs/core/lib/agenda.lib.php
+++ b/htdocs/core/lib/agenda.lib.php
@@ -576,3 +576,89 @@ function calendars_prepare_head($param)
 
 	return $head;
 }
+
+/**
+ * Complete an agenda calendar event array with contact birthday pseudo-events.
+ * Shared by the month, week and day agenda views (comm/action/index.php, comm/action/peruser.php).
+ *
+ * @param	DoliDB							$db			Database handler
+ * @param	Translate						$langs		Language object (already loaded)
+ * @param	User							$user		Current user (used for private contact visibility)
+ * @param	string							$mode		'show_day' restricts to the given day, any other value = whole month
+ * @param	int								$month		Month number (1-12)
+ * @param	int								$day		Day of month (only used when $mode == 'show_day')
+ * @param	int								$year		Year the birthday events must be placed in
+ * @param	array<int,ActionComm[]>			$eventarray	Event array to complete, keyed by GMT day timestamp (modified by reference)
+ * @param	int								$nbevents	Running event counter (modified by reference)
+ * @return	int											Number of birthday events added, or <0 if the SQL query failed
+ */
+function agenda_get_birthday_events($db, $langs, $user, $mode, $month, $day, $year, &$eventarray, &$nbevents)
+{
+	require_once DOL_DOCUMENT_ROOT.'/comm/action/class/actioncomm.class.php';
+
+	$sql = 'SELECT sp.rowid, sp.lastname, sp.firstname, sp.birthday';
+	$sql .= ' FROM '.MAIN_DB_PREFIX.'socpeople as sp';
+	$sql .= ' WHERE (priv=0 OR (priv=1 AND fk_user_creat='.((int) $user->id).'))';
+	$sql .= " AND sp.entity IN (".getEntity('contact').")";
+	if ($mode == 'show_day') {
+		$sql .= ' AND MONTH(birthday) = '.((int) $month);
+		$sql .= ' AND DAY(birthday) = '.((int) $day);
+	} else {
+		$sql .= ' AND MONTH(birthday) = '.((int) $month);
+	}
+	$sql .= ' ORDER BY birthday';
+
+	dol_syslog("agenda.lib.php::agenda_get_birthday_events", LOG_DEBUG);
+	$resql = $db->query($sql);
+	if (!$resql) {
+		dol_print_error($db);
+		return -1;
+	}
+
+	$num = $db->num_rows($resql);
+	$nbevents += $num;
+
+	$i = 0;
+	while ($i < $num) {
+		$obj = $db->fetch_object($resql);
+
+		$event = new ActionComm($db);
+
+		$event->id = $obj->rowid; // We put contact id in action id for birthdays events
+		$event->ref = (string) $event->id;
+
+		$datebirth = dol_stringtotime($obj->birthday, 1);
+		$datearray = dol_getdate($datebirth, true);
+		$event->datep = dol_mktime(0, 0, 0, $datearray['mon'], $datearray['mday'], $year, true); // For full day events, date are also GMT but they won't but converted during output
+		$event->datef = $event->datep;
+
+		$event->type_code = 'BIRTHDAY';
+		$event->type_label = '';
+		$event->type_color = '';
+		$event->type = 'birthdate';
+		$event->type_picto = 'birthdate';
+
+		$event->label = $langs->trans("Birthday").' '.dolGetFirstLastname($obj->firstname, $obj->lastname);
+		$event->percentage = 100;
+		$event->fulldayevent = 1;
+
+		$event->contact_id = $obj->rowid;
+
+		$event->date_start_in_calendar = $event->datep;
+		$event->date_end_in_calendar = $event->datef;
+
+		// Add an entry in eventarray for each day
+		$daycursor = $event->datep;
+		$annee = (int) dol_print_date($daycursor, '%Y', 'tzuserrel');
+		$mois = (int) dol_print_date($daycursor, '%m', 'tzuserrel');
+		$jour = (int) dol_print_date($daycursor, '%d', 'tzuserrel');
+
+		$daykey = dol_mktime(0, 0, 0, $mois, $jour, $annee, 'gmt');
+
+		$eventarray[$daykey][] = $event;
+
+		$i++;
+	}
+
+	return $num;
+}


### PR DESCRIPTION
`htdocs/comm/action/index.php` and `htdocs/comm/action/peruser.php` each carried an **identical ~75-line block** that queries `llx_socpeople` for contacts whose birthday falls in the shown month and pushes a `BIRTHDAY` pseudo-`ActionComm` into `$eventarray`.

This moves it to a single helper `agenda_get_birthday_events()` in `htdocs/core/lib/agenda.lib.php` (already `require_once`'d by both pages) and calls it from the two sites.

### Behaviour

- `index.php`: unchanged (verbatim extraction).
- `peruser.php`: its copy lives in a dead branch — `if ($showbirthday)` is flagged *"always false"* (`AGENDA_ENABLE_SHOW_BIRTHDAY_PER_USER`, unset by default). Two incidental differences of that copy are dropped in favour of `index.php`'s version:
  - `date_start_in_calendar` / `date_end_in_calendar` were wrapped in `$db->jdate()` applied to an **int** timestamp (no-op at best);
  - birthday rows were not counted in `$nbevents`; they now are, consistently with the other event sources on that page.

Net: 3 files, +88 / −142.