### PR TITLE
QUAL Mutualize the "exclude unsubscribed emails" SQL in mailing selectors

### DIFF
--- a/htdocs/core/modules/mailings/advthirdparties.modules.php
+++ b/htdocs/core/modules/mailings/advthirdparties.modules.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2005-2010  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
 *
 * This file is an example to follow to add your own email selector inside
 * the Dolibarr email tool.
@@ -82,8 +82,6 @@ class mailing_advthirdparties extends MailingTargets
 	public function add_to_target_spec($mailing_id, $socid, $type_of_target, $contactid)
 	{
 		// phpcs:enable
-		global $conf;
-
 		dol_syslog(get_class($this)."::add_to_target_spec socid=".formatLogObject($socid).' contactid='.formatLogObject($contactid));
 
 		$cibles = array();
@@ -95,9 +93,7 @@ class mailing_advthirdparties extends MailingTargets
 				$sql .= " FROM ".MAIN_DB_PREFIX."societe as s LEFT JOIN ".MAIN_DB_PREFIX."societe_extrafields se ON se.fk_object=s.rowid";
 				$sql .= " WHERE s.entity IN (".getEntity('societe').")";
 				$sql .= " AND s.rowid IN (".$this->db->sanitize(implode(',', $socid)).")";
-				if (empty($this->evenunsubscribe)) {
-					$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-				}
+				$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 				$sql .= " ORDER BY email";
 
 				// Stock recipients emails into targets table
@@ -148,9 +144,7 @@ class mailing_advthirdparties extends MailingTargets
 				if (count($socid) > 0) {
 					$sql .= " AND socp.fk_soc IN (".$this->db->sanitize(implode(',', $socid)).")";
 				}
-				if (empty($this->evenunsubscribe)) {
-					$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = socp.email and mu.entity = ".((int) $conf->entity).")";
-				}
+				$sql .= $this->getSqlToExcludeUnsubscribed('socp.email');
 				$sql .= " ORDER BY email";
 
 				// Stock recipients emails into targets table
@@ -223,15 +217,11 @@ class mailing_advthirdparties extends MailingTargets
 	 */
 	public function getNbOfRecipients($sql = '')
 	{
-		global $conf;
-
 		$sql = "SELECT count(distinct(s.email)) as nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 		$sql .= " WHERE s.email != ''";
 		$sql .= " AND s.entity IN (".getEntity('societe').")";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 
 		// The query must return a field "nb" to be understood by parent::getNbOfRecipients
 		return parent::getNbOfRecipients($sql);

--- a/htdocs/core/modules/mailings/contacts1.modules.php
+++ b/htdocs/core/modules/mailings/contacts1.modules.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2005-2009 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -106,16 +106,12 @@ class mailing_contacts1 extends MailingTargets
 	 */
 	public function getNbOfRecipients($sql = '')
 	{
-		global $conf;
-
 		$sql = "SELECT count(distinct(c.email)) as nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."socpeople as c";
 		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."societe as s ON s.rowid = c.fk_soc";
 		$sql .= " WHERE c.entity IN (".getEntity('contact').")";
 		$sql .= " AND c.email <> ''"; // Note that null != '' is false
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = c.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('c.email');
 		// exclude unsubscribed users
 		$sql .= " AND c.statut = 1";
 
@@ -353,7 +349,7 @@ class mailing_contacts1 extends MailingTargets
 	public function add_to_target($mailing_id)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $langs;
 
 		$filter = GETPOST('filter', 'alpha');
 		$filter_jobposition = GETPOST('filter_jobposition', 'alpha');
@@ -403,9 +399,7 @@ class mailing_contacts1 extends MailingTargets
 		$sql .= " WHERE sp.entity IN (".getEntity('contact').")";
 		$sql .= " AND sp.email <> ''";
 
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = sp.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('sp.email');
 		// Exclude unsubscribed email addresses
 		$sql .= " AND sp.statut = 1";
 		$sql .= " AND sp.email NOT IN (SELECT email FROM ".MAIN_DB_PREFIX."mailing_cibles WHERE fk_mailing=".((int) $mailing_id).")";

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2005-2010  Laurent Destailleur 	<eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009  Regis Houssin       	<regis.houssin@inodbox.com>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This file is an example to follow to add your own email selector inside
  * the Dolibarr email tool.
@@ -77,7 +77,7 @@ class mailing_eventorganization extends MailingTargets
 	public function add_to_target($mailing_id)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $langs;
 
 		$cibles = array();
 		$addDescription = '';
@@ -93,9 +93,7 @@ class mailing_eventorganization extends MailingTargets
 		if (GETPOSTINT('filter_eventorganization') > 0) {
 			$sql .= " AND e.fk_project = ".(GETPOSTINT('filter_eventorganization'));
 		}
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = e.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('e.email');
 		$sql .= " ORDER BY e.email";
 
 		// Stock recipients emails into targets table
@@ -170,17 +168,13 @@ class mailing_eventorganization extends MailingTargets
 	 */
 	public function getNbOfRecipients($sql = '')
 	{
-		global $conf;
-
 		$sql = "SELECT COUNT(DISTINCT(e.email)) as nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."eventorganization_conferenceorboothattendee as e, ";
 		$sql .= " ".MAIN_DB_PREFIX."projet as p";
 		$sql .= " WHERE e.email <> ''";
 		$sql .= " AND e.fk_project = p.rowid";
 		$sql .= " AND p.entity IN (".getEntity('project').")";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = e.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('e.email');
 
 		//print $sql;
 

--- a/htdocs/core/modules/mailings/fraise.modules.php
+++ b/htdocs/core/modules/mailings/fraise.modules.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2005       Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009  Regis Houssin           <regis.houssin@inodbox.com>
- * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -104,13 +104,10 @@ class mailing_fraise extends MailingTargets
 	 */
 	public function getNbOfRecipients($sql = '')
 	{
-		global $conf;
 		$sql  = "SELECT count(distinct(a.email)) as nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."adherent as a";
 		$sql .= " WHERE (a.email IS NOT NULL AND a.email != '') AND a.entity IN (".getEntity('member').")";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = a.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('a.email');
 
 		// The query must return a field "nb" to be understood by parent::getNbOfRecipients
 		return parent::getNbOfRecipients($sql);
@@ -243,7 +240,7 @@ class mailing_fraise extends MailingTargets
 	public function add_to_target($mailing_id)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $langs;
 
 		// Load translation files required by the page
 		$langs->loadLangs(array("members", "companies"));
@@ -288,9 +285,7 @@ class mailing_fraise extends MailingTargets
 		if (GETPOSTINT('filter_type') > 0) {
 			$sql .= " AND ta.rowid = ".(GETPOSTINT('filter_type'));
 		}
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = a.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('a.email');
 		$sql .= " ORDER BY a.email";
 		//print $sql;
 

--- a/htdocs/core/modules/mailings/modules_mailings.php
+++ b/htdocs/core/modules/mailings/modules_mailings.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2004-2008 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2004      Eric Seigne          <eric.seigne@ryxeo.com>
  * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -114,6 +114,30 @@ class MailingTargets // This can't be abstract as it is used for some method
 			$s .= ' '.$form->textwithpicto('', $langs->trans($this->tooltip), 1, 'help');
 		}
 		return $s;
+	}
+
+	/**
+	 * Return the SQL fragment that excludes email addresses which opted out of emailings
+	 * for the current entity. Returns an empty string when the selector is configured to
+	 * keep unsubscribed addresses ($this->evenunsubscribe).
+	 *
+	 * @param	string	$emailfield		SQL expression of the email column to test (e.g. 's.email', 'c.email'); it is passed through $db->sanitize()
+	 * @return	string					SQL fragment (with a leading space) to append to a WHERE clause, or ''
+	 */
+	public function getSqlToExcludeUnsubscribed($emailfield)
+	{
+		global $conf;
+
+		if (!empty($this->evenunsubscribe)) {
+			return '';
+		}
+
+		// $emailfield is a column expression of the outer query (e.g. 's.email'); it is compared to mu.email.
+		$sql = " AND NOT EXISTS (SELECT rowid FROM ".$this->db->prefix()."mailing_unsubscribe as mu";
+		$sql .= " WHERE ".$this->db->sanitize($emailfield)." = mu.email";
+		$sql .= " AND mu.entity = ".((int) $conf->entity).")";
+
+		return $sql;
 	}
 
 	/**

--- a/htdocs/core/modules/mailings/partnership.modules.php
+++ b/htdocs/core/modules/mailings/partnership.modules.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2005-2010  Laurent Destailleur 	<eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009  Regis Houssin       	<regis.houssin@inodbox.com>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This file is an example to follow to add your own email selector inside
  * the Dolibarr email tool.
@@ -84,7 +84,7 @@ class mailing_partnership extends MailingTargets
 	public function add_to_target($mailing_id)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $langs;
 
 		$cibles = array();
 		$addDescription = '';
@@ -105,9 +105,7 @@ class mailing_partnership extends MailingTargets
 		if (GETPOSTISSET('filter_status_partnership') && GETPOSTINT('filter_status_partnership') >= 0) {
 			$sql .= " AND p.status = ".((int) GETPOSTINT('filter_status_partnership'));
 		}
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 
 		$sql .= " UNION ";
 
@@ -127,9 +125,7 @@ class mailing_partnership extends MailingTargets
 		if (GETPOSTISSET('filter_status_partnership') && GETPOSTINT('filter_status_partnership') >= 0) {
 			$sql .= " AND p.status = ".((int) GETPOSTINT('filter_status_partnership'));
 		}
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 
 		$sql .= " ORDER BY email";
 
@@ -205,15 +201,11 @@ class mailing_partnership extends MailingTargets
 	 */
 	public function getNbOfRecipients($sql = '')
 	{
-		global $conf;
-
 		$sql = "SELECT count(distinct(s.email)) as nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."partnership as p, ".MAIN_DB_PREFIX."societe as s";
 		$sql .= " WHERE s.rowid = p.fk_soc AND s.email <> ''";
 		$sql .= " AND s.entity IN (".getEntity('societe').")";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 
 		$sql .= " UNION ";
 
@@ -221,9 +213,7 @@ class mailing_partnership extends MailingTargets
 		$sql .= " FROM ".MAIN_DB_PREFIX."partnership as p, ".MAIN_DB_PREFIX."adherent as s";
 		$sql .= " WHERE s.rowid = p.fk_member AND s.email <> ''";
 		$sql .= " AND s.entity IN (".getEntity('member').")";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 
 		//print $sql;
 

--- a/htdocs/core/modules/mailings/pomme.modules.php
+++ b/htdocs/core/modules/mailings/pomme.modules.php
@@ -112,9 +112,7 @@ class mailing_pomme extends MailingTargets
 		$sql .= " FROM ".MAIN_DB_PREFIX."user as u";
 		$sql .= " WHERE u.email != ''"; // u.email IS NOT NULL est implicit dans ce test
 		$sql .= " AND u.entity IN (0,".((int) $conf->entity).")";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = u.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('u.email');
 
 		// The query must return a field "nb" to be understood by parent::getNbOfRecipients
 		return parent::getNbOfRecipients($sql);
@@ -198,9 +196,7 @@ class mailing_pomme extends MailingTargets
 		if (GETPOSTISSET("filteremployee") && GETPOST("filteremployee") == '0') {
 			$sql .= " AND u.employee=0";
 		}
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = u.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('u.email');
 		$sql .= " ORDER BY u.email";
 
 		// Store recipients into targets

--- a/htdocs/core/modules/mailings/thirdparties.modules.php
+++ b/htdocs/core/modules/mailings/thirdparties.modules.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2005-2010 Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2009 Regis Houssin       <regis.houssin@inodbox.com>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This file is an example to follow to add your own email selector inside
  * the Dolibarr email tool.
@@ -81,7 +81,7 @@ class mailing_thirdparties extends MailingTargets
 	public function add_to_target($mailing_id)
 	{
 		// phpcs:enable
-		global $conf, $langs;
+		global $langs;
 
 		$cibles = array();
 
@@ -155,9 +155,7 @@ class mailing_thirdparties extends MailingTargets
 			$sql .= " WHERE s.email <> ''";
 			$sql .= " AND s.entity IN (".getEntity('societe').")";
 			$sql .= " AND s.email NOT IN (SELECT email FROM ".MAIN_DB_PREFIX."mailing_cibles WHERE fk_mailing=".((int) $mailing_id).")";
-			if (empty($this->evenunsubscribe)) {
-				$sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = s.email) = 0";
-			}
+			$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 			$sql .= $addFilter;
 		} else {
 			$sql = "SELECT s.rowid as id, s.email as email, s.nom as name, null as fk_contact, null as firstname, c.label as label";
@@ -170,9 +168,7 @@ class mailing_thirdparties extends MailingTargets
 			if (GETPOSTINT('filter_thirdparties') > 0) {
 				$sql .= " AND c.rowid=".(GETPOSTINT('filter_thirdparties'));
 			}
-			if (empty($this->evenunsubscribe)) {
-				$sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = s.email) = 0";
-			}
+			$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 			$sql .= $addFilter;
 			$sql .= " UNION ";
 			$sql .= "SELECT s.rowid as id, s.email as email, s.nom as name, null as fk_contact, null as firstname, c.label as label";
@@ -185,9 +181,7 @@ class mailing_thirdparties extends MailingTargets
 			if (GETPOSTINT('filter_thirdparties') > 0) {
 				$sql .= " AND c.rowid=".(GETPOSTINT('filter_thirdparties'));
 			}
-			if (empty($this->evenunsubscribe)) {
-				$sql .= " AND (SELECT count(*) FROM ".MAIN_DB_PREFIX."mailing_unsubscribe WHERE email = s.email) = 0";
-			}
+			$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 			$sql .= $addFilter;
 		}
 		$sql .= " ORDER BY email";
@@ -266,15 +260,11 @@ class mailing_thirdparties extends MailingTargets
 	 */
 	public function getNbOfRecipients($sql = '')
 	{
-		global $conf;
-
 		$sql = "SELECT count(distinct(s.email)) as nb";
 		$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 		$sql .= " WHERE s.email <> ''";
 		$sql .= " AND s.entity IN (".getEntity('societe').")";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 
 		// The query must return a field "nb" to be understood by parent::getNbOfRecipients
 		return parent::getNbOfRecipients($sql);

--- a/htdocs/core/modules/mailings/thirdparties_services_expired.modules.php
+++ b/htdocs/core/modules/mailings/thirdparties_services_expired.modules.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2005-2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
 * This file is an example to follow to add your own email selector inside
 * the Dolibarr email tool.
@@ -101,7 +101,7 @@ class mailing_thirdparties_services_expired extends MailingTargets
 	 */
 	public function add_to_target($mailing_id)
 	{
-		global $conf, $langs;
+		global $langs;
 
 		// phpcs:enable
 		$productid = GETPOSTINT('productid');
@@ -126,9 +126,7 @@ class mailing_thirdparties_services_expired extends MailingTargets
 		$sql .= " AND s.rowid = c.fk_soc AND cd.fk_contrat = c.rowid AND s.email != ''";
 		$sql .= " AND cd.statut= 4 AND cd.fk_product = p.rowid AND p.rowid = ".((int) $productid);
 		$sql .= " AND cd.date_fin_validite < '".$this->db->idate($now)."'";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 		$sql .= " ORDER BY s.email";
 
 		// Save target emails
@@ -202,8 +200,6 @@ class mailing_thirdparties_services_expired extends MailingTargets
 	 */
 	public function getNbOfRecipients($sql = '')
 	{
-		global $conf;
-
 		$now = dol_now();
 
 		// Example: return parent::getNbOfRecipients("SELECT count(*) as nb from dolibarr_table");
@@ -218,9 +214,7 @@ class mailing_thirdparties_services_expired extends MailingTargets
 			$sql .= " AND p.fk_product_type = 1"; // By default, only services
 		}
 		$sql .= " AND cd.date_fin_validite < '".$this->db->idate($now)."'";
-		if (empty($this->evenunsubscribe)) {
-			$sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu WHERE mu.email = s.email and mu.entity = ".((int) $conf->entity).")";
-		}
+		$sql .= $this->getSqlToExcludeUnsubscribed('s.email');
 
 		$a = parent::getNbOfRecipients($sql);
 


### PR DESCRIPTION
Every emailing target selector under `htdocs/core/modules/mailings/` carried its own copy of the same filter:

```php
if (empty($this->evenunsubscribe)) {
    $sql .= " AND NOT EXISTS (SELECT rowid FROM ".MAIN_DB_PREFIX."mailing_unsubscribe as mu
              WHERE mu.email = <x>.email and mu.entity = ".((int) $conf->entity).")";
}
```

**~21 occurrences across 8 files**, differing only by the email-column alias (`s.email`, `c.email`, `sp.email`, `socp.email`, `a.email`, `e.email`, `u.email`).

### Change

Add `MailingTargets::getSqlToExcludeUnsubscribed($emailfield)` on the parent class and call it everywhere. It returns `''` when `$this->evenunsubscribe` is set, so the `if` wrappers disappear too.

Net: 9 files, **+55 / −91**.

### Behaviour

- No change for the 18 sites already using the `NOT EXISTS ... AND mu.entity = <entity>` form.
- `thirdparties.modules.php` had **3 sites** using an older form with **no entity restriction**:
  `AND (SELECT count(*) FROM llx_mailing_unsubscribe WHERE email = s.email) = 0`.
  They now go through the helper, so they gain the `mu.entity` filter — consistent with every other selector (and correct on multi-entity installs).
- Now-unused `global $conf;` in the touched methods removed / narrowed to `global $langs;`.

PHPStan (level 10) on `htdocs/core/modules/mailings/` is clean.