### PR TITLE
QUAL modFacture: use core/extrafieldsinimport.inc.php for import extrafields

### DIFF
--- a/htdocs/core/modules/modFacture.class.php
+++ b/htdocs/core/modules/modFacture.class.php
@@ -276,17 +276,10 @@ class modFacture extends DolibarrModules
 			}
 			// Add extra fields
 			$import_extrafield_sample = array();
-			$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE elementtype = 'facture' AND entity IN (0, ".((int) $conf->entity).")";
-			$resql = $this->db->query($sql);
-			if ($resql) {
-				while ($obj = $this->db->fetch_object($resql)) {
-					$fieldname = 'extra.'.$obj->name;
-					$fieldlabel = ucfirst($obj->label);
-					$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-					$import_extrafield_sample[$fieldname] = $fieldlabel;
-				}
-			}
-			// End add extra fields
+			$keyforselect = 'facture';
+			$keyforelement = 'bill';
+			$keyforaliasextra = 'extra';
+			include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 			$this->import_fieldshidden_array[$r] = array('extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'facture');
 			$this->import_regex_array[$r] = array('f.multicurrency_code' => 'code@'.MAIN_DB_PREFIX.'multicurrency');
 			$import_sample = array(
@@ -404,17 +397,10 @@ class modFacture extends DolibarrModules
 			}
 			// Add extra fields
 			$import_extrafield_sample = array();
-			$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE elementtype = 'facture_det' AND entity IN (0, ".((int) $conf->entity).")";
-			$resql = $this->db->query($sql);
-			if ($resql) {
-				while ($obj = $this->db->fetch_object($resql)) {
-					$fieldname = 'extra.'.$obj->name;
-					$fieldlabel = ucfirst($obj->label);
-					$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-					$import_extrafield_sample[$fieldname] = $fieldlabel;
-				}
-			}
-			// End add extra fields
+			$keyforselect = 'facture_det';
+			$keyforelement = 'bill';
+			$keyforaliasextra = 'extra';
+			include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 			$this->import_fieldshidden_array[$r] = array('extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'facturedet');
 			$this->import_regex_array[$r] = array(
 				'fd.multicurrency_code' => 'code@'.MAIN_DB_PREFIX.'multicurrency'


### PR DESCRIPTION
### Context

~16 module descriptors still carry their own inline copy of

```php
$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE elementtype = '<x>' AND entity IN (0, ".((int) $conf->entity).")";
$resql = $this->db->query($sql);
if ($resql) {
    while ($obj = $this->db->fetch_object($resql)) {
        $fieldname = 'extra.'.$obj->name;
        $fieldlabel = ucfirst($obj->label);
        $this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
        $import_extrafield_sample[$fieldname] = $fieldlabel;
    }
}
```

while `modCommande`, `modHoliday`, `modAi` and the modulebuilder template already use the shared `htdocs/core/extrafieldsinimport.inc.php`.

**This PR converts one module — `modFacture` — as an example.** If the approach is OK I'll do the ~15 others the same way.

### Change

Both datasets ("Invoices" header + "InvoiceLine") now do:

```php
$keyforselect = 'facture';   // 'facture_det' for the lines
$keyforelement = 'bill';
$keyforaliasextra = 'extra';
include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
```

### Behaviour differences vs the removed inline loop

- `type = 'separate'` extrafields (form section headers) are no longer listed as importable fields — they have no storage column.
- `import_TypeFields_array` / `import_entities_array` are now filled for imported extrafields → type-aware import, consistent with `modCommande` et al. `$keyforelement = 'bill'` matches `import_icon[$r]`, so no icon/grouping change in the wizard.
- The extrafield list is cached per request (`$conf->cache['extrafieldsinimport']`) instead of being re-queried for every module instantiated on a page like `user/perms.php`.

PHPStan (level 10) on `modFacture.class.php`: clean.