### PR TITLE
QUAL Add getSalesRepresentativeSqlFilter() (mutualize the llx_societe_commerciaux filter)

### DIFF
--- a/htdocs/core/lib/company.lib.php
+++ b/htdocs/core/lib/company.lib.php
@@ -2751,6 +2751,44 @@ function show_subsidiaries($conf, $langs, $db, $object)
 
 	return $i;
 }
+
+/**
+ * Build the "EXISTS(...)" sub-query on llx_societe_commerciaux used to restrict a
+ * thirdparty-related list to the thirdparties handled by one or more sales representatives.
+ *
+ * The returned fragment has no leading " AND " / " OR " so the caller composes it, e.g.:
+ *   $sql .= " AND ".getSalesRepresentativeSqlFilter('s.rowid', $db->sanitize($search_sale));
+ *   $sql .= " AND ".getSalesRepresentativeSqlFilter('c.fk_soc', 0, 1);  // thirdparty assigned to nobody
+ *
+ * @param	string				$socidfield	SQL expression of the thirdparty rowid to test (e.g. 's.rowid', 'c.fk_soc'); passed through $db->sanitize()
+ * @param	int|string|int[]	$userids	Sales representative user id, an array of ids, or a comma-separated list of
+ *                                          ids. 0 / '' / empty array => only test that the thirdparty is assigned to
+ *                                          at least one sales representative.
+ * @param	int<0,1>			$not		1 to return "NOT EXISTS(...)" instead of "EXISTS(...)"
+ * @return	string							SQL "EXISTS(...)" / "NOT EXISTS(...)" fragment
+ */
+function getSalesRepresentativeSqlFilter($socidfield, $userids = 0, $not = 0)
+{
+	global $db;
+
+	if (!is_array($userids)) {
+		$userids = ($userids === '' || $userids === null) ? array() : explode(',', (string) $userids);
+	}
+	$userids = array_values(array_filter(array_map('intval', $userids), static function (int $v): bool {
+		return $v > 0;
+	}));
+
+	$sql = ($not ? 'NOT EXISTS' : 'EXISTS');
+	// $socidfield is a column expression of the outer query (e.g. 's.rowid'); it is compared to sc.fk_soc
+	$sql .= ' (SELECT sc.fk_soc FROM '.$db->prefix().'societe_commerciaux as sc WHERE '.$db->sanitize($socidfield).' = sc.fk_soc';
+	if (!empty($userids)) {
+		$sql .= ' AND sc.fk_user IN ('.$db->sanitize(implode(',', $userids)).')';
+	}
+	$sql .= ')';
+
+	return $sql;
+}
+
 /**
  * 		Add Event Type SQL
  *

--- a/htdocs/societe/list.php
+++ b/htdocs/societe/list.php
@@ -11,7 +11,7 @@
  * Copyright (C) 2017       Juanjo Menent      	    <jmenent@2byte.es>
  * Copyright (C) 2018       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (C) 2020       Open-Dsi                <support@open-dsi.fr>
- * Copyright (C) 2021-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2021-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2022       Anthony Berton          <anthony.berton@bb2a.fr>
  * Copyright (C) 2023       William Mead            <william.mead@manchenumerique.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
@@ -649,12 +649,12 @@ if (!empty($search_sale) && $search_sale != '-1') {
 	$search_sale_req = implode(',', $search_sale_req);
 
 	if (count($search_sale) == 1 && in_array('-2', $search_sale)) {
-		$sql .= " AND NOT EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = s.rowid)";
+		$sql .= " AND ".getSalesRepresentativeSqlFilter('s.rowid', 0, 1);
 	} elseif (count($search_sale) > 0 && !in_array('-2', $search_sale)) {
-		$sql .= " AND EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = s.rowid AND sc.fk_user IN (".$db->sanitize($search_sale_req)."))";
+		$sql .= " AND ".getSalesRepresentativeSqlFilter('s.rowid', $db->sanitize($search_sale_req));
 	} elseif (count($search_sale) > 0 && in_array('-2', $search_sale)) {
-		$sql .= " AND (EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = s.rowid AND sc.fk_user IN (".$db->sanitize($search_sale_req)."))";
-		$sql .= " OR NOT EXISTS (SELECT sc.fk_soc FROM ".MAIN_DB_PREFIX."societe_commerciaux as sc WHERE sc.fk_soc = s.rowid))";
+		$sql .= " AND (".getSalesRepresentativeSqlFilter('s.rowid', $db->sanitize($search_sale_req));
+		$sql .= " OR ".getSalesRepresentativeSqlFilter('s.rowid', 0, 1).")";
 	}
 }
 


### PR DESCRIPTION
### Context

The sub-query that restricts a thirdparty-related list to the thirdparties assigned to a sales representative:

```php
EXISTS (SELECT sc.fk_soc FROM llx_societe_commerciaux as sc
        WHERE sc.fk_soc = <x> AND sc.fk_user (= <id> | IN (<ids>)))
```

is hand-written **~100 times across ~53 files** — every `*/list.php`, several `*/index.php`, and `class/api_*.class.php` — with only the thirdparty-id column (`s.rowid`, `f.fk_soc`, `c.fk_soc`, `t.fk_soc`, …) and the user id(s) (`$search_sale`, `$user->id`, a sanitized list) changing. Also as `NOT EXISTS` (thirdparty assigned to nobody) and inside `OR` combos.

### This PR

Adds one helper to `core/lib/company.lib.php`, next to the existing `addEventTypeSQL()` / `addOtherFilterSQL()` fragment builders:

```php
getSalesRepresentativeSqlFilter($socidfield, $userids = 0, $not = 0)
```

- `$userids`: int, `int[]`, or a comma list; `0`/empty ⇒ only test "assigned to someone".
- `$not = 1` ⇒ `NOT EXISTS(...)`.
- Returns the bare `EXISTS(...)` / `NOT EXISTS(...)` so the caller composes `AND` / `OR` / parentheses.

and converts **one file — `htdocs/societe/list.php`** — as an example. If the API is OK the ~52 other call sites can follow the same way (one or a few PRs).

### Note

The helper always emits `sc.fk_user IN (...)` even for a single id (rather than `= id`); equivalent for MySQL and PostgreSQL. `societe/list.php` already used the `IN (...)` form, so its generated SQL is unchanged.

PHPStan (level 10) on both files: clean.