### PR TITLE
FIX #39848 Honor SEPA mandate output directory

### DIFF
--- a/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
+++ b/htdocs/core/modules/bank/doc/pdf_sepamandate.modules.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2024-2025	MDW					 <mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France		 <frederic.france@free.fr>
  * Copyright (C) 2024	    Nick Fragoulis
+ * Copyright (C) 2026       Nathan Pixodeo        <nathan@pixodeo.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -128,7 +129,7 @@ class pdf_sepamandate extends ModeleBankAccountDoc
 	 *	@param	int<0,1>				$hidedetails		Do not show line details
 	 *	@param	int<0,1>				$hidedesc			Do not show desc
 	 *	@param	int<0,1>				$hideref			Do not show ref
-	 *  @param  ?array<string,string>	$moreparams			More parameters
+	 *  @param  ?array<string,mixed>	$moreparams			More parameters
 	 *	@return	int<-1,1>									1 if OK, <=0 if KO
 	 */
 	public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0, $moreparams = null)
@@ -139,6 +140,9 @@ class pdf_sepamandate extends ModeleBankAccountDoc
 		if (!$object instanceof CompanyBankAccount) {
 			dol_syslog(get_class($this)."::write_file object is of type ".get_class($object)." which is not expected", LOG_ERR);
 			return -1;
+		}
+		if (empty($moreparams) && !empty($object->context['moreparams']) && is_array($object->context['moreparams'])) {
+			$moreparams = $object->context['moreparams'];
 		}
 
 		if (!is_object($outputlangs)) {

--- a/test/phpunit/CompanyBankAccountTest.php
+++ b/test/phpunit/CompanyBankAccountTest.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2010 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026       Nathan Pixodeo          <nathan@pixodeo.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,6 +31,7 @@ global $conf,$user,$langs,$db;
 //require_once 'PHPUnit/Autoload.php';
 require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
 require_once dirname(__FILE__).'/../../htdocs/societe/class/companybankaccount.class.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/files.lib.php';
 require_once dirname(__FILE__).'/CommonClassTest.class.php';
 
 if (empty($user->id)) {
@@ -98,6 +100,51 @@ class CompanyBankAccountTest extends CommonClassTest
 		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
+		return $localobject;
+	}
+
+	/**
+	 * Test that SEPA mandate generation honors the output directory passed through the object context.
+	 *
+	 * @param	CompanyBankAccount	$localobject	Bank account object
+	 * @return	CompanyBankAccount				Bank account object
+	 *
+	 * @depends	testCompanyBankAccountFetch
+	 */
+	public function testSepaMandateForcedOutputDirectory($localobject)
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$soc = new Societe($db);
+		$result = $soc->fetch($localobject->socid);
+		$this->assertGreaterThan(0, $result, $soc->errorsToString());
+
+		$outputdir = $conf->societe->multidir_output[$soc->entity ?? $conf->entity].'/'.dol_sanitizeFileName((string) $soc->id);
+		$moreparams = array(
+			'use_companybankid' => $localobject->id,
+			'force_dir_output' => $outputdir,
+		);
+		$langs->load('withdrawals');
+		$objectref = dol_sanitizeFileName($localobject->ref);
+		$expectedfile = $outputdir.'/'.$langs->transnoentitiesnoconv('SepaMandateShort').' '.$objectref.'-'.dol_sanitizeFileName($localobject->rum).'.pdf';
+		if (file_exists($expectedfile)) {
+			dol_delete_file($expectedfile);
+		}
+
+		try {
+			$result = $soc->generateDocument('sepamandate', $langs, 0, 0, 0, $moreparams);
+			$this->assertGreaterThan(0, $result, $soc->errorsToString());
+			$this->assertFileExists($expectedfile);
+		} finally {
+			if (file_exists($expectedfile)) {
+				dol_delete_file($expectedfile);
+			}
+		}
+
 		return $localobject;
 	}
 


### PR DESCRIPTION
# FIX #39848 Honor SEPA mandate output directory

`commonGenerateDocument()` stores document parameters in the generated object's context and invokes the model without the legacy seventh argument. `pdf_sepamandate` still read only that positional argument, so `force_dir_output` was lost and mandates fell back to the bank documents directory.

Use the context parameters when no positional parameters were provided, while preserving compatibility with direct callers that still pass the seventh argument.

A regression test generates the mandate through `Societe::generateDocument()` and verifies that the PDF is created in the requested third-party documents directory.