### PR TITLE
QUAL modAdherent: use core/extrafieldsinimport.inc.php for import extrafields

### DIFF
--- a/htdocs/core/modules/modAdherent.class.php
+++ b/htdocs/core/modules/modAdherent.class.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2013       Juanjo Menent           <jmenent@2byte.es>
  * Copyright (C) 2014-2015  Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2018       Alexandre Spangaro      <aspangaro@open-dsi.fr>
- * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2026		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -350,16 +350,10 @@ class modAdherent extends DolibarrModules
 			$this->import_fields_array[$r]['a.fk_soc'] = "ThirdParty";
 		}
 		// Add extra fields
-		$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND elementtype = 'adherent' AND entity IN (0,".((int) $conf->entity).")";
-		$resql = $this->db->query($sql);
-		if ($resql) {    // This can fail when class is used on old database (during migration for example)
-			while ($obj = $this->db->fetch_object($resql)) {
-				$fieldname = 'extra.'.$obj->name;
-				$fieldlabel = ucfirst($obj->label);
-				$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-			}
-		}
-		// End add extra fields
+		$keyforselect = 'adherent';
+		$keyforelement = 'member';
+		$keyforaliasextra = 'extra';
+		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 		$this->import_convertvalue_array[$r] = array(
 			'a.ref' => array(
 				'rule' => 'getrefifauto',


### PR DESCRIPTION
Follow-up of #39854 (modFacture). Same conversion for **modAdherent**: the member import dataset's inline `SELECT name, label, fieldrequired FROM llx_extrafields` loop is replaced by the shared `core/extrafieldsinimport.inc.php` include (`$keyforselect = 'adherent'`, `$keyforelement = 'member'`), like modCommande / modHoliday / modFacture already do.

Same behaviour notes as #39854: extrafields of type `separate` are no longer offered as import fields; `import_TypeFields_array` / `import_entities_array` are now populated; the list is cached per request.