### PR TITLE
QUAL modUser: use core/extrafieldsinimport.inc.php for import extrafields

### DIFF
--- a/htdocs/core/modules/modUser.class.php
+++ b/htdocs/core/modules/modUser.class.php
@@ -333,16 +333,10 @@ class modUser extends DolibarrModules
 			'u.statut' => 'Status'
 		);
 		// Add extra fields
-		$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND elementtype = 'user' AND entity IN (0,".((int) $conf->entity).")";
-		$resql = $this->db->query($sql);
-		if ($resql) {    // This can fail when class is used on old database (during migration for example)
-			while ($obj = $this->db->fetch_object($resql)) {
-				$fieldname = 'extra.'.$obj->name;
-				$fieldlabel = ucfirst($obj->label);
-				$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-			}
-		}
-		// End add extra fields
+		$keyforselect = 'user';
+		$keyforelement = 'user';
+		$keyforaliasextra = 'extra';
+		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 		$this->import_fieldshidden_array[$r] = array('u.fk_user_creat' => 'user->id', 'extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'user'); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 		$this->import_convertvalue_array[$r] = array(
 			'u.fk_state' => array('rule' => 'fetchidfromcodeid', 'classfile' => '/core/class/cstate.class.php', 'class' => 'Cstate', 'method' => 'fetch', 'dict' => 'DictionaryState'),


### PR DESCRIPTION
Follow-up of #39854 (modFacture) / #39858 / #39859. Same conversion for **modUser**: the inline `SELECT name, label, fieldrequired FROM llx_extrafields` loop(s) of the import dataset(s) are replaced by the shared `core/extrafieldsinimport.inc.php` include, as `modCommande` / `modHoliday` / `modFacture` already do. `$keyforelement` is set to each dataset's existing `import_icon` value, so no icon/grouping change.

Behaviour notes identical to #39854: `type = separate` extrafields are no longer offered as import fields; `import_TypeFields_array` / `import_entities_array` get populated; the extrafield list is cached per request.