### PR TITLE
QUAL modResource: use core/extrafieldsinimport.inc.php for import extrafields

### DIFF
--- a/htdocs/core/modules/modResource.class.php
+++ b/htdocs/core/modules/modResource.class.php
@@ -274,16 +274,10 @@ class modResource extends DolibarrModules
 		$this->import_tables_array[$r] = array('r' => MAIN_DB_PREFIX.'resource', 'extra' => MAIN_DB_PREFIX.'resource_extrafields'); // List of tables to insert into (insert done in same order)
 		$this->import_fields_array[$r] = array('r.ref' => "ResourceFormLabel_ref*", 'r.fk_code_type_resource' => 'ResourceTypeCode', 'r.description' => 'ResourceFormLabel_description', 'r.note_private' => "NotePrivate", 'r.note_public' => "NotePublic", 'r.asset_number' => 'AssetNumber', 'r.datec' => 'DateCreation');
 		// Add extra fields
-		$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND elementtype = 'resource' AND entity IN (0,".((int) $conf->entity).")";
-		$resql = $this->db->query($sql);
-		if ($resql) {    // This can fail when class is used on old database (during migration for example)
-			while ($obj = $this->db->fetch_object($resql)) {
-				$fieldname = 'extra.'.$obj->name;
-				$fieldlabel = ucfirst($obj->label);
-				$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-			}
-		}
-		// End add extra fields
+		$keyforselect = 'resource';
+		$keyforelement = 'resource';
+		$keyforaliasextra = 'extra';
+		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 		$this->import_fieldshidden_array[$r] = array('r.fk_user_author' => 'user->id', 'extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'resource'); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 		$this->import_convertvalue_array[$r] = array(
 				'r.fk_code_type_resource' => array('rule' => 'fetchidfromcodeorlabel', 'classfile' => '/core/class/ctyperesource.class.php', 'class' => 'Ctyperesource', 'method' => 'fetch', 'dict' => 'DictionaryResourceType'),


### PR DESCRIPTION
Follow-up of #39854 (modFacture) / #39858 / #39859. Same conversion for **modResource**: the inline `SELECT name, label, fieldrequired FROM llx_extrafields` loop(s) of the import dataset(s) are replaced by the shared `core/extrafieldsinimport.inc.php` include, as `modCommande` / `modHoliday` / `modFacture` already do. `$keyforelement` is set to each dataset's existing `import_icon` value, so no icon/grouping change.

Behaviour notes identical to #39854: `type = separate` extrafields are no longer offered as import fields; `import_TypeFields_array` / `import_entities_array` get populated; the extrafield list is cached per request.