### PR TITLE
QUAL modProjet: use core/extrafieldsinimport.inc.php for import extrafields

### DIFF
--- a/htdocs/core/modules/modProjet.class.php
+++ b/htdocs/core/modules/modProjet.class.php
@@ -307,16 +307,10 @@ class modProjet extends DolibarrModules
 		$this->import_fields_array[$r] = array('t.ref' => 'ProjectRef*', 't.title' => 'Label*', 't.description' => "Description", 't.fk_soc' => 'ThirdPartyName', 't.public' => "Public", 't.fk_statut' => "Status");
 		$this->import_fields_array[$r] = array_merge($this->import_fields_array[$r], array('t.fk_opp_status' => "OpportunityStatus", 't.opp_percent' => "OpportunityProbability", 't.opp_amount' => "OpportunityAmount", 't.note_public' => "NotePublic", 't.note_private' => "NotePrivate", 't.budget_amount' => "Budget", 't.dateo' => "DateStart", 't.datee' => "DateEnd", 't.usage_opportunity' => "UsageOpportunity", 't.usage_task' => 'UsageTasks', 't.usage_bill_time' => 'UsageBillTimeShort'));
 		// Add extra fields
-		$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND elementtype = 'projet' AND entity IN (0,".((int) $conf->entity).")";
-		$resql = $this->db->query($sql);
-		if ($resql) {    // This can fail when class is used on old database (during migration for example)
-			while ($obj = $this->db->fetch_object($resql)) {
-				$fieldname = 'extra.'.$obj->name;
-				$fieldlabel = ucfirst($obj->label);
-				$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-			}
-		}
-		// End add extra fields
+		$keyforselect = 'projet';
+		$keyforelement = 'project';
+		$keyforaliasextra = 'extra';
+		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 		$this->import_fieldshidden_array[$r] = array('t.fk_user_creat' => 'user->id', 't.fk_user_modif' => 'user->id', 'extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'projet'); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 		$this->import_convertvalue_array[$r] = array(
 			't.ref' => array(
@@ -353,16 +347,10 @@ class modProjet extends DolibarrModules
 			$this->import_tables_array[$r] = array('t' => MAIN_DB_PREFIX.'projet_task', 'extra' => MAIN_DB_PREFIX.'projet_task_extrafields'); // List of tables to insert into (insert done in same order)
 			$this->import_fields_array[$r] = array('t.fk_projet' => 'ProjectRef*', 't.ref' => 'RefTask*', 't.label' => 'LabelTask*', 't.dateo' => "DateStart", 't.datee' => "DateEnd", 't.planned_workload' => "PlannedWorkload", 't.progress' => "Progress", 't.note_private' => "NotePrivate", 't.note_public' => "NotePublic", 't.datec' => "DateCreation");
 			// Add extra fields
-			$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND elementtype = 'projet_task' AND entity IN (0,".((int) $conf->entity).")";
-			$resql = $this->db->query($sql);
-			if ($resql) {    // This can fail when class is used on old database (during migration for example)
-				while ($obj = $this->db->fetch_object($resql)) {
-					$fieldname = 'extra.'.$obj->name;
-					$fieldlabel = ucfirst($obj->label);
-					$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-				}
-			}
-			// End add extra fields
+			$keyforselect = 'projet_task';
+			$keyforelement = 'task';
+			$keyforaliasextra = 'extra';
+			include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 			$this->import_fieldshidden_array[$r] = array('t.fk_user_creat' => 'user->id', 'extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'projet_task'); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 			$this->import_convertvalue_array[$r] = array(
 				't.fk_projet' => array('rule' => 'fetchidfromref', 'classfile' => '/projet/class/project.class.php', 'class' => 'Project', 'method' => 'fetch', 'element' => 'Project'),


### PR DESCRIPTION
Follow-up of #39854 (modFacture) / #39858 / #39859. Same conversion for **modProjet**: the inline `SELECT name, label, fieldrequired FROM llx_extrafields` loop(s) of the import dataset(s) are replaced by the shared `core/extrafieldsinimport.inc.php` include, as `modCommande` / `modHoliday` / `modFacture` already do. `$keyforelement` is set to each dataset's existing `import_icon` value, so no icon/grouping change.

Behaviour notes identical to #39854: `type = separate` extrafields are no longer offered as import fields; `import_TypeFields_array` / `import_entities_array` get populated; the extrafield list is cached per request.