### PR TITLE
QUAL modService: use core/extrafieldsinimport.inc.php for import extrafields

### DIFF
--- a/htdocs/core/modules/modService.class.php
+++ b/htdocs/core/modules/modService.class.php
@@ -615,17 +615,10 @@ class modService extends DolibarrModules
 		}
 		// Add extra fields
 		$import_extrafield_sample = array();
-		$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND elementtype = 'product' AND entity IN (0,".((int) $conf->entity).")";
-		$resql = $this->db->query($sql);
-		if ($resql) {    // This can fail when class is used on old database (during migration for example)
-			while ($obj = $this->db->fetch_object($resql)) {
-				$fieldname = 'extra.'.$obj->name;
-				$fieldlabel = ucfirst($obj->label);
-				$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-				$import_extrafield_sample[$fieldname] = $fieldlabel;
-			}
-		}
-		// End add extra fields
+		$keyforselect = 'product';
+		$keyforelement = 'service';
+		$keyforaliasextra = 'extra';
+		include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 		$this->import_fieldshidden_array[$r] = array('extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'product'); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 
 		// field order as per structure of table llx_product
@@ -768,17 +761,10 @@ class modService extends DolibarrModules
 
 				// Add extra fields
 				$import_extrafield_sample = array();
-				$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND  elementtype = 'product_fournisseur_price' AND entity IN (0, ".((int) $conf->entity).")";
-				$resql = $this->db->query($sql);
-				if ($resql) {    // This can fail when class is used on old database (during migration for example)
-					while ($obj = $this->db->fetch_object($resql)) {
-						$fieldname = 'extra.'.$obj->name;
-						$fieldlabel = ucfirst($obj->label);
-						$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-						$import_extrafield_sample[$fieldname] = $fieldlabel;
-					}
-				}
-				// End add extra fields
+				$keyforselect = 'product_fournisseur_price';
+				$keyforelement = 'service';
+				$keyforaliasextra = 'extra';
+				include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 
 				// Add some field automatically (if they are not yet provided explicitly)
 				$this->import_fieldshidden_array[$r] = array(
@@ -867,17 +853,10 @@ class modService extends DolibarrModules
 
 				// Add extra fields
 				$import_extrafield_sample = array();
-				$sql = "SELECT name, label, fieldrequired FROM ".MAIN_DB_PREFIX."extrafields WHERE type <> 'separate' AND elementtype = 'product_price' AND entity IN (0, ".((int) $conf->entity).")";
-				$resql = $this->db->query($sql);
-				if ($resql) {    // This can fail when class is used on old database (during migration for example)
-					while ($obj = $this->db->fetch_object($resql)) {
-						$fieldname = 'extra.'.$obj->name;
-						$fieldlabel = ucfirst($obj->label);
-						$this->import_fields_array[$r][$fieldname] = $fieldlabel.($obj->fieldrequired ? '*' : '');
-						$import_extrafield_sample[$fieldname] = $fieldlabel;
-					}
-				}
-				// End add extra fields
+				$keyforselect = 'product_price';
+				$keyforelement = 'service';
+				$keyforaliasextra = 'extra';
+				include DOL_DOCUMENT_ROOT.'/core/extrafieldsinimport.inc.php';
 				$this->import_fieldshidden_array[$r] = array('extra.fk_object' => 'lastrowid-'.MAIN_DB_PREFIX.'product_price'); // aliastable.field => ('user->id' or 'lastrowid-'.tableparent)
 				$this->import_regex_array[$r] = array('pr.datec' => '^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$', 'pr.recuperableonly' => '^[0|1]$');
 				$this->import_convertvalue_array[$r] = array(


### PR DESCRIPTION
Follow-up of #39854 (modFacture) / #39858 / #39859. Same conversion for **modService**: the inline `SELECT name, label, fieldrequired FROM llx_extrafields` loop(s) of the import dataset(s) are replaced by the shared `core/extrafieldsinimport.inc.php` include, as `modCommande` / `modHoliday` / `modFacture` already do. `$keyforelement` is set to each dataset's existing `import_icon` value, so no icon/grouping change.

Behaviour notes identical to #39854: `type = separate` extrafields are no longer offered as import fields; `import_TypeFields_array` / `import_entities_array` get populated; the extrafield list is cached per request.