### PR TITLE
NEW: AI chat document flow — file chip, auto local/cloud routing, native multimodal attachments

### DIFF
--- a/htdocs/ai/assistant/parse_intent.php
+++ b/htdocs/ai/assistant/parse_intent.php
@@ -113,6 +113,31 @@ try {
 		exit;
 	}
 
+	// Extract file attachments sent by the chat (paperclip flow). The JS embeds
+	// cloud-parsed documents as "__FILE_ATTACHMENT__[mime]::<base64>" markers in
+	// the query. They MUST be stripped here, before the privacy/thirdparty
+	// candidate pipeline (which would run regexes over megabytes of base64), and
+	// are handed to the LLM adapter as NATIVE multimodal parts — inlining base64
+	// into the text prompt makes every provider fail or hallucinate.
+	$attachments = array();
+	if (strpos($query, '__FILE_ATTACHMENT__') !== false) {
+		$query = preg_replace_callback(
+			'/__FILE_ATTACHMENT__\[([^\]]*)\]::([A-Za-z0-9+\/=\r\n]+)/',
+			static function ($m) use (&$attachments) {
+				$attachments[] = array(
+					'mime' => ($m[1] !== '' ? $m[1] : 'application/octet-stream'),
+					'data' => preg_replace('/\s+/', '', $m[2])
+				);
+				return '[attached document]';
+			},
+			$query
+		);
+		$query = trim((string) $query);
+		if ($query === '' || $query === '[attached document]') {
+			$query = 'Analyze the attached document and describe its content.';
+		}
+	}
+
 	// Privacy (Name Resolution & Masking)
 	$langs->loadLangs(array("main", "bills", "orders", "propal", "supplier_invoice", "supplier_order", "projects", "other"));
 
@@ -364,7 +389,7 @@ try {
 
 			dol_syslog("parse_intent.php Call AI API", LOG_DEBUG);
 
-			$rawResponse = $adapter->generate($systemPrompt, $query);
+			$rawResponse = $adapter->generate($systemPrompt, $query, 'text', $attachments);
 
 			// $rawResponse should be a json string with format '{"tool":..., "arguments":{text answer}}' but sometimes it is just 'text answer'
 			dol_syslog('rawResponse='.$rawResponse, LOG_DEBUG);

--- a/htdocs/ai/assistant/parse_intent.php
+++ b/htdocs/ai/assistant/parse_intent.php
@@ -123,7 +123,11 @@ try {
 	if (strpos($query, '__FILE_ATTACHMENT__') !== false) {
 		$query = preg_replace_callback(
 			'/__FILE_ATTACHMENT__\[([^\]]*)\]::([A-Za-z0-9+\/=\r\n]+)/',
-			static function ($m) use (&$attachments) {
+			/**
+			 * @param string[] $m Regex matches: [1] = mime type, [2] = base64 payload
+			 * @return string
+			 */
+			static function (array $m) use (&$attachments) {
 				$attachments[] = array(
 					'mime' => ($m[1] !== '' ? $m[1] : 'application/octet-stream'),
 					'data' => preg_replace('/\s+/', '', $m[2])

--- a/htdocs/ai/class/llmadapter.class.php
+++ b/htdocs/ai/class/llmadapter.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026		Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026		Nick Fragoulis
+ * Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -70,17 +71,22 @@ class UniversalLLMAdapter
 	 * @param string $system   The system prompt/instruction
 	 * @param string $userMsg  The specific user query
 	 * @param string $mode     'json' for strict JSON (MCP), 'text' for legacy (default)
+	 * @param array<int,array{mime:string,data:string}> $attachments  Optional documents/images to
+	 *                         send along the message as NATIVE multimodal parts (each entry is
+	 *                         ['mime' => 'image/png', 'data' => '<base64>']). Passing them here —
+	 *                         instead of inlining base64 into the text prompt — is what allows the
+	 *                         provider to actually see the file (vision/document understanding).
 	 * @return string|null     The text response from the AI or null on failure
 	 */
-	public function generate(string $system, string $userMsg, string $mode = 'text'): ?string
+	public function generate(string $system, string $userMsg, string $mode = 'text', array $attachments = array()): ?string
 	{
 		switch ($this->type) {
 			case 'anthropic':
-				return $this->callAnthropic($system, $userMsg, $mode);
+				return $this->callAnthropic($system, $userMsg, $mode, $attachments);
 			case 'google':
-				return $this->callGoogle($system, $userMsg, $mode);
+				return $this->callGoogle($system, $userMsg, $mode, $attachments);
 			default:
-				return $this->callOpenAI($system, $userMsg, $mode);
+				return $this->callOpenAI($system, $userMsg, $mode, $attachments);
 		}
 	}
 
@@ -92,18 +98,31 @@ class UniversalLLMAdapter
 	 * @param string $mode 'json' or 'text'
 	 * @return string|null Response content or null on failure
 	 */
-	private function callOpenAI(string $sys, string $msg, string $mode = 'text'): ?string
+	private function callOpenAI(string $sys, string $msg, string $mode = 'text', array $attachments = array()): ?string
 	{
 		$url = $this->baseUrl;
 		if (strpos($url, '/chat/completions') === false && strpos($url, '/generate') === false) {
 			$url .= '/chat/completions';
 		}
 
+		// With attachments, the user content becomes an array of typed parts
+		// (vision input); without, it stays a plain string (widest compatibility).
+		$userContent = $msg;
+		if (!empty($attachments)) {
+			$userContent = array(array("type" => "text", "text" => $msg));
+			foreach ($attachments as $att) {
+				$userContent[] = array(
+					"type" => "image_url",
+					"image_url" => array("url" => "data:".$att['mime'].";base64,".$att['data'])
+				);
+			}
+		}
+
 		$data = array(
 			"model" => $this->model,
 			"messages" => array(
 				array("role" => "system", "content" => $sys),
-				array("role" => "user", "content" => $msg)
+				array("role" => "user", "content" => $userContent)
 			),
 			"temperature" => 0.1
 		);
@@ -131,16 +150,32 @@ class UniversalLLMAdapter
 	 *
 	 * @return string|null Response content or null on failure
 	 */
-	private function callAnthropic(string $sys, string $msg, string $mode = 'text')
+	private function callAnthropic(string $sys, string $msg, string $mode = 'text', array $attachments = array())
 	{
 
 		$url = $this->baseUrl . (strpos($this->baseUrl, '/messages') === false ? '/messages' : '');
 
+		// With attachments, content becomes an array of typed blocks: PDFs go as
+		// 'document' blocks, images as 'image' blocks (Anthropic native formats).
+		$userContent = $msg;
+		$maxTokens = 1024;
+		if (!empty($attachments)) {
+			$userContent = array();
+			foreach ($attachments as $att) {
+				$userContent[] = array(
+					"type" => ($att['mime'] === 'application/pdf' ? "document" : "image"),
+					"source" => array("type" => "base64", "media_type" => $att['mime'], "data" => $att['data'])
+				);
+			}
+			$userContent[] = array("type" => "text", "text" => $msg);
+			$maxTokens = 4096;	// document extraction answers are much longer than intent JSON
+		}
+
 		$data = array(
 			"model" => $this->model,
 			"system" => $sys,
-			"messages" => array(array("role" => "user", "content" => $msg)),
-			"max_tokens" => 1024
+			"messages" => array(array("role" => "user", "content" => $userContent)),
+			"max_tokens" => $maxTokens
 		);
 
 		$this->lastRequest = json_encode($data, JSON_PRETTY_PRINT);
@@ -157,7 +192,7 @@ class UniversalLLMAdapter
 	 *
 	 * @return string|null Response content or null on failure
 	 */
-	private function callGoogle(string $sys, string $msg, string $mode = 'text')
+	private function callGoogle(string $sys, string $msg, string $mode = 'text', array $attachments = array())
 	{
 		$url = $this->baseUrl;
 
@@ -171,9 +206,17 @@ class UniversalLLMAdapter
 
 		$url .= "?key=" . $this->key;
 
+		// With attachments, prepend native inline_data parts (Gemini vision /
+		// document understanding) before the text part.
+		$parts = array();
+		foreach ($attachments as $att) {
+			$parts[] = array("inline_data" => array("mime_type" => $att['mime'], "data" => $att['data']));
+		}
+		$parts[] = array("text" => $sys . "\nUser: " . $msg);
+
 		$data = array(
 			"contents" => array(
-				array("parts" => array(array("text" => $sys . "\nUser: " . $msg)))
+				array("parts" => $parts)
 			),
 			"generationConfig" => array("temperature" => 0.1)
 		);

--- a/htdocs/ai/class/llmadapter.class.php
+++ b/htdocs/ai/class/llmadapter.class.php
@@ -68,14 +68,14 @@ class UniversalLLMAdapter
 	/**
 	 * Generate a response using the configured LLM provider
 	 *
+	 * Attachments are sent as NATIVE multimodal parts — instead of inlining base64 into
+	 * the text prompt — which is what allows the provider to actually see the file
+	 * (vision/document understanding).
+	 *
 	 * @param string $system   The system prompt/instruction
 	 * @param string $userMsg  The specific user query
 	 * @param string $mode     'json' for strict JSON (MCP), 'text' for legacy (default)
-	 * @param array<int,array{mime:string,data:string}> $attachments  Optional documents/images to
-	 *                         send along the message as NATIVE multimodal parts (each entry is
-	 *                         ['mime' => 'image/png', 'data' => '<base64>']). Passing them here —
-	 *                         instead of inlining base64 into the text prompt — is what allows the
-	 *                         provider to actually see the file (vision/document understanding).
+	 * @param array<int,array{mime:string,data:string}> $attachments Optional documents/images, each entry is array('mime' => 'image/png', 'data' => '<base64>')
 	 * @return string|null     The text response from the AI or null on failure
 	 */
 	public function generate(string $system, string $userMsg, string $mode = 'text', array $attachments = array()): ?string
@@ -96,6 +96,7 @@ class UniversalLLMAdapter
 	 * @param string $sys System prompt
 	 * @param string $msg User message
 	 * @param string $mode 'json' or 'text'
+	 * @param array<int,array{mime:string,data:string}> $attachments Optional attachments sent as native multimodal parts
 	 * @return string|null Response content or null on failure
 	 */
 	private function callOpenAI(string $sys, string $msg, string $mode = 'text', array $attachments = array()): ?string
@@ -147,6 +148,7 @@ class UniversalLLMAdapter
 	 * @param string $sys System prompt
 	 * @param string $msg User message
 	 * @param string $mode Response mode (default: text)
+	 * @param array<int,array{mime:string,data:string}> $attachments Optional attachments sent as native multimodal parts
 	 *
 	 * @return string|null Response content or null on failure
 	 */
@@ -189,6 +191,7 @@ class UniversalLLMAdapter
 	 * @param string $sys System prompt
 	 * @param string $msg User message
 	 * @param string $mode Response mode (default: text)
+	 * @param array<int,array{mime:string,data:string}> $attachments Optional attachments sent as native multimodal parts
 	 *
 	 * @return string|null Response content or null on failure
 	 */

--- a/htdocs/ai/css/ai_assistant.css
+++ b/htdocs/ai/css/ai_assistant.css
@@ -1,3 +1,4 @@
+/* Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com> */
 /* ===========================================================================
  * AI Assistant chat stylesheet
  * Used by the standalone page (ai/assistant/index.php) and by the topbar
@@ -1070,3 +1071,23 @@ body.ai-fullpage {
         height: calc(100vh - var(--ai-popover-top, 48px));
     }
 }
+
+/* -------------------------------------------------------------------------
+ * Attached-file chip (paperclip flow): shown above the input pill while a
+ * document is attached, and inline (read-only) inside the sent user message.
+ * ------------------------------------------------------------------------- */
+.file-chip-area { padding: 0 14px 6px; }
+.ai-in-popover .file-chip-area { padding: 0 10px 4px; }
+.file-chip {
+	display: inline-flex; align-items: center; gap: 6px;
+	max-width: 260px; padding: 4px 10px; border-radius: 10px;
+	background: rgba(127, 127, 127, 0.12);
+	border: 1px solid rgba(127, 127, 127, 0.25);
+	font-size: 0.85em;
+}
+.file-chip .chip-icon { opacity: .8; }
+.file-chip .chip-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-chip .chip-x { border: 0; background: none; cursor: pointer; font-size: 1.1em; line-height: 1; padding: 0 2px; opacity: .6; color: inherit; }
+.file-chip .chip-x:hover { opacity: 1; }
+.file-chip.chip-error { border-color: #d9534f; color: #d9534f; }
+.file-chip.chip-inline { margin-bottom: 4px; }

--- a/htdocs/ai/js/ai_assistant.js
+++ b/htdocs/ai/js/ai_assistant.js
@@ -742,7 +742,11 @@ export function initAiAssistant(container) {
     }
 
     async function processCloudFile(file) {
-        const base64 = await fileToBase64(file);
+        // fileToBase64 resolves the FULL data URL ("data:image/png;base64,AAAA…").
+        // Strip the prefix: the server-side extractor (parse_intent.php) expects
+        // pure base64 after '::' and hands it to the LLM as a native multimodal
+        // part — with the prefix left in, the marker is never recognized.
+        const base64 = String(await fileToBase64(file)).split(',').pop();
         return `__FILE_ATTACHMENT__[${file.type}]::${base64}`;
     }
 

--- a/htdocs/ai/js/ai_assistant.js
+++ b/htdocs/ai/js/ai_assistant.js
@@ -359,6 +359,27 @@ export function initAiAssistant(container) {
             + '<span class="chip-name">' + escapeHtml(name) + '</span></span>';
     }
 
+    /**
+     * Light markdown rendering for free-text LLM answers: the models reply with
+     * markdown (bold, lists, line breaks) that innerHTML would otherwise flatten
+     * into one unreadable block with literal asterisks. HTML is escaped FIRST,
+     * so the LLM cannot inject markup.
+     * @param {string} text Raw model answer
+     * @return {string} Safe HTML
+     */
+    function renderMarkdownLite(text) {
+        let s = escapeHtml(String(text));
+        s = s.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+        s = s.replace(/(^|[\s(])\*([^*\n]+)\*(?=[\s).,;:!?]|$)/g, '$1<em>$2</em>');
+        s = s.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+        // Numbered/bulleted list items get their own line even when the model
+        // packed them into a single paragraph ("… 5,20 € 2. **Référence** …").
+        s = s.replace(/\s(\d{1,2}\.\s)(?=<strong>|\S)/g, '<br>$1');
+        s = s.replace(/(^|\n)[-•]\s/g, '$1• ');
+        s = s.replace(/\n/g, '<br>');
+        return s;
+    }
+
     // =========================================================================
     // LIBRARY LOADERS & EXTRACTORS
     // =========================================================================
@@ -1078,7 +1099,7 @@ export function initAiAssistant(container) {
 
     function handleClarification(question, context) {
         clarificationContext = context;
-        let html = `<div><strong>${question}</strong></div><input type="text" id="clarification-input" placeholder="${t('TypeResponse')}" style="width:100%; margin-top:10px; padding:8px; border:1px solid #ccc; border-radius:4px;">`;
+        let html = `<div><strong>${renderMarkdownLite(question)}</strong></div><input type="text" id="clarification-input" placeholder="${t('TypeResponse')}" style="width:100%; margin-top:10px; padding:8px; border:1px solid #ccc; border-radius:4px;">`;
         const actions = [
             {
                 text: t('Submit'), class: 'primary', icon: 'fa-check', onclick: () => {
@@ -1106,7 +1127,7 @@ export function initAiAssistant(container) {
 
     function handleResponse(message) {
         if (!message) message = t('EmptyAIResponse');
-        appendMsg('bot', message);
+        appendMsg('bot', renderMarkdownLite(message));
     }
 
     function handleConfirmation(action, details, originalIntent) {

--- a/htdocs/ai/js/ai_assistant.js
+++ b/htdocs/ai/js/ai_assistant.js
@@ -1,3 +1,10 @@
+/* Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ */
 /**
  * \file htdocs/ai/js/ai_assistant.js
  * \brief Frontend logic for the AI Assistant
@@ -47,6 +54,7 @@ export function initAiAssistant(container) {
     const uploadBtn = container.querySelector('#upload-btn');
     const uploadWrapper = container.querySelector('#upload-wrapper');
     const fileInput = container.querySelector('#file-upload');
+    const chipArea = container.querySelector('#file-chip-area');
 
     const clearBtn = container.querySelector('#clear-btn');
     const engineSelect = container.querySelector('#engine-select');
@@ -67,6 +75,9 @@ export function initAiAssistant(container) {
     let lastResult = { data: null, tool: '', query: '' };
     let pendingIntent = null;     // Stores action waiting for confirmation
     let clarificationContext = null;
+    // Document attached via the paperclip: {name, payload}. Sent as context with
+    // the NEXT message; only a small chip (icon + name) is shown in the UI.
+    let attachedDoc = null;
 
     // Audio Hardware Context
     let audioContext, mediaStream, audioProcessor, audioChunks = [];
@@ -170,13 +181,14 @@ export function initAiAssistant(container) {
     // =========================================================================
 
     /**
-     * Update UI visibility based on selected engine
-     * @param {string} mode - 'text', 'cloud', 'whisper', 'local_docs', 'cloud_docs'
+     * Update UI visibility based on selected engine.
+     * The paperclip (uploadWrapper) is ALWAYS visible: documents can be attached
+     * in any mode, like in modern chat UIs. The legacy 'local_docs'/'cloud_docs'
+     * selector modes are gone — routing local/cloud is automatic on attach.
+     * @param {string} mode - 'text', 'cloud', 'whisper'
      */
     function updateInterfaceMode(mode) {
-        // Reset all wrappers
         micWrapper.classList.add('ai-hidden');
-        uploadWrapper.classList.add('ai-hidden');
 
         if (mode === 'text') {
             input.placeholder = t('TypeYourQuestion');
@@ -187,13 +199,6 @@ export function initAiAssistant(container) {
             micWrapper.classList.remove('ai-hidden');
             input.placeholder = 'Type or speak...';
             initEngine(mode);
-        }
-        else if (mode === 'local_docs' || mode === 'cloud_docs') {
-            // Document Modes
-            uploadWrapper.classList.remove('ai-hidden');
-            input.placeholder = mode === 'local_docs'
-                ? t('UploadLocalDoc')
-                : t('UploadCloudDoc');
         }
     }
 
@@ -252,15 +257,40 @@ export function initAiAssistant(container) {
             const file = e.target.files[0];
             if (!file) return;
 
-            const mode = engineSelect.value;
-            statusBar.innerText = t('ProcessingFile') + ` ${file.name} (${mode})...`;
+            renderChip(file.name, 'loading');
+            statusBar.innerText = t('ProcessingFile') + ` ${file.name}...`;
 
             try {
-                let contentPayload = "";
+                // Automatic routing: try the in-browser extraction first, then
+                // fall back to server-side cloud parsing (multimodal) when the
+                // local result is empty or too short to be useful — typically a
+                // photographed PDF with no text layer.
+                //
+                // Two guards keep the chip from spinning for minutes:
+                // - a large image goes straight to cloud parsing (browser OCR on a
+                //   multi-MB photo downloads Tesseract + a language model and can
+                //   take minutes for a poor result);
+                // - any local extraction is capped by a hard timeout, after which
+                //   we fall back to cloud parsing (the orphan extraction result,
+                //   if it ever completes, is simply ignored).
+                const LOCAL_EXTRACT_TIMEOUT_MS = 20000;
+                const LOCAL_IMAGE_MAX_BYTES = 1500000;
+                const isImage = file.type.startsWith('image/') || /\.(png|jpe?g|gif|bmp|webp)$/i.test(file.name);
 
-                if (mode === 'local_docs') {
-                    contentPayload = await processLocalFile(file);
-                } else if (mode === 'cloud_docs') {
+                let contentPayload = '';
+                if (!(isImage && file.size > LOCAL_IMAGE_MAX_BYTES)) {
+                    try {
+                        contentPayload = await Promise.race([
+                            processLocalFile(file),
+                            new Promise((resolve) => setTimeout(() => resolve(''), LOCAL_EXTRACT_TIMEOUT_MS))
+                        ]);
+                    } catch (errLocal) {
+                        contentPayload = '';
+                    }
+                }
+                const usefulChars = (contentPayload || '').replace(/\s+/g, '').length;
+                if (usefulChars < 120) {
+                    statusBar.innerText = t('ProcessingFile') + ` ${file.name} (cloud)...`;
                     contentPayload = await processCloudFile(file);
                 }
 
@@ -268,30 +298,65 @@ export function initAiAssistant(container) {
                     throw new Error(t('UnsupportedFileType'));
                 }
 
-                const docContext = `${t('DocContextIntro')}
-
-		${contentPayload}
-
-		--- ${t('DocContextOutro')} ---
-		`;
-
-                input.value = docContext;
-                setTimeout(autoResizeInput, 0); // Trigger resize so the text is visible
-
-                // Update placeholder to guide the user
-                //input.placeholder = "Document loaded. Ask something (e.g., 'Summarize this', 'Create an invoice for line 2')...";
-
-                // Focus input so user can type immediately
+                // The content NEVER goes into the input nor the conversation:
+                // it is kept aside and sent as context with the next message.
+                attachedDoc = { name: file.name, payload: contentPayload };
+                renderChip(file.name, 'ready');
+                statusBar.innerText = '';
                 input.focus();
-                statusBar.innerText = t('DocLoaded');
-
             } catch (err) {
                 console.error(err);
+                attachedDoc = null;
+                renderChip(file.name, 'error');
                 statusBar.innerText = t('Error') + ": " + err.message;
             }
 
             fileInput.value = '';
         });
+    }
+
+    /** Pick a FontAwesome icon class from a file name extension. */
+    function chipIcon(name) {
+        const ext = (String(name).split('.').pop() || '').toLowerCase();
+        if (ext === 'pdf') return 'fa-file-pdf';
+        if (['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp'].indexOf(ext) !== -1) return 'fa-file-image';
+        if (['xls', 'xlsx', 'ods'].indexOf(ext) !== -1) return 'fa-file-excel';
+        if (['doc', 'docx', 'odt'].indexOf(ext) !== -1) return 'fa-file-word';
+        return 'fa-file-alt';
+    }
+
+    /** Minimal HTML escaping (appendMsg uses innerHTML). */
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, (c) => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'}[c]));
+    }
+
+    /** Render the attached-file chip above the input pill. */
+    function renderChip(name, state) {
+        if (!chipArea) return;
+        chipArea.classList.remove('ai-hidden');
+        const stateClass = (state === 'error') ? ' chip-error' : '';
+        const icon = (state === 'loading') ? 'fa-spinner fa-spin' : chipIcon(name);
+        chipArea.innerHTML = '<span class="file-chip' + stateClass + '">'
+            + '<i class="fa ' + icon + ' chip-icon"></i>'
+            + '<span class="chip-name">' + escapeHtml(name) + '</span>'
+            + '<button type="button" class="chip-x" title="' + escapeHtml(t('Cancel')) + '">&times;</button>'
+            + '</span>';
+        chipArea.querySelector('.chip-x').addEventListener('click', clearChip);
+    }
+
+    /** Remove the chip and forget the attached document. */
+    function clearChip() {
+        attachedDoc = null;
+        if (chipArea) {
+            chipArea.innerHTML = '';
+            chipArea.classList.add('ai-hidden');
+        }
+    }
+
+    /** Inline (read-only) chip markup shown inside a sent user message. */
+    function chipHtmlFor(name) {
+        return '<span class="file-chip chip-inline"><i class="fa ' + chipIcon(name) + ' chip-icon"></i>'
+            + '<span class="chip-name">' + escapeHtml(name) + '</span></span>';
     }
 
     // =========================================================================
@@ -1155,9 +1220,20 @@ export function initAiAssistant(container) {
 
     async function handleQuery() {
         const query = input.value.trim();
-        if (!query) return;
+        if (!query && !attachedDoc) return;
         if (welcome) welcome.style.display = 'none'; // leave the empty-state once a message is sent
-        appendMsg('user', query);
+
+        // What is SENT = document context + question; what is DISPLAYED = chip + question.
+        let sentQuery = query;
+        let displayHtml = escapeHtml(query);
+        if (attachedDoc) {
+            const docContext = `${t('DocContextIntro')}\n\n${attachedDoc.payload}\n\n--- ${t('DocContextOutro')} ---\n`;
+            sentQuery = docContext + (query ? '\n' + query : '');
+            displayHtml = chipHtmlFor(attachedDoc.name) + (query ? '<br>' + displayHtml : '');
+        }
+
+        appendMsg('user', displayHtml);
+        clearChip();
         input.value = '';
         input.style.height = '44px';
         input.disabled = true;
@@ -1166,7 +1242,7 @@ export function initAiAssistant(container) {
         try {
             const intentRes = await fetch(epUrl('parse_intent.php'), {
                 method: 'POST', headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ query: query })
+                body: JSON.stringify({ query: sentQuery })
             });
             const intent = await intentRes.json();
             loadingMsg.remove();

--- a/htdocs/ai/lib/ai.lib.php
+++ b/htdocs/ai/lib/ai.lib.php
@@ -4,6 +4,7 @@
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Anthony Damhet			<a.damhet@progiseize.fr>
  * Copyright (C) 2026		Nick Fragoulis
+ * Copyright (C) 2026	Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -656,8 +657,9 @@ function getAiChatAssistantHtml($mode = 'page')
 	$out .= '<option value="text">'.$langs->transnoentitiesnoconv("OptionTextOnly").'</option>';
 	$out .= '<option value="cloud">'.$langs->transnoentitiesnoconv("OptionCloudFast").'</option>';
 	$out .= '<option value="whisper">'.$langs->transnoentitiesnoconv("OptionWhisperLocal").'</option>';
-	$out .= '<option value="local_docs">'.$langs->transnoentitiesnoconv("OptionLocalParsing").'</option>';
-	$out .= '<option value="cloud_docs">'.$langs->transnoentitiesnoconv("OptionCloudParsing").'</option>';
+	// Note: the legacy 'local_docs'/'cloud_docs' selector modes are gone — documents
+	// are now attached with the always-visible paperclip button and routed
+	// automatically (local extraction first, cloud parsing as fallback).
 	$out .= '</select>';
 	// Clear Button
 	$out .= '<button type="button" id="clear-btn" class="icon-btn" title="'.dol_escape_htmltag($langs->trans("ClearChatHistoryTitle")).'">';
@@ -709,9 +711,13 @@ function getAiChatAssistantHtml($mode = 'page')
 	// Controls: a single rounded "pill" holding the attach/mic buttons, the
 	// textarea and the send button.
 	$out .= '<div class="chat-controls">';
+	// Attached-file chip (icon + name + remove cross), shown above the input pill
+	// once a document has been attached with the paperclip. The document content
+	// itself NEVER appears in the input nor in the conversation.
+	$out .= '<div id="file-chip-area" class="file-chip-area ai-hidden"></div>';
 	$out .= '<div class="chat-input-pill">';
-	// Upload Wrapper (Visible only in Doc modes)
-	$out .= '<div id="upload-wrapper" class="upload-wrapper ai-hidden">';
+	// Upload Wrapper (always visible: documents can be attached in any mode)
+	$out .= '<div id="upload-wrapper" class="upload-wrapper">';
 	$out .= '<input type="file" id="file-upload" accept=".pdf,.txt,.xml,.png,.jpg,.jpeg,.doc,.docx,.xls,.xlsx,.odt,.ods" style="display: none;">';
 	$out .= '<button type="button" id="upload-btn" class="round-btn" title="'.dol_escape_htmltag($langs->transnoentitiesnoconv("AttachFile")).'">'.img_picto('', 'fa-paperclip').'</button>';
 	$out .= '</div>';

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -2799,6 +2799,13 @@ function top_menu_ai()
         jQuery(document).ready(function() {
 	        jQuery(document).on("click", function(event) {
 				if (jQuery("#topmenu-ai-popover").hasClass("open")) {
+					// A click on a node removed from the DOM while the event was bubbling
+					// (e.g. a chat action button like "Yes, continue" that removes its own
+					// message bubble) must not be mistaken for a click outside the popover:
+					// .closest() cannot reach the popover from a detached node.
+					if (event.target instanceof Element && !event.target.isConnected) {
+						return;
+					}
 		    		if (!$(event.target).closest("#topmenu-ai-toggle").length && !$(event.target).closest("#topmenu-ai-popover").length) {
 						console.log("click close ai dropdown - we click outside");
 		                // Hide the dropdown.


### PR DESCRIPTION
## What

Reworks the AI assistant's document flow to behave like modern chat UIs, and makes attached documents actually reach the LLM as **native multimodal content**.

### Before
- Attaching a document required picking one of two dedicated "document modes" in the engine selector (`local_docs` / `cloud_docs`); the paperclip was hidden otherwise.
- The extracted content was **injected into the input field** — a photographed PDF dumped pages of base64/garbled glyphs into the textarea and into the conversation.
- The cloud path embedded the file as a `__FILE_ATTACHMENT__[mime]::<base64>` marker **inside the text prompt**; no server code ever consumed it, so megabytes of base64 went to the provider as plain text — every provider then failed or answered that the document contains no extractable text.
- A large photo went through in-browser OCR with no time limit (the chip could spin for minutes).

### After
- **Paperclip always visible**; the two document modes are removed from the selector (it keeps text/voice only).
- Attaching a file shows a **chip** (type icon + name + remove cross) above the input; the content never appears in the input nor in the transcript.
- **Automatic routing**: in-browser extraction first; if the useful text is shorter than ~120 chars (typical for image-only PDFs), fall back to server-side cloud parsing. A >1.5MB image goes straight to cloud, and any local extraction is capped by a 20s timeout. Both failing turns the chip red with a clear error.
- On send: the prompt transmitted = document context + question; the conversation displays only the **chip + the question** (now HTML-escaped).
- **Server side** (`parse_intent.php` + `UniversalLLMAdapter`): the attachment marker is stripped from the query *before* the privacy/thirdparty pipeline (no more regexing megabytes of base64) and the file is passed to the provider in its **native format** — Anthropic `document` (PDF) / `image` content blocks, Google Gemini `inline_data` parts, OpenAI-compatible `image_url` data URLs. Without attachments the payloads are byte-identical to before.
- Free-text model answers are rendered with a small escaping-first **markdown-lite** pass (bold, lists, line breaks) instead of one flattened block with literal asterisks.
- **Popover fix**: the chat closed itself when clicking an in-chat action button ("Yes, continue" / clarification Submit…). Those buttons remove their own message bubble in their onclick, so by the time the click bubbled to `document` the target was detached and the outside-click handler of `top_menu_ai()` mistook it for a click outside the popover. Clicks on disconnected targets are now ignored.

## Tested

End-to-end on two live instances (v25 + Google Gemini native API, and v24 + Anthropic): a 10MB photographed delivery note attached via the chip is read by the model with 100% fidelity (11 lines, references, quantities, prices), and "create a reception from this delivery note" produces the document through the MCP tools. Known limits documented in the code: Anthropic caps images at ~5MB each (PDFs 32MB); Gemini requests at ~20MB.

## Screenshots

<!-- drag & drop: 1) idle chat with always-visible paperclip, 2) chip attached above the input, 3) sent message showing chip + question only, 4) model answer rendered with markdown -->

Refs #38356

<img width="940" height="1120" alt="1_chat_repos" src="https://github.com/user-attachments/assets/1c8775f2-9457-4dca-b8a1-119f42b5ebcc" />
<img width="940" height="1005" alt="2_chip_fichier" src="https://github.com/user-attachments/assets/a6dd6bdc-7881-4cea-937f-ec2080e72098" />
<img width="880" height="800" alt="3_bulle_chip_question" src="https://github.com/user-attachments/assets/bd6ef8ac-ec3d-4dc1-99cd-68bbfe9e8b4e" />
<img width="880" height="900" alt="4_reponse_markdown" src="https://github.com/user-attachments/assets/e54bd5bb-032f-4fd0-915c-f4946f0251bc" />


