### PR TITLE
FIX #39721 Default custom module URL root

### DIFF
--- a/htdocs/filefunc.inc.php
+++ b/htdocs/filefunc.inc.php
@@ -11,6 +11,7 @@
  * Copyright (C) 2015      Bahfir Abbes         <bafbes@gmail.com>
  * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024      Frédéric France      <frederic.france@free.fr>
+ * Copyright (C) 2026      Nathan Pixodeo       <nathan@pixodeo.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -362,6 +363,9 @@ if (empty($dolibarr_main_url_root) && !defined('NOREQUIREVIRTUALURL')) {
 	die;
 }
 
+if (empty($dolibarr_main_url_root_alt)) {
+	$dolibarr_main_url_root_alt = '/custom';
+}
 if (empty($dolibarr_main_document_root_alt)) {
 	$dolibarr_main_document_root_alt = $dolibarr_main_document_root.'/custom';
 }


### PR DESCRIPTION
# FIX #39721 Default custom module URL root

`filefunc.inc.php` already defaults an omitted alternate document root to `htdocs/custom`, but leaves the matching URL root empty. `master.inc.php` therefore registers the custom directory with an empty URL prefix, so `dol_buildpath()` finds a custom module file but returns `/module/...` instead of `/custom/module/...`.

Default an omitted `$dolibarr_main_url_root_alt` to `/custom` beside the existing document-root fallback. Explicit alternate URL roots remain unchanged.

Validation:
- `php -l htdocs/filefunc.inc.php`
- `git diff --check`
- focused `dol_buildpath()` probe covering the empty root, `/custom`, an explicit `/extensions` root, and absolute custom URLs