### PR TITLE
FIX Re-point phpstan baseline entries after functions.lib.php split

### DIFF
--- a/dev/build/phpstan/phpstan-baseline.neon
+++ b/dev/build/phpstan/phpstan-baseline.neon
@@ -3451,12 +3451,6 @@ parameters:
 			path: ../../../htdocs/core/lib/functions.lib.php
 
 		-
-			message: '#^If condition is always true\.$#'
-			identifier: if.alwaysTrue
-			count: 3
-			path: ../../../htdocs/core/lib/functions.lib.php
-
-		-
 			message: '#^Instanceof between DOMDocument and DOMDocument will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1
@@ -3483,7 +3477,7 @@ parameters:
 		-
 			message: '#^Negated boolean expression is always true\.$#'
 			identifier: booleanNot.alwaysTrue
-			count: 2
+			count: 1
 			path: ../../../htdocs/core/lib/functions.lib.php
 
 		-
@@ -3505,16 +3499,34 @@ parameters:
 			path: ../../../htdocs/core/lib/functions.lib.php
 
 		-
-			message: '#^Ternary operator condition is always false\.$#'
-			identifier: ternary.alwaysFalse
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 1
 			path: ../../../htdocs/core/lib/functions.lib.php
 
 		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 3
+			path: ../../../htdocs/core/lib/html.lib.php
+
+		-
+			message: '#^Negated boolean expression is always true\.$#'
+			identifier: booleanNot.alwaysTrue
+			count: 1
+			path: ../../../htdocs/core/lib/html.lib.php
+
+		-
+			message: '#^Ternary operator condition is always false\.$#'
+			identifier: ternary.alwaysFalse
+			count: 1
+			path: ../../../htdocs/core/lib/html.lib.php
+
+		-
 			message: '#^Ternary operator condition is always true\.$#'
 			identifier: ternary.alwaysTrue
-			count: 7
-			path: ../../../htdocs/core/lib/functions.lib.php
+			count: 6
+			path: ../../../htdocs/core/lib/html.lib.php
 
 		-
 			message: '#^If condition is always true\.$#'


### PR DESCRIPTION
## Problem

`develop` CI (`phpstan / php-stan (8.2)`) is red: **11 errors in `htdocs/core/lib/html.lib.php`**.

They are not new: commit `7942c040629` *"QUAL: Split file functions.lib.php into functions.lib.php + html.lib.php"* moved code that carried **accepted `phpstan-baseline.neon` entries**, but every entry still points at `functions.lib.php`. The PHPStan CI job only analyses changed files, so those lines were not re-checked on the split PR — they surfaced on the next push to `develop`.

## Fix

Move the relocated counts from `functions.lib.php` to `htdocs/core/lib/html.lib.php` in `dev/build/phpstan/phpstan-baseline.neon`:

| identifier | functions.lib.php | html.lib.php |
|---|---|---|
| `if.alwaysTrue` | 3 → 0 | +3 |
| `booleanNot.alwaysTrue` | 2 → 1 | +1 |
| `ternary.alwaysFalse` | 1 → 0 | +1 |
| `ternary.alwaysTrue` | 7 → 1 | +6 |

Residual `functions.lib.php` counts were verified by regenerating the baseline for both files with the existing baseline temporarily disabled. **No code change** — the underlying conditions (in `dol_banner_tab()`, `img_picto()`, `dolGetStatus()`, `show_actions_done()`) were already baselined debt before the split and can be cleaned up separately.

## Test

`php vendor/bin/phpstan analyse -a dev/build/phpstan/bootstrap_action.php htdocs/core/lib/html.lib.php htdocs/core/lib/functions.lib.php` → `[OK] No errors`.