### PR TITLE
QUAL dol_banner_tab: drop always-true $cssclass/$width ternaries

### DIFF
--- a/dev/build/phpstan/phpstan-baseline.neon
+++ b/dev/build/phpstan/phpstan-baseline.neon
@@ -3523,12 +3523,6 @@ parameters:
 			path: ../../../htdocs/core/lib/html.lib.php
 
 		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
-			count: 6
-			path: ../../../htdocs/core/lib/html.lib.php
-
-		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1

--- a/htdocs/core/lib/html.lib.php
+++ b/htdocs/core/lib/html.lib.php
@@ -1,5 +1,6 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur			<eldy@users.sourceforge.net>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -798,7 +799,7 @@ function dol_banner_tab($object, $paramid, $morehtml = '', $shownav = 1, $fieldi
 				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"></div>';
 			} else {    // Show no photo link
 				$nophoto = '/public/theme/common/nophoto.png';
-				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"><img class="photo' . $modulepart . ($cssclass ? ' ' . $cssclass : '') . '" title="' . dol_escape_htmltag($langs->trans("UploadAnImageToSeeAPhotoHere", $langs->transnoentitiesnoconv("Documents"))) . '" alt="No photo"' . ($width ? ' style="width: ' . $width . 'px"' : '') . ' src="' . DOL_URL_ROOT . $nophoto . '"></div>';
+				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"><img class="photo' . $modulepart . ' ' . $cssclass . '" title="' . dol_escape_htmltag($langs->trans("UploadAnImageToSeeAPhotoHere", $langs->transnoentitiesnoconv("Documents"))) . '" alt="No photo" style="width: ' . $width . 'px" src="' . DOL_URL_ROOT . $nophoto . '"></div>';
 			}
 		}
 	} elseif ($object->element == 'category') {
@@ -819,7 +820,7 @@ function dol_banner_tab($object, $paramid, $morehtml = '', $shownav = 1, $fieldi
 				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"></div>';
 			} else {    // Show no photo link
 				$nophoto = '/public/theme/common/nophoto.png';
-				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"><img class="photo' . $modulepart . ($cssclass ? ' ' . $cssclass : '') . '" title="' . dol_escape_htmltag($langs->trans("UploadAnImageToSeeAPhotoHere", $langs->transnoentitiesnoconv("Documents"))) . '" alt="No photo"' . ($width ? ' style="width: ' . $width . 'px"' : '') . ' src="' . DOL_URL_ROOT . $nophoto . '"></div>';
+				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"><img class="photo' . $modulepart . ' ' . $cssclass . '" title="' . dol_escape_htmltag($langs->trans("UploadAnImageToSeeAPhotoHere", $langs->transnoentitiesnoconv("Documents"))) . '" alt="No photo" style="width: ' . $width . 'px" src="' . DOL_URL_ROOT . $nophoto . '"></div>';
 			}
 		}
 	} elseif ($object->element == 'bom') {
@@ -840,7 +841,7 @@ function dol_banner_tab($object, $paramid, $morehtml = '', $shownav = 1, $fieldi
 				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"></div>';
 			} else {    // Show no photo link
 				$nophoto = '/public/theme/common/nophoto.png';
-				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"><img class="photo' . $modulepart . ($cssclass ? ' ' . $cssclass : '') . '" title="' . dol_escape_htmltag($langs->trans("UploadAnImageToSeeAPhotoHere", $langs->transnoentitiesnoconv("Documents"))) . '" alt="No photo"' . ($width ? ' style="width: ' . $width . 'px"' : '') . ' src="' . DOL_URL_ROOT . $nophoto . '"></div>';
+				$morehtmlleft .= '<div class="floatleft inline-block valignmiddle divphotoref"><img class="photo' . $modulepart . ' ' . $cssclass . '" title="' . dol_escape_htmltag($langs->trans("UploadAnImageToSeeAPhotoHere", $langs->transnoentitiesnoconv("Documents"))) . '" alt="No photo" style="width: ' . $width . 'px" src="' . DOL_URL_ROOT . $nophoto . '"></div>';
 			}
 		}
 	} elseif ($object->element == 'ticket') {


### PR DESCRIPTION
Part of cleaning the 11 PHPStan errors that appeared in `htdocs/core/lib/html.lib.php` after the `functions.lib.php` split (see #39883, which re-points the baseline).

In the `product`, `category` and `bom` branches of `dol_banner_tab()`, `$cssclass` and `$width` are set to constant non-empty values (`'photowithmargin photoref'`, `80`) immediately above the *"no photo"* `<img>` line, so:

- `($cssclass ? ' ' . $cssclass : '')` is always `' ' . $cssclass`
- `($width ? ' style="width: ' . $width . 'px"' : '')` is always `' style="width: ' . $width . 'px"'`

The true branch is inlined. **No behaviour change** (PHPStan proves the conditions constant). The `ticket` branch builds its no-photo markup differently and is untouched.

Also removes the `ternary.alwaysTrue` (count 6) `html.lib.php` baseline entry.

### Stacking
1. #39883 (baseline re-point)
2. **this PR**
3. #TBD img_picto
4. #TBD dolGetStatus
5. #TBD show_actions_done

Merge in order; each rebases cleanly once the previous is in.

### Test
`phpstan analyse -a dev/build/phpstan/bootstrap_action.php htdocs/core/lib/html.lib.php` → `[OK] No errors`.