### PR TITLE
FIX Undefined property stdClass::$extraparams in fichinter/card.php

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -1704,7 +1704,7 @@ if ($action == 'create') {
 
 		// Intervention lines
 		$sql = 'SELECT ft.rowid, ft.description, ft.fk_fichinter, ft.duree, ft.rang,';
-		$sql .= ' ft.special_code, ft.product_type,';
+		$sql .= ' ft.special_code, ft.product_type, ft.extraparams,';
 		$sql .= ' ft.date as date_intervention';
 		$sql .= ' FROM '.MAIN_DB_PREFIX.'fichinterdet as ft';
 		$sql .= ' WHERE ft.fk_fichinter = '.((int) $object->id);
@@ -1748,8 +1748,8 @@ if ($action == 'create') {
 					}
 					if (!empty($objp->special_code) || $objp->product_type == 9) {
 						$line_color = $object->getSubtotalColors($objp->duree);
-						$line_options = json_decode($objp->extraparams, true);
-						$line_options = is_array($line_options) ? $line_options['subtotal'] : array();
+						$line_options = !empty($objp->extraparams) ? (array) json_decode($objp->extraparams, true) : array();
+						$line_options = $line_options['subtotal'] ?? array();
 						print '<td colspan="3" ><strong>'.dol_htmlentitiesbr($objp->description).'</strong>';
 						if (array_key_exists('titleshowuponpdf', $line_options)) {
 							echo '&nbsp;' . img_picto($langs->trans("ShowUPOnPDF"), 'invoicing');


### PR DESCRIPTION
## Bug

```
Warning: Undefined property: stdClass::$extraparams in htdocs/fichinter/card.php on line 1751
```

Raised when viewing a *fiche d'intervention* that contains a subtotal / title line. Subtotals on interventions are a `develop`-only feature (on 23.0/24.0 the create UI is gated behind an extra `SUBTOTAL_TITLE_FICHINTER` constant and `Fichinter::getSubtotalColors()` / `addSubtotalLine()` do not exist), so this only occurs on `develop`.

## Cause

The "Intervention lines" query only selects
`ft.rowid, ft.description, ft.fk_fichinter, ft.duree, ft.rang, ft.special_code, ft.product_type, ft.date`.
The subtotal-line branch then does `json_decode($objp->extraparams, true)` on a column that was never fetched.

## Fix

- Add `ft.extraparams` to the `SELECT`.
- Decode defensively: `!empty(...) ? (array) json_decode(...) : array()` then `['subtotal'] ?? array()`.
  This also removes a latent `Undefined array key 'subtotal'` notice and the PHP 8.1 `json_decode(null)` deprecation, and matches `htdocs/core/tpl/subtotal_expedition_view.tpl.php`.

## Test

`php -l htdocs/fichinter/card.php` OK. View a fiche intervention with a subtotal line: no more warning, the ShowUPOnPDF / % / page-break markers still render.