### PR TITLE
FIX Undefined variable $withproject in core/tpl/contacts.tpl.php

### DIFF
--- a/dev/tools/phan/baseline.txt
+++ b/dev/tools/phan/baseline.txt
@@ -102,6 +102,7 @@ return [
         'htdocs/core/modules/supplier_proposal/doc/pdf_zenith.modules.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchProperty', 'PhanUndeclaredProperty'],
         'htdocs/core/modules/workstation/mod_workstation_advanced.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/multicompany_page.php' => ['PhanTypeMismatchArgument'],
+        'htdocs/core/tpl/contacts.tpl.php' => ['PhanPluginUndeclaredVariableIsset', 'PhanUndeclaredProperty'],
         'htdocs/core/tpl/massactions_pre.tpl.php' => ['PhanTypeMismatchArgumentNullable', 'PhanUndeclaredProperty'],
         'htdocs/core/tpl/objectline_view.tpl.php' => ['PhanUndeclaredProperty'],
         'htdocs/core/tpl/passwordreset.tpl.php' => ['PhanUndeclaredGlobalVariable'],

--- a/htdocs/core/tpl/contacts.tpl.php
+++ b/htdocs/core/tpl/contacts.tpl.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2012       Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2013-2015  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2015-2016  Charlie BENKE 	        <charlie@patas-monkey.com>
- * Copyright (C) 2021-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2021-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW					    <mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Solution Libre SAS	<contact@solution-libre.fr>
  *
@@ -290,11 +290,11 @@ foreach (array('internal', 'external') as $source) {
 		if ($contact['source'] == 'internal') {
 			$entry->status = $contact['statuscontact'] ? $contact['status'] : 0;		// statuscontact=status of contact, status=status of link
 			$entry->status_html = $userstatic->LibStatut($entry->status == 4 ? 1 : 0, 3);
-			$entry->status_html = '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?id='.((int) $object->id).'&action=swapstatut&token='.newToken().'&ligne='.((int) $entry->id).($withproject ? '&withproject=1' : '').'">'.$entry->status_html.'</a>';
+			$entry->status_html = '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?id='.((int) $object->id).'&action=swapstatut&token='.newToken().'&ligne='.((int) $entry->id).(!empty($withproject) ? '&withproject=1' : '').'">'.$entry->status_html.'</a>';
 		} elseif ($contact['source'] == 'external') {
 			$entry->status = $contact['statuscontact'] ? $contact['status'] : 0;		// statuscontact=status of contact, status=status of link
 			$entry->status_html = $contactstatic->LibStatut($entry->status == 4 ? 1 : 0, 3);
-			$entry->status_html = '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?id='.((int) $object->id).'&action=swapstatut&token='.newToken().'&ligne='.((int) $entry->id).($withproject ? '&withproject=1' : '').'">'.$entry->status_html.'</a>';
+			$entry->status_html = '<a class="reposition" href="'.$_SERVER["PHP_SELF"].'?id='.((int) $object->id).'&action=swapstatut&token='.newToken().'&ligne='.((int) $entry->id).(!empty($withproject) ? '&withproject=1' : '').'">'.$entry->status_html.'</a>';
 		}
 
 		$list[] = $entry;


### PR DESCRIPTION
## Bug

```
Warning: Undefined variable $withproject in htdocs/core/tpl/contacts.tpl.php on line 293
```

Reproduced on `contrat/contact.php?id=<n>` (also affects `commande/contact.php`, `fichinter/contact.php`, `expedition/contact.php`, … — every page that includes the contacts tab except `projet/tasks/contact.php`).

## Cause

`$withproject` is optional (`@var ?int $withproject`) and only set by `projet/tasks/contact.php`. The `swapstatut` link built for the internal / external contact rows (lines 293 & 297) references it unguarded:

```php
.($withproject ? '&withproject=1' : '')
```

The rest of the template already guards it (`!empty($withproject)`, lines 131 & 181). Regression from the contacts-tab refactor `33df9eac1b44` (2026-08-07); present in `24.0` and `develop`.

## Fix

- Guard both occurrences with `!empty()`.
- Second commit: add `htdocs/core/tpl/contacts.tpl.php` to `dev/tools/phan/baseline.txt` `file_suppressions`. The file has pre-existing, never-baselined phan issues (`PhanPluginUndeclaredVariableIsset` on `isset($permissiontoadd)` line 64, `PhanUndeclaredProperty` on `$object->socid` lines 187/199 — blame 2023-2024) that only surface because the phan PR job analyses changed files. Suppressed the same way as the other `core/tpl/*.tpl.php` entries.

Targeted at `24.0` (oldest affected); to be forward-ported to `develop`.

## Test

`php -l` OK. `phan --file-list <contacts.tpl.php> -B dev/tools/phan/baseline.txt` → no issue for the file. Open a contract / order / intervention contacts tab: no warning; the status toggle link still works, and from a project task it still carries `&withproject=1`.