### PR TITLE
Fix #39801 skip the cron safety net when the connection is already closed

### DIFF
--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1348,7 +1348,10 @@ class Cronjob extends CommonObject
 		$cronjobpid = (int) $this->pid;
 		$dbs = $this->db;
 		register_shutdown_function(static function () use ($cronjobid, $cronjobpid, $dbs) {
-			if (empty($cronjobid) || empty($dbs)) {
+			// The job may have closed the connection before ending, and a shutdown handler runs after that.
+			// Querying a closed mysqli connection raises an Error, not an Exception, so it would escape the
+			// try/catch below and turn into a fatal error at every run (#39801).
+			if (empty($cronjobid) || empty($dbs) || empty($dbs->connected)) {
 				return;
 			}
 


### PR DESCRIPTION
The shutdown handler added to unlock jobs stuck with processing=1 runs after the job has finished, and a job may have closed the database connection before that point.

Querying a closed mysqli connection raises an Error. Error is not an Exception, so it is not caught by the try/catch that wraps the rollback just above, and the run ends with the fatal reported in the issue at mysqli.class.php:361, repeated at every cron run.

The guard already tests empty($dbs), but that stays false since the object still exists, only its connection is gone. Testing $dbs->connected covers the real condition: it is set to true on a successful connect and back to false by close(), in mysqli, pgsql and sqlite3 alike, so the safety net still runs normally and only skips when there is nothing left to query.

Cause and fix reported by @denisbolussetli in #39801.