### PR TITLE
Fix #39046 split the cash control closing date in the user timezone

### DIFF
--- a/htdocs/compta/cashcontrol/cashcontrol_card.php
+++ b/htdocs/compta/cashcontrol/cashcontrol_card.php
@@ -253,7 +253,10 @@ if ($action == "start" && $permissiontoadd) {
 		}
 		dol_syslog('The closing date will be '.dol_print_date($dateclosegmt, 'standard', 'gmt').' UTC');
 
-		$tmparray = dol_getdate($dateclosegmt, false, 'gmt');
+		// The closing timestamp is built from the date the user picked, in the user timezone, so it must
+		// be split back in that same timezone. Splitting it in GMT shifts the stored period to the next
+		// day in UTC- timezones, since 23:59:59 local is already the day after in UTC (#39046).
+		$tmparray = dol_getdate($dateclosegmt, false, empty($_SESSION["dol_tz_string"]) ? @date_default_timezone_get() : $_SESSION["dol_tz_string"]);
 
 		$object->day_close = GETPOSTINT('closeday') ? $tmparray['mday'] : null;
 		$object->month_close = GETPOSTINT('closemonth') ? $tmparray['mon'] : null;


### PR DESCRIPTION
The closing timestamp is built from the date the user picked with dol_mktime(..., 'tzuserrel'), so it is a UTC instant representing 23:59:59 in the user timezone. It was then split back into day/month/year with dol_getdate(..., 'gmt').

In a UTC- timezone that instant already falls on the next day in UTC, so the period was stored one day later than the date selected. Splitting it in the timezone it was built in fixes it.

Checked the four cases, only the UTC- one changes:

    America/La_Paz     picked 2026-06-11  before 2026-06-12  after 2026-06-11
    Europe/Paris       picked 2026-06-11  before 2026-06-11  after 2026-06-11
    UTC                picked 2026-06-11  before 2026-06-11  after 2026-06-11
    Pacific/Auckland   picked 2026-06-11  before 2026-06-11  after 2026-06-11

The timezone expression is the same one dol_mktime uses for 'tzuserrel', dol_tz_string from the session with the server timezone as fallback.

Reported by @rolandojar in #39046.