### PR TITLE
Fix #39035 close the tags left open in the timeline message excerpt

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9292,6 +9292,50 @@ function dol_string_neverthesehtmltags($stringtoclean, $disallowed_tags = array(
  * @return	string				Output text
  * @see dol_nboflines_bis(), dol_string_nohtmltag(), dol_escape_htmltag()
  */
+/**
+ *  Close the HTML tags left open in a truncated HTML string.
+ *  Truncating HTML on a separator can cut inside a block, and an unclosed tag makes the browser nest
+ *  everything that follows inside it. Only tags really left open are closed, in reverse order.
+ *
+ *  @param	string	$text		HTML string, possibly with unclosed tags
+ *  @return	string				Same string with the missing closing tags appended
+ *  @see dolGetFirstLineOfText()
+ */
+function dolCloseUnclosedHtmlTags($text)
+{
+	if (!is_string($text) || $text === '') {
+		return $text;
+	}
+
+	// Tags that never carry a closing tag
+	$selfclosing = array('br', 'hr', 'img', 'input', 'meta', 'link', 'source', 'col', 'area', 'base', 'embed', 'param', 'track', 'wbr');
+
+	$opened = array();
+	if (preg_match_all('/<\s*(\/?)([a-zA-Z][a-zA-Z0-9]*)[^>]*?(\/?)\s*>/', $text, $matches, PREG_SET_ORDER)) {
+		foreach ($matches as $match) {
+			$tag = strtolower($match[2]);
+			if (in_array($tag, $selfclosing) || !empty($match[3])) {
+				continue;
+			}
+			if (empty($match[1])) {
+				$opened[] = $tag;
+			} else {
+				// Close the most recent matching opened tag, ignore a stray closing tag
+				$idx = array_search($tag, array_reverse($opened, true), true);
+				if ($idx !== false) {
+					unset($opened[$idx]);
+				}
+			}
+		}
+	}
+
+	foreach (array_reverse($opened) as $tag) {
+		$text .= '</'.$tag.'>';
+	}
+
+	return $text;
+}
+
 function dolGetFirstLineOfText($text, $nboflines = 1, $charset = 'UTF-8')
 {
 	if ($nboflines == 1) {
@@ -16785,6 +16829,10 @@ function show_actions_messaging($conf, $langs, $db, $filterobj, $objcon = null, 
 				$truncateLines = getDolGlobalInt('MAIN_TRUNCATE_TIMELINE_MESSAGE', 3);
 				$newmess = dol_htmlentitiesbr($histo[$key]['message']);
 				$truncatedText = dolGetFirstLineOfText($newmess, $truncateLines);
+				// dolGetFirstLineOfText() cuts on <br> without caring about tag balance, so a message wrapped in
+				// a block tag leaves the excerpt with an unclosed tag. The browser then nests the read more link
+				// and the full text inside the excerpt, and hiding the excerpt hides the whole message (#39035).
+				$truncatedText = dolCloseUnclosedHtmlTags($truncatedText);
 				if ($truncateLines > 0 && strlen($newmess) > strlen($truncatedText)) {
 					$out .= '<div class="readmore-block --closed" >';
 					$out .= '	<div class="readmore-block__excerpt">';

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -9284,15 +9284,6 @@ function dol_string_neverthesehtmltags($stringtoclean, $disallowed_tags = array(
 
 
 /**
- * Return first line of text. Cut will depends if content is HTML or not.
- *
- * @param 	string	$text		Input text
- * @param	int		$nboflines  Nb of lines to get (default is 1 = first line only)
- * @param   string  $charset    Charset of $text string (UTF-8 by default)
- * @return	string				Output text
- * @see dol_nboflines_bis(), dol_string_nohtmltag(), dol_escape_htmltag()
- */
-/**
  *  Close the HTML tags left open in a truncated HTML string.
  *  Truncating HTML on a separator can cut inside a block, and an unclosed tag makes the browser nest
  *  everything that follows inside it. Only tags really left open are closed, in reverse order.
@@ -9336,6 +9327,15 @@ function dolCloseUnclosedHtmlTags($text)
 	return $text;
 }
 
+/**
+ * Return first line of text. Cut will depends if content is HTML or not.
+ *
+ * @param 	string	$text		Input text
+ * @param	int		$nboflines  Nb of lines to get (default is 1 = first line only)
+ * @param   string  $charset    Charset of $text string (UTF-8 by default)
+ * @return	string				Output text
+ * @see dol_nboflines_bis(), dol_string_nohtmltag(), dol_escape_htmltag()
+ */
 function dolGetFirstLineOfText($text, $nboflines = 1, $charset = 'UTF-8')
 {
 	if ($nboflines == 1) {


### PR DESCRIPTION
Reproduced exactly as described in the issue.

dolGetFirstLineOfText() builds the excerpt by splitting on <br> and stopping after N lines, without tracking tag balance. A message written by the WYSIWYG editor is usually wrapped in a block tag, so the excerpt ends with that tag still open. dolPrintHTML() filters tags but does not balance them, so the unclosed tag reaches the browser, which then nests the read more link and the whole .readmore-block__full-text inside .readmore-block__excerpt. Opening then matches the rule in theme/eldy/timeline.inc.php:223 that hides the excerpt, and the message disappears instead of expanding.

Verified on the real code path:

    excerpt before  <div>line1<br>line2<br>line3...        opens=1 closes=0
    excerpt after   <div>line1<br>line2<br>line3...</div>  opens=1 closes=1

The helper only appends the closings for tags actually left open, in reverse order, skips void elements and self closed tags, and ignores a stray closing tag. Checked against balanced input, plain text, nested tags, void elements and empty string, none of them are modified.

Reported with a full root cause analysis by @glu000 in #39035.