### PR TITLE
Fix #39774 scope the TakePOS cash fence check on the current entity

### DIFF
--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -281,7 +281,8 @@ if (empty($reshook)) {
 	$tmpcurrentday = dol_getdate(dol_now());
 
 	$sql = "SELECT MIN(ref) as firstref FROM ".MAIN_DB_PREFIX."pos_cash_fence";
-	$sql .= " WHERE posnumber = ".((int) $takeposterminal);
+	$sql .= " WHERE entity = ".((int) $conf->entity);
+	$sql .= " AND posnumber = ".((int) $takeposterminal);
 	$sql .= " AND year_close = ".((int) $tmpcurrentday['year']);
 	$sql .= " AND (";
 	$sql .= " (month_close IS NULL AND day_close IS NULL)";


### PR DESCRIPTION
The query in takepos/invoice.php that looks for a cash control already closed for the current terminal filters on posnumber, year and status, but not on entity. llx_pos_cash_fence does carry an entity column, and the two sibling queries in takepos/index.php (lines 1174 and 1584) both filter on it, so this one is an omission rather than a choice.

Terminal numbers are not unique across entities in MultiCompany, so a cash control closed for terminal 1 in entity 2 was seen as belonging to terminal 1 in entity 1. The result is a wrong ACashControlHasBeenclosedForCurrentDay error that blocks recording payments in an entity whose own terminal is still open.

The query only exists on 24.0 and develop, earlier branches do not have this code, so this targets 24.0.

Reported with both queries side by side by @catrielr in #39774.