### PR TITLE
FIX Subtotal buttons never shown on draft supplier invoice

### DIFF
--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -4415,7 +4415,7 @@ if ($action == 'create') {
 			// modified by hook
 			if (empty($reshook)) {
 				// Subtotal
-				if ($object->status === FactureFournisseur::STATUS_DRAFT && isModEnabled('subtotals')
+				if ($object->status == FactureFournisseur::STATUS_DRAFT && isModEnabled('subtotals')
 					&& (getDolGlobalString('SUBTOTAL_TITLE_'.strtoupper($object->element)) || getDolGlobalString('SUBTOTAL_'.strtoupper($object->element)) || getDolGlobalString('SUBTOTAL_TEXT_'.strtoupper($object->element)))) {
 					$langs->load('subtotals');
 


### PR DESCRIPTION
## Bug

On `fourn/facture/card.php`, the **Subtotal** action button (Add title line / Add subtotal line / Add text line) never appears on a draft supplier invoice, even with subtotals enabled for `INVOICE_SUPPLIER` in the Subtotals module setup.

## Cause

```php
if ($object->status === FactureFournisseur::STATUS_DRAFT && isModEnabled('subtotals') && ...) {
```

`FactureFournisseur::fetch()` does `$this->status = $obj->status;` with **no cast**, so after loading `$object->status` is the string `"0"`. `STATUS_DRAFT` is the int `0`, and `"0" === 0` is `false` → the whole block is skipped.

This is the only one of the seven object cards using `===`; `compta/facture`, `comm/propal`, `commande`, `fourn/commande`, `supplier_proposal` and `fichinter` all use `==`. Regression from #34125.

## Fix

`===` → `==`, one character, aligned with the other cards.

## Test

Enable subtotals for *Supplier invoice* in the Subtotals module setup, open a **draft** supplier invoice → the "Subtotal" split button now shows and the three add-line forms work.