### PR TITLE
NEW pdf_soleil (intervention): render subtotals module lines

### DIFF
--- a/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
+++ b/htdocs/core/modules/fichinter/doc/pdf_soleil.modules.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2013		Cédric Salvador				<csalvador@gpcsolutions.fr>
  * Copyright (C) 2015       Marcos García               <marcosgdf@gmail.com>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024	    Nick Fragoulis
  * Copyright (C) 2024		Alexandre Spangaro			<alexandre@inovea-conseil.com>
  *
@@ -311,18 +311,55 @@ class pdf_soleil extends ModelePDFFicheinter
 						// Description of product line
 						$curX = $this->posxdesc - 1;
 
-						// Description of product line
-						if (!getDolGlobalString('FICHINTER_DATE_WITHOUT_HOUR')) {
-							$txt = $outputlangs->transnoentities("Date")." : ".dol_print_date($objectligne->datei, 'dayhour', false, $outputlangs, true);
+						// Subtotals module: a title / subtotal / free-text line has no date nor duration,
+						// it is shown as a (possibly coloured) section band instead of a standard line.
+						$issubtotalline = (defined('SUBTOTALS_SPECIAL_CODE') && $objectligne->special_code == SUBTOTALS_SPECIAL_CODE);
+						$subtotalbgcolor = null;
+
+						if ($issubtotalline) {
+							$outputlangs->load('subtotals');
+							$level = (int) $objectligne->duration;	// For fichinter the subtotal depth is stored in the duree field
+							$linetext = $objectligne->desc;
+							if ($level < 0) {
+								// Closing "subtotal" line: an intervention PDF has no amount to sum, so it is only a section marker
+								$linetext = getDolGlobalString('SUBTOTAL_LINE_TEXT_DOES_NOT_INCLUDE_TITLE_TEXT') ? $outputlangs->transnoentities('SubTotal') : $outputlangs->transnoentities('SubtotalOf', $objectligne->desc);
+							}
+							$indent = str_repeat('&nbsp;', max(0, abs($level) - 1) * 4);
+							$txt = '';
+							$desc = $indent.($level != 0 ? '<strong>' : '').dol_htmlentitiesbr($linetext, 1).($level != 0 ? '</strong>' : '');
+							if ($level != 0) {
+								$subtotalbgcolor = colorStringToArray(getDolGlobalString('SUBTOTAL_BACK_COLOR_LEVEL_'.abs($level), 'ffffff'));
+							}
 						} else {
-							$txt = $outputlangs->transnoentities("Date")." : ".dol_print_date($objectligne->datei, 'day', false, $outputlangs, true);
+							// Description of product line
+							if (!getDolGlobalString('FICHINTER_DATE_WITHOUT_HOUR')) {
+								$txt = $outputlangs->transnoentities("Date")." : ".dol_print_date($objectligne->datei, 'dayhour', false, $outputlangs, true);
+							} else {
+								$txt = $outputlangs->transnoentities("Date")." : ".dol_print_date($objectligne->datei, 'day', false, $outputlangs, true);
+							}
+
+							if ($objectligne->duration > 0) {
+								$txt .= " - ".$outputlangs->transnoentities("Duration")." : ".convertSecondToTime($objectligne->duration);
+							}
+							$txt = '<strong>'.dol_htmlentitiesbr($txt, 1, $outputlangs->charset_output).'</strong>';
+							$desc = dol_htmlentitiesbr($objectligne->desc, 1);
 						}
 
-						if ($objectligne->duration > 0) {
-							$txt .= " - ".$outputlangs->transnoentities("Duration")." : ".convertSecondToTime($objectligne->duration);
+						// Paint the coloured band behind a title/subtotal line (measure its height first)
+						if ($issubtotalline && is_array($subtotalbgcolor)) {
+							$pdf->startTransaction();
+							$pdf->writeHTMLCell(0, 0, $curX, $curY + 1, dol_concatdesc($txt, $desc), 0, 1, false);
+							$subtotalh = $pdf->GetY() - $curY;
+							$subtotalpage = $pdf->getPage();
+							$pdf->rollbackTransaction(true);
+							if ($subtotalpage == $pageposbefore) {
+								$pdf->SetFillColor($subtotalbgcolor[0], $subtotalbgcolor[1], $subtotalbgcolor[2]);
+								$pdf->Rect($this->marge_gauche, $curY + 1, $this->page_largeur - $this->marge_gauche - $this->marge_droite, max(2, $subtotalh), 'F');
+								if (!colorIsLight(implode(',', $subtotalbgcolor))) {
+									$pdf->SetTextColor(255, 255, 255);
+								}
+							}
 						}
-						$txt = '<strong>'.dol_htmlentitiesbr($txt, 1, $outputlangs->charset_output).'</strong>';
-						$desc = dol_htmlentitiesbr($objectligne->desc, 1);
 
 						$pdf->startTransaction();
 						$pdf->writeHTMLCell(0, 0, $curX, $curY + 1, dol_concatdesc($txt, $desc), 0, 1, false);
@@ -350,6 +387,10 @@ class pdf_soleil extends ModelePDFFicheinter
 							}
 						} else { // No pagebreak
 							$pdf->commitTransaction();
+						}
+
+						if ($issubtotalline) {
+							$pdf->SetTextColor(0, 0, 0);
 						}
 
 						$nexY = $pdf->GetY();


### PR DESCRIPTION
## Context

The **soleil** PDF model is the only one for interventions, and it never rendered subtotals-module lines: a title / subtotal / free-text line was printed like a normal line ("Date : … - Duration : …" + description).

`pdf_soleil` is an **old-style** template (no `$this->cols` / `printColDescContent`), so the shared `pdf_render_subtotals()` helper can't be reused.

## Change

Lightweight handling added inside the existing line loop:

- A line with `special_code == SUBTOTALS_SPECIAL_CODE` is drawn as a **section band** instead of a date/duration line.
- For fichinter the depth is stored in the `duree` field: `>0` = title, `<0` = subtotal marker, `0` = free-text line (already the case in `Fichinter::fetch_lines()`).
- Title / subtotal lines get the configured `SUBTOTAL_BACK_COLOR_LEVEL_x` background — height is measured in a throw-away transaction, then the rectangle is painted behind the text — with **bold** text, a per-level indent and a contrasting colour (`colorIsLight`). Text lines stay plain.
- A closing subtotal line shows `SubtotalOf` / `SubTotal` (an intervention PDF has no amount to sum).
- Degrades gracefully: if no colour is configured the band is white and only bold + indent distinguish the line.

## Limitations (follow-up)

- The band is not repeated on the overflow part when a title wraps across a page break (guarded off in that case).
- `titleforcepagebreak` / `titleshowuponpdf` / `titleshowtotalexludingvatonpdf` options are not applied (the last two are meaningless without amount columns).

## Test

⚠️ **Not visually verified — I could not render a PDF here.** Needs a manual check:
- Enable subtotals for *Intervention*, on a draft intervention add a title + a couple of lines + a subtotal + a text line, generate the soleil PDF → the title/subtotal rows appear as coloured bold bands, indented by level; normal lines unchanged.

`php -l`, PHPStan (level 10) and pre-commit (phpcs) all pass.