### PR TITLE
FIX #39756 Use configured printer for template test

### DIFF
--- a/htdocs/admin/receiptprinter.php
+++ b/htdocs/admin/receiptprinter.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2020      Andreu Bisquerra Gaya <jove@bisquerra.com>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Abbes Bahfir		 <contact@ab1consult.com><bafbes@gmail.com>
+ * Copyright (C) 2026      Nathan Pixodeo        <nathan@pixodeo.net>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -205,25 +206,35 @@ if ($action == 'testprinter2' && $user->admin) {
 
 if ($action == 'testtemplate' && $user->admin) {
 	$error = 0;
-	// if (empty($printerid)) {
-	//     $error++;
-	//     setEventMessages($langs->trans("PrinterIdEmpty"), null, 'errors');
-	// }
-
-	// if (! $error) {
-	// test
-	require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
-	$object = new Facture($db);
-	$object->initAsSpecimen();
-	//$object->fetch(18);
-	//var_dump($object->lines);
-	$ret = $printer->sendToPrinter($object, $templateid, 1);
-	if ($ret == 0) {
-		setEventMessages($langs->trans("TestTemplateToPrinter", $printername), null);
-	} else {
-		setEventMessages($printer->error, $printer->errors, 'errors');
+	if (empty($printerid)) {
+		$ret = $printer->listPrinters();
+		if ($ret > 0) {
+			$error++;
+			setEventMessages($printer->error, $printer->errors, 'errors');
+		} elseif (!empty($printer->listprinters)) {
+			// Keep the historic first-printer behavior without assuming its rowid is 1.
+			$printerid = (int) min(array_column($printer->listprinters, 'rowid'));
+		}
 	}
-	//}
+	if (!$error && empty($printerid)) {
+		$error++;
+		setEventMessages($langs->trans("PrinterIdEmpty"), null, 'errors');
+	}
+
+	if (!$error) {
+		// test
+		require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
+		$object = new Facture($db);
+		$object->initAsSpecimen();
+		//$object->fetch(18);
+		//var_dump($object->lines);
+		$ret = $printer->sendToPrinter($object, $templateid, $printerid);
+		if ($ret == 0) {
+			setEventMessages($langs->trans("TestTemplateToPrinter", $printername), null);
+		} else {
+			setEventMessages($printer->error, $printer->errors, 'errors');
+		}
+	}
 	$action = '';
 }
 


### PR DESCRIPTION
# FIX #39756 Use configured printer for template test

The receipt template test hard-coded printer rowid `1`, so it returned `PrinterDontExist` when the first database row had been deleted even though another printer was configured.

When no printer is explicitly supplied, the test now resolves the lowest configured printer rowid. This preserves the historical first-printer behavior without assuming a particular database ID. An explicit `printerid` is still honored, and an empty printer setup reports `PrinterIdEmpty` without attempting to print.

Checks:
- `php -l htdocs/admin/receiptprinter.php`
- focused printer-selection regression matrix (rowid 2 only, unordered multiple printers, explicit selection, no printers, and list failure)
- `git diff --check`