### PR TITLE
FIX Undefined array key on extrafields admin list for a config-disabled type

### DIFF
--- a/htdocs/core/tpl/admin_extrafields_edit.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_edit.tpl.php
@@ -37,14 +37,18 @@
  * @var string $attrname
  * @var string $action
  * @var string $elementtype
+ * @var ?string $pagekey
  * @var string $textobject
  * @var string[] $type2label
  */
-'@phan-var-force string $attrname';
-'@phan-var-force string $action';
-'@phan-var-force string $elementtype';
-'@phan-var-force string $textobject';
-'@phan-var-force string[] $type2label';
+'
+@phan-var-force string $attrname
+@phan-var-force string $action
+@phan-var-force string $elementtype
+@phan-var-force ?string $pagekey
+@phan-var-force string $textobject
+@phan-var-force string[] $type2label
+';
 
 // Protection to avoid direct call of template
 if (empty($conf) || !is_object($conf)) {

--- a/htdocs/core/tpl/admin_extrafields_view.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_view.tpl.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2010-2018	Laurent Destailleur	    <eldy@users.sourceforge.net>
  * Copyright (C) 2012-2021	Regis Houssin		    <regis.houssin@inodbox.com>
- * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -37,6 +37,12 @@
  * @var string $textobject
  * @var string[] $type2label
  */
+'
+@phan-var-force string $action
+@phan-var-force string $elementtype
+@phan-var-force string $textobject
+@phan-var-force string[] $type2label
+';
 // Protection to avoid direct call of template
 if (empty($langs) || !is_object($langs)) {
 	print "Error, template page can't be called as URL";

--- a/htdocs/core/tpl/admin_extrafields_view.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_view.tpl.php
@@ -34,12 +34,14 @@
  *
  * @var string $action
  * @var string $elementtype
+ * @var ?string $pagekey
  * @var string $textobject
  * @var string[] $type2label
  */
 '
 @phan-var-force string $action
 @phan-var-force string $elementtype
+@phan-var-force ?string $pagekey
 @phan-var-force string $textobject
 @phan-var-force string[] $type2label
 ';

--- a/htdocs/core/tpl/admin_extrafields_view.tpl.php
+++ b/htdocs/core/tpl/admin_extrafields_view.tpl.php
@@ -155,9 +155,12 @@ if (isset($extrafields->attributes[$elementtype]['type']) && is_array($extrafiel
 		// Key
 		print '<td title="'.dol_escape_htmltag($key).'" class="tdoverflowmax100">'.dol_escape_htmltag($key)."</td>\n";
 		// Type
-		$typetoshow = $type2label[$extrafields->attributes[$elementtype]['type'][$key]];
+		$fieldtype = $extrafields->attributes[$elementtype]['type'][$key];
+		// $type2label may not contain the type of an already existing field when that type has been
+		// disabled by config (icon => MAIN_USE_EXTRAFIELDS_ICON, point/polygon/... => MAIN_USE_GEOPHP)
+		$typetoshow = $type2label[$fieldtype] ?? $fieldtype;
 		print '<td title="'.dol_escape_htmltag($typetoshow).'" class="tdoverflowmax100">';
-		print getPictoForType($extrafields->attributes[$elementtype]['type'][$key]);
+		print getPictoForType($fieldtype);
 		print dol_escape_htmltag($typetoshow);
 		print "</td>\n";
 		// Size


### PR DESCRIPTION
## Bug

```
Warning: Undefined array key "icon" in htdocs/core/tpl/admin_extrafields_view.tpl.php on line 158
```
on `admin/extrafields.php?elementtype=adherent` (any element type that has an existing extrafield of type `icon`).

## Cause

`admin/extrafields.php` builds `$type2label` with `ExtraFields::getListOfTypesLabels()`, which deliberately removes some types depending on config:

```php
if (!getDolGlobalString('MAIN_USE_EXTRAFIELDS_ICON')) {
    unset($arraytype2label['icon']);
}
if (!getDolGlobalString('MAIN_USE_GEOPHP')) {
    unset($arraytype2label['point']); // + multipts / linestrg / polygon
}
```

When such a field already exists in the database, the view template did `$type2label[$type]` with no guard → `Undefined array key` and an empty *Type* cell. (`getPictoForType()` on the next line already knows all those types, hence the inconsistency.)

## Fix

Fall back to the raw type key when it is not in `$type2label`, so the type name still shows.

## Test

`php -l`, PHPStan level 10, phpcs pass. Open the extrafields admin page for an element type that has an `icon` (or geometry) extrafield while the corresponding option is off → no warning, the *Type* column shows `icon`.