### PR TITLE
Fix: Close template selector popup when clicking outside

### DIFF
--- a/htdocs/core/tpl/formlayoutai.tpl.php
+++ b/htdocs/core/tpl/formlayoutai.tpl.php
@@ -93,6 +93,14 @@ if (!empty($showlinktolayout)) {	// May be set only if MAIN_EMAIL_USE_LAYOUT is 
 								jQuery(".ai_input'.$htmlname.'").hide();
 								jQuery("#pageContent").show();	// May exists for website page only
 							});
+						jQuery(document).on("click", function (event) {
+							templateselector = jQuery(".template-selector");
+							templateselectorbutton = jQuery("#linkforlayouttemplates");
+							if (!templateselector.is(event.target) && !templateselectorbutton.is(event.target) && jQuery(event.target).closest(templateselector).length === 0 && jQuery(event.target).closest(templateselectorbutton).length === 0 && templateselector.is(":visible")) {
+								console.log("You clicked outside of template-selector - we close it");
+								jQuery(".template-selector").hide();
+							}
+						});
 						});
 					</script>
 					';


### PR DESCRIPTION
On the mailing card page (`htdocs/comm/mailing/card.php`), the popup to fill a message with a template was not closing when clicking outside of it.

This fix adds a click outside handler to close the template-selector, following the same pattern as the AI dropdown handler already present in the template file.

**File changed:**
- `htdocs/core/tpl/formlayoutai.tpl.php` - Added jQuery click handler to close template-selector popup when clicking outside

**Fix:**
Added 8 lines (96-103) in formlayoutai.tpl.php that implement the click outside detection and close the popup.

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>