### PR TITLE
FIX Catch Throwable (not only Exception) around native DB driver calls

### DIFF
--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -132,7 +132,7 @@ class DoliDBMysqli extends DoliDB
 						// To upgrade database default, you can do: ALTER DATABASE databasename CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 						$this->db->set_charset($clientmustbe); // This set charset, but with a bad collation (colllation is forced later)
-					} catch (Exception $e) {
+					} catch (Throwable $e) {
 						print 'Failed to force character_set_client to '.$clientmustbe." (according to setup) to match the one of the server database.<br>\n";
 						print $e->getMessage();
 						print "<br>\n";
@@ -230,7 +230,7 @@ class DoliDBMysqli extends DoliDB
 		$result = false;
 		try {
 			$result = $this->db->select_db($database);
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			// Nothing done on error
 		}
 		return $result;
@@ -265,7 +265,7 @@ class DoliDBMysqli extends DoliDB
 			} else {
 				$tmp = new mysqli($host, $login, $passwd, $name, $port);
 			}
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			dol_syslog(get_class($this)."::connect failed", LOG_DEBUG);
 		}
 		return $tmp;
@@ -353,7 +353,7 @@ class DoliDBMysqli extends DoliDB
 
 		try {
 			$ret = $this->db->query($query, $result_mode);
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			dol_syslog(get_class($this)."::query Exception in query instead of returning an error: ".$e->getMessage(), LOG_ERR);
 			$ret = false;
 		}

--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -432,7 +432,7 @@ class DoliDBPgsql extends DoliDB
 			$con_string = "dbname='".$name."' user='".$login."' password='".$passwd."'"; // $name may be empty
 			try {
 				$this->db = @pg_connect($con_string);
-			} catch (Exception $e) {
+			} catch (Throwable $e) {
 				// No message
 			}
 		}
@@ -449,7 +449,7 @@ class DoliDBPgsql extends DoliDB
 			$con_string = "host='".$host."' port='".$port."' dbname='".$name."' user='".$login."' password='".$passwd."'";
 			try {
 				$this->db = @pg_connect($con_string);
-			} catch (Exception $e) {
+			} catch (Throwable $e) {
 				print $e->getMessage();
 			}
 		}

--- a/htdocs/core/db/sqlite3.class.php
+++ b/htdocs/core/db/sqlite3.class.php
@@ -342,7 +342,7 @@ class DoliDBSqlite3 extends DoliDB
 			//$this->db = new PDO("sqlite:".$dir.'/database_'.$name.'.sdb');
 			$this->db = new SQLite3($database_name);
 			//$this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			$this->error = self::LABEL.' '.$e->getMessage().' current dir='.$database_name;
 			return false;
 		}
@@ -481,7 +481,7 @@ class DoliDBSqlite3 extends DoliDB
 			if ($ret) {
 				$this->queryString = $query;
 			}
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			$this->error = $this->db->lastErrorMsg();
 		}
 


### PR DESCRIPTION
## Problem

The database drivers (`htdocs/core/db/mysqli.class.php`, `pgsql.class.php`, `sqlite3.class.php`) protect the raw driver calls with:

```php
try {
    $ret = $this->db->query($query, $result_mode);
} catch (Exception $e) {
    dol_syslog(...);
    $ret = false;
}
```

Under **PHP 8** this does not cover a lost connection:

- Calling a method on a mysqli handle whose connection has dropped throws **`\Error`** – *"mysqli object is already closed"* / *"Property access is not allowed yet"* – **not** a `\Exception`.
- A bad argument type throws `\TypeError` / `\ValueError`.

`\Error`, `\TypeError`, `\ValueError` are `\Throwable` but **not** `\Exception`, so `catch (Exception)` lets them through and the whole request dies with an *uncaught fatal*, instead of the wrapper returning `false` and Dolibarr logging a normal SQL error (`$this->lasterror` / `$this->lasterrno`).

## Fix

Widen the 8 `catch (Exception $e)` blocks in the three drivers to `catch (Throwable $e)`.

`\Throwable` is the common parent of `\Exception` and `\Error`, so this can only catch **more**, never less — no behaviour change on the paths that already worked.

## Test

`php -l`, PHPStan level 10 and phpcs pass. Killing the DB connection mid-request now makes `DoliDB::query()` return `false` (and log the error) instead of raising an uncaught `\Error`.