### PR TITLE
FIX #39909 Fiscal year counters drop the first day of the period

### DIFF
--- a/htdocs/core/class/fiscalyear.class.php
+++ b/htdocs/core/class/fiscalyear.class.php
@@ -519,7 +519,7 @@ class Fiscalyear extends CommonObject
 		$sql = "SELECT count(DISTINCT piece_num) as nb";
 		$sql .= " FROM ".$this->db->prefix()."accounting_bookkeeping";
 		$sql .= " WHERE entity IN (".getEntity('bookkeeping', 0).")";
-		$sql .= " AND doc_date >= '".$this->db->idate($datestart)."' and doc_date <= '".$this->db->idate($dateend)."'";
+		$sql .= " AND doc_date >= DATE('".$this->db->idate($datestart)."') and doc_date <= DATE('".$this->db->idate($dateend)."')";
 
 		$nb = 0;
 		$resql = $this->db->query($sql);
@@ -554,7 +554,7 @@ class Fiscalyear extends CommonObject
 		$sql = "SELECT count(rowid) as nb";
 		$sql .= " FROM ".$this->db->prefix()."accounting_bookkeeping ";
 		$sql .= " WHERE entity IN (".getEntity('bookkeeping', 0).")";
-		$sql .= " AND doc_date >= '".$this->db->idate($datestart)."' and doc_date <= '".$this->db->idate($dateend)."'";
+		$sql .= " AND doc_date >= DATE('".$this->db->idate($datestart)."') and doc_date <= DATE('".$this->db->idate($dateend)."')";
 
 		$nb = 0;
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
Fixes #39909

## What this fixes

On the fiscal years list (Accounting → Setup → Fiscal periods), **Number of entries**
and **Number of movements** silently omit every ledger line dated on the **first day of
the period**. Opening balances are dated on that very day, so the loss is large: on our
instance the screen reported `2 entries / 6 movements` where the ledger holds `15 / 194`.

## Why

`accountancy/admin/fiscalyear.php:196-197` passes the **raw value** of a `date` column
where the two methods expect a timestamp. `idate()` does not reject it: it falls into the
legacy rescue branch of `dol_print_date()`, which logs the call as faulty
(`"called with a bad value"`, `LOG_WARNING`), **parses the string as UTC**
(`dol_mktime(..., true)`) and then **renders it in the server timezone**.

Read as UTC, written as local — `+1h` on `Europe/Paris` in January:

```
Europe/Paris  ->  2026-01-01 01:00:00
UTC           ->  2026-01-01 00:00:00
```

`doc_date` is itself a `date` column, widened to `00:00:00` for the comparison, so the
whole first day fails `>=`. The upper bound gains the same hour but stays inclusive,
which is why exactly one day disappears rather than the window sliding.

This is not specific to 1 January: on an ordinary Monday, 2025-03-03, the same shift
turns 119 rows into 116.

## The change

Truncate the **bound**, not the column, so the index on `doc_date` stays usable —
`EXPLAIN` still reports `type: range` on `idx_accounting_bookkeeping_doc_date`:

```php
-$sql .= " AND doc_date >= '".$this->db->idate($datestart)."' and doc_date <= '".$this->db->idate($dateend)."'";
+$sql .= " AND doc_date >= DATE('".$this->db->idate($datestart)."') and doc_date <= DATE('".$this->db->idate($dateend)."')";
```

Two lines, one file. Fixing the callers to pass timestamps would arguably be cleaner, but
that is a wider change than a maintenance branch should carry.

## Verified

On a MariaDB instance with two fiscal years, server timezone `Europe/Paris`, PHP 8.3:

| Fiscal year | Before | After | Ledger |
|---|---|---|---|
| 2026 | 2 / 6 | **15 / 194** | 15 / 194 |
| 2025 | 459 / 1528 | **464 / 1724** | 464 / 1724 |

## Branch

Opened against `22.0` per CONTRIBUTING (oldest affected, N-2). The defect is identical
from `16.0.0` to `develop`, so it should propagate upward without conflict.

## Not covered

`htdocs/accountancy/class/bookkeeping.class.php` builds its bounds the same way at lines
2981-2982 and 3112-3113, the latter inside `closeFiscalPeriod()`. There the column is
wrapped in `DATE()` while the bound is not, so it looks exposed to the same shift — with
a heavier consequence, since opening entries would be left out of the carry-forward. I
have not touched it: I have no way to exercise the closing path safely, and this PR is
meant to stay atomic.
