### PR TITLE
FIX Undefined array key "search_options_<field>" in Task::getTasksArray()

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1268,7 +1268,11 @@ class Task extends CommonObjectLine
 		// Add where from extra fields
 		$extrafieldsobjectkey = 'projet_task';
 		$extrafieldsobjectprefix = 'efpt.';
-		$search_options_pattern = 'search_task_options_'; // Aligned with perweek.php/perday.php that build $search_array_options with this prefix (via extrafields->getOptionalsFromPost('projet_task', '', 'search_task_')). Without it, the SQL template falls back to 'search_options_' and the preg_replace fails to strip the actual prefix, generating phantom column names like efpt.search_task_options_<field>.
+		// $search_array_options may arrive with either the 'search_options_' prefix (projet/tasks.php, built
+		// with getOptionalsFromPost(..., 'search_')) or the 'search_task_options_' prefix (perweek/perday/
+		// permonth.php, built with getOptionalsFromPost(..., 'search_task_')). Strip either one so the SQL
+		// template gets the bare field name and not a phantom column like efpt.search_[task_]options_<field>.
+		$search_options_pattern = 'search_(?:task_)?options_';
 		global $db, $conf; // needed for extrafields_list_search_sql.tpl
 		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 


### PR DESCRIPTION
## Bug

```
Warning: Undefined array key "search_options_tasktype" in htdocs/core/tpl/extrafields_list_search_sql.tpl.php on line 62
```
on `projet/tasks.php?id=<n>` when the `projet_task` object type has an extrafield used as a list filter.

## Cause

`Task::getTasksArray()` includes `core/tpl/extrafields_list_search_sql.tpl.php`, which does:

```php
$tmpkey = preg_replace('/'.$search_options_pattern.'/', '', $key);
$typ = $extrafields->attributes[$extrafieldsobjectkey]['type'][$tmpkey];
```

#38564 hardcoded `$search_options_pattern = 'search_task_options_'` to fix the phantom `efpt.search_task_options_*` column for **perweek / perday / permonth.php**, which build `$search_array_options` with `getOptionalsFromPost(..., 'search_task_')`.

But **`projet/tasks.php`** builds it with `getOptionalsFromPost(..., 'search_')` → keys are `search_options_<field>`. The hardcoded `search_task_options_` pattern doesn't match, the prefix is not stripped, `$tmpkey` stays `search_options_tasktype`, and:
- `$extrafields->attributes['projet_task']['type']['search_options_tasktype']` → `Undefined array key`;
- the SQL gets a phantom `efpt.search_options_<field>` column (the very bug #38564 tried to fix, just for the other caller).

## Fix

Strip **either** prefix:

```php
$search_options_pattern = 'search_(?:task_)?options_';
```

`preg_replace` turns both `search_options_tasktype` and `search_task_options_tasktype` into `tasktype`.

Present since #38564 (23.0 / 24.0 / develop).

## Test

`php -l`, PHPStan level 10, phpcs pass. Open a project task list with an extrafield filter column: no warning, the filter now actually applies.