### PR TITLE
FIX Subtotal text line: tiny 'text content' textarea in the add dialog

### DIFF
--- a/htdocs/core/tpl/subtotal_create.tpl.php
+++ b/htdocs/core/tpl/subtotal_create.tpl.php
@@ -99,7 +99,7 @@ if ($type == 'title') {
 		);
 	}
 
-	$formquestion[] = array('type' => 'textarea', 'name' => 'subtotaltextcontent', 'label' => $langs->trans("SubtotalTextContent"));
+	$formquestion[] = array('type' => 'textarea', 'name' => 'subtotaltextcontent', 'label' => $langs->trans("SubtotalTextContent"), 'morecss' => 'quatrevingtpercent', 'moreattr' => 'rows="4"');
 }
 
 $page = $_SERVER["PHP_SELF"];


### PR DESCRIPTION
## Bug

When adding a *text* subtotal line, the **Contenu du texte** / *Text content* textarea in the "Add a subtotal line" dialog is rendered as a tiny box (browser-default ~2 rows × 20 cols).

## Cause

`subtotal_create.tpl.php` builds that field as a `formconfirm()` question of `type => textarea`. The textarea branch of `Form::formconfirm()` outputs the `<textarea>` with only the caller's `morecss` / `moreattr` — no `rows`, no `cols`, no width class — and this caller passed none. The inline edit widget (`subtotal_edit.tpl.php`) already renders its equivalent textarea with `rows="4" cols="40"`.

## Fix

Pass `morecss => 'quatrevingtpercent'` and `moreattr => 'rows="4"'` for the `subtotaltextcontent` question so the add dialog matches the edit widget.

develop-only: the predefined-text / text-content feature for subtotal lines does not exist on 24.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)