### PR TITLE
FIX MultiCurrency::syncRates() does not fill $this->errors on failure

### DIFF
--- a/htdocs/multicurrency/class/multicurrency.class.php
+++ b/htdocs/multicurrency/class/multicurrency.class.php
@@ -674,6 +674,7 @@ class MultiCurrency extends CommonObject
 			} else {
 				setEventMessages($langs->trans('Use of API for currency update is disabled by option MULTICURRENCY_DISABLE_SYNC_CURRENCYLAYER'), null, 'errors');
 			}
+			$this->errors[] = $langs->trans('Use of API for currency update is disabled by option MULTICURRENCY_DISABLE_SYNC_CURRENCYLAYER');
 			return -1;
 		}
 
@@ -736,11 +737,13 @@ class MultiCurrency extends CommonObject
 				dol_syslog("Failed to call endpoint ".$error_info_syslog, LOG_WARNING);
 
 				$this->output = $langs->trans('multicurrency_syncronize_error', $error_info);
+				$this->errors[] = $this->output;
 
 				return -1;
 			}
 		} else {
 			$this->output = $resget['curl_error_msg'];
+			$this->errors[] = $this->output;
 
 			return -1;
 		}


### PR DESCRIPTION
## Summary

`MultiCurrency::syncRates()` only set `$this->output` on its failure paths and never `$this->error` / `$this->errors`:

- sync disabled by `MULTICURRENCY_DISABLE_SYNC_CURRENCYLAYER`
- endpoint reachable but returned `success=false`
- transport / curl error (empty content)

Callers that inspect the error array — most notably `Cronjob::run_jobs()` for the currency auto-update cron job — therefore fall back to a generic *"Unknown error" / "Erreur inconnue"* instead of showing the real cause (missing API key, disabled option, curl message…).

This fills `$this->errors[]` on every failure path, leaving `$this->output` untouched for the callers that already use it.

Extracted from #39542 (only the `htdocs/multicurrency/class/multicurrency.class.php` change), so it can be reviewed and merged on its own.

## Test plan
- [x] `php -l` OK, pre-commit (PHPStan/Phan/phpcs) OK
- [x] Trigger the currency update cron job without an API key → the job now reports the sync error text instead of "Erreur inconnue"

🤖 Generated with [Claude Code](https://claude.com/claude-code)