### PR TITLE
FIX phan fails on every PR: dol_string_onlythesehtmlattributes() docblock rejects the null it accepts

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -5959,7 +5959,7 @@ function dol_string_onlythesehtmltags($stringtoclean, $cleanalsosomestyles = 1, 
  *  This method is used for example by dol_htmlwithnojs() when option MAIN_RESTRICTHTML_REMOVE_ALSO_BAD_ATTRIBUTES is set to 1.
  *
  *	@param	string		$stringtoclean		String to clean
- *  @param	string[]	$allowed_attributes	Array of tags not allowed
+ *  @param	string[]|null	$allowed_attributes	Array of attributes to keep (null = default list)
  *  @param	int|null	$ishtml				Use 1 if string is not an HTML content. 0 if it is, null if unknown.
  *	@return string	    					String cleaned
  *


### PR DESCRIPTION
Since f36f25cb211 ("Complete fix for #39770"), `dol_htmlwithnojs()` calls:

```php
$out = dol_string_onlythesehtmlattributes($out, null, $outishtml);
```

The signature of `dol_string_onlythesehtmlattributes()` defaults `$allowed_attributes` to `null` and its body starts with `is_null($allowed_attributes)` to load the default list — but the docblock declares `string[]` only. Phan therefore fails with `PhanTypeMismatchArgumentProbablyReal` on every PR analyzed against current develop (seen on #39677 among others).

One-line docblock fix: `string[]|null`, with a note that null means the default list. No behaviour change.