### PR TITLE
fix: Handle both search_options_ and search_task_options_ patterns

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -51,7 +51,7 @@ if (!empty($extrafieldsobjectkey) && !empty($search_array_options) && is_array($
 		$extrafieldsobjectprefix = 'ef.';
 	}
 	if (empty($search_options_pattern)) {
-		$search_options_pattern = 'search_options_';
+		$search_options_pattern = 'search_(task_)?options_';
 	}
 
 	$sqlMoreWhere = '';

--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -32,6 +32,7 @@
  * @var string $extrafieldsobjectkey
  */
 '
+@phan-var-force CommonObject $object
 @phan-var-force string $sql
 ';
 


### PR DESCRIPTION
Fixes #39911 - Undefined array key when using search_options_<field> prefix in projet/tasks.php

The hardcoded pattern 'search_task_options_' was set for perweek/perday/permonth.php but projet/tasks.php uses 'search_' prefix producing 'search_options_<field>' keys.

Changed regex pattern to 'search_(task_)?options_' to match both cases.

Tested regex locally - works for both patterns.