### PR TITLE
NEW Product mass VAT change tool: block the UI while the conversion runs

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -473,3 +473,4 @@ NotSupportedOnKits=Not supported on kits
 ProductLangExtrafieldsSetup=Product translations Extrafields
 
 WithoutVATCode=Without VAT code
+MassConvertInProgress=Conversion in progress, please wait. On a large catalog this can run for several minutes.

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -472,3 +472,4 @@ NotSupportedOnKits=Non pris en charge sur les kits
 ProductLangExtrafieldsSetup=produit traductions Champs supplémentaires
 
 WithoutVATCode=Sans code de TVA
+MassConvertInProgress=Conversion en cours, merci de patienter. Sur un gros catalogue, elle peut durer plusieurs minutes.

--- a/htdocs/product/admin/product_tools.php
+++ b/htdocs/product/admin/product_tools.php
@@ -395,6 +395,17 @@ if (empty($mysoc->country_code)) {
 	print '</div>';
 
 	print '</form>';
+
+	// The conversion loops over every matching product with updatePrice(): on a large
+	// catalog the request runs for minutes with no feedback, which invites re-submits.
+	// Show the native blocking overlay (dolBlockUI + working.gif) while it runs.
+	print '<script>
+	jQuery(function() {
+		jQuery("#convert_vatrate").closest("form").on("submit", function() {
+			dolBlockUI("'.dol_escape_js($langs->transnoentities("MassConvertInProgress")).'");
+		});
+	});
+	</script>';
 }
 
 // End of page


### PR DESCRIPTION
Follow-up to #39826.

The conversion loops over every matching product with `updatePrice()`: on a large catalog the request runs for **minutes** with no feedback at all. Observed in production on a ~1700-product catalog: the operator, seeing nothing happen, re-submitted twice — three concurrent submissions queued on the session lock, and the first responses were abandoned with 0 bytes served.

This wires the **native** `dolBlockUI()` overlay (the `#dol-block-ui` div is already printed on every page by `main.inc.php`, backed by `working.gif`) to the tool's form submit:

- immediate visual feedback (spinner + translated message warning it can take minutes),
- double submissions prevented by the overlay itself (no need to disable the submit button, which would drop its name from the POST).

Two new lang keys (`MassConvertInProgress`, en + fr), anchored next to the #39826 keys.