### PR TITLE
FIX #39768 Preserve template sender after attachment

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2022		Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2023		Anthony Berton			<anthony.berton@bb2a.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Nathan Pixodeo			<nathan@pixodeo.net>
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -686,6 +687,7 @@ class FormMail extends Form
 						&& !preg_match('/user_aliases/', $this->fromtype)
 						&& !preg_match('/global_aliases/', $this->fromtype)
 						&& !preg_match('/senderprofile/', $this->fromtype)
+						&& !preg_match('/from_template_(\d+)/', $this->fromtype)
 					) {
 						// Use this->fromname and this->frommail or error if not defined
 						$out .= $this->fromname;


### PR DESCRIPTION
## Summary

- keep a template-backed `from_template_<id>` sender selected after an attachment resubmits the mail form
- preserve the numeric template-id contract already used by the send path

## Root cause

The attachment POST preserves `fromtype=from_template_<id>`. `FormMail::get_form()` creates that sender option and `actions_sendmails.inc.php` resolves it, but the form's valid sender-type gate did not recognize it. The resubmitted form therefore entered the custom-sender branch with empty `fromname` and `frommail`, producing `ErrorNoMailDefinedForThisUser`.

This change admits only `from_template_<numeric id>`, so malformed empty-id keys remain rejected.

Scope: this fixes the sender reset described in issue #39768. It does not change the separately observed recipient-validation behavior because that was not proven to share the same cause.

## Verification

- focused runtime probe of the real `FormMail::get_form()` attachment-resubmit path: template sender option present and selected, no missing-email warning
- malformed `from_template_` remains rejected
- `php -l htdocs/core/class/html.formmail.class.php`
- `git diff --check`