### PR TITLE
Fix #39802 open a real new connection for each PostgreSQL handle

### DIFF
--- a/htdocs/core/db/pgsql.class.php
+++ b/htdocs/core/db/pgsql.class.php
@@ -420,7 +420,10 @@ class DoliDBPgsql extends DoliDB
 		if ((!empty($host) && $host == "socket") && !defined('NOLOCALSOCKETPGCONNECT')) {
 			$con_string = "dbname='".$name."' user='".$login."' password='".$passwd."'"; // $name may be empty
 			try {
-				$this->db = @pg_connect($con_string);
+				// PGSQL_CONNECT_FORCE_NEW is required: pg_connect() otherwise returns the connection already
+				// opened for the same connection string, so a second handle would share the main one and
+				// closing it would close the connection still in use by the caller.
+				$this->db = @pg_connect($con_string, PGSQL_CONNECT_FORCE_NEW);
 			} catch (Exception $e) {
 				// No message
 			}
@@ -437,7 +440,7 @@ class DoliDBPgsql extends DoliDB
 
 			$con_string = "host='".$host."' port='".$port."' dbname='".$name."' user='".$login."' password='".$passwd."'";
 			try {
-				$this->db = @pg_connect($con_string);
+				$this->db = @pg_connect($con_string, PGSQL_CONNECT_FORCE_NEW);
 			} catch (Exception $e) {
 				print $e->getMessage();
 			}


### PR DESCRIPTION
pg_connect() reuses the connection already opened for the same connection string within one process. So when a second DoliDBPgsql is built with the same parameters as the main $db, it does not open anything, it gets the same underlying link. Closing that second handle then closes the connection the caller is still using, and the caller's next query raises an uncaught Error since PHP 8.1, which the @ operator on pg_query() cannot suppress.

Reproduced against PostgreSQL 16, both halves:

    without FORCE_NEW   same underlying resource? YES
                        caller COMMIT -> FATAL Error: PostgreSQL connection has already been closed
    with FORCE_NEW      same underlying resource? no, distinct
                        caller COMMIT -> ok, transaction intact

which is the exact message reported in #39802 and #39804.

The mysqli driver is not affected because it always does new mysqli(), a genuinely distinct object, which is why only PostgreSQL installs see this. Passing PGSQL_CONNECT_FORCE_NEW aligns the pgsql driver with that behaviour.

connect() is only called once per instance, from the constructor, so this does not change anything for the main $db, it only makes additional handles real. Also checked that connections are still released: opening five extra handles adds five backends in pg_stat_activity and closing them brings the count back down, so no leak.

This fixes the two reported call sites at once, the Webhook trigger ($dbhistory) and session in database ($dbsession), rather than patching each one.

Reported with a complete root cause analysis by @hisie in #39802 and @hisie in #39804.