### PR TITLE
Fix #37881 keep the selected user in the propal list filter

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -1199,7 +1199,7 @@ if ($user->hasRight('user', 'user', 'lire')) {
 if ($user->hasRight('user', 'user', 'lire')) {
 	$moreforfilter .= '<div class="divsearchfield">';
 	$tmptitle = $langs->trans('LinkedToSpecificUsers');
-	$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers((empty($search_user) ? -2 : 0), 'search_user', $tmptitle, '', 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');
+	$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers($search_user, 'search_user', $tmptitle, '', 0, '', '', 0, 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');
 	$moreforfilter .= '</div>';
 }
 // If the user can view products


### PR DESCRIPTION
This covers the CASE 1 part of the report, the search_user selector resetting to the current user after applying the filter.

comm/propal/list.php passed a computed value instead of the filter itself:

    $form->select_dolusers((empty($search_user) ? -2 : 0), 'search_user', ...)

so as soon as a user was selected the method received 0, and select_dolusers() replaces an empty numeric value by the current user (html.form.class.php:2230). The chosen user was therefore lost on every redisplay.

    no filter        before -2 kept          after '' kept, no forcing
    filter user 7    before forced to me     after 7 kept
    filter user 1    before forced to me     after 1 kept

The empty case stays safe because is_numeric('') is false, so the forcing branch is not entered, and line 350 already resets search_user to '' when filters are cleared.

Every other list passes the variable directly, commande, commande/list_det, compta/facture, contrat, expedition, expensereport and fourn/commande, so this aligns propal on the existing pattern. 18.0 also has the correct form, the computed expression only appears from 21.0 onwards, which is why this targets 21.0.

Note this PR only fixes that one symptom. The permission scoping issues described for CASE 0 and CASE 2 are a separate matter and are not addressed here.

Reported by @PsyCrow-code in #37881.