### PR TITLE
Fix #36418 read the timesheet restriction constant as an integer

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -2058,9 +2058,9 @@ class Task extends CommonObjectLine
 			$this->timespent_note = trim($this->timespent_note);
 		}
 
-		if (getDolGlobalString('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS')) {
+		if (getDolGlobalInt('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS')) {
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
-			$restrictBefore = dol_time_plus_duree(dol_now(), - $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS, 'm');
+			$restrictBefore = dol_time_plus_duree(dol_now(), - getDolGlobalInt('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS'), 'm');
 
 			if ($this->timespent_date < $restrictBefore) {
 				$this->error = $langs->trans('TimeRecordingRestrictedToNMonthsBack', getDolGlobalString('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS'));
@@ -2172,9 +2172,9 @@ class Task extends CommonObjectLine
 
 		$error = 0;
 
-		if (getDolGlobalString('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS')) {
+		if (getDolGlobalInt('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS')) {
 			require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
-			$restrictBefore = dol_time_plus_duree(dol_now(), - $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS, 'm');
+			$restrictBefore = dol_time_plus_duree(dol_now(), - getDolGlobalInt('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS'), 'm');
 
 			if ($this->timespent_date < $restrictBefore) {
 				$this->error = $langs->trans('TimeRecordingRestrictedToNMonthsBack', getDolGlobalString('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS'));


### PR DESCRIPTION
Not the change proposed in the issue, which would break the control, but a real inconsistency found while checking it.

updateTimeSpent() and delTimeSpent() apply a unary minus directly on the raw constant:

    if (getDolGlobalString('PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS')) {
        $restrictBefore = dol_time_plus_duree(dol_now(), - $conf->global->PROJECT_TIMESHEET_PREVENT_AFTER_MONTHS, 'm');

$conf->global->... is a string. The guard uses getDolGlobalString(), so any non empty value enters the block, and a non numeric one then reaches the unary minus:

    -'6'    -> -6
    -'abc'  -> TypeError: Unsupported operand types: string * int

which is a fatal on PHP 8. addTimeSpent() is already written with getDolGlobalInt() and is not affected, so this only aligns the two other methods on the form the first one already uses.

$conf stays used elsewhere in both methods, so the global declaration is still needed.

On the change suggested in the issue: $this->timespent_date is a timestamp on every path that reaches these methods (dol_mktime in tasks/time.php, dol_time_plus_duree in permonth and perweek, dol_stringtotime in api_tasks, jdate in the class itself), and $restrictBefore is a timestamp too, so the existing comparison is consistent. Adding strtotime() would return false for a timestamp and make the guard reject every entry. I left a note about that in the issue.