### PR TITLE
Fix #36489 honour RECEPTION_ALLOW_NEGATIVE_QTY on close, reopen and back to draft

### DIFF
--- a/htdocs/reception/class/reception.class.php
+++ b/htdocs/reception/class/reception.class.php
@@ -1748,7 +1748,7 @@ class Reception extends CommonObject
 
 						$qty = $obj->qty;
 
-						if ($qty <= 0) {
+						if ($qty == 0 || ($qty < 0 && !getDolGlobalInt('RECEPTION_ALLOW_NEGATIVE_QTY'))) {
 							continue;
 						}
 
@@ -1906,7 +1906,7 @@ class Reception extends CommonObject
 
 						$qty = $obj->qty;
 
-						if ($qty <= 0) {
+						if ($qty == 0 || ($qty < 0 && !getDolGlobalInt('RECEPTION_ALLOW_NEGATIVE_QTY'))) {
 							continue;
 						}
 						dol_syslog(get_class($this)."::reopen reception movement index ".$i." ed.rowid=".$obj->rowid);
@@ -2041,7 +2041,7 @@ class Reception extends CommonObject
 
 						$qty = $obj->qty;
 
-						if ($qty <= 0) {
+						if ($qty == 0 || ($qty < 0 && !getDolGlobalInt('RECEPTION_ALLOW_NEGATIVE_QTY'))) {
 							continue;
 						}
 


### PR DESCRIPTION
valid() already handles the negative case with an opt-in constant (reception.class.php:633):

    if ($qty == 0 || ($qty < 0 && !getDolGlobalInt('RECEPTION_ALLOW_NEGATIVE_QTY'))) {
        continue;
    }

but setClosed(), reOpen() and setDraft() still had the older hardcoded form:

    if ($qty <= 0) {
        continue;
    }

so with the option enabled a negative line was validated and moved stock in valid(), yet produced no movement when closing, and no reverse movement when reopening or going back to draft. That is the missing stock movement described in the issue.

The three now use the same condition as valid(). Default behaviour is unchanged:

    RECEPTION_ALLOW_NEGATIVE_QTY=0   qty=5 moved,  qty=0 skipped,  qty=-3 skipped   (identical to before)
    RECEPTION_ALLOW_NEGATIVE_QTY=1   qty=5 moved,  qty=0 skipped,  qty=-3 moved     (only this case changes)

setClosed() calls reception() like valid() does, while reOpen() and setDraft() call livraison() to reverse it, so the same relaxation has to apply to all three or a validated negative reception could not be undone.

This PR only covers the class. The other half of your report, the $totalqty > 0 check in reception/card.php that blocks creating the reception in the first place, is left out: the equivalent condition there is commented out at card.php:401 and re-enabling it is a wider change that deserves a maintainer decision.

Reported by @matthieu-michou-wattandsea in #36489.