### PR TITLE
Fix #35916 filter on the product when looking for a batch in TakePOS

### DIFF
--- a/htdocs/product/class/productbatch.class.php
+++ b/htdocs/product/class/productbatch.class.php
@@ -428,8 +428,6 @@ class Productbatch extends CommonObject
 		} else {
 			$sql .= ", ".$this->db->prefix()."product_stock as ps";
 			$sql .= " WHERE t.fk_product_stock = ps.rowid AND ps.fk_entrepot = ".((int) $fk_warehouse);
-			// The same batch number can exist on several products, so the product must be part of the
-			// filter when it is known, otherwise the first matching row of another product is returned.
 			if ($fk_product > 0) {
 				$sql .= " AND ps.fk_product = ".((int) $fk_product);
 			}

--- a/htdocs/product/class/productbatch.class.php
+++ b/htdocs/product/class/productbatch.class.php
@@ -406,9 +406,10 @@ class Productbatch extends CommonObject
 	 *  @param	integer		$sellby   			sell-by date for object - deprecated: a search must be done on batch number
 	 *  @param	string		$batch_number   	batch number for object
 	 *  @param	int			$fk_warehouse		filter on warehouse (use it if you don't have $fk_product_stock)
+	 *  @param	int			$fk_product			filter on product (same batch number can exist on several products)
 	 *  @return int          					Return integer <0 if KO, >0 if OK
 	 */
-	public function find($fk_product_stock = 0, $eatby = null, $sellby = null, $batch_number = '', $fk_warehouse = 0)
+	public function find($fk_product_stock = 0, $eatby = null, $sellby = null, $batch_number = '', $fk_warehouse = 0, $fk_product = 0)
 	{
 		$where = array();
 
@@ -427,6 +428,11 @@ class Productbatch extends CommonObject
 		} else {
 			$sql .= ", ".$this->db->prefix()."product_stock as ps";
 			$sql .= " WHERE t.fk_product_stock = ps.rowid AND ps.fk_entrepot = ".((int) $fk_warehouse);
+			// The same batch number can exist on several products, so the product must be part of the
+			// filter when it is known, otherwise the first matching row of another product is returned.
+			if ($fk_product > 0) {
+				$sql .= " AND ps.fk_product = ".((int) $fk_product);
+			}
 		}
 		if (!empty($eatby)) {
 			array_push($where, " eatby = '".$this->db->idate($eatby)."'"); // deprecated

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -392,7 +392,7 @@ if (empty($reshook)) {
 					// var_dump('fk_product='.$line->fk_product.' batch='.$line->batch.' warehouse='.$line->fk_warehouse.' qty='.$line->qty);
 					if ($line->batch != '' && $warehouseid > 0) {
 						$prod_batch = new Productbatch($db);
-						$prod_batch->find(0, '', '', $line->batch, $warehouseid);
+						$prod_batch->find(0, '', '', $line->batch, $warehouseid, $line->fk_product);
 
 						$mouvP = new MouvementStock($db);
 						$mouvP->setOrigin($invoice->element, $invoice->id);


### PR DESCRIPTION
Productbatch::find() builds its filter on warehouse and batch number only when no fk_product_stock is given:

    $sql .= ", ".$this->db->prefix()."product_stock as ps";
    $sql .= " WHERE t.fk_product_stock = ps.rowid AND ps.fk_entrepot = ".((int) $fk_warehouse);

The product is never part of it, so with the same batch number on several products the method returns the first matching row, which may belong to a different product. takepos/invoice.php:395 then passes $prod_batch->id to livraison(), so llx_product_batch is decremented on the wrong lot while the total stock of the right product is updated. That is the mismatch described in the issue.

Reproduced on MariaDB with two products sharing batch LOT-A in the same warehouse, selling product 202:

    before   rowid=1  fk_product_stock=1  qty=50   <- lot of product 101
    after    rowid=2  fk_product_stock=2  qty=7    <- correct lot of product 202

Rather than add a helper query in TakePOS, I added an optional $fk_product argument to find() and pass $line->fk_product from the caller. That keeps the fix at the level where the ambiguity is, and find() has only this one active caller in the tree, so the new argument breaks nothing. Default value 0 keeps the previous behaviour for any external code calling it.

Reported with a precise root cause by @petertambach in #35916.