### PR TITLE
Fix #35818 remove the db property from nested objects in the webhook payload

### DIFF
--- a/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
+++ b/htdocs/core/triggers/interface_95_modWebhook_WebhookTriggers.class.php
@@ -97,6 +97,11 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 					unset($resobject->object->errors);
 				}
 
+				// dol_clone() only drops the db property of the object itself, the objects nested into
+				// arrays such as lines or linkedObjects keep theirs. That inflates the payload and sends
+				// the database host, name and user to the remote endpoint, so remove them too (#35818).
+				$this->removeDbFromPayload($resobject->object);
+
 				$jsonstr = json_encode($resobject);
 
 				$headers = array(
@@ -129,5 +134,34 @@ class InterfaceWebhookTriggers extends DolibarrTriggers
 			return $errors * -1;
 		}
 		return $nbPosts;
+	}
+
+	/**
+	 *  Remove the db property from a payload, including the objects nested into its arrays.
+	 *
+	 *  @param	object|array<mixed>	$payload	Payload to clean, modified in place
+	 *  @param	int					$depth		Current recursion depth, used as a safety stop
+	 *  @return	void
+	 */
+	private function removeDbFromPayload(&$payload, $depth = 0)
+	{
+		if ($depth > 10) {	// Safety stop, a linked object may refer back to its parent
+			return;
+		}
+
+		if (is_array($payload)) {
+			foreach ($payload as $key => $value) {
+				if (is_array($value) || is_object($value)) {
+					$this->removeDbFromPayload($payload[$key], $depth + 1);
+				}
+			}
+		} elseif (is_object($payload)) {
+			unset($payload->db);
+			foreach (get_object_vars($payload) as $key => $value) {
+				if (is_array($value) || is_object($value)) {
+					$this->removeDbFromPayload($payload->$key, $depth + 1);
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
The trigger already builds the payload with dol_clone($object, 2), which keeps only scalar and array properties, so the db of the object itself never reaches the JSON. But that mode copies arrays as they are, so every object nested into lines or linkedObjects keeps its own db.

That is the second half of the report, and it matters beyond size: DoliDB exposes database_host, database_name and database_user, so those were being sent to the remote endpoint once per nested object.

Measured on a payload with one line and one linked object:

    before  334 bytes, database_user appears 3 times
    after    79 bytes, database_user appears 0 times
    payload  {"id":5,"ref":"PR-1","lines":[{"id":9}],"linkedObjects":{"propal":[{"id":10}]}}

The business data is kept, only db is removed. I did not reuse cleanObjectDatas() from the Zapier trigger because it drops lines and linkedObjects entirely, which would change what webhook consumers receive.

The walk has a depth limit of 10 because a linked object can refer back to its parent. Verified that a circular reference is handled without an infinite loop and that db is still removed on both ends.

Reported by @TitCaz in #35818.