### PR TITLE
Fix #34094 create the categorie extrafields table and fix its name in the list

### DIFF
--- a/htdocs/categories/categorie_list.php
+++ b/htdocs/categories/categorie_list.php
@@ -272,7 +272,7 @@ $sqlfields = $sql; // $sql fields to remove for count total
 $sql .= " FROM ".$db->prefix().$object->table_element." as t";
 //$sql .= " LEFT JOIN ".$db->prefix()."anothertable as rc ON rc.parent = t.rowid";
 if (isset($extrafields->attributes[$object->table_element]['label']) && is_array($extrafields->attributes[$object->table_element]['label']) && count($extrafields->attributes[$object->table_element]['label'])) {
-	$sql .= " LEFT JOIN ".$db->prefix().$object->table_element."s_extrafields as ef on (t.rowid = ef.fk_object)";
+	$sql .= " LEFT JOIN ".$db->prefix().$object->table_element."_extrafields as ef on (t.rowid = ef.fk_object)";
 }
 // Add table from hooks
 $parameters = array();

--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -130,4 +130,17 @@ ALTER TABLE llx_facture ADD INDEX idx_facture_situation_cycle_ref (situation_cyc
 
 
 
+-- Categories support extrafields (Categorie::fetch_optionals is called and the list joins the table)
+-- but the table was never created, so the category list failed as soon as an extrafield was defined.
+create table llx_categorie_extrafields
+(
+  rowid                     integer AUTO_INCREMENT PRIMARY KEY,
+  tms                       timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  fk_object                 integer NOT NULL,
+  import_key                varchar(14)
+) ENGINE=innodb;
+
+ALTER TABLE llx_categorie_extrafields ADD UNIQUE INDEX uk_categorie_extrafields (fk_object);
+
+
 -- end of migration - nothing after this line

--- a/htdocs/install/mysql/tables/llx_categorie_extrafields.key.sql
+++ b/htdocs/install/mysql/tables/llx_categorie_extrafields.key.sql
@@ -1,0 +1,20 @@
+-- ========================================================================
+-- Copyright (C) 2026 Dolicraft                <contact@dolicraft.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ===================================================================
+
+
+ALTER TABLE llx_categorie_extrafields ADD UNIQUE INDEX uk_categorie_extrafields (fk_object);

--- a/htdocs/install/mysql/tables/llx_categorie_extrafields.sql
+++ b/htdocs/install/mysql/tables/llx_categorie_extrafields.sql
@@ -1,0 +1,25 @@
+-- ========================================================================
+-- Copyright (C) 2026 Dolicraft                <contact@dolicraft.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <https://www.gnu.org/licenses/>.
+--
+-- ========================================================================
+
+create table llx_categorie_extrafields
+(
+  rowid                     integer AUTO_INCREMENT PRIMARY KEY,
+  tms                       timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  fk_object                 integer NOT NULL,
+  import_key                varchar(14)                          		-- import key
+) ENGINE=innodb;


### PR DESCRIPTION
Two problems, both needed to make the category list work once an extrafield is defined.

First, categories/categorie_list.php joins with a stray s:

    $sql .= " LEFT JOIN ".$db->prefix().$object->table_element."s_extrafields as ef on ..."

which resolves to llx_categories_extrafields. Every other list writes $object->table_element."_extrafields" (societe/list.php:619, compta/facture/list.php:846), and this is the only occurrence of the typo in the tree.

Second, the correct table did not exist either. There are 153 llx_*_extrafields.sql files in install/mysql/tables and none for categorie, even though Categorie::fetch_optionals() is called on fetch and its extrafields are deleted on removal. So fixing the name alone would only have moved the crash.

This adds llx_categorie_extrafields.sql and its .key.sql following the structure of the other extrafields tables, a migration block for existing installs, and removes the extra s.

Verified on MariaDB:

    before   ERROR 1146 Table 'llx_categories_extrafields' doesn't exist
    after    query returns rows normally
    migration block applies and creates uk_categorie_extrafields on fk_object

Targeting develop because the fix needs a migration and 24.0.0-25.0.0.sql is the one still being built.

Reported by @JonBendtsen in #34094.