### PR TITLE
NEW Move the SQL coding-rule checks to a standalone lint (run once per pipeline)

### DIFF
--- a/.github/workflows/ci-on-pull_request.yml
+++ b/.github/workflows/ci-on-pull_request.yml
@@ -21,6 +21,12 @@ jobs:
     needs: [pre-commit]
     with:
       gh_event: ${{ github.event_name }}
+  coding-rules:
+    uses: ./.github/workflows/coding-rules.yml
+    secrets: inherit
+    needs: [pre-commit]
+    with:
+      gh_event: ${{ github.event_name }}
   #windows-ci:
   #  needs: [pre-commit, phan, phpstan]
   #  secrets: inherit

--- a/.github/workflows/ci-on-push.yml
+++ b/.github/workflows/ci-on-push.yml
@@ -26,6 +26,12 @@ jobs:
     needs: [pre-commit]
     with:
       gh_event: ${{ github.event_name }}
+  coding-rules:
+    uses: ./.github/workflows/coding-rules.yml
+    secrets: inherit
+    needs: [pre-commit]
+    with:
+      gh_event: ${{ github.event_name }}
   windows-ci:
     if: github.ref == 'refs/heads/develop'  # Condition for branch "develop"
     needs: [pre-commit, phan, phpstan]

--- a/.github/workflows/coding-rules.yml
+++ b/.github/workflows/coding-rules.yml
@@ -1,0 +1,47 @@
+---
+# Static coding-convention checks (SQL install/migration file rules for now).
+#
+# These checks are pure file scanning - they depend neither on the PHP version
+# nor on the DB engine - so instead of re-running them on every PHPUnit matrix
+# leg they run a single time here, via dev/tools/lint-coding-rules.php.
+#
+# The same rules are still available as PHPUnit tests (test/phpunit/CodingSqlTest,
+# @group lint) for local use.
+name: Coding rules
+
+# yamllint disable-line rule:truthy
+on:
+  # workflow called by a parent workflow (ci-on-push.yml / ci-on-pull_request.yml)
+  workflow_call:
+    inputs:
+      gh_event:
+        required: true
+        type: string
+  # can be run manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: coding-rules-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  gh_event: ${{ inputs.gh_event || github.event_name }}
+  GITHUB_JSON: ${{ toJSON(github) }}  # Helps in debugging Github Action
+
+jobs:
+  coding-rules:
+    name: Run coding rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none  # disable xdebug / pcov
+
+      - name: Run coding-rules lint
+        run: php dev/tools/lint-coding-rules.php

--- a/dev/tools/CodingRulesLint.class.php
+++ b/dev/tools/CodingRulesLint.class.php
@@ -1,0 +1,219 @@
+<?php
+/* Copyright (C) 2013-2024  Laurent Destailleur  <eldy@users.sourceforge.net>
+ * Copyright (C) 2026       Frédéric France      <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    dev/tools/CodingRulesLint.class.php
+ * \brief   Static coding-convention checks, runnable outside PHPUnit.
+ *
+ * The rules implemented here were extracted, unchanged, from
+ * test/phpunit/CodingSqlTest so that they can run *once per pipeline* from a
+ * plain CLI script (dev/tools/lint-coding-rules.php, wired to the CI
+ * "coding-rules" job) instead of *once per PHPUnit matrix leg* - they are pure
+ * file scanning and depend neither on the PHP version nor on the DB engine.
+ *
+ * test/phpunit/CodingSqlTest now only calls into this class (thin wrappers,
+ * @group lint).
+ */
+class CodingRulesLint
+{
+	/**
+	 * @var string[] Human readable message for every rule violation found so far.
+	 */
+	public $violations = array();
+
+	/**
+	 * @var bool When true, print the "Process dir ... / Check sql file ..." progress lines.
+	 */
+	public $verbose = false;
+
+	/**
+	 * @var string Absolute path to the htdocs/ directory to scan.
+	 */
+	private $docroot;
+
+	/**
+	 * Constructor
+	 *
+	 * @param string|null $docroot Path to the htdocs/ directory (defaults to the one of this repository)
+	 */
+	public function __construct($docroot = null)
+	{
+		$this->docroot = rtrim($docroot ?: dirname(__DIR__, 2).'/htdocs', '/');
+	}
+
+	/**
+	 * Record a rule violation when $ok is false.
+	 *
+	 * Drop-in replacement for the $this->assertTrue($ok, $message) calls of the
+	 * original PHPUnit test: same semantics (the message only matters on
+	 * failure) but collected in $this->violations instead of thrown.
+	 *
+	 * @param bool   $ok      Condition that must hold
+	 * @param string $message Message describing the violation
+	 * @return void
+	 */
+	private function report($ok, $message)
+	{
+		if (!$ok) {
+			$this->violations[] = $message;
+		}
+	}
+
+	/**
+	 * Print a progress line when verbose mode is on.
+	 *
+	 * @param string $line Line to print (no trailing newline needed)
+	 * @return void
+	 */
+	private function trace($line)
+	{
+		if ($this->verbose) {
+			print $line."\n";
+		}
+	}
+
+	/**
+	 * Check the install SQL scripts (install/mysql/{data,tables,migration}) against
+	 * Dolibarr's SQL coding rules.
+	 *
+	 * Extracted verbatim from CodingSqlTest::testSql().
+	 *
+	 * @return void
+	 */
+	public function checkInstallSqlFiles()
+	{
+		$listofsqldir = array($this->docroot.'/install/mysql/data', $this->docroot.'/install/mysql/tables', $this->docroot.'/install/mysql/migration');
+
+		foreach ($listofsqldir as $dir) {
+			$this->trace('Process dir '.$dir);
+			$filesarray = scandir($dir);
+
+			foreach ($filesarray as $key => $file) {
+				if (! preg_match('/\.sql$/', $file)) {
+					continue;
+				}
+
+				$this->trace('Check sql file '.$file);
+				$filecontent = file_get_contents($dir.'/'.$file);
+
+				// Allow some string sequences
+				$filecontent = str_replace(
+					array('`rank`', '["', '"]', '{"', '"}', '("', '")', 'href="', '">'),
+					array('_rank_', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__'),
+					$filecontent
+				);
+
+				// To accept " after the comment tag
+				//$filecontent = preg_replace('/^--.*$/', '', $filecontent);
+				$filecontent = preg_replace('/--.*?\n/', '', $filecontent);
+
+				$result = strpos($filecontent, '`');
+				//print __METHOD__." Result for checking we don't have back quote = ".$result."\n";
+				$this->report($result === false, 'Found back quote into '.$file.'. Bad.');
+
+				$result = strpos($filecontent, '"');
+				//print __METHOD__." Result for checking we don't have double quote = ".$result."\n";
+				$this->report($result === false, 'Found double quote that is not [" neither {" (used for json content) neither (" (used for content with string like isModEnabled("")) into '.$file.'. Bad.');
+
+				$result = strpos($filecontent, 'int(');
+				//print __METHOD__." Result for checking we don't have 'int(' instead of 'integer' = ".$result."\n";
+				$this->report($result === false, 'Found int(x) or tinyint(x) instead of integer or tinyint into '.$file.'. Bad.');
+
+				$result = strpos($filecontent, 'ADD UNIQUE KEY');
+				//print __METHOD__." Result for checking we don't have 'ON DELETE CASCADE' = ".$result."\n";
+				$this->report($result === false, 'Found ADD UNIQUE KEY instead of ADD UNIQUE INDEX into '.$file.'. Bad.');
+
+				$result = strpos($filecontent, 'ON DELETE CASCADE');
+				//print __METHOD__." Result for checking we don't have 'ON DELETE CASCADE' = ".$result."\n";
+				$this->report($result === false, 'Found ON DELETE CASCADE into '.$file.'. Bad.');
+
+				$result = strpos($filecontent, 'NUMERIC(');
+				//print __METHOD__." Result for checking we don't have 'NUMERIC(' = ".$result."\n";
+				$this->report($result === false, 'Found NUMERIC( into '.$file.'. Bad.');
+
+				$result = strpos($filecontent, 'NUMERIC(');
+				//print __METHOD__." Result for checking we don't have 'curdate(' = ".$result."\n";
+				$this->report($result === false, 'Found curdate( into '.$file.'. Bad. Current date must be generated with PHP.');
+
+				$result = strpos($filecontent, 'integer(');
+				//print __METHOD__." Result for checking we don't have 'integer(' = ".$result."\n";
+				$this->report($result === false, 'Found value in parenthesis after the integer. It must be integer not integer(x) into '.$file.'. Bad.');
+
+				$result = strpos($filecontent, 'timestamp,');
+				//print __METHOD__." Result for checking we don't have 'NUMERIC(' = ".$result."\n";
+				$this->report($result === false, 'Found type timestamp without option DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP after into '.$file.'. Bad.');
+
+				if ($dir == $this->docroot.'/install/mysql/migration') {
+					// Test for migration files only
+				} elseif ($dir == $this->docroot.'/install/mysql/data') {
+					// Test for data files only
+				} else {
+					if (preg_match('/\.key\.sql$/', $file)) {
+						// Test for key files only
+					} else {
+						// Test for non key files only
+						$result = (strpos($filecontent, 'KEY ') && strpos($filecontent, 'PRIMARY KEY') == 0);
+						//print __METHOD__." Result for checking we don't have ' KEY ' instead of a sql file to create index = ".$result."\n";
+						$this->report($result === false, 'Found KEY into '.$file.'. Bad.');
+
+						$result = stripos($filecontent, 'ENGINE=innodb');
+						//print __METHOD__." Result for checking we have the ENGINE=innodb string = ".$result."\n";
+						$this->report($result > 0, 'The ENGINE=innodb was not found into '.$file.'. Add it or just fix syntax to match case.');
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Check the demo init SQL files (dev/initdemo) do not leak secrets or personal data.
+	 *
+	 * Extracted verbatim from CodingSqlTest::testInitData().
+	 *
+	 * @return void
+	 */
+	public function checkInitDemoFiles()
+	{
+		$initdemodir = dirname($this->docroot).'/dev/initdemo';
+
+		$filesarray = scandir($initdemodir);
+		foreach ($filesarray as $key => $file) {
+			if (! preg_match('/\.sql$/', $file)) {
+				continue;
+			}
+
+			$this->trace('Check sql file '.$file);
+			$filecontent = file_get_contents($initdemodir.'/'.$file);
+
+			// We protect this string key that is legitimate into the init of demo file
+			$filecontent = str_replace("BLOCKEDLOG_HMAC_KEY',0,'dolcrypt:", "__STRINGOK__", $filecontent);
+
+			$result = strpos($filecontent, 'dolcrypt:');
+			$this->report($result === false, 'Found a "dolcrypt:" into file '.$file);
+
+			$result = strpos($filecontent, '@gmail.com');
+			$this->report($result === false, 'Found a bad key @gmail into file '.$file);
+
+			$result = strpos($filecontent, 'eldy@');
+			$this->report($result === false, 'Found a bad key eldy@ into file '.$file);
+
+			$result = strpos($filecontent, 'INSERT INTO `llx_oauth_token`');
+			$this->report($result === false, 'Found a non expected insert into file '.$file);
+		}
+	}
+}

--- a/dev/tools/lint-coding-rules.php
+++ b/dev/tools/lint-coding-rules.php
@@ -1,0 +1,59 @@
+#!/usr/bin/env php
+<?php
+/* Copyright (C) 2026 Frédéric France <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    dev/tools/lint-coding-rules.php
+ * \brief   Run the static coding-convention checks once (used by the CI "coding-rules" job).
+ *
+ * These checks are pure file scanning: they depend neither on the PHP version
+ * nor on the DB engine, so there is no point re-running them on every PHPUnit
+ * matrix leg. This script runs them a single time per pipeline.
+ *
+ * Currently covers the SQL file rules previously enforced by
+ * test/phpunit/CodingSqlTest::testSql() and ::testInitData().
+ *
+ * Usage:  php dev/tools/lint-coding-rules.php [-v|--verbose]
+ * Exit:   0 = no violation, 1 = at least one violation (all are printed)
+ */
+
+if (php_sapi_name() !== 'cli') {
+	fwrite(STDERR, "Error: ".basename(__FILE__)." must be run from the command line (PHP CLI).\n");
+	exit(1);
+}
+
+require_once __DIR__.'/CodingRulesLint.class.php';
+
+$docroot = __DIR__.'/../../htdocs';
+
+$lint = new CodingRulesLint($docroot);
+$lint->verbose = in_array('-v', $argv, true) || in_array('--verbose', $argv, true);
+
+$lint->checkInstallSqlFiles();
+$lint->checkInitDemoFiles();
+
+if (!empty($lint->violations)) {
+	fwrite(STDERR, "\nCoding rule violation(s) found:\n\n");
+	foreach ($lint->violations as $violation) {
+		fwrite(STDERR, " - ".$violation."\n");
+	}
+	fwrite(STDERR, "\n".count($lint->violations)." violation(s).\n");
+	exit(1);
+}
+
+print "Coding rules: OK (no violation).\n";
+exit(0);

--- a/test/phpunit/CodingSqlTest.php
+++ b/test/phpunit/CodingSqlTest.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2013 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023 Alexandre Janniaux   <alexandre.janniaux@gmail.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -130,143 +130,37 @@ class CodingSqlTest extends CommonClassTest
 	/**
 	 * testSql
 	 *
-	 * @return string
+	 * The rules themselves live in dev/tools/CodingRulesLint.class.php so they can
+	 * also be run once per pipeline by dev/tools/lint-coding-rules.php (CI job
+	 * "coding-rules") instead of once per PHPUnit matrix leg - they are pure file
+	 * scanning and depend neither on the PHP version nor on the DB engine.
+	 *
+	 * @group lint
+	 * @return void
 	 */
 	public function testSql()
 	{
-		global $conf,$user,$langs,$db;
-		$conf = $this->savconf;
-		$user = $this->savuser;
-		$langs = $this->savlangs;
-		$db = $this->savdb;
+		require_once dirname(__FILE__).'/../../dev/tools/CodingRulesLint.class.php';
 
-		$listofsqldir = array(DOL_DOCUMENT_ROOT.'/install/mysql/data', DOL_DOCUMENT_ROOT.'/install/mysql/tables', DOL_DOCUMENT_ROOT.'/install/mysql/migration');
+		$lint = new CodingRulesLint(DOL_DOCUMENT_ROOT);
+		$lint->checkInstallSqlFiles();
 
-		foreach ($listofsqldir as $dir) {
-			print 'Process dir '.$dir."\n";
-			$filesarray = scandir($dir);
-
-			foreach ($filesarray as $key => $file) {
-				if (! preg_match('/\.sql$/', $file)) {
-					continue;
-				}
-
-				print 'Check sql file '.$file."\n";
-				$filecontent = file_get_contents($dir.'/'.$file);
-
-				// Allow some string sequences
-				$filecontent = str_replace(
-					array('`rank`', '["', '"]', '{"', '"}', '("', '")', 'href="', '">'),
-					array('_rank_', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__', '__OKSTRING__'),
-					$filecontent
-				);
-
-				// To accept " after the comment tag
-				//$filecontent = preg_replace('/^--.*$/', '', $filecontent);
-				$filecontent = preg_replace('/--.*?\n/', '', $filecontent);
-
-				$result = strpos($filecontent, '`');
-				//print __METHOD__." Result for checking we don't have back quote = ".$result."\n";
-				$this->assertTrue($result === false, 'Found back quote into '.$file.'. Bad.');
-
-				$result = strpos($filecontent, '"');
-				//print __METHOD__." Result for checking we don't have double quote = ".$result."\n";
-				$this->assertTrue($result === false, 'Found double quote that is not [" neither {" (used for json content) neither (" (used for content with string like isModEnabled("")) into '.$file.'. Bad.');
-
-				$result = strpos($filecontent, 'int(');
-				//print __METHOD__." Result for checking we don't have 'int(' instead of 'integer' = ".$result."\n";
-				$this->assertTrue($result === false, 'Found int(x) or tinyint(x) instead of integer or tinyint into '.$file.'. Bad.');
-
-				$result = strpos($filecontent, 'ADD UNIQUE KEY');
-				//print __METHOD__." Result for checking we don't have 'ON DELETE CASCADE' = ".$result."\n";
-				$this->assertTrue($result === false, 'Found ADD UNIQUE KEY instead of ADD UNIQUE INDEX into '.$file.'. Bad.');
-
-				$result = strpos($filecontent, 'ON DELETE CASCADE');
-				//print __METHOD__." Result for checking we don't have 'ON DELETE CASCADE' = ".$result."\n";
-				$this->assertTrue($result === false, 'Found ON DELETE CASCADE into '.$file.'. Bad.');
-
-				$result = strpos($filecontent, 'NUMERIC(');
-				//print __METHOD__." Result for checking we don't have 'NUMERIC(' = ".$result."\n";
-				$this->assertTrue($result === false, 'Found NUMERIC( into '.$file.'. Bad.');
-
-				$result = strpos($filecontent, 'NUMERIC(');
-				//print __METHOD__." Result for checking we don't have 'curdate(' = ".$result."\n";
-				$this->assertTrue($result === false, 'Found curdate( into '.$file.'. Bad. Current date must be generated with PHP.');
-
-				$result = strpos($filecontent, 'integer(');
-				//print __METHOD__." Result for checking we don't have 'integer(' = ".$result."\n";
-				$this->assertTrue($result === false, 'Found value in parenthesis after the integer. It must be integer not integer(x) into '.$file.'. Bad.');
-
-				$result = strpos($filecontent, 'timestamp,');
-				//print __METHOD__." Result for checking we don't have 'NUMERIC(' = ".$result."\n";
-				$this->assertTrue($result === false, 'Found type timestamp without option DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP after into '.$file.'. Bad.');
-
-				if ($dir == DOL_DOCUMENT_ROOT.'/install/mysql/migration') {
-					// Test for migration files only
-				} elseif ($dir == DOL_DOCUMENT_ROOT.'/install/mysql/data') {
-					// Test for data files only
-				} else {
-					if (preg_match('/\.key\.sql$/', $file)) {
-						// Test for key files only
-					} else {
-						// Test for non key files only
-						$result = (strpos($filecontent, 'KEY ') && strpos($filecontent, 'PRIMARY KEY') == 0);
-						//print __METHOD__." Result for checking we don't have ' KEY ' instead of a sql file to create index = ".$result."\n";
-						$this->assertTrue($result === false, 'Found KEY into '.$file.'. Bad.');
-
-						$result = stripos($filecontent, 'ENGINE=innodb');
-						//print __METHOD__." Result for checking we have the ENGINE=innodb string = ".$result."\n";
-						$this->assertGreaterThan(0, $result, 'The ENGINE=innodb was not found into '.$file.'. Add it or just fix syntax to match case.');
-					}
-				}
-			}
-		}
-
-		return;
+		$this->assertSame(array(), $lint->violations, "\n".implode("\n", $lint->violations));
 	}
 
 	/**
 	 * testInitData
 	 *
-	 * @return string
+	 * @group lint
+	 * @return void
 	 */
 	public function testInitData()
 	{
-		global $conf,$user,$langs,$db;
-		$conf = $this->savconf;
-		$user = $this->savuser;
-		$langs = $this->savlangs;
-		$db = $this->savdb;
+		require_once dirname(__FILE__).'/../../dev/tools/CodingRulesLint.class.php';
 
-		$filesarray = scandir(DOL_DOCUMENT_ROOT.'/../dev/initdemo');
-		foreach ($filesarray as $key => $file) {
-			if (! preg_match('/\.sql$/', $file)) {
-				continue;
-			}
+		$lint = new CodingRulesLint(DOL_DOCUMENT_ROOT);
+		$lint->checkInitDemoFiles();
 
-			print 'Check sql file '.$file."\n";
-			$filecontent = file_get_contents(DOL_DOCUMENT_ROOT.'/../dev/initdemo/'.$file);
-
-			// We protect this string key that is legitimate into the init of demo file
-			$filecontent = str_replace("BLOCKEDLOG_HMAC_KEY',0,'dolcrypt:", "__STRINGOK__", $filecontent);
-
-			$result = strpos($filecontent, 'dolcrypt:');
-			print __METHOD__." Result for checking we don't have a crypted value that could not be decrypted on a restored instance with other key = ".$result."\n";
-			$this->assertTrue($result === false, 'Found a "dolcrypt:" into file '.$file);
-
-			$result = strpos($filecontent, '@gmail.com');
-			print __METHOD__." Result for checking we don't have personal data = ".$result."\n";
-			$this->assertTrue($result === false, 'Found a bad key @gmail into file '.$file);
-
-			$result = strpos($filecontent, 'eldy@');
-			print __METHOD__." Result for checking we don't have personal data = ".$result."\n";
-			$this->assertTrue($result === false, 'Found a bad key eldy@ into file '.$file);
-
-			$result = strpos($filecontent, 'INSERT INTO `llx_oauth_token`');
-			print __METHOD__." Result for checking we don't have data into llx_oauth_token = ".$result."\n";
-			$this->assertTrue($result === false, 'Found a non expected insert into file '.$file);
-		}
-
-		return;
+		$this->assertSame(array(), $lint->violations, "\n".implode("\n", $lint->violations));
 	}
 }


### PR DESCRIPTION
## Why

`CodingSqlTest::testSql()` / `::testInitData()` are **pure file scanning** — they
check `htdocs/install/mysql/{data,tables,migration}/*.sql` and `dev/initdemo/*.sql`
against Dolibarr's SQL conventions (`ENGINE=innodb`, no backquote / `"` / `int(x)` /
`ADD UNIQUE KEY` / `ON DELETE CASCADE` …, no leaked `dolcrypt:` / PII).

They depend **neither on the PHP version nor on the DB engine**, yet living inside
`AllTests.php` they are replayed on every matrix leg — Travis (3 PHP × 2 DB) and,
with #39823, the new `install-phpunit` legs (mariadb + pgsql). Wasted work, and a
lint failure gets mixed into a functional test run.

## What

| File | |
|---|---|
| `dev/tools/CodingRulesLint.class.php` | The rules, extracted **unchanged**. The only transformation is `$this->assertTrue($cond, $msg)` → `$this->report($cond, $msg)` (and `assertGreaterThan(0, $x, …)` → `report($x > 0, …)`): same semantics, collected in `->violations` instead of thrown. No PHPUnit, no DB, no Dolibarr bootstrap needed. |
| `dev/tools/lint-coding-rules.php` | CLI entry point. Prints every violation, exit `1` if any, `0` otherwise. `-v` for progress lines. |
| `.github/workflows/coding-rules.yml` + wiring in `ci-on-pull_request.yml` / `ci-on-push.yml` | One `coding-rules` job (`needs: [pre-commit]`), same shape as `phan` / `phpstan`. |
| `test/phpunit/CodingSqlTest.php` | `testSql` / `testInitData` become thin wrappers over `CodingRulesLint`, tagged `@group lint` (so #39823's `--exclude-group lint` skips them on the install-phpunit legs). `testEscape` / `testEscapeForLike` — driver-specific, real DB tests — are untouched. |

No behaviour change: the CLI and the PHPUnit wrappers run the exact same code path.
Verified locally (`php dev/tools/lint-coding-rules.php` → `OK`, and a crafted bad
`.sql` → exit 1 with the expected message).

## Scope / follow-up

- This is deliberately **SQL only**. The same treatment for
  `CodingPhpTest::testPHP()` needs the shared `*_MODULE_MAPPING` constants moved
  out of `CommonClassTest` (also used by `ModulesTest`), so it deserves its own PR.
- Overlaps trivially with #39823 on `CodingSqlTest.php` (that PR only adds the
  `@group lint` annotation, which this rewrite keeps) — whichever lands first, the
  other rebases cleanly.

Opening as **draft**: needs a green CI run (local PHPUnit here has no DB) and
@eldy's opinion on the direction before finalising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
