### PR TITLE
Fix #35476 strip $ID$ from sellist filters written with the search filter syntax

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1544,15 +1544,15 @@ class ExtraFields
 							} elseif (substr($_SERVER["PHP_SELF"], -8) == 'list.php') {
 								// In filters of list views, we do not want $ID$ replaced by 0. So we remove the '=' condition.
 								// Do nothing if condition is using 'IN' keyword
-								// Replace 'column = $ID$' by "column"
+								// Replace 'column = $ID$' by an always true test, the parent object is unknown in a list
 								$word = '#\b([a-zA-Z0-9-\.-_]+)\b *= *\$ID\$#';
-								$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
-								// Replace '$ID$ = column' by "column"
+								$InfoFieldList[4] = preg_replace($word, '1 = 1', $InfoFieldList[4]);
+								// Replace '$ID$ = column' by an always true test
 								$word = '#\$ID\$ *= *\b([a-zA-Z0-9-\.-_]+)\b#';
-								$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
-								// Same with the Universal Search Filter syntax, '(column:=:$ID$)' by "(column)"
+								$InfoFieldList[4] = preg_replace($word, '1 = 1', $InfoFieldList[4]);
+								// Same with the Universal Search Filter syntax, '(column:=:$ID$)'
 								$word = '#\b([a-zA-Z0-9-\.-_]+)\b *: *[<>!=]?= *: *\$ID\$#';
-								$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
+								$InfoFieldList[4] = preg_replace($word, '1 = 1', $InfoFieldList[4]);
 							} else {
 								$InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);
 							}
@@ -1814,15 +1814,15 @@ class ExtraFields
 						} elseif (substr($_SERVER["PHP_SELF"], -8) == 'list.php') {
 							// In filters of list views, we do not want $ID$ replaced by 0. So we remove the '=' condition.
 							// Do nothing if condition is using 'IN' keyword
-							// Replace 'column = $ID$' by "column"
+							// Replace 'column = $ID$' by an always true test, the parent object is unknown in a list
 							$word = '#\b([a-zA-Z0-9-\.-_]+)\b *= *\$ID\$#';
-							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
-							// Replace '$ID$ = column' by "column"
+							$InfoFieldList[4] = preg_replace($word, '1 = 1', $InfoFieldList[4]);
+							// Replace '$ID$ = column' by an always true test
 							$word = '#\$ID\$ *= *\b([a-zA-Z0-9-\.-_]+)\b#';
-							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
-							// Same with the Universal Search Filter syntax, '(column:=:$ID$)' by "column"
+							$InfoFieldList[4] = preg_replace($word, '1 = 1', $InfoFieldList[4]);
+							// Same with the Universal Search Filter syntax, '(column:=:$ID$)'
 							$word = '#\b([a-zA-Z0-9-\.-_]+)\b *: *[<>!=]?= *: *\$ID\$#';
-							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
+							$InfoFieldList[4] = preg_replace($word, '1 = 1', $InfoFieldList[4]);
 						} else {
 							$InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);
 						}

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1544,10 +1544,10 @@ class ExtraFields
 							} elseif (substr($_SERVER["PHP_SELF"], -8) == 'list.php') {
 								// In filters of list views, we do not want $ID$ replaced by 0. So we remove the '=' condition.
 								// Do nothing if condition is using 'IN' keyword
-								// Replace 'column = $ID$' by "word"
+								// Replace 'column = $ID$' by "column"
 								$word = '#\b([a-zA-Z0-9-\.-_]+)\b *= *\$ID\$#';
 								$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
-								// Replace '$ID$ = column' by "word"
+								// Replace '$ID$ = column' by "column"
 								$word = '#\$ID\$ *= *\b([a-zA-Z0-9-\.-_]+)\b#';
 								$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
 								// Same with the Universal Search Filter syntax, '(column:=:$ID$)' by "(column)"
@@ -1814,13 +1814,13 @@ class ExtraFields
 						} elseif (substr($_SERVER["PHP_SELF"], -8) == 'list.php') {
 							// In filters of list views, we do not want $ID$ replaced by 0. So we remove the '=' condition.
 							// Do nothing if condition is using 'IN' keyword
-							// Replace 'column = $ID$' by "word"
+							// Replace 'column = $ID$' by "column"
 							$word = '#\b([a-zA-Z0-9-\.-_]+)\b *= *\$ID\$#';
 							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
-							// Replace '$ID$ = column' by "word"
+							// Replace '$ID$ = column' by "column"
 							$word = '#\$ID\$ *= *\b([a-zA-Z0-9-\.-_]+)\b#';
 							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
-							// Same with the Universal Search Filter syntax, '(column:=:$ID$)' by "(column)"
+							// Same with the Universal Search Filter syntax, '(column:=:$ID$)' by "column"
 							$word = '#\b([a-zA-Z0-9-\.-_]+)\b *: *[<>!=]?= *: *\$ID\$#';
 							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
 						} else {

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1550,6 +1550,9 @@ class ExtraFields
 								// Replace '$ID$ = column' by "word"
 								$word = '#\$ID\$ *= *\b([a-zA-Z0-9-\.-_]+)\b#';
 								$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
+								// Same with the Universal Search Filter syntax, '(column:=:$ID$)' by "(column)"
+								$word = '#\b([a-zA-Z0-9-\.-_]+)\b *: *[<>!=]?= *: *\$ID\$#';
+								$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
 							} else {
 								$InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);
 							}
@@ -1816,6 +1819,9 @@ class ExtraFields
 							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
 							// Replace '$ID$ = column' by "word"
 							$word = '#\$ID\$ *= *\b([a-zA-Z0-9-\.-_]+)\b#';
+							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
+							// Same with the Universal Search Filter syntax, '(column:=:$ID$)' by "(column)"
+							$word = '#\b([a-zA-Z0-9-\.-_]+)\b *: *[<>!=]?= *: *\$ID\$#';
 							$InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);
 						} else {
 							$InfoFieldList[4] = str_replace('$ID$', '0', $InfoFieldList[4]);


### PR DESCRIPTION
On a list view there is no current object id, so extrafields.class.php does not replace \$ID\$ by 0, it removes the condition that uses it:

    // Replace 'column = $ID$' by "word"
    $word = '#\\b([a-zA-Z0-9-\\.-_]+)\\b *= *\\$ID\\$#';
    $InfoFieldList[4] = preg_replace($word, '$1', $InfoFieldList[4]);

Both regexes only match the old 'column = \$ID\$' form. A filter written with the Universal Search Filter syntax keeps its placeholder:

    old syntax   (projectid = $ID$) and (active = 1)     ->  (projectid) and (active = 1)
    USF syntax   (projectid:=:$ID$) and (active:=:1)     ->  unchanged, $ID$ survives

and \$ID\$ then reaches the database as a bare ID column, which is the reported error:

    before   ERROR 1054 Unknown column 'ID' in 'WHERE'
    after    the query runs and returns the rows

This adds the equivalent regex for the USF form, in the two places where the block is duplicated (showInputField and showOutputField). Checked that it only touches what it should:

    (projectid:=:$ID$)      -> (projectid)            cleaned
    (projectid:!=:$ID$)     -> (projectid)            cleaned
    (projectid = $ID$)      -> (projectid)            old syntax still works
    (projectid:=:$MODE$)    -> unchanged              other placeholders survive
    (projectid:in:1,2,3)    -> unchanged              IN conditions untouched

Reported by @fernandomacho in #35476.