### PR TITLE
Fix wrong condition >= 0 instead of > 0 in fetchObjectLinked()

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4498,7 +4498,7 @@ abstract class CommonObject
 									$object = new $className($this->db);
 									'@phan-var-force CommonObject $object';
 									$ret = $object->fetch($objectid);
-									if ($ret >= 0) {
+									if ($ret > 0) {
 										$this->linkedObjects[$objecttype][$i] = $object;
 									}
 								}


### PR DESCRIPTION
# FIX|Fix fetchObjectLinked() adds empty objects when linked record does not exist

In `fetchObjectLinked()` (`core/class/commonobject.class.php`), the condition `if ($ret >= 0)` was incorrectly treating a "not found" result (ret = 0) the same as a successful fetch (ret = 1).

This caused empty objects (id=0, ref=null, socid=0) to be added to `linkedObjects`, typically when an orphan row exists in `llx_element_element` pointing to a deleted or non-existent record.

In practice, this triggered a TypeError / HTTP 500 during invoice validation when the workflow `WORKFLOW_INVOICE_CLASSIFY_BILLED_PROPAL` called `classifyBilled()` on a linked proposal: PDF generation received an empty `Propal` object, `fetch_thirdparty()` loaded nothing (due to empty `socid`), and the PDF model crashed with a null `$buyer`.

Fix: change condition from `>= 0` to `> 0` so only successfully loaded objects are added to `linkedObjects`.