### PR TITLE
FIX Access denied when changing account type on bank account creation…

### DIFF
--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -77,6 +77,10 @@ $hookmanager->initHooks(array('bankcard', 'globalcard'));
 // Security check
 $id = GETPOSTINT("id") ? GETPOSTINT("id") : GETPOST('ref');
 $fieldid = GETPOSTINT("id") ? 'rowid' : 'ref';
+if ($action == 'create' || $action == 'add') {
+	// On creation, the posted ref is the ref of the record to create, not the ref of an existing record to check permission on
+	$id = '';
+}
 
 if (GETPOSTINT("id") || GETPOST("ref")) {
 	if (GETPOSTINT("id")) {


### PR DESCRIPTION
# FIX Access denied when changing account type on bank account creation form                                                                                                                                         

  ## Bug

  On the bank account creation form, if the ref typed by the user contains at least
  one digit (e.g. `BQ1`), changing the **account type** (or the **bank country**)
  results in an "Access denied" page instead of reloading the form.

  ### Steps to reproduce

  1. Go to Bank/Cash > New financial account
  2. Fill in Ref with a value containing a digit, e.g. `BQ1`, and a label
  3. Change the account type (e.g. from "Current or credit card account" to "Cash account")
  4. The javascript reloads the form with `action=create` => "Access denied"

  Works fine if the ref contains no digit, which makes the bug look random.

  ### Cause

  The form reload posts `action=create` with all typed fields, including `ref`.
  The security check at the top of `compta/bank/card.php` then treats this posted
  ref as the ref of an existing account:

  ```php
  $id = GETPOSTINT("id") ? GETPOSTINT("id") : GETPOST('ref');
  $fieldid = GETPOSTINT("id") ? 'rowid' : 'ref';
  ...
  $result = restrictedArea($user, 'banque', $id, 'bank_account&bank_account', '', '', $fieldid);

  restrictedArea() sanitizes the value by stripping non-digit characters
  (BQ1 becomes 1), and since the result is > 0 it calls
  checkUserAccessToObject(), which runs
  SELECT COUNT(...) FROM llx_bank_account WHERE ref IN ('1') AND entity IN (...).
  No such record exists (the user is precisely creating it), so accessforbidden()
  is called.

  Fix
  
  Reset $id to an empty value when $action is create or add, so no object
  permission check is done during creation (there is no record to check yet).
  The module/permission level checks of restrictedArea() still apply.
