### PR TITLE
FIX #39920 Qualify OAuth token row ID

### DIFF
--- a/htdocs/api/class/api_access.class.php
+++ b/htdocs/api/class/api_access.class.php
@@ -150,7 +150,7 @@ class DolibarrApiAccess implements iAuthenticate
 				}
 			} else {
 				if (isModEnabled('multicompany') && getDolGlobalString('MULTICOMPANY_TRANSVERSE_MODE') && defined("DOLENTITY")) {
-					$sql = "SELECT DISTINCT u.login, u.datec, u.api_key as use_api, oat.tokenstring as api_key, oat.entity as token_entity, rowid as token_rowid,";
+					$sql = "SELECT DISTINCT u.login, u.datec, u.api_key as use_api, oat.tokenstring as api_key, oat.entity as token_entity, oat.rowid as token_rowid,";
 					$sql .= " oat.tms as date_modification,";
 					$sql .= " gu.entity";
 					$sql .= " FROM ".$this->db->prefix()."oauth_token AS oat";
@@ -161,7 +161,7 @@ class DolibarrApiAccess implements iAuthenticate
 					$sql .= " AND gu.entity = oat.entity";
 					$sql .= " AND oat.service = 'dolibarr_rest_api'";
 				} else {
-					$sql = "SELECT u.login, u.datec, u.api_key as use_api, u.entity, oat.tokenstring as api_key, oat.entity as token_entity, rowid as token_rowid,";
+					$sql = "SELECT u.login, u.datec, u.api_key as use_api, u.entity, oat.tokenstring as api_key, oat.entity as token_entity, oat.rowid as token_rowid,";
 					$sql .= " oat.tms as date_modification";
 					$sql .= " FROM ".$this->db->prefix()."oauth_token AS oat";
 					$sql .= " JOIN ".$this->db->prefix()."user AS u ON u.rowid = oat.fk_user";


### PR DESCRIPTION
Fixes #39920.

With API_IN_TOKEN_TABLE enabled, both token lookup queries on 23.0 join oauth_token to user (and the transverse branch also joins usergroup_user) but select an unqualified rowid. The database rejects the query as ambiguous, so REST API authentication returns HTTP 503.

Qualify token_rowid as oat.rowid in both the standard and multicompany transverse branches. Version 23.0 is the oldest affected branch; forward merges will also carry the remaining transverse correction to 24.0 and develop.

This restores on the maintenance line the qualification introduced by #38082. The later #39409 forward merge left the transverse query unqualified on newer branches.

Validation:
- Focused SQL reproduction: both unqualified joins fail with ambiguous column name: rowid; both qualified queries return the expected token row
- php -l htdocs/api/class/api_access.class.php
- git diff --check