### PR TITLE
FIX: Record fk_user_modif when updating a contract

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -9,7 +9,7 @@
  * Copyright (C) 2013		Florian Henry			<florian.henry@open-concept.pro>
  * Copyright (C) 2014-2015	Marcos García			<marcosgdf@gmail.com>
  * Copyright (C) 2018   	Nicolas ZABOURI			<info@inovea-conseil.com>
- * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2015-2018	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
@@ -1415,6 +1415,7 @@ class Contrat extends CommonObject
 		$sql .= " note_private=".(isset($this->note_private) ? "'".$this->db->escape($this->note_private)."'" : "null").",";
 		$sql .= " note_public=".(isset($this->note_public) ? "'".$this->db->escape($this->note_public)."'" : "null").",";
 		$sql .= " import_key=".(isset($this->import_key) ? "'".$this->db->escape($this->import_key)."'" : "null").",";
+		$sql .= " fk_user_modif=".(isset($user->id) ? ((int) $user->id) : "null").",";
 		$sql .= " extraparams=".(isset($extraparams) ? "'".$this->db->escape($extraparams)."'" : "null");
 		$sql .= " WHERE rowid=".((int) $this->id);
 
@@ -1451,6 +1452,9 @@ class Contrat extends CommonObject
 			$this->db->rollback();
 			return -1 * $error;
 		} else {
+			if (isset($user->id)) {
+				$this->fk_user_modif = (int) $user->id;
+			}
 			$this->db->commit();
 			return 1;
 		}

--- a/test/phpunit/ContratTest.php
+++ b/test/phpunit/ContratTest.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2010-2014 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -156,6 +156,13 @@ class ContratTest extends CommonClassTest
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
+
+		// Check that the user of last modification has been recorded
+		$sql = "SELECT fk_user_modif FROM ".MAIN_DB_PREFIX."contrat WHERE rowid = ".((int) $localobject->id);
+		$resql = $db->query($sql);
+		$objcheck = $db->fetch_object($resql);
+		$this->assertEquals($user->id, $objcheck->fk_user_modif, 'fk_user_modif must be set to the user doing the update');
+
 		return $result;
 	}
 


### PR DESCRIPTION
## What

`Contrat::update()` builds its `UPDATE llx_contrat SET ...` statement without the `fk_user_modif` column, so the id of the user doing the modification is never stored — unlike `Commande::update()`, `Fichinter::update()` and others which all set it.

Visible symptoms:
- REST API `PUT /contracts/{id}` leaves `fk_user_modif` untouched
- cron jobs / CLI scripts / any direct `$contract->update($user)` call

## How

- Add `fk_user_modif=` to the `UPDATE` statement in `Contrat::update()`, using the same idiom as `Commande::update()`.
- Also set `$this->fk_user_modif` on the in-memory object on success.
- Add a regression assertion in `ContratTest::testContratUpdate` (checked: it fails without the fix, passes with it).

## Tests

- `phpunit test/phpunit/ContratTest.php` → OK (5 tests)
- PHPStan level 10 on `htdocs/contrat/class/contrat.class.php` → no errors

To be forward-ported 22.0 → 23.0 → 24.0 → develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)