### PR TITLE
FIX: Use the provided user (not global $user) when stamping fk_user_modif from extrafields

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -12,7 +12,7 @@
  * Copyright (C) 2017       ATM Consulting      <support@atm-consulting.fr>
  * Copyright (C) 2017-2019  Nicolas ZABOURI     <info@inovea-conseil.com>
  * Copyright (C) 2017       Rui Strecht         <rui.strecht@aliartalentos.com>
- * Copyright (C) 2018-2025  Frédéric France     <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2018       Josep Lluís Amador  <joseplluis@lliuretic.cat>
  * Copyright (C) 2023       Gauthier VERDOL     <gauthier.verdol@atm-consulting.fr>
  * Copyright (C) 2021       Grégory Blémand     <gregory.blemand@atm-consulting.fr>
@@ -7164,7 +7164,7 @@ abstract class CommonObject
 		// Update also the user of last modification in parent table
 		if (!$error && !empty($this->fields['fk_user_modif'])) {
 			$sql = "UPDATE ".$this->db->prefix().$this->table_element;
-			$sql .= " SET fk_user_modif = ".(int) $user->id;
+			$sql .= " SET fk_user_modif = ".(int) $userused->id;
 			$sql .= " WHERE ".(empty($this->table_rowid) ? 'rowid' : $this->db->sanitize($this->table_rowid))." = ".((int) $this->id);
 			$this->db->query($sql);
 		}
@@ -7592,7 +7592,7 @@ abstract class CommonObject
 			// Update also the user of last modification in parent table
 			if (!$error && !empty($this->fields['fk_user_modif'])) {
 				$sql = "UPDATE ".$this->db->prefix().$this->table_element;
-				$sql .= " SET fk_user_modif = ".(int) $user->id;
+				$sql .= " SET fk_user_modif = ".(int) $userused->id;
 				$sql .= " WHERE ".(empty($this->table_rowid) ? 'rowid' : $this->db->sanitize($this->table_rowid))." = ".((int) $this->id);
 				$this->db->query($sql);
 			}


### PR DESCRIPTION
## What

`insertExtraFields()` and `updateExtraField()` accept a `$userused` parameter (falling back to the global `$user` when empty). But when they sync `fk_user_modif` on the **parent** table, they use the global `$user` directly instead of `$userused`.

Consequence: when an explicit user is passed — REST API (`DolibarrApiAccess::$user`), cron jobs, CLI scripts, batch imports — the wrong user id is stored in `fk_user_modif` (or `0` when no global `$user` is set at all).

In a plain web request the two happen to be the same object, so the bug is invisible there.

## How

Use `$userused` on both `SET fk_user_modif = ...` lines. `$userused` is already guaranteed to be a valid `User` object at that point (set at the top of each method).

## Reproduction

With global `$user` = id 1 and `$userused` = id 3 passed explicitly:

| call | before | after |
|------|--------|-------|
| `updateExtraField('...', '...', $userused)` | stored `1` | stored `3` |
| `insertExtraFields('...', $userused)` | stored `1` | stored `3` |

## Tests

- `phpunit test/phpunit/CommonObjectTest.php` and `ContratTest.php` → OK
- PHPStan level 10 on `htdocs/core/class/commonobject.class.php` → no errors

No dedicated PHPUnit test added: exercising this needs creating/dropping an extrafield in the DB inside the test (nothing in the current suite does that), which is disproportionate for a two-line parameter fix. Verified manually with the reproduction above.

The `fk_user_modif` sync in these two methods was introduced in 23.0 (commit affaa5da9b3), so this is the oldest affected branch. To be forward-ported 23.0 → 24.0 → develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)