### PR TITLE
FIX: Contract service lines have no background on card

### DIFF
--- a/htdocs/theme/eldy/global.inc.php
+++ b/htdocs/theme/eldy/global.inc.php
@@ -1,6 +1,6 @@
 <?php
 /* Copyright (C) 2004-2024	Laurent Destailleur			<eldy@users.sourceforge.net>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025		Marc de Lima Lucio			<marc-dll@user.noreply.github.com>
  *
@@ -5261,7 +5261,7 @@ tr.liste_sub_total, tr.liste_sub_total td {
 	border-bottom: 1px solid #aaa;
 }
 /* to avoid too much border on contract card */
-.tableforservicepart1 .impair, .tableforservicepart1 .pair, .tableforservicepart2 .impair, .tableforservicepart2 .pair {
+.tableforservicepart1 .impair, .tableforservicepart1 .pair, .tableforservicepart1 .oddeven, .tableforservicepart2 .impair, .tableforservicepart2 .pair, .tableforservicepart2 .oddeven {
 	background: #FFF;
 }
 .tableforservicepart1 tbody tr td, .tableforservicepart2 tbody tr td {

--- a/htdocs/theme/md/style.css.php
+++ b/htdocs/theme/md/style.css.php
@@ -8,7 +8,7 @@
  * Copyright (C) 2018       Ferran Marcet           <fmarcet@2byte.es>
  * Copyright (C) 2021-2023  Anthony Berton          <anthony.berton@bb2a.fr>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024		Frédéric France				<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France				<frederic.france@free.fr>
  * Copyright (C) 2025		Marc de Lima Lucio			<marc-dll@user.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -5279,7 +5279,7 @@ tr.liste_sub_total, tr.liste_sub_total td {
 	border-bottom: 2px solid #aaa;
 }
 
-.tableforservicepart1 .impair, .tableforservicepart1 .pair, .tableforservicepart2 .impair, .tableforservicepart2 .pair {
+.tableforservicepart1 .impair, .tableforservicepart1 .pair, .tableforservicepart1 .oddeven, .tableforservicepart2 .impair, .tableforservicepart2 .pair, .tableforservicepart2 .oddeven {
 	background: #FFF;
 }
 .tableforservicepart1 tbody tr td, .tableforservicepart2 tbody tr td {


### PR DESCRIPTION
## What

On the contract card, the service line rows have no background of their own: the page background shows through them. Order lines, by contrast, always have a solid (striped) background.

| | markup | why it gets a background |
|---|---|---|
| Order lines | `<table id="tablelines" class="noborder noshadow">` | covered by the generic `.noborder:not(.editmode) > tbody > tr:nth-child(even/odd)` zebra rules |
| Contract service lines | `<table class="... tableforservicepart1 ...">` / `tableforservicepart2`, rows `class="oddeven"` | **nothing** — not `.noborder`/`.liste`, and the dedicated rule only matched `.impair`/`.pair` |

The dedicated rule:
```css
.tableforservicepart1 .impair, .tableforservicepart1 .pair,
.tableforservicepart2 .impair, .tableforservicepart2 .pair { background: #FFF; }
```
was never updated when `contrat/card.php` switched its line rows from `pair`/`impair` to `oddeven`. On the stock theme the area behind is white so it goes unnoticed; with a custom background colour it is clearly visible.

## How

Add `.oddeven` to that selector in both themes (`eldy/global.inc.php`, `md/style.css.php`). Value kept as `#FFF` to preserve the current appearance where rows are styled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)