### PR TITLE
FIX Mo::processBOM() ignores qty value for qty_frozen BOM lines

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -819,7 +819,7 @@ class Mo extends CommonObject
 
 		$quantity /= $bom->qty;
 		foreach ($bom->lines as $line) {
-			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : 1;
+			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : $line->qty;
 
 			$tmpproduct = new Product($this->db);
 			$tmpproduct->fetch($line->fk_product);


### PR DESCRIPTION
## FIX: `Mo::processBOM()` ignores the `qty` value for `qty_frozen` BOM lines

Fixes #38177

> Rebased version of #38178, which targeted `23.0`. Same one-line fix, now on `24.0`. The previous PR is closed in favour of this one.

### Description

When creating a Manufacturing Order from a Bill of Materials, lines marked as `qty_frozen` have their consumption quantity hardcoded to `1`, regardless of the `qty` value defined on the BOM line itself.

In `Mo::processBOM()` (`htdocs/mrp/class/mo.class.php`, line 822 on `24.0`):

```php
$quantity_line = !$line->qty_frozen
    ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1)
    : 1;   // <- always 1, ignores the BOM value
```

This is inconsistent with the documented semantics of `qty_frozen`: **"frozen"** means **"do NOT scale with the MO quantity"**, not **"force to 1"**. The line's BOM-defined `qty` should be used as-is.

### Fix

```diff
-$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : 1;
+$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : $line->qty;
```

### Testing

Run on live instances, `24.0` (24.0.0) and `23.0` (23.0.3), before and after the change, by creating real MOs from a real BOM through `Mo::create()` (which is what the MO card does).

BOM: 1 finished good ← **10 kg** of `MP1` with `qty_frozen = 1`, **2 units** of `MP2` not frozen.

| MO qty | line | before | after | expected |
|---|---|---|---|---|
| 1 | MP1 (frozen) | 1 | **10** | 10 |
| 1 | MP2 (scaled) | 2 | 2 | 2 |
| 3 | MP1 (frozen) | **1** | **10** | 10 |
| 3 | MP2 (scaled) | 6 | 6 | 6 |
| 7 | MP1 (frozen) | **1** | **10** | 10 |
| 7 | MP2 (scaled) | 14 | 14 | 14 |

- Non-frozen lines are unaffected at every quantity — the proportional scaling `$line->qty * $quantity / efficiency` is untouched.
- Same results on `23.0` and `24.0`, so the bug and the fix behave identically on both.

#### Nested BOMs — behaviour change worth reviewing

A frozen line that points to a child BOM (`fk_bom_child`) passes `$quantity_line` as the quantity modifier of the recursion, so it is affected too.

Parent BOM: 1 finished good ← **5** sub-assemblies, line frozen, exploded through a child BOM of **4** `MP2` per sub-assembly. MO of 2 finished goods:

| | consumption produced |
|---|---|
| before | 4 × `MP2` — as if a single sub-assembly were needed |
| after | **20 × `MP2`** — 5 sub-assemblies × 4, the frozen quantity honoured through the child BOM |

The new figure is the one consistent with the BOM, but this is a real behaviour change for nested BOMs with frozen lines, so I am flagging it explicitly rather than burying it.

- [x] PHP lint OK.

### Affects

The bug is present in `23.0`, `24.0` and `develop`.
