### PR TITLE
FIX MRP REST API produceAndConsumeAll records produced goods at price 0

### DIFF
--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -671,7 +671,30 @@ class Mos extends DolibarrApi
 							$stockmove->origin_type = 'mo';
 							$stockmove->origin_id = $this->mo->id;
 							if ($qtytoprocess >= 0) {
-								$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $line->fk_product, (int) $line->fk_warehouse, $qtytoprocess, 0, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
+								// Entering the produced goods into stock is the only movement that may carry
+								// a value: the manufacturing cost of one unit, that is the sum of qty * unit
+								// cost over the lines to consume, divided by the quantity produced. Unit cost
+								// follows the same priority chain as the web UI: cost_price, then pmp, then
+								// the lowest supplier price. Computed here, inside the stock entry branch, so
+								// it can never reach a stock exit.
+								$mfgcost = 0;
+								foreach ($this->mo->lines as $consumedline) {
+									if ($consumedline->role == 'toconsume') {
+										$consumedproduct = new Product($this->db);
+										$consumedproduct->fetch($consumedline->fk_product);
+										$consumedcost = price2num(!empty($consumedproduct->cost_price) ? $consumedproduct->cost_price : $consumedproduct->pmp);
+										if (empty($consumedcost)) {
+											require_once DOL_DOCUMENT_ROOT.'/fourn/class/fournisseur.product.class.php';
+											$productFournisseur = new ProductFournisseur($this->db);
+											if ($productFournisseur->find_min_price_product_fournisseur($consumedline->fk_product, $consumedline->qty) > 0) {
+												$consumedcost = $productFournisseur->fourn_unitprice;
+											}
+										}
+										$mfgcost += price2num(($consumedline->qty * $consumedcost) / ($this->mo->qty > 0 ? $this->mo->qty : 1), 'MU');
+									}
+								}
+								$mfgcost = (float) price2num($mfgcost, 'MU');
+								$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $line->fk_product, (int) $line->fk_warehouse, $qtytoprocess, $mfgcost, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
 							} else {
 								$idstockmove = $stockmove->livraison(DolibarrApiAccess::$user, $line->fk_product, (int) $line->fk_warehouse, $qtytoprocess, 0, $labelmovement, dol_now(), '', '', (string) $tmpproduct->status_batch, $id_product_batch, $codemovement);
 							}


### PR DESCRIPTION
# FIX: the MRP REST API records produced goods at price 0

> Replaces #38156, which targeted `23.0` and had drifted from its own description. Narrowed to the single change that is actually reproducible and measured, and rebased onto `24.0`. See *Scope* at the end for what was dropped and why.

## The bug

`POST /mos/{id}/produceandconsumeall` hardcodes `price = 0` on the `reception()` call that enters the produced goods into stock:

```php
$idstockmove = $stockmove->reception(..., $qtytoprocess, 0, $labelmovement, ...);
```

Every Manufacturing Order closed through the REST API therefore leaves `pmp = 0` on the produced product, which makes cost tracking unusable for any workflow that automates MO closing. The web UI does not have the problem: `mo_production.php` sends a manufacturing cost (`pricetoproduce`, preset from `cost_price` / `pmp`) on that same movement.

## The fix

Pass the manufacturing cost to `reception()` — the stock *entry* — instead of `0`. The cost of one produced unit is the sum of `qty × unit cost` over the lines to consume, divided by the quantity produced, with the priority chain the web UI already uses: `cost_price`, then `pmp`, then the lowest supplier price.

`livraison()` calls keep `price = 0`. Those are stock *exits*, and as @eldy pointed out on the previous PR, the average weighted price must never be modified on a stock exit. That review comment is what this version is built on.

## How it was verified

Run end to end on two live instances, through the real HTTP endpoint (not a unit harness), before and after the change. BOM: 1 finished good ← 2 × `MP1` + 4 × `MP2`, MO of 5, warehouse set on every line.

**Cost taken from `cost_price`** (`MP1` 3.00, `MP2` 1.50) — expected unit cost `(10×3 + 20×1.50) / 5 = 12.00`:

| movement | before | after |
|---|---|---|
| `MP1` exit, qty −10 | `price 0.00` | `price 0.00` |
| `MP2` exit, qty −20 | `price 0.00` | `price 0.00` |
| finished good entry, qty 5 | `price 0.00` | **`price 12.00`** |
| `pmp` of the finished good | `0` | **`12.00`** |

**Cost falling back to `pmp`** (no `cost_price`; `pmp` 4.00 and 2.00, built by real stock entries) — expected `(10×4 + 20×2) / 5 = 16.00`: the produced entry comes out at **`16.00`**, exits still at `0.00`.

**Non-regression, nothing known** (no `cost_price`, no `pmp`, no supplier price): the produced entry stays at **`0.00`**, i.e. identical to the current behaviour. The change can only add a cost that was previously lost, never alter one that was already correct.

Same figures on **24.0** (24.0.0) and **23.0** (23.0.3), and the patch applies cleanly to both. HTTP 200 on every call, PHP lint OK.

## Scope

The previous PR also touched two other places. Both are dropped here, deliberately:

- The `arraytoconsume` / `arraytoproduce` path of the same endpoint. Testing it showed **it cannot run at all on current `24.0`, patched or not**: `$moline->fk_stock_movement = $idstockmove;` is assigned before the movement is created, so `MoLine::create()` fails on `fk_mrp_production_stock_movement` and the endpoint answers `500`. That is a separate, pre-existing bug — I did not want to bury it inside a pricing change. Happy to open a PR for it if useful.
- `produceAndConsume()`, negative-quantity consumption. That is a return to stock, and `mo_production.php:341` passes `0` for exactly that case, so changing it here would have made the API diverge from the UI.
