### PR TITLE
FIX MRP REST API produceAndConsumeAll always fails when given explicit arrays

### DIFF
--- a/htdocs/mrp/class/api_mos.class.php
+++ b/htdocs/mrp/class/api_mos.class.php
@@ -482,7 +482,7 @@ class Mos extends DolibarrApi
 					if (empty($value["objectid"])) {
 						throw new RestException(500, "Field objectid required in ".$arrayname);
 					}
-					$tmpproduct->fetch($value["qty"]);
+					$tmpproduct->fetch($value["objectid"]);
 					if (empty($value["qty"])) {
 						throw new RestException(500, "Field qty required in ".$arrayname);
 					}
@@ -505,48 +505,34 @@ class Mos extends DolibarrApi
 
 							$stockmove->setOrigin($this->mo->element, $this->mo->id);
 
+							// Record the stock movement first: the line below stores its ID, and
+							// llx_mrp_production.fk_stock_movement is a foreign key on llx_stock_mouvement.
 							if ($arrayname == 'arraytoconsume') {
-								$moline = new MoLine($this->db);
-								$moline->fk_mo = $this->mo->id;
-								$moline->position = $pos;
-								$moline->fk_product = $value["objectid"];
-								$moline->fk_warehouse = (int) $value["fk_warehouse"];
-								$moline->qty = $qtytoprocess;
-								$moline->batch = (string) $tmpproduct->status_batch;
-								$moline->role = 'toproduce';
-								$moline->fk_mrp_production = 0;
-								$moline->fk_stock_movement = $idstockmove;
-								$moline->fk_user_creat = DolibarrApiAccess::$user->id;
-
-								$resultmoline = $moline->create(DolibarrApiAccess::$user);
-								if ($resultmoline <= 0) {
-									$error++;
-									throw new RestException(500, $moline->error);
-								}
 								$idstockmove = $stockmove->livraison(DolibarrApiAccess::$user, $value["objectid"], $value["fk_warehouse"], $qtytoprocess, 0, $labelmovement, dol_now(), '', '', (string) $tmpproduct->status_batch, $id_product_batch, $codemovement);
 							} else {
-								$moline = new MoLine($this->db);
-								$moline->fk_mo = $this->mo->id;
-								$moline->position = $pos;
-								$moline->fk_product = $value["objectid"];
-								$moline->fk_warehouse = $value["fk_warehouse"];
-								$moline->qty = $qtytoprocess;
-								$moline->batch = (string) $tmpproduct->status_batch;
-								$moline->role = 'toconsume';
-								$moline->fk_mrp_production = 0;
-								$moline->fk_stock_movement = $idstockmove;
-								$moline->fk_user_creat = DolibarrApiAccess::$user->id;
-
-								$resultmoline = $moline->create(DolibarrApiAccess::$user);
-								if ($resultmoline <= 0) {
-									$error++;
-									throw new RestException(500, $moline->error);
-								}
 								$idstockmove = $stockmove->reception(DolibarrApiAccess::$user, $value["objectid"], $value["fk_warehouse"], $qtytoprocess, 0, $labelmovement, '', '', (string) $tmpproduct->status_batch, dol_now(), $id_product_batch, $codemovement);
 							}
 							if ($idstockmove < 0) {
 								$error++;
 								throw new RestException(500, $stockmove->error);
+							}
+
+							$moline = new MoLine($this->db);
+							$moline->fk_mo = $this->mo->id;
+							$moline->position = $pos;
+							$moline->fk_product = $value["objectid"];
+							$moline->fk_warehouse = (int) $value["fk_warehouse"];
+							$moline->qty = $qtytoprocess;
+							$moline->batch = (string) $tmpproduct->status_batch;
+							$moline->role = ($arrayname == 'arraytoconsume' ? 'toproduce' : 'toconsume');
+							$moline->fk_mrp_production = 0;
+							$moline->fk_stock_movement = $idstockmove > 0 ? $idstockmove : null;
+							$moline->fk_user_creat = DolibarrApiAccess::$user->id;
+
+							$resultmoline = $moline->create(DolibarrApiAccess::$user);
+							if ($resultmoline <= 0) {
+								$error++;
+								throw new RestException(500, $moline->error ? $moline->error : implode(', ', $moline->errors));
 							}
 						}
 						if (!$error) {
@@ -564,13 +550,13 @@ class Mos extends DolibarrApi
 								$moline->role = 'produced';
 							}
 							$moline->fk_mrp_production = 0;
-							$moline->fk_stock_movement = $idstockmove;
+							$moline->fk_stock_movement = $idstockmove > 0 ? $idstockmove : null;
 							$moline->fk_user_creat = DolibarrApiAccess::$user->id;
 
 							$resultmoline = $moline->create(DolibarrApiAccess::$user);
 							if ($resultmoline <= 0) {
 								$error++;
-								throw new RestException(500, $moline->error);
+								throw new RestException(500, $moline->error ? $moline->error : implode(', ', $moline->errors));
 							}
 
 							$pos++;


### PR DESCRIPTION
# FIX: `produceAndConsumeAll` always fails when given explicit arrays

Found while testing #39942 on a live instance. It is independent of that PR — this path fails on plain `24.0`.

**Please read the *History* and *What this does not fix* sections before merging.** This is a crash fix, and I would rather have your call on the endpoint's future than merge something that half-revives it.

## Symptom

`POST /mos/{id}/produceandconsumeall` with `arraytoconsume` and `arraytoproduce` answers **`500 Internal Server Error` with an empty message**, for any payload.

## Causes

Three, all in the same block, plus one that hid them.

**1. The MO line is created before the stock movement it points to.**

```php
$idstockmove = 0;
...
$moline->fk_stock_movement = $idstockmove;   // still 0
$resultmoline = $moline->create(...);        // fails here
$idstockmove = $stockmove->livraison(...);   // movement created after
```

`llx_mrp_production.fk_stock_movement` has a foreign key on `llx_stock_mouvement`, so `0` is rejected:

```
Cannot add or update a child row: a foreign key constraint fails
(`llx_mrp_production`, CONSTRAINT `fk_mrp_production_stock_movement`
 FOREIGN KEY (`fk_stock_movement`) REFERENCES `llx_stock_mouvement` (`rowid`))
```

Fixed by recording the movement first and then storing its ID — the order `produceAndConsume()` already uses.

**2. The "consumption done" line stores the same ID unguarded.** With no `fk_warehouse`, no movement is recorded, `$idstockmove` stays `0`, and the same foreign key trips. The other paths write `$idstockmove > 0 ? $idstockmove : null`; this one now does too.

**3. `$tmpproduct` is fetched with the quantity instead of the product ID.**

```php
$tmpproduct->fetch($value["qty"]);   // objectid was meant
```

So the batch check and every error message in the block are about whatever product happens to have that `rowid`.

**And why the 500 was empty:** both "cannot create" branches reported `$moline->error`, which `CommonObject` leaves empty when the reason went to `errors[]`.

Since the two branches then differed only by the movement call and the role, they are merged into one block. No behaviour is added: the roles, the warehouse and `$pos` are the ones already in place.

## History — this is a known, parked endpoint

I found this after the fact, and it matters for what you may want to do with the PR:

- **2024-02-27, #28481** — @Humml87 reported this endpoint returning exactly this empty `500` (*"api_mos.class.php:544 at call stage"*), and noted *"I found some logical errors"*. Same failure as here, two years ago.
- **2024-05-28, #29777** — his rewrite (+125/−255) was closed without merge.
- **2024-05-29, `ccb0ae04e4`** — you renamed the method: *"API is not working, so we rename it to allow use of another one that can work correcly."* `produceAndConsume` became **`produceAndConsumeAll`**.
- **2024-05-29, `73e0dcabd3`** — you added the new `produceAndConsume`, which records only `consumed` / `produced` lines.

So this block belongs to the API you deliberately set aside. The route is still published, and it still answers `500` rather than something explicit, which is why I am proposing the fix — but you may prefer to deprecate the array form instead. Your call; I will follow it.

## Verified on a live 24.0 (24.0.0), through the HTTP endpoint

| call | before | after |
|---|---|---|
| explicit arrays, warehouse set | **500**, empty message | **200**, 3 movements recorded and linked |
| same, `fk_warehouse` key omitted | **500** at the "consumption done" line | **200**, lines written with `fk_stock_movement = NULL` |
| consume product #37 with `qty: 36`, where 36 is the ID of another, batch-managed product | **500** — *"Product MRPT-FINI must be in batch"*, naming a product that is not the one being consumed | **200** |

PHP lint OK.

## What this does **not** fix, and why I stopped here

With the crash gone, the rows this path writes are still not the ones the working endpoint writes. Same MO, same operation, measured on the bench:

`produceandconsume` (the working one) — each line done is attached to the line planned:

```
rowid  product  qty  role      fk_mrp_production  fk_stock_movement
147    36        5   consumed  144                80
148    37       10   produced  145                81
149    38       20   produced  146                82
```

`produceandconsumeall` with the explicit arrays, this PR applied — a duplicate planned line per entry, with the role the other way round, and the line done left unattached:

```
rowid  product  qty  role       fk_mrp_production  fk_stock_movement
153    36        5   toproduce  0                  83   <- product being consumed, declared "to produce"
154    36        5   consumed   0                  83
155    37       10   toconsume  0                  84   <- product being produced, declared "to consume"
156    37       10   produced   0                  84
```

Two separate problems: the role assignment (`arraytoconsume` writes `'toproduce'` and vice versa), and `fk_mrp_production = 0` instead of the planned line's ID. Checked on both MO shapes — a manufacturing BOM (`bomtype 0`: main product `toproduce`, components `toconsume`) and a disassembly BOM (`bomtype 1`: main product `toconsume`, components `toproduce`) — the assignment is wrong in both, so it is not a disassembly special case.

I left all of that untouched: it is a data-model change on an endpoint you parked, not a crash. Tell me which you want and I will do it here or in a follow-up:

1. merge this as a crash fix and leave the rest;
2. let me also put the roles right and attach `fk_mrp_production`, so the array form behaves like `produceAndConsume`;
3. drop this and deprecate the array form instead — I will send documentation and a clear error message rather than a fix.
