### PR TITLE
FIX #39933 Localize edited line quantity

### DIFF
--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -284,7 +284,7 @@ $coldisplay++;
 		// for example always visible on invoice but must be visible only if stock module on and stock decrease option is on invoice validation and status is not validated
 		// must also not be output for most entities (proposal, intervention, ...)
 		//if($line->qty > $line->stock) print img_picto($langs->trans("StockTooLow"),"warning", 'style="vertical-align: bottom;"')." ";
-		print '<input size="3" type="text" class="flat right" name="qty" id="qty" value="'.(GETPOSTISSET('qty') ? GETPOST('qty') : $line->qty).'"';
+		print '<input size="3" type="text" class="flat right" name="qty" id="qty" value="'.(GETPOSTISSET('qty') ? GETPOST('qty') : price($line->qty, 0, '', 0, 0)).'"';
 		if ($situationinvoicelinewithparent) {	// Do not allow editing during a situation cycle
 			print ' readonly';
 		}


### PR DESCRIPTION
## Summary

- format stored line quantities with the active locale in edit forms
- preserve the submitted quantity unchanged when redisplaying validation errors
- reuse the same formatter already used by the line view template

## Root cause

The shared edit template writes the database float directly into the input value. In a French locale, a stored quantity such as `1.5` is therefore displayed with a dot even though the form parser and surrounding amounts use a comma.

## Verification

- focused Dolibarr formatter proof with French separators: `1.5` renders as `1,5` and parses back to `1.5`
- `php -l htdocs/core/tpl/objectline_edit.tpl.php`
- `git diff --check`
- confirmed the same raw rendering exists on 22.0 through develop

The separate malformed mixed-separator input behavior mentioned in the report is intentionally out of scope.

Fixes #39933