### PR TITLE
FIX #39680 Disable unavailable BookCal document generation

### DIFF
--- a/htdocs/bookcal/class/availabilities.class.php
+++ b/htdocs/bookcal/class/availabilities.class.php
@@ -950,29 +950,7 @@ class Availabilities extends CommonObject
 	 */
 	public function generateDocument($modele, $outputlangs, $hidedetails = 0, $hidedesc = 0, $hideref = 0, $moreparams = null)
 	{
-		global $langs;
-
-		$result = 0;
-
-		$langs->load("agenda");
-
-		if (!dol_strlen($modele)) {
-			$modele = 'standard_availabilities';
-
-			if (!empty($this->model_pdf)) {
-				$modele = $this->model_pdf;
-			} elseif (getDolGlobalString('AVAILABILITIES_ADDON_PDF')) {
-				$modele = getDolGlobalString('AVAILABILITIES_ADDON_PDF');
-			}
-		}
-
-		$modelpath = "core/modules/bookcal/doc/";
-
-		if (!empty($modele)) {
-			$result = $this->commonGenerateDocument($modelpath, $modele, $outputlangs, $hidedetails, $hidedesc, $hideref, $moreparams);
-		}
-
-		return $result;
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- disable BookCal availability document generation while no generator exists
- avoid loading the nonexistent `standard_availabilities` document model after create/update
- remove the dead generator path while preserving the public method and its disabled return value

## Root cause

Cleanup commit `fd2ea78e9bf` removed the old document-generation disable condition even though no BookCal availability document generator exists. The common create/update action therefore called `commonGenerateDocument()` and reported `Failed to load doc generator with modelpaths=core/modules/bookcal/doc/ - modele=standard_availabilities`.

`Calendar::generateDocument()` already returns `0` while its document generator is unavailable. This patch gives availabilities the same behavior.

## Verification

- focused runtime proof: `generateDocument()` returns without calling a generator
- PHP syntax check
- PHP_CodeSniffer with the project ruleset
- codespell
- `git diff --check`

Fix #39680