### PR TITLE
Fix deposit receipt download link

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -9,7 +9,7 @@
  * Copyright (C) 2013		Florian Henry			<florian.henry@open-concept.pro>
  * Copyright (C) 2014-2015	Marcos García			<marcosgdf@gmail.com>
  * Copyright (C) 2018   	Nicolas ZABOURI			<info@inovea-conseil.com>
- * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2015-2018	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2024		William Mead			<william.mead@manchenumerique.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
@@ -1415,6 +1415,7 @@ class Contrat extends CommonObject
 		$sql .= " note_private=".(isset($this->note_private) ? "'".$this->db->escape($this->note_private)."'" : "null").",";
 		$sql .= " note_public=".(isset($this->note_public) ? "'".$this->db->escape($this->note_public)."'" : "null").",";
 		$sql .= " import_key=".(isset($this->import_key) ? "'".$this->db->escape($this->import_key)."'" : "null").",";
+		$sql .= " fk_user_modif=".(isset($user->id) ? ((int) $user->id) : "null").",";
 		$sql .= " extraparams=".(isset($extraparams) ? "'".$this->db->escape($extraparams)."'" : "null");
 		$sql .= " WHERE rowid=".((int) $this->id);
 
@@ -1451,6 +1452,9 @@ class Contrat extends CommonObject
 			$this->db->rollback();
 			return -1 * $error;
 		} else {
+			if (isset($user->id)) {
+				$this->fk_user_modif = (int) $user->id;
+			}
 			$this->db->commit();
 			return 1;
 		}

--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -8,6 +8,7 @@
  * Copyright (C) 2022		Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2023		Anthony Berton			<anthony.berton@bb2a.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		Nathan Pixodeo			<nathan@pixodeo.net>
  *
  *
  * This program is free software; you can redistribute it and/or modify
@@ -686,6 +687,7 @@ class FormMail extends Form
 						&& !preg_match('/user_aliases/', $this->fromtype)
 						&& !preg_match('/global_aliases/', $this->fromtype)
 						&& !preg_match('/senderprofile/', $this->fromtype)
+						&& !preg_match('/from_template_(\d+)/', $this->fromtype)
 					) {
 						// Use this->fromname and this->frommail or error if not defined
 						$out .= $this->fromname;

--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -284,7 +284,7 @@ $coldisplay++;
 		// for example always visible on invoice but must be visible only if stock module on and stock decrease option is on invoice validation and status is not validated
 		// must also not be output for most entities (proposal, intervention, ...)
 		//if($line->qty > $line->stock) print img_picto($langs->trans("StockTooLow"),"warning", 'style="vertical-align: bottom;"')." ";
-		print '<input size="3" type="text" class="flat right" name="qty" id="qty" value="'.(GETPOSTISSET('qty') ? GETPOST('qty') : $line->qty).'"';
+		print '<input size="3" type="text" class="flat right" name="qty" id="qty" value="'.(GETPOSTISSET('qty') ? GETPOST('qty') : price($line->qty, 0, '', 0, 0)).'"';
 		if ($situationinvoicelinewithparent) {	// Do not allow editing during a situation cycle
 			print ' readonly';
 		}

--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -1046,8 +1046,8 @@ class EcmFiles extends CommonObject
 				$tmppath = preg_replace('/^(\d+\/)?fournisseur\/commande\//', '', $this->filepath);
 			} elseif ($option == 'tax-vat') {	// Remove part "tax/vat/"
 				$tmppath = preg_replace('/^(\d+\/)?tax\/vat\//', '', $this->filepath);
-			} elseif ($option == 'remisecheque') {	// Remove part "tax/vat/"
-				$tmppath = preg_replace('/^bank\/checkdeposits\//', '', $this->filepath);
+			} elseif ($option == 'remisecheque') {	// Remove part "[entityid/]bank/checkdeposits/"
+				$tmppath = preg_replace('/^(\d+\/)?bank\/checkdeposits\//', '', $this->filepath);
 			} else {
 				if ((int) $this->entity > 1) {
 					// Remove the part "entityid/commande/" into "entityid/commande/REFXXX" to get only the ref

--- a/test/phpunit/ContratTest.php
+++ b/test/phpunit/ContratTest.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2010-2014 Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2023      Alexandre Janniaux   <alexandre.janniaux@gmail.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -156,6 +156,13 @@ class ContratTest extends CommonClassTest
 
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
+
+		// Check that the user of last modification has been recorded
+		$sql = "SELECT fk_user_modif FROM ".MAIN_DB_PREFIX."contrat WHERE rowid = ".((int) $localobject->id);
+		$resql = $db->query($sql);
+		$objcheck = $db->fetch_object($resql);
+		$this->assertEquals($user->id, $objcheck->fk_user_modif, 'fk_user_modif must be set to the user doing the update');
+
 		return $result;
 	}
 


### PR DESCRIPTION
## Bug

On a multi-entity setup (Multicompany, entity id > 1), clicking the **file name**
of the generated PDF in the "Attached files" block of a check deposit
(Bank > Check deposits > card) returns:

```
ErrorFileDoesNotExists: 3/bank/checkdeposits/CHK-26-08-00022/bordereau-CHK-26-08-00022.pdf
```

Downloading the very same file through the preview (magnifier) icon works fine,
which makes the bug easy to miss.

## How to reproduce

1. Enable Multicompany and work in an entity whose id is > 1.
2. Give the user the **ECM read** permission (`ecm->read`). This is required:
   without it, `FormFile::showdocuments()` falls back to a plain link
   (`html.formfile.class.php`, "Define relative path for download link") which is
   correct, and the bug does not show up.
3. Create and validate a check deposit, then generate its PDF (`blochet` model).
4. Click on the **file name** in the "Attached files" block.

## Root cause

`llx_ecm_files.filepath` is stored relative to `DOL_DATA_ROOT`, so on any entity
other than 1 it always carries the entity prefix. This is done by
`addFileIntoDatabaseIndex()` in `core/lib/files.lib.php`:

```php
$rel_dir = preg_replace('/^'.preg_quote(DOL_DATA_ROOT, '/').'/', '', $dir);
```

Actual row for the file above:

| filepath | filename | entity |
|---|---|---|
| `3/bank/checkdeposits/CHK-26-08-00022` | `bordereau-CHK-26-08-00022.pdf` | 3 |

`EcmFiles::getNomUrl()` must strip the module part of that path before building
the `document.php` URL. Every branch handles the optional entity prefix
with `(\d+\/)?` — except the `remisecheque` one:

```php
} elseif ($option == 'facture_fournisseur') {
    $tmppath = preg_replace('/^(\d+\/)?fournisseur\/facture\//', '', $this->filepath);
} elseif ($option == 'commande_fournisseur') {
    $tmppath = preg_replace('/^(\d+\/)?fournisseur\/commande\//', '', $this->filepath);
} elseif ($option == 'tax-vat') {
    $tmppath = preg_replace('/^(\d+\/)?tax\/vat\//', '', $this->filepath);
} elseif ($option == 'remisecheque') {
    $tmppath = preg_replace('/^bank\/checkdeposits\//', '', $this->filepath);  // <-- (\d+\/)? missing
} else {
    if ((int) $this->entity > 1) { ... }   // even the default branch handles it
}
```

Because the regex is anchored on `^bank/`, nothing is stripped when the path
starts with `3/`, and `$tmppath` keeps the whole `3/bank/checkdeposits/CHK-26-08-00022`.

`document.php` then prepends the module directory a second time, in
`dol_check_secure_access_document()` (`core/lib/files.lib.php`):

```php
$original_file = $conf->bank->dir_output.'/checkdeposits/'.$original_file;
```

which produces a duplicated path:

```
/…/documents/3/bank/checkdeposits/  +  3/bank/checkdeposits/CHK-26-08-00022/bordereau-….pdf
```

The file obviously does not exist there, hence `ErrorFileDoesNotExists`.

On entity 1 the `filepath` has no numeric prefix, the regex matches, and
everything works — which is why this went unnoticed.

Side note: the inline comment on that branch is a leftover copy/paste from the
`tax-vat` branch above (`// Remove part "tax/vat/"`), which supports the
"forgotten line" hypothesis.

## Fix

Handle the optional entity prefix, exactly like the neighbouring branches, and
fix the misleading comment.

```diff
-			} elseif ($option == 'remisecheque') {	// Remove part "tax/vat/"
-				$tmppath = preg_replace('/^bank\/checkdeposits\//', '', $this->filepath);
+			} elseif ($option == 'remisecheque') {	// Remove part "[entityid/]bank/checkdeposits/"
+				$tmppath = preg_replace('/^(\d+\/)?bank\/checkdeposits\//', '', $this->filepath);
```

## No regression on single-entity setups

| `filepath` | before | after |
|---|---|---|
| `bank/checkdeposits/CHK-26-08-00022` | `CHK-26-08-00022` | `CHK-26-08-00022` |
| `3/bank/checkdeposits/CHK-26-08-00022` | `3/bank/checkdeposits/CHK-26-08-00022` ❌ | `CHK-26-08-00022` ✅ |
| `12/bank/checkdeposits/CHK-26-08-00022` | `12/bank/checkdeposits/CHK-26-08-00022` ❌ | `CHK-26-08-00022` ✅ |

The single-entity case is byte-for-byte unchanged.

## Affected versions

Reproduced on **22.0.5**. The block is byte-identical in **23.0.4**, **24.0.0**
and current **develop**, so all of them are affected.
