### PR TITLE
Variant fix

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -2390,7 +2390,6 @@ if ($action == 'create') {
 
 		print '<td class="titlefieldcreate fieldrequired">' . $langs->trans('Customer') . '</td>';
 		$shipping_method_id = 0;
-		$warehouse_id = 0;
 
 		if ($socid > 0) {
 			print '<td class="valuefieldcreate">';

--- a/htdocs/core/tpl/objectline_create.tpl.php
+++ b/htdocs/core/tpl/objectline_create.tpl.php
@@ -758,6 +758,40 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 
 	/* JQuery for product free or predefined select */
 	jQuery(document).ready(function() {
+		function getSelectedProductCombinationsData() {
+			var data = {};
+			jQuery('#attributes_box select[name^="combinations["]').each(function() {
+				data[jQuery(this).attr('name')] = jQuery(this).val();
+			});
+			return data;
+		}
+
+		function refreshProductPriceFromSelectedCombinations() {
+			var productId = jQuery('#idprod').val();
+			if (!productId) {
+				return;
+			}
+
+			var postData = jQuery.extend({
+				'id': productId,
+				'socid': <?php print $object->socid; ?>,
+				'token': '<?php print currentToken(); ?>',
+				'addalsovatforthirdpartyid': 1
+			}, getSelectedProductCombinationsData());
+
+			jQuery.post('<?php echo DOL_URL_ROOT; ?>/product/ajax/products.php?action=fetch', postData, function(data) {
+				if (<?php echo (int) $inputalsopricewithtax; ?> == 1 && data.pricebasetype == 'TTC' && <?php print getDolGlobalInt('MAIN_NO_INPUT_PRICE_WITH_TAX') ? 'false' : 'true'; ?>) {
+					jQuery('#price_ttc').val(data.price_ttc);
+				} else {
+					jQuery('#price_ht').val(data.price_ht);
+				}
+			}, 'json');
+		}
+
+		jQuery(document).on('change', '#attributes_box select[name^="combinations["]', function() {
+			refreshProductPriceFromSelectedCombinations();
+		});
+
 		jQuery("#price_ht").keyup(function(event) {
 			// console.log(event.which);		// discard event tag and arrows
 			if (event.which != 9 && (event.which < 37 ||event.which > 40) && jQuery("#price_ht").val() != '') {
@@ -892,7 +926,7 @@ if (!empty($usemargins) && $user->hasRight('margins', 'creer')) {
 					// Get the price for the product and display it
 					console.log("Load unit price and set it into #price_ht or #price_ttc for product id="+$(this).val()+" socid=<?php print $object->socid; ?>");
 					$.post('<?php echo DOL_URL_ROOT; ?>/product/ajax/products.php?action=fetch',
-						{ 'id': $(this).val(), 'socid': <?php print $object->socid; ?>, 'token': '<?php print currentToken(); ?>', 'addalsovatforthirdpartyid': 1 },
+						jQuery.extend({ 'id': $(this).val(), 'socid': <?php print $object->socid; ?>, 'token': '<?php print currentToken(); ?>', 'addalsovatforthirdpartyid': 1 }, getSelectedProductCombinationsData()),
 						function(data) {
 							console.log("objectline_create.tpl Load unit price ends, we got value ht="+data.price_ht+" ttc="+data.price_ttc+" pricebasetype="+data.pricebasetype);
 

--- a/htdocs/product/ajax/products.php
+++ b/htdocs/product/ajax/products.php
@@ -91,12 +91,27 @@ if ($action == 'fetch' && !empty($id)) {
 	// action='fetch' is used to get product information on a product. So when action='fetch', id must be the product id.
 	require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 	require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
+	if (isModEnabled('variants')) {
+		require_once DOL_DOCUMENT_ROOT.'/variants/class/ProductCombination.class.php';
+	}
 
 	top_httphead('application/json');
 
 	$outjson = array();
 
 	$object = new Product($db);
+	if (isModEnabled('variants')) {
+		$combinations = GETPOST('combinations', 'array:alphanohtml');
+		if (!empty($combinations)) {
+			$prodcomb = new ProductCombination($db);
+			$combination = $prodcomb->fetchByProductCombination2ValuePairs($id, $combinations);
+			if ($combination) {
+				// Fetch the concrete variant product so returned prices include the configured price impact.
+				$id = (int) $combination->fk_product_child;
+			}
+		}
+	}
+
 	$ret = $object->fetch($id);
 	if ($ret > 0) {
 		$outref = $object->ref;


### PR DESCRIPTION
# Fix #32625 Apply variants on sales lines

Prices variants were not applied when selecting it in propal or invoice.

With this fix, selecting a variant changes automatically the price to reflect variant in value or in percentage.

Important note: because I am not experimented developper, this patch has been guided by AI. I could understand this it doesn't respect guidelines, so feel free to rewrite the solution. But I really need this function working. Thanks for your comprehension.