### PR TITLE
Fix Silent failure when mass deleting bookkeeping entries outside active fiscal period

### DIFF
--- a/htdocs/accountancy/bookkeeping/list.php
+++ b/htdocs/accountancy/bookkeeping/list.php
@@ -521,6 +521,10 @@ if (empty($reshook)) {
 					$result = $object->deleteMvtNum($object->piece_num);
 					if ($result > 0) {
 						$nbok++;
+					} elseif ($result == 0) {
+						setEventMessages($langs->trans("ErrorBookkeepingDocDateNotOnActiveFiscalPeriod"), null, 'errors');
+						$error += 1;
+						break;
 					} else {
 						setEventMessages($object->error, $object->errors, 'errors');
 						$error += 1;

--- a/htdocs/accountancy/bookkeeping/listbyaccount.php
+++ b/htdocs/accountancy/bookkeeping/listbyaccount.php
@@ -518,6 +518,10 @@ if (empty($reshook)) {
 					$result = $object->deleteMvtNum($object->piece_num);
 					if ($result > 0) {
 						$nbok++;
+					} elseif ($result == 0) {
+						setEventMessages($langs->trans("ErrorBookkeepingDocDateNotOnActiveFiscalPeriod"), null, 'errors');
+						$error += 1;
+						break;
 					} else {
 						setEventMessages($object->error, $object->errors, 'errors');
 						$error += 1;


### PR DESCRIPTION
# FIX Fix Silent failure when mass deleting bookkeeping entries outside active fiscal period

When using mass delete in **Comptabilité → Journaux** (`list.php` / `listbyaccount.php`), if the selected entries have a `doc_date` outside the active fiscal period, `deleteMvtNum()` returns `0` (no rows deleted due to the fiscal period SQL filter) but `$object->error` is empty.
                                                                                                                                                                                                                                                
The existing `else` branch calls `setEventMessages($object->error, $object->errors, 'errors')` with empty parameters, which triggers only a silent `dol_syslog` warning, no message is shown to the user, and the transaction is rolled back silently.
                                                                                                                                                                                                                                                
**Fix:** explicitly handle `$result == 0` with the existing translation key `ErrorBookkeepingDocDateNotOnActiveFiscalPeriod` to inform the user that the deletion was blocked because the document date is not within the active fiscal period.

**Files changed:**
- `htdocs/accountancy/bookkeeping/list.php`                                                                                                                                                                                                    
- `htdocs/accountancy/bookkeeping/listbyaccount.php`