### PR TITLE
FIX insertExtraFields() silently stored null for an unresolvable link extrafield

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -7212,7 +7212,11 @@ abstract class CommonObject
 
 							$obj = $this->db->getRow($sqlFetchObject);
 
-							if ($obj !== false) {
+							// getRow() returns an object on success, int 0 when the query succeeded but
+							// returned no row, and false on SQL failure. Testing "!== false" let the 0
+							// through as a success: $obj->rowid on an int is null, $res was set to 1 and
+							// null was stored in the column while a success was reported.
+							if (is_object($obj)) {
 								$objectId = $obj->rowid;
 								$res = 1;
 							} else {


### PR DESCRIPTION
# FIX insertExtraFields() silently stored null for an unresolvable link extrafield

`DoliDB::getRow()` has three possible return values, as documented in its own docblock:

```php
 * @return 	bool|int|object    			False on failure, 0 on empty, object on success
```

In the `case 'link'` branch of `CommonObject::insertExtraFields()`, the result was tested with `if ($obj !== false)`. The `int 0` returned when the query succeeds but matches no row — that is, exactly the "id or ref not found" case this check was added for — therefore fell into the success branch:

```php
$obj = $this->db->getRow($sqlFetchObject);

if ($obj !== false) {          // 0 !== false is true
    $objectId = $obj->rowid;   // (0)->rowid evaluates to null
    $res = 1;                  // reported as a success
} else {
    $res = -1;
}

if ($res > 0) {
    $new_array_options[$key] = $objectId;   // null is stored
} else {
    $this->error = "Id/Ref '".$value."' for object '".$object->element."' not found";
    return -1;
}
```

So `null` was stored in the extrafield column while the method returned a success, with no error message and no log entry. The error branch below was only ever reached on an actual SQL failure.

Using `is_object()` makes the not-found case reach that error branch as originally intended, and leaves both the SQL failure case and the nominal case unchanged:

| `getRow()` returns | before | after |
|---|---|---|
| object (found) | success | success, unchanged |
| `0` (no row) | **success, null stored** | error, `return -1` |
| `false` (SQL error) | error | error, unchanged |

The impact is worse for a `link` extrafield whose target class does not always resolve to the same table: the id is then looked up in the wrong table, is not found, and the stored value is destroyed. Because the id ranges of two tables usually overlap, the value survives whenever the id happens to exist in the other table too, which makes the data loss intermittent and hard to notice.

Introduced by #33460, which replaced two `$object->fetch()` calls with a single `getRow()` query.
