### PR TITLE
FIX: Product API returns many fields unrelated to the product

### DIFF
--- a/htdocs/api/class/api.class.php
+++ b/htdocs/api/class/api.class.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2016		Laurent Destailleur		<eldy@users.sourceforge.net>
 /* Copyright (C) 2015       Jean-François Ferry     <jfefe@aternatik.fr>
  * Copyright (C) 2016	    Laurent Destailleur		<eldy@users.sourceforge.net>
- * Copyright (C) 2020-2025  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2020-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2025-2026	William Mead			<william@m34d.com>
  *
@@ -376,6 +376,13 @@ class DolibarrApi
 		unset($object->stats_reception);
 		unset($object->stats_mrptoconsume);
 		unset($object->stats_mrptoproduce);
+		unset($object->stats_bom);
+		unset($object->stats_mo);
+		unset($object->stats_expedition);
+		unset($object->stats_facturerec);
+		unset($object->stats_facture_fournisseur);
+		unset($object->stats_facturefournrec);
+		unset($object->stats_proposal_supplier);
 
 		unset($object->fieldsforcombobox);
 		unset($object->regeximgext);

--- a/htdocs/product/class/api_products.class.php
+++ b/htdocs/product/class/api_products.class.php
@@ -2433,6 +2433,49 @@ class Products extends DolibarrApi
 		}
 
 		unset($object->module);
+
+		// Document/line totals carried by CommonObject: always empty for a standalone product
+		unset($object->total_ht);
+		unset($object->total_tva);
+		unset($object->total_ttc);
+		unset($object->total_localtax1);
+		unset($object->total_localtax2);
+		unset($object->multicurrency_total_ht);
+		unset($object->multicurrency_total_tva);
+		unset($object->multicurrency_total_ttc);
+		unset($object->multicurrency_total_localtax1);
+		unset($object->multicurrency_total_localtax2);
+		unset($object->totalpaid);
+		unset($object->totalpaid_multicurrency);
+
+		// Validation/closure workflow fields: a product is never validated or closed
+		unset($object->date_validation);
+		unset($object->date_cloture);
+		unset($object->user_validation_id);
+		unset($object->user_closing_id);
+
+		// Supplier buying-price context: only filled after get_buyprice(), not by a plain read
+		// (complements fourn_pu / fourn_socid / ref_fourn / product_fourn_id already removed above)
+		unset($object->buyprice);
+		unset($object->fourn_qty);
+		unset($object->fourn_multicurrency_price);
+		unset($object->fourn_multicurrency_unitprice);
+		unset($object->fourn_multicurrency_tx);
+		unset($object->fourn_multicurrency_id);
+		unset($object->fourn_multicurrency_code);
+		unset($object->vatrate_supplier);
+		unset($object->desc_supplier);
+		unset($object->default_vat_code_supplier);
+		unset($object->product_fourn_price_id);
+
+		// Transient scaffolding not related to the product record
+		unset($object->specimen);
+		unset($object->canvas);
+		unset($object->res);
+		unset($object->other);
+		unset($object->warehouse);
+		unset($object->warehouse_id);
+
 		return $object;
 	}
 


### PR DESCRIPTION
## What / Why

`Products::get()` / `getByRef()` / `getByRefExt()` / `getByBarcode()` currently return ~160 top-level keys. About a third of them are empty `CommonObject` fields or transient `Product` properties that are never populated on a product read and have nothing to do with the product record (document totals, validation/closure workflow fields, supplier buying-price context filled only by `get_buyprice()`, and framework scaffolding).

This makes responses noisier and larger than needed (also relevant for anyone caching them).

## Changes

- `htdocs/api/class/api.class.php::_cleanObjectDatas()` — also strip the `stats_*` accumulator arrays that were added to `Product` after the original list and never added here: `stats_bom`, `stats_mo`, `stats_expedition`, `stats_facturerec`, `stats_facture_fournisseur`, `stats_facturefournrec`, `stats_proposal_supplier`. Same intent as the eight `stats_*` already unset just above.
- `htdocs/product/class/api_products.class.php::_cleanObjectDatas()` — strip:
  - document/line totals: `total_ht/tva/ttc/localtax1/localtax2`, `multicurrency_total_*`, `totalpaid`, `totalpaid_multicurrency`
  - validation/closure workflow: `date_validation`, `date_cloture`, `user_validation_id`, `user_closing_id`
  - remaining supplier buying-price context: `buyprice`, `fourn_qty`, `fourn_multicurrency_*`, `vatrate_supplier`, `desc_supplier`, `default_vat_code_supplier`, `product_fourn_price_id` (complements `fourn_pu` / `fourn_socid` / `ref_fourn` / `product_fourn_id` already removed)
  - transient scaffolding: `specimen`, `canvas`, `res`, `other`, `warehouse`, `warehouse_id`

All removed properties are always `null` / `0` / `[]` on a product read. Real product data (`pmp`, `cost_price`, `accountancy_code_*`, `multiprices*`, `array_options`, stock fields, …) is untouched.

## Impact

Behaviour change on the response shape: the product GET payload goes from ~162 to ~123 top-level keys. No consumer can be relying on a meaningful value in the removed keys since they are always empty.

## Tests

- `php -l` on both files, PHPStan (pre-commit, level from `phpstan.neon.dist`) and phpcs pass.
- Manual: `GET` on a product with `includestockdata` + `includesubproducts` + `includeparentid` + `includetrans` — targeted keys gone, core product fields intact.



Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
