### PR TITLE
FIX Task extrafield filter on time spent per week page triggers SQL error

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1265,6 +1265,7 @@ class Task extends CommonObjectLine
 		// Add where from extra fields
 		$extrafieldsobjectkey = 'projet_task';
 		$extrafieldsobjectprefix = 'efpt.';
+		$search_options_pattern = 'search_(task_)?options_'; // Callers use keys 'search_options_xxx' (tasks.php) or 'search_task_options_xxx' (perweek.php)
 		global $db, $conf; // needed for extrafields_list_search_sql.tpl
 		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 


### PR DESCRIPTION
On Projects > Activity > Time spent (per week) (`projet/activity/perweek.php`), submitting the filter form with any value in a task extrafield search input makes the page fail with a technical error:

```
DB_ERROR_NOSUCHFIELD - Unknown column 'efpt.search_task_options_<name>' in 'WHERE'
```

To reproduce: create an extrafield (e.g. type boolean) on the Task element, open the Time spent per week page, pick a value in that extrafield's filter and submit. The generated SQL contains e.g. `AND (efpt.search_task_options_<name> LIKE '%-1%')`.

Cause: `perweek.php` builds its task search criteria with `$extrafields->getOptionalsFromPost('projet_task', '', 'search_task_')`, producing keys `search_task_options_<name>`, and passes them to `Task::getTasksArray()`. That method includes `core/tpl/extrafields_list_search_sql.tpl.php` without setting `$search_options_pattern`, so the template falls back to `'search_options_'`. The `preg_replace` that strips the key prefix does not match, the extrafield type lookup fails (PHP warning "Undefined array key"), and the generic LIKE branch builds the WHERE clause on the literal POST key instead of the column name.

Fix: set `$search_options_pattern = 'search_(task_)?options_'` before the include. The template uses the variable inside a `preg_replace()`, so this single pattern handles both key forms reaching `getTasksArray()`: `search_task_options_*` from `perweek.php` and plain `search_options_*` from `projet/tasks.php` (the other caller passing search filters).

Note: 23.0 got a partial fix for this in #38564 (since 23.0.4), but its fixed-string pattern `'search_task_options_'` breaks the `tasks.php` caller the same way (#39911) - separate follow-up PR opened on 23.0 for that: #39967. This PR fixes 22.0, which never received the backport. When merging 22.0 upward, this line should resolve in favor of the regex form.