### PR TITLE
FIX Task extrafield filter on project task list triggers SQL error (follow-up of #38564)

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -1268,7 +1268,7 @@ class Task extends CommonObjectLine
 		// Add where from extra fields
 		$extrafieldsobjectkey = 'projet_task';
 		$extrafieldsobjectprefix = 'efpt.';
-		$search_options_pattern = 'search_task_options_'; // Aligned with perweek.php/perday.php that build $search_array_options with this prefix (via extrafields->getOptionalsFromPost('projet_task', '', 'search_task_')). Without it, the SQL template falls back to 'search_options_' and the preg_replace fails to strip the actual prefix, generating phantom column names like efpt.search_task_options_<field>.
+		$search_options_pattern = 'search_(task_)?options_'; // Callers use keys 'search_options_xxx' (tasks.php) or 'search_task_options_xxx' (perweek.php)
 		global $db, $conf; // needed for extrafields_list_search_sql.tpl
 		include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 


### PR DESCRIPTION
Fixes #39911. Follow-up of #38564.

Since #38564 (in 23.0.4), filtering the task list of a project (`projet/tasks.php`) by a task extrafield fails with a technical error:

```
DB_ERROR_NOSUCHFIELD - Unknown column 'efpt.search_options_<name>' in 'WHERE'
```

To reproduce: create an extrafield on the Task element, open a project's Tasks tab, pick a value in that extrafield's filter and submit.

Cause: #38564 set `$search_options_pattern` to the fixed string `'search_task_options_'` in `Task::getTasksArray()`, matching the keys built by `perweek.php`. But `projet/tasks.php` builds its criteria with `getOptionalsFromPost($taskstatic->table_element, '', 'search_')`, producing plain `search_options_<name>` keys, which that pattern no longer strips - same failure mode as the original bug, on the other caller.

Note that #39916 (develop) tried to fix #39911 by changing the template's *default* pattern to `'search_(task_)?options_'`, but that default only applies when the caller does not set the variable: `getTasksArray()` does set it, so the template default is shadowed and the error still occurs on current develop after #39916 (verified on a live develop instance: perweek OK, tasks.php still fails).

Fix: use the pattern `'search_(task_)?options_'` in `getTasksArray()` itself - the template applies it via `preg_replace()`, so both key forms are handled (`tasks.php` and `perweek.php`). Same value as the template default introduced by #39916, now applied where it is effective. Verified on a live instance: no more SQL error on either page, and the filter semantics are correct for both key forms.

Same issue fixed on 22.0 (which never received the #38564 backport, so the original perweek error is still live there): #39966
