### PR TITLE
Fix HTML output for trextrafieldseparator

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2870,7 +2870,7 @@ class ExtraFields
 			$disabledcookiewrite = 1; // We keep status of group unchanged into the cookie
 		}
 
-		$out = '<'.$tagtype.' id="trextrafieldseparator'.$key.(!empty($object->id) ? '_'.$object->id : '').'" class="trextrafieldseparator trextrafieldseparator'.$key.(!empty($object->id) ? '_'.$object->id : '').'">';
+		$out = '<'.$tagtype.' id="trextrafieldseparator'.$key.'" class="trextrafieldseparator trextrafieldseparator'.$key.'">';
 		$out .= '<'.$tagtype_dyn.' '.(!empty($colspan) ? 'colspan="' . $colspan . '"' : '').'>';
 		if ($mode == 'create' || $mode == 'edit') {
 			$out .= '<br>';


### PR DESCRIPTION
key is note necessary in html id and in html class it's quite counterproductive at this place

<img width="745" height="340" alt="image" src="https://github.com/user-attachments/assets/c90a7940-2715-4cf9-8aae-ccea3d4daced" />

