### PR TITLE
FIX: Subtotals - fix updateSubtotalLineBlockLines() (wrong property, OOB loop, missing branches)

### DIFF
--- a/htdocs/subtotals/class/commonsubtotal.class.php
+++ b/htdocs/subtotals/class/commonsubtotal.class.php
@@ -766,7 +766,7 @@ trait CommonSubtotal
 						$this->lines[$i]->product_type,
 						$this->lines[$i]->array_options,
 						$this->lines[$i]->ref_supplier,
-						$this->lines[$i]->fk_unit,
+						(int) $this->lines[$i]->fk_unit,
 						$this->lines[$i]->multicurrency_subprice
 					);
 				} elseif ($current_module == 'order_supplier' && $this instanceof CommandeFournisseur) {

--- a/htdocs/subtotals/class/commonsubtotal.class.php
+++ b/htdocs/subtotals/class/commonsubtotal.class.php
@@ -649,7 +649,7 @@ trait CommonSubtotal
 		$result = 0;
 		$linerang -= 1;
 
-		$nb_lines = count($this->lines)+1;
+		$nb_lines = count($this->lines);
 
 		for ($i = $linerang+1; $i < $nb_lines; $i++) {
 			if ($this->lines[$i]->special_code == SUBTOTALS_SPECIAL_CODE) {
@@ -697,8 +697,8 @@ trait CommonSubtotal
 						$this->lines[$i]->qty,
 						$mode == 'discount' ? $value : $this->lines[$i]->remise_percent,
 						$mode == 'tva' ? $value : $this->lines[$i]->tva_tx,
-						$this->lines[$i]->localtax1_rate,
-						$this->lines[$i]->localtax2_rate,
+						$this->lines[$i]->localtax1_tx,
+						$this->lines[$i]->localtax2_tx,
 						$line_price_base_type,
 						$this->lines[$i]->info_bits,
 						$this->lines[$i]->date_start,
@@ -724,8 +724,8 @@ trait CommonSubtotal
 						$this->lines[$i]->qty,
 						$mode == 'discount' ? $value : $this->lines[$i]->remise_percent,
 						$mode == 'tva' ? $value : $this->lines[$i]->tva_tx,
-						$this->lines[$i]->localtax1_rate,
-						$this->lines[$i]->localtax2_rate,
+						$this->lines[$i]->localtax1_tx,
+						$this->lines[$i]->localtax2_tx,
 						$this->lines[$i]->desc,
 						$line_price_base_type,
 						$this->lines[$i]->info_bits,
@@ -741,6 +741,57 @@ trait CommonSubtotal
 						$this->lines[$i]->array_options,
 						$this->lines[$i]->fk_unit,
 						$this->lines[$i]->multicurrency_subprice
+					);
+				} elseif ($current_module == 'supplier_proposal' && $this instanceof SupplierProposal) {
+					// Preserve the original entry mode of the line so the total is not drifted by rounding.
+					$line_price_base_type = $this->lines[$i]->getPriceBaseType();
+					$line_pu = ($line_price_base_type === 'TTC') ? $this->lines[$i]->subprice_ttc : $this->lines[$i]->subprice;
+					$result = $this->updateline(
+						$this->lines[$i]->id,
+						$line_pu,
+						$this->lines[$i]->qty,
+						$mode == 'discount' ? $value : $this->lines[$i]->remise_percent,
+						$mode == 'tva' ? $value : $this->lines[$i]->tva_tx,
+						$this->lines[$i]->localtax1_tx,
+						$this->lines[$i]->localtax2_tx,
+						$this->lines[$i]->desc,
+						$line_price_base_type,
+						$this->lines[$i]->info_bits,
+						$this->lines[$i]->special_code,
+						$this->lines[$i]->fk_parent_line,
+						0,
+						$this->lines[$i]->fk_fournprice,
+						$this->lines[$i]->pa_ht,
+						$this->lines[$i]->label,
+						$this->lines[$i]->product_type,
+						$this->lines[$i]->array_options,
+						$this->lines[$i]->ref_supplier,
+						$this->lines[$i]->fk_unit,
+						$this->lines[$i]->multicurrency_subprice
+					);
+				} elseif ($current_module == 'order_supplier' && $this instanceof CommandeFournisseur) {
+					// Preserve the original entry mode of the line so the total is not drifted by rounding.
+					$line_price_base_type = $this->lines[$i]->getPriceBaseType();
+					$line_pu = ($line_price_base_type === 'TTC') ? $this->lines[$i]->subprice_ttc : $this->lines[$i]->subprice;
+					$result = $this->updateline(
+						$this->lines[$i]->id,
+						$this->lines[$i]->desc,
+						$line_pu,
+						$this->lines[$i]->qty,
+						$mode == 'discount' ? $value : $this->lines[$i]->remise_percent,
+						$mode == 'tva' ? $value : $this->lines[$i]->tva_tx,
+						$this->lines[$i]->localtax1_tx,
+						$this->lines[$i]->localtax2_tx,
+						$line_price_base_type,
+						$this->lines[$i]->info_bits,
+						$this->lines[$i]->product_type,
+						0,
+						$this->lines[$i]->date_start,
+						$this->lines[$i]->date_end,
+						$this->lines[$i]->array_options,
+						$this->lines[$i]->fk_unit,
+						$this->lines[$i]->multicurrency_subprice,
+						$this->lines[$i]->ref_supplier
 					);
 				}
 				if ($result < 0) {


### PR DESCRIPTION
## What

`CommonSubtotal::updateSubtotalLineBlockLines()` is the handler behind "apply this VAT rate / this discount to every line of the block" on proposal, order, supplier proposal, supplier order and invoice cards. It had three independent bugs.

### 1. Wrong property name -> local taxes silently zeroed on orders and proposals

The `commande` and `propal` branches read `$this->lines[$i]->localtax1_rate` / `localtax2_rate`. Those properties do not exist on `OrderLine` / `PropaleLigne` — every other place in core (269 occurrences) uses `localtax1_tx` / `localtax2_tx` (the `facture` branch already does). The undefined property resolves to `null`, so calling `updateline()` with it **resets the line's local taxes (RE/IRPF, etc.) to 0** every time a VAT rate or a discount is applied to a block on a customer order or a proposal. Renamed to `localtax1_tx` / `localtax2_tx`.

### 2. Out-of-bounds array access

```php
$nb_lines = count($this->lines)+1;
for ($i = $linerang+1; $i < $nb_lines; $i++) {
    if ($this->lines[$i]->special_code == SUBTOTALS_SPECIAL_CODE) {
```

On the last iteration `$i == count($this->lines)`, an index one past the end. PHP 8 raises "Undefined array key" then "Attempt to read property 'special_code' on null" (fatal if warnings are promoted to exceptions in the environment). Fixed to `count($this->lines)`.

### 3. supplier_proposal / order_supplier silently do nothing

The method only has branches for `facture`, `commande`, `propal`, yet `supplier_proposal/card.php:607,610` and `fourn/commande/card.php:332,338` both call it. The loop ran, no `if` matched, `$result` stayed `0`, the method returned `1` — the "apply VAT/discount to block" action was a **silent no-op** for supplier proposals and supplier orders.

Added the two missing branches, built directly from the real signatures (they are not just copies of the propal/commande branches — the parameter order/count genuinely differs):

```php
public function updateline($rowid, $pu, $qty, $remise_percent, $txtva, $txlocaltax1 = 0, $txlocaltax2 = 0, $desc = '', $price_base_type = 'HT', $info_bits = 0, $special_code = 0, $fk_parent_line = 0, $skip_update_total = 0, $fk_fournprice = 0, $pa_ht = 0, $label = '', $type = 0, $array_options = [], $ref_supplier = '', $fk_unit = 0, $pu_ht_devise = 0)
```
`htdocs/supplier_proposal/class/supplier_proposal.class.php:755`

```php
public function updateline($rowid, $desc, $pu, $qty, $remise_percent, $txtva, $txlocaltax1 = 0, $txlocaltax2 = 0, $price_base_type = 'HT', $info_bits = 0, $type = 0, $notrigger = 0, $date_start = 0, $date_end = 0, $array_options = [], $fk_unit = null, $pu_ht_devise = 0, $ref_supplier = '')
```
`htdocs/fourn/class/fournisseur.commande.class.php:3148`

Same "preserve the original entry mode (HT/TTC) so the total doesn't drift on rounding" pattern already used by the three existing branches.

## Tests

- `php -l`, PHPStan (level from `phpstan.neon.dist`, project bootstrap against a live DB), PHP_CodeSniffer, Phan: all pass (pre-commit).
- PHPStan in particular type-checks each `updateline()` call against the real method signature, which is the strongest available check that the new branches' argument mapping is correct.
- No behaviour change for `facture`, `commande`, `propal` beyond the localtax fix and the loop-bound fix.

## Related

Independent from #39965 and #39971 (different files/lines, no overlap).
