### PR TITLE
Fix ecmfiles getnomurl shared entity

### DIFF
--- a/htdocs/ecm/class/ecmfiles.class.php
+++ b/htdocs/ecm/class/ecmfiles.class.php
@@ -1040,6 +1040,10 @@ class EcmFiles extends CommonObject
 		}
 
 		if ($option) {
+			// $this->filepath is relative to DOL_DATA_ROOT, so its leading numeric part, when present, is the
+			// entity the file is physically stored into. It may differ from $this->entity, which is the entity
+			// of the session when the file was indexed (case of a thirdparty shared between entities).
+			$entityoffile = (preg_match('/^(\d+)\//', $this->filepath, $reg) ? (int) $reg[1] : 1);
 			if ($option == 'facture_fournisseur') {
 				$tmppath = preg_replace('/^(\d+\/)?fournisseur\/facture\//', '', $this->filepath);
 			} elseif ($option == 'commande_fournisseur') {
@@ -1049,15 +1053,10 @@ class EcmFiles extends CommonObject
 			} elseif ($option == 'remisecheque') {	// Remove part "tax/vat/"
 				$tmppath = preg_replace('/^bank\/checkdeposits\//', '', $this->filepath);
 			} else {
-				if ((int) $this->entity > 1) {
-					// Remove the part "entityid/commande/" into "entityid/commande/REFXXX" to get only the ref
-					$tmppath = preg_replace('/^\d+\/[^\/]+\//', '', $this->filepath);
-				} else {
-					// Remove the part "commande/" into "commande/REFXXX" to get only the ref
-					$tmppath = preg_replace('/^[^\/]+\//', '', $this->filepath);
-				}
+				// Remove the part "[entityid/]commande/" into "[entityid/]commande/REFXXX" to get only the ref
+				$tmppath = preg_replace('/^(\d+\/)?[^\/]+\//', '', $this->filepath);
 			}
-			$url = DOL_URL_ROOT.'/document.php?modulepart='.urlencode($option).'&file='.urlencode($tmppath.'/'.$this->filename).'&entity='.((int) $this->entity);
+			$url = DOL_URL_ROOT.'/document.php?modulepart='.urlencode($option).'&file='.urlencode($tmppath.'/'.$this->filename).'&entity='.$entityoffile;
 		} else {
 			$url = DOL_URL_ROOT.'/ecm/file_card.php?id='.$this->id;
 		}


### PR DESCRIPTION
## Bug description

On a multi-entity setup (Multicompany) with **thirdparty sharing** enabled, clicking the
**file name** of any document in the "Attached files" block of a shared thirdparty card
returns:

```
ErrorFileDoesNotExists: societe/470/attachment.jpg
```

The preview (magnifier) icon on the very same row works fine, which makes the bug easy
to miss. It affects **both** manually uploaded attachments and generated documents
(e.g. account statements produced by external modules), and is not specific to
thirdparties: any shared object (product, project, ticket… when the corresponding
Multicompany sharing is enabled) is affected the same way, since all `*/document.php`
pages use the same storage rule.

## How to reproduce

1. Enable Multicompany and thirdparty sharing; create a thirdparty in entity 1.
2. Log into entity 3, open the shared thirdparty card, upload an attachment.
3. Give the user the **ECM read** permission (`ecm->read`) — required: without it,
   `FormFile::showdocuments()` builds a plain (correct) link instead of calling
   `EcmFiles::getNomUrl()`, and the bug does not show up.
4. Click on the **file name** in the "Attached files" block → `ErrorFileDoesNotExists`.

## Root cause

Two facts combine:

**1. `llx_ecm_files.entity` stores the entity of the *session*, not the entity of the
storage location.** Files attached to an object are always stored under the entity of
the **object** (`$conf->societe->multidir_output[$object->entity]` — same formula in
`societe/document.php`, `product/document.php`, `projet/document.php`,
`compta/facture/document.php`), while the index rows are written with the entity of
the **session** (`CommonObject::indexFile()`: `$ecmfile->entity = $conf->entity;` and
`EcmFiles::create()` fallback: `$this->entity = $conf->entity;`).

For a non-shared object both values always match, so the problem is invisible. For an
object owned by entity 1 but consulted from entity 3, the row reads:

| filepath | entity | actual storage |
|---|---|---|
| `societe/470` | **3** | entity **1** (no prefix) |

**2. `EcmFiles::getNomUrl()` trusts that field twice.** It uses `$this->entity` both to
pick the regex that strips the module part of the path, and to write `&entity=` into
the URL:

```php
} else {
    if ((int) $this->entity > 1) {
        // Remove the part "entityid/commande/" into "entityid/commande/REFXXX" to get only the ref
        $tmppath = preg_replace('/^\d+\/[^\/]+\//', '', $this->filepath);   // prefix REQUIRED
    } else {
        // Remove the part "commande/" into "commande/REFXXX" to get only the ref
        $tmppath = preg_replace('/^[^\/]+\//', '', $this->filepath);
    }
}
$url = DOL_URL_ROOT.'/document.php?...&file='.urlencode($tmppath.'/'.$this->filename).'&entity='.((int) $this->entity);
```

With `entity = 3` and `filepath = societe/470`, the first regex (anchored on a
mandatory numeric prefix) matches nothing, so `$tmppath` keeps the whole
`societe/470`; and the URL carries `entity=3`. `document.php` then prepends
`$conf->societe->multidir_output[3]`, producing a duplicated, non-existent path:

```
/…/documents/3/societe/  +  societe/470/attachment.jpg   → does not exist
```

## Tests and results

Variable-by-variable trace on real `llx_ecm_files` rows from a production database
(8 entities, thirdparty sharing enabled). For each case: the row as stored, the URL
built by the current code, and the URL built after the fix.

**Case 1 — Uploaded attachment on a shared thirdparty (broken today)**

```
DB row : filepath = societe/470              entity = 3    (file physically stored under entity 1)
Before : file=societe/470/attachment.jpg &entity=3  → /…/3/societe/ + societe/470/attachment.jpg  → NOT FOUND
After  : file=470/attachment.jpg         &entity=1  → /…/societe/   + 470/attachment.jpg          → FOUND
```

**Case 2 — Document generated from entity 2 on a thirdparty owned by entity 3 (broken today)**

```
DB row : filepath = 3/societe/1107           entity = 2
Before : file=1107/statement.pdf &entity=2  → /…/2/societe/ + 1107/statement.pdf  → NOT FOUND
After  : file=1107/statement.pdf &entity=3  → /…/3/societe/ + 1107/statement.pdf  → FOUND
```

In this case the path stripping happens to succeed and only the entity is wrong —
proving that fixing the regex alone is not enough: the `&entity=` parameter must also
come from the right source.

**Case 3 — Invoice of entity 3, not shared (works today)**

```
DB row : filepath = 3/facture/FA2609-1654    entity = 3
Before : file=FA2609-1654/FA2609-1654.pdf &entity=3  → FOUND
After  : byte-identical URL
```

**Case 4 — Single-entity installation (works today)**

```
DB row : filepath = commande/CO12            entity = 1
Before : file=CO12/order.pdf &entity=1  → FOUND
After  : byte-identical URL
```

Additional checks:

- Cases 3 and 4 show the fix is a no-op whenever index and path are consistent (all
  non-shared objects, all single-entity installations).
- After the fix, the produced URLs are exactly the ones the preview (magnifier) link
  already uses — verified against Apache access logs (real file size returned instead
  of a ~130-byte error message).
- Same inconsistency confirmed for **shared products** on another production instance
  (`filepath = 2/produit/PRODREF`, `entity = 3`, file physically under entity 2), so
  the fix also covers product/project/ticket sharing.
- Safety check for deriving the entity from the path: over 60,819 ECM rows with a
  numeric path prefix in a production DB, every distinct prefix matched a declared
  entity in `llx_entity`; first-level directories are module names and never start
  with a digit, so a path without a numeric prefix always belongs to entity 1.

## Proposed fix

Derive both the entity and the stripped path from `filepath`, which is relative to
`DOL_DATA_ROOT` and therefore describes the real storage location — and make the
entity prefix optional in the default branch, exactly as the `facture_fournisseur`,
`commande_fournisseur` and `tax-vat` branches of the same function already do with
`(\d+\/)?`:

```diff
 		if ($option) {
+			// $this->filepath is relative to DOL_DATA_ROOT, so its leading numeric part, when present, is the
+			// entity the file is physically stored into. It may differ from $this->entity, which is the entity
+			// of the session when the file was indexed (case of a thirdparty shared between entities).
+			$entityoffile = (preg_match('/^(\d+)\//', $this->filepath, $reg) ? (int) $reg[1] : 1);
+
 			if ($option == 'facture_fournisseur') {
 				...
 			} else {
-				if ((int) $this->entity > 1) {
-					// Remove the part "entityid/commande/" into "entityid/commande/REFXXX" to get only the ref
-					$tmppath = preg_replace('/^\d+\/[^\/]+\//', '', $this->filepath);
-				} else {
-					// Remove the part "commande/" into "commande/REFXXX" to get only the ref
-					$tmppath = preg_replace('/^[^\/]+\//', '', $this->filepath);
-				}
+				// Remove the part "[entityid/]commande/" into "[entityid/]commande/REFXXX" to get only the ref
+				$tmppath = preg_replace('/^(\d+\/)?[^\/]+\//', '', $this->filepath);
 			}
-			$url = DOL_URL_ROOT.'/document.php?modulepart='.urlencode($option).'&file='.urlencode($tmppath.'/'.$this->filename).'&entity='.((int) $this->entity);
+			$url = DOL_URL_ROOT.'/document.php?modulepart='.urlencode($option).'&file='.urlencode($tmppath.'/'.$this->filename).'&entity='.$entityoffile;
```

No data migration, nothing moved on disk, nothing regenerated: only the link changes,
and only where it is currently broken. Access control is unchanged:
`dol_check_secure_access_document()` still checks the user's permissions and the
entity filter, and the derived entity comes from the database row, not from user input.

## Related fix in the same function

The `remisecheque` branch a few lines above has the same missing optional prefix
(plus a copy/pasted comment from the `tax-vat` branch), which breaks the check deposit
receipt download for any entity > 1 even without sharing:

```diff
-			} elseif ($option == 'remisecheque') {	// Remove part "tax/vat/"
-				$tmppath = preg_replace('/^bank\/checkdeposits\//', '', $this->filepath);
+			} elseif ($option == 'remisecheque') {	// Remove part "[entityid/]bank/checkdeposits/"
+				$tmppath = preg_replace('/^(\d+\/)?bank\/checkdeposits\//', '', $this->filepath);
```

## Affected versions

Reproduced on **22.0.5**. The block is byte-identical in **23.0.4** (l. 1042-1050),
**24.0.0** (l. 1050-1058) and current **develop** — none of them fix it.
