### PR TITLE
FIX: Subtotals - getSubtotalLineAmount() no longer assumes lines indexed by rang

### DIFF
--- a/htdocs/subtotals/class/commonsubtotal.class.php
+++ b/htdocs/subtotals/class/commonsubtotal.class.php
@@ -810,30 +810,60 @@ trait CommonSubtotal
 	}
 
 	/**
+	 * Return the sum of the total_ht (or multicurrency_total_ht) of the lines located above the given
+	 * subtotal line, up to (and excluding) the first title line of the same level or higher.
+	 * Deeper title lines and subtotal lines do not contribute.
+	 *
+	 * Lines are scanned by descending rang: $this->lines is not assumed to be indexed by rang - 1.
+	 *
+	 * @param object	$line			Subtotal line that needs its amount.
+	 * @param bool		$multicurrency	True to sum multicurrency_total_ht instead of total_ht.
+	 * @return float					The computed amount.
+	 *
+	 * @phan-suppress PhanUndeclaredProperty
+	 */
+	public function getSubtotalLineAmountValue($line, $multicurrency = false)
+	{
+		$field = $multicurrency ? 'multicurrency_total_ht' : 'total_ht';
+
+		$abovelines = array();
+		$aboverangs = array();
+		foreach ($this->lines as $l) {
+			if (!is_object($l) || $l->rang >= $line->rang) {
+				continue;
+			}
+			$aboverangs[] = (int) $l->rang;
+			$abovelines[] = $l;
+		}
+		// Scan the lines above the current one from the nearest to the farthest.
+		array_multisort($aboverangs, SORT_DESC, SORT_NUMERIC, $abovelines);
+
+		$final_amount = 0;
+		foreach ($abovelines as $l) {
+			if ($l->special_code == SUBTOTALS_SPECIAL_CODE && $l->qty > 0) {
+				if ($l->qty <= abs($line->qty)) {
+					break;
+				}
+				continue;
+			}
+			$final_amount += (float) $l->$field;
+		}
+
+		return $final_amount;
+	}
+
+	/**
 	 * Return the total_ht of lines that are above the current line (excluded) and that are not a subtotal line
 	 * until a title line of the same level is found
 	 *
 	 * @param object	$line	Line that needs the subtotal amount.
-	 * @return string	$total_ht
+	 * @return string			Formatted amount
 	 *
 	 * @phan-suppress PhanUndeclaredProperty
 	 */
 	public function getSubtotalLineAmount($line)
 	{
-		$final_amount = 0;
-		for ($i = $line->rang-1; $i > 0; $i--) {
-			if (is_null($this->lines[$i-1]) || $this->lines[$i-1]->rang >= $line->rang) {
-				continue;
-			}
-			if ($this->lines[$i-1]->special_code == SUBTOTALS_SPECIAL_CODE && $this->lines[$i-1]->qty > 0) {
-				if ($this->lines[$i-1]->qty <= abs($line->qty)) {
-					return price($final_amount);
-				}
-			} else {
-				$final_amount += $this->lines[$i-1]->total_ht;
-			}
-		}
-		return price($final_amount);
+		return price($this->getSubtotalLineAmountValue($line, false));
 	}
 
 	/**
@@ -841,26 +871,13 @@ trait CommonSubtotal
 	 * until a title line of the same level is found
 	 *
 	 * @param object	$line	Line that needs the subtotal amount with multicurrency mod activated.
-	 * @return string	$total_ht
+	 * @return string			Formatted amount
 	 *
 	 * @phan-suppress PhanUndeclaredProperty
 	 */
 	public function getSubtotalLineMulticurrencyAmount($line)
 	{
-		$final_amount = 0;
-		for ($i = $line->rang-1; $i > 0; $i--) {
-			if (is_null($this->lines[$i-1]) || $this->lines[$i-1]->rang >= $line->rang) {
-				continue;
-			}
-			if ($this->lines[$i-1]->special_code == SUBTOTALS_SPECIAL_CODE && $this->lines[$i-1]->qty>0) {
-				if ($this->lines[$i-1]->qty <= abs($line->qty)) {
-					return price($final_amount);
-				}
-			} else {
-				$final_amount += $this->lines[$i-1]->multicurrency_total_ht;
-			}
-		}
-		return price($final_amount);
+		return price($this->getSubtotalLineAmountValue($line, true));
 	}
 
 	/**

--- a/htdocs/subtotals/core/substitutions/functions_subtotals.lib.php
+++ b/htdocs/subtotals/core/substitutions/functions_subtotals.lib.php
@@ -35,13 +35,9 @@ function subtotals_completesubstitutionarray_lines(&$substitutionarray, $langs, 
 		$substitutionarray['is_not_subtotals_line'] = !$substitutionarray['is_subtotals_line'];
 		$substitutionarray['is_subtotals_title'] = (($line->special_code == constant('SUBTOTALS_SPECIAL_CODE')) && $line->qty > 0);
 		$substitutionarray['is_subtotals_subtotal'] = (($line->special_code == constant('SUBTOTALS_SPECIAL_CODE')) && $line->qty < 0);
-		$subtotal_total = 0;
-		if (isModEnabled('multicurrency') && $object->multicurrency_code != getDolCurrency()) {
-			$subtotal_total = $object->getSubtotalLineMulticurrencyAmount($line); // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
-		} else {
-			$subtotal_total = $object->getSubtotalLineAmount($line); // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
-		}
-		$substitutionarray['subtotals_total'] = ($subtotal_total == 0) ? "" : $subtotal_total;
+		$usemulticurrency = (isModEnabled('multicurrency') && $object->multicurrency_code != getDolCurrency());
+		$subtotal_total_value = $object->getSubtotalLineAmountValue($line, $usemulticurrency); // @phan-suppress-current-line PhanPluginUnknownObjectMethodCall
+		$substitutionarray['subtotals_total'] = ($subtotal_total_value == 0) ? "" : price($subtotal_total_value);
 		$substitutionarray['subtotals_level'] = abs($line->qty);
 	} else {
 		$substitutionarray['is_subtotals_line'] = false;


### PR DESCRIPTION
## What

`CommonSubtotal::getSubtotalLineAmount()` and `getSubtotalLineMulticurrencyAmount()` compute the "total excl. VAT" shown next to a subtotal line. They iterated with:

```php
for ($i = $line->rang - 1; $i > 0; $i--) {
    if (is_null($this->lines[$i-1]) || $this->lines[$i-1]->rang >= $line->rang) { continue; }
    ...
    $final_amount += $this->lines[$i-1]->total_ht;
}
```

i.e. they assume the line at array index `k` has `rang == k + 1`. When the rangs are **not** a contiguous `1..N` sequence — which happens after line deletions / reorders — the loop never visits lines whose array index is `>= $line->rang - 1`, so the sub-total is wrong or incomplete.

These values feed the PDF models (`pdf_sponge`, `pdf_octopus`, `pdf_cyan`, `pdf_eratosthene`, `pdf_zenith`), the `subtotal_view` / `originsubtotalline` templates and the ODT `subtotals_total` substitution.

A second, smaller issue: `functions_subtotals.lib.php` did `($subtotal_total == 0)` on the **`price()` string** — in a comma-decimal locale `"0,00" == 0` is `false`, so a genuinely-zero sub-total was emitted as `"0,00"` in ODT output instead of `""`.

## Fix

- New `getSubtotalLineAmountValue($line, $multicurrency = false)`: filters `$this->lines` to the lines *above* the current one and scans them by **descending rang** (no index assumption), applying the exact same rule as before — sum `total_ht` / `multicurrency_total_ht`, skip deeper title lines, stop at the first title of the same level or higher; subtotal lines contribute their `total_ht` (≈ 0) as they did before. Returns a `float`.
- `getSubtotalLineAmount()` / `getSubtotalLineMulticurrencyAmount()` keep their `price()` return value and become one-line wrappers, so the PDF/template call sites are unchanged.
- `functions_subtotals.lib.php` now tests the float value and calls `price()` only when non-zero.

## Behaviour

Identical output for a normally-ordered line list; correct output when rangs have gaps. Non-zero `subtotals_total` in ODT is unchanged (`price()` of the same amount); a zero one is now blank as intended.

## Tests

`php -l`, PHPStan (level from `phpstan.neon.dist`, project bootstrap) and Phan pass via pre-commit.

## Related

Item #9 of the subtotals review. Independent from #39965, #39971, #39972, #39974, #39975.



Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
