### PR TITLE
FIX: Subtotals - read SUBTOTAL_*_MAX_DEPTH as an int, not a string

### DIFF
--- a/htdocs/admin/subtotals.php
+++ b/htdocs/admin/subtotals.php
@@ -93,7 +93,7 @@ $conditions = [
 $max_depth = 0;
 
 foreach ($modules as $const => $desc) {
-	$const_depth = getDolGlobalString('SUBTOTAL_' . $const . '_MAX_DEPTH', 2);
+	$const_depth = getDolGlobalInt('SUBTOTAL_' . $const . '_MAX_DEPTH', 2);
 
 	$constante_title = 'SUBTOTAL_TITLE_' . $const;
 	$constante_subtotal = 'SUBTOTAL_' . $const;
@@ -210,7 +210,7 @@ if (empty($conf->use_javascript_ajax)) {
 		print '<input type="hidden" name="action" value="SUBTOTAL_' . $const . '_MAX_DEPTH">';
 		print '<input size="3" type="text" class="center"';
 		print $can_modify ? '' : ' disabled="disabled" ';
-		print 'name="SUBTOTAL_' . $const . '_MAX_DEPTH" value="' . getDolGlobalString('SUBTOTAL_' . $const . '_MAX_DEPTH', $can_modify ? 2 : 0) . '">';
+		print 'name="SUBTOTAL_' . $const . '_MAX_DEPTH" value="' . getDolGlobalInt('SUBTOTAL_' . $const . '_MAX_DEPTH', $can_modify ? 2 : 0) . '">';
 		print $can_modify ? '<input type="submit" class="button button-edit reposition smallpaddingimp" name="Button"value="' . $langs->trans("Modify") . '">' : '';
 		print '</form>';
 		print '</td>';

--- a/htdocs/subtotals/class/commonsubtotal.class.php
+++ b/htdocs/subtotals/class/commonsubtotal.class.php
@@ -848,7 +848,7 @@ trait CommonSubtotal
 	public function getPossibleLevels($langs)
 	{
 		$depth_array = array();
-		$max_depth = getDolGlobalString('SUBTOTAL_'.strtoupper($this->element).'_MAX_DEPTH', 2);
+		$max_depth = getDolGlobalInt('SUBTOTAL_'.strtoupper($this->element).'_MAX_DEPTH', 2);
 		for ($i = 0; $i < $max_depth; $i++) {
 			$depth_array[$i + 1] = $langs->trans("SubtotalLevel", $i + 1);
 		}


### PR DESCRIPTION
## What

`SUBTOTAL_<MODULE>_MAX_DEPTH` is written as an int:

```php
dolibarr_set_const($db, $action, GETPOSTINT($action), 'int', 0, '', $conf->entity);   // admin/subtotals.php:117
```

but read back as a string and then used as a number:

- `CommonSubtotal::getPossibleLevels()` — `for ($i = 0; $i < $max_depth; $i++)` with `$max_depth = getDolGlobalString(..., 2)`
- `admin/subtotals.php` — `$const_depth = getDolGlobalString(..., 2)` then `max($const_depth, $max_depth)`, feeding another `for` loop

It works via PHP type juggling, but the reader should match the writer. Switched the three reads of this constant to `getDolGlobalInt()`.

## Tests

`php -l`, PHPStan, phpcs, Phan pass (pre-commit). No behaviour change for any valid stored value.

## Related

Minor item #8 of the subtotals review. Independent from the other open subtotals PRs.
