### PR TITLE
FIX: Subtotals admin - close the colors form and keep its buttons inside it

### DIFF
--- a/htdocs/admin/subtotals.php
+++ b/htdocs/admin/subtotals.php
@@ -128,7 +128,7 @@ if (preg_match('/^SUBTOTAL_.*$/', $action)) {
 	}
 }
 
-if ($action == 'update_colors') {
+if ($action == 'update_colors' && !GETPOST('cancel', 'alpha')) {
 	foreach ($colors as $const => $color) {
 		$color_to_update = GETPOST($const, 'aZ09');
 		if ($color_to_update != $color['color']) {
@@ -244,12 +244,14 @@ if (empty($conf->use_javascript_ajax)) {
 	}
 
 	print '</table>' . "\n";
-}
 
-print '<div class="center">';
-print '<input class="button button-save reposition buttonforacesave" type="submit" name="submit" value="' . $langs->trans("Save") . '">';
-print '<input class="button button-cancel reposition" type="submit" name="cancel" value="' . $langs->trans("Cancel") . '">';
-print '</div>';
+	print '<div class="center">';
+	print '<input class="button button-save reposition buttonforacesave" type="submit" name="submit" value="' . $langs->trans("Save") . '">';
+	print '<input class="button button-cancel reposition" type="submit" name="cancel" value="' . $langs->trans("Cancel") . '">';
+	print '</div>';
+
+	print '</form>';
+}
 
 // End of page
 llxFooter();


### PR DESCRIPTION
## What

In `admin/subtotals.php`, the "back colors" `<form>` opened right after the modules table is never closed with `</form>`, and the Save / Cancel submit buttons are printed **after** the `if (empty($conf->use_javascript_ajax)) { … } else { … }` block:

- when JavaScript is disabled, the `else` (and its `<form>`) is skipped entirely, so the Save / Cancel buttons render outside any form and do nothing;
- otherwise they only end up in the colors form thanks to the browser's implicit form closing at end of body.

`Cancel` also currently re-runs the `update_colors` action (it submits the same form, and the handler only checks `$action == 'update_colors'`).

## Fix

- Move the button `<div class="center">` inside the colors form, before a new explicit `</form>`, and inside the `else` branch so nothing renders form-less.
- Guard the action with `if ($action == 'update_colors' && !GETPOST('cancel', 'alpha'))` so `Cancel` just re-displays the page instead of saving.

## Tests

`php -l`, PHPStan, phpcs, Phan pass (pre-commit). Manual: Save persists the colors as before; Cancel now leaves them unchanged; no orphan buttons when JS is disabled.

## Related

Minor item #12 of the subtotals review. Independent from the other open subtotals PRs.
