### PR TITLE
FIX: Subtotals - allow a title/line described only by "0"

### DIFF
--- a/htdocs/subtotals/class/commonsubtotal.class.php
+++ b/htdocs/subtotals/class/commonsubtotal.class.php
@@ -79,7 +79,7 @@ trait CommonSubtotal
 	 */
 	public function addSubtotalLine($langs, $desc, $depth, $options = array(), $parent_line = 0)
 	{
-		if (empty($desc)) {
+		if (!isset($desc) || trim((string) $desc) === '') {
 			$this->errors[] = $langs->trans("TitleNeedDesc");
 			return -1;
 		}


### PR DESCRIPTION
## What

`CommonSubtotal::addSubtotalLine()` starts with:

```php
if (empty($desc)) {
    $this->errors[] = $langs->trans("TitleNeedDesc");
    return -1;
}
```

`empty()` is also `true` for the string `"0"`, so a title (or subtotal line) whose description is exactly `0` is rejected with *TitleNeedDesc*.

## Fix

```php
if (!isset($desc) || trim((string) $desc) === '') {
```

Rejects only a genuinely blank description (null / `''` / whitespace-only) and accepts `"0"`.

## Tests

`php -l`, PHPStan, phpcs, Phan pass (pre-commit). Adding a title named `0` now works; empty and whitespace-only descriptions are still refused.

## Related

Minor item #10 of the subtotals review. Independent from the other open subtotals PRs.