### PR TITLE
FIX: Subtotals - persist subtotal options on supplier proposals and interventions

### DIFF
--- a/htdocs/subtotals/class/commonsubtotal.class.php
+++ b/htdocs/subtotals/class/commonsubtotal.class.php
@@ -302,7 +302,14 @@ trait CommonSubtotal
 		}
 
 
-		if ($current_module != 'shipping') {
+		if ($current_module != 'shipping' && $result > 0) {
+			// SupplierProposal::addline() and Fichinter::addline() do not append the new line
+			// to $this->lines, so reload the lines before looking the new one up by id.
+			if ($current_module == 'supplier_proposal') {
+				$this->fetch($this->id);
+			} elseif ($current_module == 'fichinter') {
+				$this->fetch_lines();
+			}
 			foreach ($this->lines as $line) {
 				'@phan-var-force CommonObjectLine $line';
 				/** @var CommonObjectLine $line */


### PR DESCRIPTION
## What

`addSubtotalLine()` inserts the line via `$this->addline(...)`, then loops `$this->lines` to find the new line by id and store `extraparams['subtotal']` — the *show unit price / total excl. VAT / page break on PDF* options.

That lookup only succeeds if the module's `addline()` appended the new line to `$this->lines`:

| module | `addline()` appends to `$this->lines`? |
|---|---|
| facture / propal / commande / order_supplier / invoice_supplier | yes |
| facturerec | no, but the subtotals code already calls `$this->fetch_lines()` right after |
| **supplier_proposal** | **no** |
| **fichinter** | **no** |

So for supplier proposals and interventions the options were silently discarded.

## Fix

Reload the lines for those two modules before the lookup:
- `fichinter` → `$this->fetch_lines()`
- `supplier_proposal` → `$this->fetch($this->id)` (it has no `fetch_lines()`)

Also only run the lookup when `$result > 0` (the insert succeeded).

## Tests

`php -l`, PHPStan, phpcs, Phan pass (pre-commit). Manual: adding a title line with *show on PDF* options ticked on a supplier proposal / intervention now keeps them (visible after reload and in the generated PDF/ODT).

## Related

Item #11 of the subtotals review. `updateSubtotalLine()` is not affected — there the line already exists in `$this->lines` from the card's initial fetch.