### PR TITLE
QUAL: DAV - use $user->hasRight() in CdavLib

### DIFF
--- a/htdocs/dav/dav.class.php
+++ b/htdocs/dav/dav.class.php
@@ -1,6 +1,6 @@
 <?php
 /* Copyright (C) 2018	Destailleur Laurent	<eldy@users.sourceforge.net>
- * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2025-2026	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -253,11 +253,11 @@ class CdavLib
 		$calendarId = (int) $calendarId;
 		$calevents = array();
 
-		if (!$this->user->rights->agenda->myactions->read) {
+		if (!$this->user->hasRight('agenda', 'myactions', 'read')) {
 			return $calevents;
 		}
 
-		if ($calendarId != $this->user->id && (!isset($this->user->rights->agenda->allactions->read) || !$this->user->rights->agenda->allactions->read)) {
+		if ($calendarId != $this->user->id && !$this->user->hasRight('agenda', 'allactions', 'read')) {
 			return $calevents;
 		}
 


### PR DESCRIPTION
`CdavLib::getFullCalendarObjects()` (CalDAV backend) checked permissions via `$this->user->rights->agenda->…` directly:

- `!$this->user->rights->agenda->myactions->read` → `!$this->user->hasRight('agenda', 'myactions', 'read')`
- `(!isset($this->user->rights->agenda->allactions->read) || !$this->user->rights->agenda->allactions->read)` → `!$this->user->hasRight('agenda', 'allactions', 'read')` (`hasRight()` already returns `false` when the permission is unset)

`$this->user` is a fully loaded `User` (`dav/fileserver.php` does `new User()` + `loadRights()`; covered by `CDavLibTest`). No behaviour change. `php -l`, PHPStan, phpcs, Phan pass.