### PR TITLE
FIX: Persist member civility set through the civility_code property

### DIFF
--- a/htdocs/adherents/class/adherent.class.php
+++ b/htdocs/adherents/class/adherent.class.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2009-2017	Regis Houssin				<regis.houssin@inodbox.com>
  * Copyright (C) 2014-2018	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2015		Marcos García				<marcosgdf@gmail.com>
- * Copyright (C) 2015-2025  Frédéric France				<frederic.france@free.fr>
+ * Copyright (C) 2015-2026  Frédéric France				<frederic.france@free.fr>
  * Copyright (C) 2015		Raphaël Doursenaud			<rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2016		Juanjo Menent				<jmenent@2byte.es>
  * Copyright (C) 2018-2019	Thibault FOUCART			<support@ptibogxiv.net>
@@ -810,6 +810,10 @@ class Adherent extends CommonObject
 		// Clean parameters
 		$this->lastname = trim($this->lastname) ? trim($this->lastname) : trim($this->lastname);
 		$this->firstname = trim($this->firstname) ? trim($this->firstname) : trim($this->firstname);
+		// civility_code is the reference property. Fall back to the deprecated civility_id alias only when civility_code was not set by the caller.
+		if (empty($this->civility_code) && !empty($this->civility_id)) {
+			$this->civility_code = $this->civility_id;
+		}
 		if (isset($this->gender)) {
 			$this->gender = trim($this->gender);
 		}
@@ -835,7 +839,7 @@ class Adherent extends CommonObject
 		$sql = "UPDATE ".MAIN_DB_PREFIX."adherent SET";
 		$sql .= " ref = '".$this->db->escape($this->ref)."'";
 		$sql .= ", ref_ext = ".(empty($this->ref_ext) ? "null" : "'".$this->db->escape($this->ref_ext)."'");
-		$sql .= ", civility = ".($this->civility_id ? "'".$this->db->escape($this->civility_id)."'" : "null");
+		$sql .= ", civility = ".($this->civility_code ? "'".$this->db->escape($this->civility_code)."'" : "null");
 		$sql .= ", firstname = ".($this->firstname ? "'".$this->db->escape($this->firstname)."'" : "null");
 		$sql .= ", lastname = ".($this->lastname ? "'".$this->db->escape($this->lastname)."'" : "null");
 		$sql .= ", gender = ".($this->gender != -1 ? "'".$this->db->escape($this->gender)."'" : "null"); // 'man' or 'woman'
@@ -961,7 +965,7 @@ class Adherent extends CommonObject
 						}
 
 						$luser->ref = $this->ref;
-						$luser->civility_id = $this->civility_id;
+						$luser->civility_code = $this->civility_code;
 						$luser->firstname = $this->firstname;
 						$luser->lastname = $this->lastname;
 						$luser->gender = $this->gender;

--- a/test/phpunit/AdherentTest.php
+++ b/test/phpunit/AdherentTest.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2010      Laurent Destailleur   <eldy@users.sourceforge.net>
  * Copyright (C) 2013      Marcos García         <marcosgdf@gmail.com>
  * Copyright (C) 2023      Alexandre Janniaux    <alexandre.janniaux@gmail.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -156,6 +156,7 @@ class AdherentTest extends CommonClassTest
 		$result = $localobject->fetch($id);
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
+		$this->assertEquals('MR', $localobject->civility_code);		// Value set by initAsSpecimen() and stored by create()
 		return $localobject;
 	}
 
@@ -203,7 +204,8 @@ class AdherentTest extends CommonClassTest
 
 		$timestamp = dol_now();
 
-		$localobject->civility_id = 0;
+		$localobject->civility_id = 0;			// Deprecated alias, must be ignored in favor of civility_code
+		$localobject->civility_code = '';
 		$localobject->login = 'newlogin';
 		$localobject->company = 'New company label';
 		$localobject->note_public = 'New note public after update';
@@ -237,7 +239,7 @@ class AdherentTest extends CommonClassTest
 		print __METHOD__." id=".$localobject->id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 
-		$this->assertEquals($localobject->civility_id, $newobject->civility_id);
+		$this->assertEquals($localobject->civility_code, $newobject->civility_code);
 		$this->assertEquals($localobject->login, $newobject->login);
 		$this->assertEquals($localobject->company, $newobject->company);
 		$this->assertEquals($localobject->note_public, $newobject->note_public);


### PR DESCRIPTION
## What

`Adherent::update()` is the single place that persists a member's civility (`create()` also routes through it). It read only the **deprecated** `civility_id` alias, whereas `htdocs/adherents/card.php` feeds `civility_code` on both member creation and edition. As a result, changing a member's civility from the card was never saved.

This supersedes #39739, which only addressed the create path (`civility_id ?: civility_code`): on edit, `fetch()` has already populated `civility_id` from the database, so the stale value kept winning, and the `civility_id`-first order also broke `AdherentTest::testAdherentUpdate` on Travis.

## How

- `update()` normalizes `civility_code` from the deprecated `civility_id` **only when the caller left `civility_code` unset**, so legacy callers keep working while `card.php` (and any new code) driving `civility_code` now takes precedence.
- The civility is then persisted from `civility_code`.
- The member -> linked-user sync assigned `$luser->civility_id`, an undeclared dynamic property that `User::update()` ignores entirely; it now assigns `civility_code`, so the sync actually propagates.

## Tests

`test/phpunit/AdherentTest.php`:
- `testAdherentUpdate` now clears the civility through the real `civility_code` property (keeping `civility_id = 0` to assert the deprecated alias is ignored) and checks the round-trip on `civility_code`.
- `testAdherentFetch` gains a positive assertion that `create()` stored the specimen civility (`MR`).

Full `AdherentTest` suite passes locally (13 tests / 49 assertions); phpcs and PHPStan clean on the changed `htdocs/` file.

## Note on the failing `phpstan` check

The `phpstan / php-stan (8.2)` job fails only on pre-existing errors in `test/phpunit/AdherentTest.php` (`extends unknown class CommonClassTest`, undefined `assertLessThan()` / `$savconf` …). `.github/scripts/get_changed_php.sh` passes every changed `.php` file to `phpstan analyse` on the command line, which overrides the `paths:` restriction in `phpstan.neon.dist`; `test/phpunit/` is not in `paths:` and has no baseline entries, so any PR touching a test file triggers this (e.g. #39755, merged with the same red check). No error comes from `htdocs/adherents/class/adherent.class.php`. Travis (the check that was red on #39739) is green.


Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
