### PR TITLE
QUAL: Use User->status instead of the deprecated User->statut

### DIFF
--- a/htdocs/compta/facture/prelevement.php
+++ b/htdocs/compta/facture/prelevement.php
@@ -992,7 +992,6 @@ if ($object->id > 0) {
 			$tmpuser->email = $obj->email;
 			$tmpuser->lastname = $obj->lastname;
 			$tmpuser->firstname = $obj->firstname;
-			$tmpuser->statut = $obj->user_status;
 			$tmpuser->status = $obj->user_status;
 
 			print '<tr class="oddeven">';
@@ -1128,7 +1127,6 @@ if ($object->id > 0) {
 			$tmpuser->email = $obj->email;
 			$tmpuser->lastname = $obj->lastname;
 			$tmpuser->firstname = $obj->firstname;
-			$tmpuser->statut = $obj->user_status;
 			$tmpuser->status = $obj->user_status;
 			$tmpuser->photo = $obj->user_photo;
 

--- a/htdocs/core/lib/openid_connect.lib.php
+++ b/htdocs/core/lib/openid_connect.lib.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2017      Open-DSI             <support@open-dsi.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -145,8 +146,7 @@ function openid_connect_create_user($db, $userinfo, $login, $entity)
 	$newuser = new User($db);
 	$newuser->login = $sanitized_login;
 	$newuser->entity = $entity;
-	$newuser->statut = 1; // Active
-	$newuser->status = 1; // Active (alias)
+	$newuser->status = 1; // Active
 
 	if (property_exists($userinfo, $claim_email)) {
 		$newuser->email = $userinfo->$claim_email;
@@ -172,7 +172,7 @@ function openid_connect_create_user($db, $userinfo, $login, $entity)
 	}
 	$adminuser = new User($db);
 	$result_fetch = $adminuser->fetch($creator_id);
-	if ($result_fetch <= 0 || empty($adminuser->admin) || $adminuser->statut != 1) {
+	if ($result_fetch <= 0 || empty($adminuser->admin) || $adminuser->status != 1) {
 		dol_syslog("openid_connect_create_user::Error: configured creator user ID=".$creator_id." is not a valid active admin", LOG_ERR);
 		return -2;
 	}

--- a/htdocs/core/lib/ws.lib.php
+++ b/htdocs/core/lib/ws.lib.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2011 		Laurent Destailleur  	<eldy@users.sourceforge.net>
  * Copyright (C) 2024		MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,7 +65,7 @@ function check_authentication($authentication, &$error, &$errorcode, &$errorlabe
 			$errorlabel = 'Bad value for login or password';
 		}
 
-		if (!$error && $fuser->statut == 0) {
+		if (!$error && $fuser->status == 0) {
 			$error++;
 			$errorcode = 'ERROR_USER_DISABLED';
 			$errorlabel = 'This user has been locked or disabled';

--- a/htdocs/salaries/virement_request.php
+++ b/htdocs/salaries/virement_request.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2017-2019  Alexandre Spangaro      <aspangaro@open-dsi.fr>
  * Copyright (C) 2021		Gauthier VERDOL         <gauthier.verdol@atm-consulting.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -595,7 +595,6 @@ if ($resql) {
 			$tmpuser->email = $obj->email;
 			$tmpuser->lastname = $obj->lastname;
 			$tmpuser->firstname = $obj->firstname;
-			$tmpuser->statut = $obj->user_status;
 			$tmpuser->status = $obj->user_status;
 
 			print '<tr class="oddeven">';
@@ -713,7 +712,6 @@ if ($resql) {
 			$tmpuser->email = $obj->email;
 			$tmpuser->lastname = $obj->lastname;
 			$tmpuser->firstname = $obj->firstname;
-			$tmpuser->statut = $obj->user_status;
 			$tmpuser->status = $obj->user_status;
 
 			print '<tr class="oddeven">';

--- a/htdocs/user/bank.php
+++ b/htdocs/user/bank.php
@@ -9,7 +9,7 @@
  * Copyright (C) 2015-2024  Alexandre Spangaro          <alexandre@inovea-conseil.com>
  * Copyright (C) 2021       Gauthier VERDOL             <gauthier.verdol@atm-consulting.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2026       Charlene Benke              <charlene@patas-monkey.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -396,7 +396,7 @@ if ($action != 'edit' && $action != 'create') {		// If not bank account yet, $ac
 	print '<table class="border centpercent tableforfield">';
 
 	print '<tr><td class="titlefieldmiddle">'.$langs->trans("Login").'</td>';
-	if (!empty($object->ldap_sid) && $object->statut == 0) {
+	if (!empty($object->ldap_sid) && $object->status == 0) {
 		print '<td class="error">';
 		print $langs->trans("LoginAccountDisableInDolibarr");
 		print '</td>';

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -1672,11 +1672,11 @@ class User extends CommonObject
 		$error = 0;
 
 		// Check parameters
-		if (isset($this->statut)) {
-			if ($this->statut == $status) {
+		if (isset($this->status)) {
+			if ($this->status == $status) {
 				return 0;
 			}
-		} elseif (isset($this->status) && $this->status == $status) {
+		} elseif (isset($this->statut) && $this->statut == $status) {	// $this->statut is deprecated
 			return 0;
 		}
 
@@ -3445,7 +3445,7 @@ class User extends CommonObject
 	 */
 	public function getLibStatut($mode = 0)
 	{
-		return $this->LibStatut(isset($this->statut) ? (int) $this->statut : (int) $this->status, $mode);
+		return $this->LibStatut(isset($this->status) ? (int) $this->status : (int) $this->statut, $mode);	// $this->statut is deprecated
 	}
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps

--- a/htdocs/user/home.php
+++ b/htdocs/user/home.php
@@ -171,7 +171,6 @@ if ($resql) {
 		$obj = $db->fetch_object($resql);
 
 		$fuserstatic->id = $obj->rowid;
-		$fuserstatic->statut = $obj->statut;
 		$fuserstatic->status = $obj->statut;
 		$fuserstatic->lastname = $obj->lastname;
 		$fuserstatic->firstname = $obj->firstname;

--- a/htdocs/user/list.php
+++ b/htdocs/user/list.php
@@ -1060,7 +1060,6 @@ while ($i < $imaxinloop) {
 	$object->admin = $obj->admin;
 	$object->ref = (string) $obj->rowid;
 	$object->login = $obj->login;
-	$object->statut = (int) $obj->status;
 	$object->status = (int) $obj->status;
 	$object->office_phone = $obj->office_phone;
 	$object->user_mobile = $obj->user_mobile;
@@ -1211,7 +1210,6 @@ while ($i < $imaxinloop) {
 				$user2->user_mobile = $obj->user_mobile;
 				$user2->email = $obj->email2;
 				$user2->socid = $obj->fk_soc2;
-				$user2->statut = $obj->status2;
 				$user2->status = $obj->status2;
 				if (isModEnabled('multicompany') && $obj->admin2 && !$obj->entity2) {
 					print img_picto($langs->trans("SuperAdministratorDesc"), 'superadmin', 'class="valignmiddle paddingright"');
@@ -1251,7 +1249,8 @@ while ($i < $imaxinloop) {
 		// Email
 		if (!empty($arrayfields['u.email']['checked'])) {
 			$showinvalidemail = (int) !getDolGlobalInt('MAIN_SHOW_INVALID_EMAIL_IN_LIST'); // to avoid slow display
-			print '<td class="tdoverflowmax150" title="'.dolPrintHTMLForAttribute($obj->email).'">'.dol_print_email($obj->email, $obj->rowid, $obj->fk_soc, 1, 0, $showinvalidemail, 1)."</td>\n";
+			$email = (string) $obj->email;
+			print '<td class="tdoverflowmax150" title="'.dolPrintHTMLForAttribute($email).'">'.dol_print_email($email, $obj->rowid, $obj->fk_soc, 1, 0, $showinvalidemail, 1)."</td>\n";
 			if (!$i) {
 				$totalarray['nbfield']++;
 			}

--- a/htdocs/user/note.php
+++ b/htdocs/user/note.php
@@ -131,7 +131,7 @@ if ($id) {
 
 	// Login
 	print '<tr><td class="titlefield">'.$langs->trans("Login").'</td>';
-	if (!empty($object->ldap_sid) && $object->statut == 0) {
+	if (!empty($object->ldap_sid) && $object->status == 0) {
 		print '<td class="error">';
 		print $langs->trans("LoginAccountDisableInDolibarr");
 		print '</td>';

--- a/htdocs/user/notify/card.php
+++ b/htdocs/user/notify/card.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2010-2014  Juanjo Menent	    <jmenent@2byte.es>
  * Copyright (C) 2015       Marcos García       <marcosgdf@gmail.com>
  * Copyright (C) 2016       Abbes Bahfir        <contact@dolibarrpar.com>
- * Copyright (C) 2024-2025  Frédéric France     <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2024		MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Charlene Benke		<charlene@patas-monkey.com>
  *
@@ -188,7 +188,7 @@ if ($result > 0) {
 
 	// Login
 	print '<tr><td class="titlefield">'.$langs->trans("Login").'</td>';
-	if (!empty($object->ldap_sid) && $object->statut == 0) {
+	if (!empty($object->ldap_sid) && $object->status == 0) {
 		print '<td class="error">';
 		print $langs->trans("LoginAccountDisableInDolibarr");
 		print '</td>';


### PR DESCRIPTION
## What

`User->statut` has been deprecated since **19.0** in favour of `User->status` (`@deprecated Use $status` on the property). `User::fetch()` and `User::setstatus()` still keep both in sync, so nothing is broken today, but several core spots still read or write the deprecated alias.

This switches the remaining core usages to `User->status` and makes the class itself prefer the non-deprecated property.

## Changes

- **`user/class/user.class.php`**
  - `setstatus()` — the "no change" guard now tests `$this->status` first, `$this->statut` as fallback
  - `getLibStatut()` — `isset($this->status) ? status : statut` (order inverted)
- **Reads switched to `->status`** (objects are `fetch()`-ed users, so `->status` is populated):
  - `core/lib/ws.lib.php` (`check_authentication`)
  - `core/lib/openid_connect.lib.php` (creator admin check; also drops the now-redundant `$newuser->statut = 1` line, `->status` was already set right after)
  - `user/bank.php`, `user/note.php`, `user/notify/card.php` (`$object->statut == 0` disabled-account notice)
  - `webservices/server_user.php` — value now read from `$user->status`; the `'statut'` response key is kept for backward compatibility
- **Redundant deprecated writes removed** where `->status` was already assigned on the next line (temp `User` objects used only for `getNomUrl()`):
  - `user/list.php` (x2), `user/home.php`, `salaries/virement_request.php` (x2), `compta/facture/prelevement.php` (x2)

No behaviour change. The `fetch()` / `setstatus()` dual-write is intentionally left in place.

## Left as-is

- `user/class/user.class.php` `fetch()` / `setstatus()` dual-write (compat layer)
- `get_full_tree()` `'statut'` array key (documented return-array shape)
- `user/class/api_users.class.php` (already handles both `statut` and `status`)

## Tests

`php -l`, PHP_CodeSniffer (`dev/setup/codesniffer/ruleset.xml`), PHPStan level 10 (`bootstrap_action.php`) and Phan (config + baseline, analysis restricted to the changed files) all clean locally.


Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
