### PR TITLE
QUAL: Use getDolGlobalString() instead of redundant $conf->global-> ternaries

### DIFF
--- a/htdocs/bookcal/availabilities_agenda.php
+++ b/htdocs/bookcal/availabilities_agenda.php
@@ -55,7 +55,7 @@ if (GETPOST('actioncode', 'array')) {
 		$actioncode = '0';
 	}
 } else {
-	$actioncode = GETPOST("actioncode", "alpha", 3) ? GETPOST("actioncode", "alpha", 3) : (GETPOST("actioncode") == '0' ? '0' : (!getDolGlobalString('AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT') ? '' : $conf->global->AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT));
+	$actioncode = GETPOST("actioncode", "alpha", 3) ? GETPOST("actioncode", "alpha", 3) : (GETPOST("actioncode") == '0' ? '0' : getDolGlobalString('AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT'));
 }
 
 $search_rowid = GETPOST('search_rowid');

--- a/htdocs/core/modules/barcode/mod_barcode_product_standard.php
+++ b/htdocs/core/modules/barcode/mod_barcode_product_standard.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2006-2014  Laurent Destailleur     <eldy@users.sourceforge.net>
  * Copyright (C) 2007-2012  Regis Houssin           <regis.houssin@inodbox.com>
  * Copyright (C) 2011       Juanjo Menent	        <jmenent@2byte.es>
- * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -326,12 +326,10 @@ class mod_barcode_product_standard extends ModeleNumRefBarCode
 	public function verif_syntax($codefortest, $typefortest)
 	{
 		// phpcs:enable
-		global $conf;
-
 		$result = 0;
 
 		// Get Mask value
-		$mask = !getDolGlobalString('BARCODE_STANDARD_PRODUCT_MASK') ? '' : $conf->global->BARCODE_STANDARD_PRODUCT_MASK;
+		$mask = getDolGlobalString('BARCODE_STANDARD_PRODUCT_MASK');
 		if (!$mask) {
 			$this->error = 'NotConfigured';
 			return -1;

--- a/htdocs/core/modules/barcode/mod_barcode_thirdparty_standard.php
+++ b/htdocs/core/modules/barcode/mod_barcode_thirdparty_standard.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2007-2012 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2011      Juanjo Menent	    <jmenent@2byte.es>
  * Copyright (C) 2022      Faustin Boitel <fboitel@enseirb-matmeca.fr>
- * Copyright (C) 2024		Frédéric France			    <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			    <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -347,12 +347,10 @@ class mod_barcode_thirdparty_standard extends ModeleNumRefBarCode
 	public function verif_syntax($codefortest, $typefortest)
 	{
 		// phpcs:enable
-		global $conf;
-
 		$result = 0;
 
 		// Get Mask value
-		$mask = !getDolGlobalString('BARCODE_STANDARD_THIRDPARTY_MASK') ? '' : $conf->global->BARCODE_STANDARD_THIRDPARTY_MASK;
+		$mask = getDolGlobalString('BARCODE_STANDARD_THIRDPARTY_MASK');
 		if (!$mask) {
 			$this->error = 'NotConfigured';
 			return -1;

--- a/htdocs/core/modules/propale/mod_propale_saphir.php
+++ b/htdocs/core/modules/propale/mod_propale_saphir.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2004-2010 Laurent Destailleur         <eldy@users.sourceforge.net>
  * Copyright (C) 2005-2007 Regis Houssin               <regis.houssin@inodbox.com>
  * Copyright (C) 2008      Raphael Bertrand (Resultic) <raphael.bertrand@resultic.fr>
- * Copyright (C) 2024-2025  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -65,7 +65,7 @@ class mod_propale_saphir extends ModeleNumRefPropales
 	 */
 	public function info($langs)
 	{
-		global $conf, $langs, $db;
+		global $langs, $db;
 
 		$langs->load("bills");
 
@@ -92,7 +92,7 @@ class mod_propale_saphir extends ModeleNumRefPropales
 
 		// Setting of prefix
 		$texte .= '<tr><td>'.$langs->trans("Mask").':</td>';
-		$mask = !getDolGlobalString('PROPALE_SAPHIR_MASK') ? '' : $conf->global->PROPALE_SAPHIR_MASK;
+		$mask = getDolGlobalString('PROPALE_SAPHIR_MASK');
 		$texte .= '<td class="right nowraponall">'.$form->textwithpicto('<input type="text" class="flat minwidth175" name="maskpropal" value="'.$mask.'">', $tooltip, 1, 'help', 'valignmiddle', 0, 3, $this->name).'</td>';
 
 		$texte .= '<td class="left"><input type="submit" class="button button-edit reposition smallpaddingimp" name="Button" value="'.$langs->trans("Save").'"></td>';
@@ -139,12 +139,12 @@ class mod_propale_saphir extends ModeleNumRefPropales
 	 */
 	public function getNextValue($objsoc, $propal)
 	{
-		global $db, $conf;
+		global $db;
 
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 
 		// On defini critere recherche compteur
-		$mask = !getDolGlobalString('PROPALE_SAPHIR_MASK') ? '' : $conf->global->PROPALE_SAPHIR_MASK;
+		$mask = getDolGlobalString('PROPALE_SAPHIR_MASK');
 
 		if (!$mask) {
 			$this->error = 'NotConfigured';

--- a/htdocs/core/modules/societe/mod_codeclient_elephant.php
+++ b/htdocs/core/modules/societe/mod_codeclient_elephant.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2007-2012 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2011      Juanjo Menent	    <jmenent@2byte.es>
  * Copyright (C) 2013-2018 Philippe Grand      	<philippe.grand@atoo-net.com>
- * Copyright (C) 2020-2025  Frédéric France		<frederic.france@free.fr>
+ * Copyright (C) 2020-2026  Frédéric France		<frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Eric Seigne 		<eric.seigne@cap-rel.fr>
  * Copyright (C) 2025		Charlene Benke 		<charlene@patas-monkey.com>
@@ -316,8 +316,6 @@ class mod_codeclient_elephant extends ModeleThirdPartyCode
 	 */
 	public function verif($db, &$code, $soc, $type)
 	{
-		global $conf;
-
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 
 		$result = 0;
@@ -334,10 +332,10 @@ class mod_codeclient_elephant extends ModeleThirdPartyCode
 			// Get Mask value
 			$mask = '';
 			if ($type == 0) {
-				$mask = !getDolGlobalString('COMPANY_ELEPHANT_MASK_CUSTOMER') ? '' : $conf->global->COMPANY_ELEPHANT_MASK_CUSTOMER;
+				$mask = getDolGlobalString('COMPANY_ELEPHANT_MASK_CUSTOMER');
 			}
 			if ($type == 1) {
-				$mask = !getDolGlobalString('COMPANY_ELEPHANT_MASK_SUPPLIER') ? '' : $conf->global->COMPANY_ELEPHANT_MASK_SUPPLIER;
+				$mask = getDolGlobalString('COMPANY_ELEPHANT_MASK_SUPPLIER');
 			}
 			if (!$mask) {
 				$this->error = 'NotConfigured';

--- a/htdocs/core/modules/supplier_proposal/mod_supplier_proposal_saphir.php
+++ b/htdocs/core/modules/supplier_proposal/mod_supplier_proposal_saphir.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2005-2007 Regis Houssin               <regis.houssin@inodbox.com>
  * Copyright (C) 2008      Raphael Bertrand (Resultic) <raphael.bertrand@resultic.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2025       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2025-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -137,12 +137,12 @@ class mod_supplier_proposal_saphir extends ModeleNumRefSupplierProposal
 	 */
 	public function getNextValue($objsoc, $supplier_proposal)
 	{
-		global $db, $conf;
+		global $db;
 
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 
 		// On defini critere recherche compteur
-		$mask = !getDolGlobalString('SUPPLIER_PROPOSAL_SAPHIR_MASK') ? '' : $conf->global->SUPPLIER_PROPOSAL_SAPHIR_MASK;
+		$mask = getDolGlobalString('SUPPLIER_PROPOSAL_SAPHIR_MASK');
 
 		if (!$mask) {
 			$this->error = 'NotConfigured';

--- a/htdocs/fourn/commande/info.php
+++ b/htdocs/fourn/commande/info.php
@@ -77,7 +77,7 @@ if (GETPOST('actioncode', 'array')) {
 		$actioncode = '0';
 	}
 } else {
-	$actioncode = GETPOST("actioncode", "alpha", 3) ? GETPOST("actioncode", "alpha", 3) : (GETPOST("actioncode") == '0' ? '0' : (!getDolGlobalString('AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECTS') ? '' : $conf->global->AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECTS));
+	$actioncode = GETPOST("actioncode", "alpha", 3) ? GETPOST("actioncode", "alpha", 3) : (GETPOST("actioncode") == '0' ? '0' : getDolGlobalString('AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECTS'));
 }
 $search_rowid = GETPOST('search_rowid');
 $search_agenda_label = GETPOST('search_agenda_label');

--- a/htdocs/public/company/new.php
+++ b/htdocs/public/company/new.php
@@ -403,7 +403,7 @@ print '<td>' . img_picto('', 'object_phoning_fax', 'class="pictofixedwidth"') . 
 print '</tr>';
 
 // Email / Web
-print '<tr><td>' . $form->editfieldkey('EMail', 'email', '', $object, 0, 'string', '', !getDolGlobalString('SOCIETE_EMAIL_MANDATORY') ? '' : $conf->global->SOCIETE_EMAIL_MANDATORY) . '</td>';
+print '<tr><td>' . $form->editfieldkey('EMail', 'email', '', $object, 0, 'string', '', getDolGlobalInt('SOCIETE_EMAIL_MANDATORY')) . '</td>';
 print '<td>' . img_picto('', 'object_email', 'class="pictofixedwidth"') . ' <input type="text" class="maxwidth200 widthcentpercentminusx" name="email" id="email" value="' . $object->email . '"></td>';
 if (isModEnabled('mailing') && getDolGlobalString('THIRDPARTY_SUGGEST_ALSO_ADDRESS_CREATION')) {
 	if ($conf->browser->layout == 'phone') {

--- a/htdocs/recruitment/core/modules/recruitment/doc/pdf_standard_recruitmentjobposition.modules.php
+++ b/htdocs/recruitment/core/modules/recruitment/doc/pdf_standard_recruitmentjobposition.modules.php
@@ -9,7 +9,7 @@
  * Copyright (C) 2012-2014  Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2017       Ferran Marcet           <fmarcet@2byte.es>
- * Copyright (C) 2018-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -296,7 +296,7 @@ class pdf_standard_recruitmentjobposition extends ModelePDFRecruitmentJobPositio
 				$cert = empty($user->conf->CERTIFICATE_CRT) ? '' : $user->conf->CERTIFICATE_CRT;
 				// If user has no certificate, we try to take the company one
 				if (!$cert) {
-					$cert = !getDolGlobalString('CERTIFICATE_CRT') ? '' : $conf->global->CERTIFICATE_CRT;
+					$cert = getDolGlobalString('CERTIFICATE_CRT');
 				}
 				// If a certificate is found
 				if ($cert) {

--- a/htdocs/workstation/workstation_agenda.php
+++ b/htdocs/workstation/workstation_agenda.php
@@ -56,7 +56,7 @@ if (GETPOST('actioncode', 'array')) {
 		$actioncode = '0';
 	}
 } else {
-	$actioncode = GETPOST("actioncode", "alpha", 3) ? GETPOST("actioncode", "alpha", 3) : (GETPOST("actioncode") == '0' ? '0' : (!getDolGlobalString('AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT') ? '' : $conf->global->AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT));
+	$actioncode = GETPOST("actioncode", "alpha", 3) ? GETPOST("actioncode", "alpha", 3) : (GETPOST("actioncode") == '0' ? '0' : getDolGlobalString('AGENDA_DEFAULT_FILTER_TYPE_FOR_OBJECT'));
 }
 
 $search_rowid = GETPOST('search_rowid');


### PR DESCRIPTION
## What

Mechanical cleanup of the pattern

```php
!getDolGlobalString('X') ? '' : $conf->global->X
```

which is exactly `getDolGlobalString('X')` — collapsing it removes the last raw `$conf->global->` reads in these 10 files. Where the constant is a numeric flag (`SOCIETE_EMAIL_MANDATORY`, passed as `editfieldkey()`'s `int $fieldrequired`), `getDolGlobalInt()` is used instead.

A few numbering-model methods (`mod_barcode_*::verif_syntax()`, `mod_propale_saphir`, `mod_codeclient_elephant::verif()`, `mod_supplier_proposal_saphir::getNextValue()`) had their `$conf` only for that read; the now-dead `global $conf;` is removed.

No behaviour change.

## Not included on purpose

Files touched by the same pattern but carrying unrelated pre-existing phan/phpstan findings that would be dragged into CI scope (`core/lib/functions2.lib.php`, `fourn/commande/card.php`, `user/param_ihm.php`, `core/menus/standard/auguria.lib.php`) are left for follow-up PRs that also address those findings.

## Tests

`php -l`, PHP_CodeSniffer, local pre-commit (PHPStan + Phan) and CI-style PHPStan level 10 (`bootstrap_action.php`) all clean on the changed files.


Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
