### PR TITLE
Qual: eventorganization - use getDolGlobal* instead of $conf->global->

### DIFF
--- a/htdocs/eventorganization/class/conferenceorboothattendee.class.php
+++ b/htdocs/eventorganization/class/conferenceorboothattendee.class.php
@@ -1,6 +1,6 @@
 <?php
 /* Copyright (C) 2017	Laurent Destailleur <eldy@users.sourceforge.net>
- * Copyright (C) 2024-2025  Frédéric France     <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -233,7 +233,7 @@ class ConferenceOrBoothAttendee extends CommonObject
 	 */
 	public function __construct(DoliDB $db)
 	{
-		global $conf, $langs;
+		global $langs;
 
 		$this->db = $db;
 
@@ -248,10 +248,9 @@ class ConferenceOrBoothAttendee extends CommonObject
 		}
 
 		if (getDolGlobalString('EVENTORGANIZATION_FILTERATTENDEES_CAT')) {
-			$this->fields['fk_soc']['type'] .= ' AND rowid IN (SELECT DISTINCT c.fk_soc FROM '.MAIN_DB_PREFIX.'categorie_societe as c WHERE c.fk_categorie='.(int) $conf->global->EVENTORGANIZATION_FILTERATTENDEES_CAT.')';
+			$this->fields['fk_soc']['type'] .= ' AND rowid IN (SELECT DISTINCT c.fk_soc FROM '.MAIN_DB_PREFIX.'categorie_societe as c WHERE c.fk_categorie='.getDolGlobalInt('EVENTORGANIZATION_FILTERATTENDEES_CAT').')';
 		}
-		if (isset($conf->global->EVENTORGANIZATION_FILTERATTENDEES_TYPE)
-			&& getDolGlobalString('EVENTORGANIZATION_FILTERATTENDEES_TYPE') !== ''
+		if (getDolGlobalString('EVENTORGANIZATION_FILTERATTENDEES_TYPE') !== ''
 			&& getDolGlobalString('EVENTORGANIZATION_FILTERATTENDEES_TYPE') !== '-1') {
 			$this->fields['fk_soc']['type'] .= ' AND (client:=:'.((int) getDolGlobalInt('EVENTORGANIZATION_FILTERATTENDEES_TYPE', 0) . ')');
 		}


### PR DESCRIPTION
`conferenceorboothattendee.class.php` `__construct()`:

- `EVENTORGANIZATION_FILTERATTENDEES_CAT` read via `getDolGlobalInt()`.
- `isset($conf->global->EVENTORGANIZATION_FILTERATTENDEES_TYPE)` guard removed — the very next condition `getDolGlobalString('...') !== ''` already covers the "not set" case.
- Dead `global $conf` removed (`$langs` kept).

Remaining `$conf->global->EVENTORGANIZATION_CONFERENCEORBOOTHATTENDEE_ADDON = ...` is a write (runtime default), left as-is.

No behaviour change. `php -l`, PHP_CodeSniffer, PHPStan (level 10 + pre-commit `--level=9`) and Phan clean.