### PR TITLE
Fix #36749 report a missing dom extension in the installer

### DIFF
--- a/htdocs/install/check.php
+++ b/htdocs/install/check.php
@@ -193,6 +193,15 @@ if (!function_exists("simplexml_load_string")) {
 	print '<img src="../theme/eldy/img/tick.png" alt="Ok" class="valignmiddle paddingright"> '.$langs->trans("PHPSupport", "Xml")."<br>\n";
 }
 
+// Check if Dom is supported. Dolibarr uses DOMDocument to sanitize html, so a page can not even be rendered without it.
+if (!extension_loaded("dom")) {
+	$langs->load("errors");
+	print '<img src="../theme/eldy/img/warning.png" alt="Error" class="valignmiddle paddingright"> '.$langs->trans("ErrorPHPDoesNotSupport", "Dom")."<br>\n";
+	// $checksok = 0;	// If ko, just warning. So check must still be 1 (otherwise no way to install)
+} else {
+	print '<img src="../theme/eldy/img/tick.png" alt="Ok" class="valignmiddle paddingright"> '.$langs->trans("PHPSupport", "Dom")."<br>\n";
+}
+
 // Check if UTF8 is supported
 if (!function_exists("utf8_encode")) {
 	$langs->load("errors");


### PR DESCRIPTION
install/check.php verifies mbstring, json, gd, curl, calendar, simplexml, utf8, intl and imap, but never dom. So an install on a PHP built without it completes with no warning, and the first page rendered dies exactly as reported.

The reason it is fatal rather than degraded: dol_htmlwithnojs() instantiates DOMDocument with no guard, unlike the tidy block a few lines below which is wrapped in class_exists(). login.tpl.php:272 reaches it through dolPrintHTML(), so the login page itself cannot render.

    with dom     tick    PHPSupport(Dom)
    without dom  warning ErrorPHPDoesNotSupport(Dom)

Reported as a warning rather than a blocking error, following every other extension check in that file, which all carry the same commented-out $checksok = 0 and the note "If ko, just warning. So check must still be 1 (otherwise no way to install)". Both translation keys already exist in install.lang, so nothing to add there.

Arguably dom deserves to be blocking given that no page renders without it, but making it the first blocking extension check is a behaviour decision for a maintainer rather than something to slip into a bug fix.

Reported by @Zulgrib in #36749.