### PR TITLE
Fix #39933 render remise_percent in the locale format when editing a line

### DIFF
--- a/htdocs/core/tpl/objectline_edit.tpl.php
+++ b/htdocs/core/tpl/objectline_edit.tpl.php
@@ -319,7 +319,7 @@ $coldisplay++;
 	// Discount
 	$coldisplay++;
 	if (($line->info_bits & 2) != 2) {
-		print '<input type="text" class="flat right width40" name="remise_percent" id="remise_percent" value="'.(GETPOSTISSET('remise_percent') ? GETPOST('remise_percent') : ($line->remise_percent ? $line->remise_percent : '')).'"';
+		print '<input type="text" class="flat right width40" name="remise_percent" id="remise_percent" value="'.(GETPOSTISSET('remise_percent') ? GETPOST('remise_percent') : ($line->remise_percent ? price($line->remise_percent, 0, '', 0, 0) : '')).'"';
 		if ($situationinvoicelinewithparent) {
 			print ' readonly';
 		}


### PR DESCRIPTION
Follow-up to #39945, which fixed the quantity on the same form.

The discount field is still printed raw while the money fields of that form go through price():

    line 256  price_ht               price($line->pu_ht, 0, '', 0)
    line 264  multicurrency_subprice price($line->multicurrency_subprice)
    line 287  qty                    price(...)   <- fixed by #39945
    line 322  remise_percent         raw          <- this PR

@mdeweerd asked for it explicitly on the issue, on the grounds that remise_percent should follow the same localize on output, delocalize on input rule.

Safe for the same reason as the quantity: every consumer already parses the submitted value with price2num(), in propal and commande alike (comm/propal/card.php:1244 and :1888, commande/card.php:998 and :1645), so the entry point was the only thing out of line.

Round trip checked in fr_FR, a locale with a decimal comma and a space thousand separator:

    db 2.50000000     shown "2,5"        parsed 2.5       ok
    db 10.00000000    shown "10"         parsed 10        ok
    db 1234.56000000  shown "1 234,56"   parsed 1234.56   ok

Rebased on 22.0 after #39945 landed, so the diff is now the single remaining line.