### PR TITLE
Fix #37353 restore the contact category export

### DIFF
--- a/htdocs/core/modules/modCategorie.class.php
+++ b/htdocs/core/modules/modCategorie.class.php
@@ -358,7 +358,8 @@ class modCategorie extends DolibarrModules
 		}
 
 		// 4 Contacts
-		if (isModEnabled("contact")) {
+		// Contacts belong to the societe module, there is no "contact" module to enable
+		if (isModEnabled("societe")) {
 			$categcode = 'contact';
 			$r++;
 			$this->export_code[$r] = $this->rights_class.'_4_'.$categcode;


### PR DESCRIPTION
The dataset that exports contacts with their tags is declared in modCategorie behind:

    // 4 Contacts
    if (isModEnabled("contact")) {

but there is no contact module in Dolibarr. Contacts belong to societe, and MODULE_MAPPING lists 'socpeople' => 'contact' as a rename of the element, not as an enableable module. No module ever sets MAIN_MODULE_CONTACT, so the condition is always false and the dataset simply stops being registered, which is why the export disappeared after upgrading from 21 to 22.

Two things in the same file confirm what the guard should be:

    line 148  "4=Contact" in the type example list  ->  isModEnabled("societe")
    line 685  the IMPORT block for llx_categorie_contact  ->  isModEnabled("societe")

so the import side of the very same table already uses societe, and only the export was wrong. It is also the only occurrence of isModEnabled("contact") in the whole tree.

The SQL of the export itself is unchanged between 21.0 and 22.0, only the guard was added around it, which matches a regression that removes the entry rather than breaking the query.

Reported by @bod29 in #37353.