### PR TITLE
QUAL Fix dol_print_error() called with wrong type in dol_htmlwithnojs

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -6281,7 +6281,7 @@ function dol_htmlwithnojs($stringtoencode, $nouseofiframesandbox = 0, $check = '
 		// First clean HTML content
 		do {
 			if ($antiinfinitloop >= 20) {
-				dol_print_error('', "Infinite loop detected after ".$antiinfinitloop." iterations in dol_htmlwithnojs");
+				dol_print_error(null, "Infinite loop detected after ".$antiinfinitloop." iterations in dol_htmlwithnojs");
 				die;	// We must not break and we must not return a string for security issue. This should never happen.
 			}
 			$antiinfinitloop++;


### PR DESCRIPTION
dol_print_error($db = null, ...) declares $db as DoliDB|null, but the anti-infinite-loop guard added to dol_htmlwithnojs() passed an empty string instead, which is exactly the type mismatch phan flags. Pass null, matching the function's own documented default and every other call site that has no DB handler available at that point.

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# UIUX|Uiux [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

