### PR TITLE
Fix #40014 search bookkeeping entries by movement number on PostgreSQL

### DIFF
--- a/htdocs/accountancy/bookkeeping/list.php
+++ b/htdocs/accountancy/bookkeeping/list.php
@@ -716,8 +716,9 @@ if (count($filter) > 0) {
 			$sqlwhere[] = "t.subledger_account >= '".$db->escape($value)."'";
 		} elseif ($key == 't.subledger_account<=') {
 			$sqlwhere[] = "t.subledger_account <= '".$db->escape($value)."'";
-			/* } elseif ($key == 't.fk_doc' || $key == 't.fk_docdet' || $key == 't.piece_num') { // these fields doesn't exists
-			$sqlwhere[] = $db->sanitize($key).' = '.((int) $value); */
+		} elseif ($key == 't.piece_num') {
+			// piece_num is an integer column, a LIKE on it is translated to ILIKE by the pgsql driver and fails
+			$sqlwhere[] = natural_search($key, $value, 1, 1);
 		} elseif ($key == 't.subledger_account' || $key == 't.numero_compte') {
 			$sqlwhere[] = $db->sanitize($key)." LIKE '".$db->escape($db->escapeforlike($value))."%'";
 			/* } elseif ($key == 't.subledger_account') { // test is always false


### PR DESCRIPTION
The diagnosis in the issue is correct. t.piece_num had no explicit branch in the filter dispatch, so it fell through to a LIKE, which the pgsql driver rewrites as ILIKE against an integer column.

Reproduced on PostgreSQL 16, the exact error from the report:

    SELECT piece_num FROM bk t WHERE (t.piece_num ILIKE '%7%');
    ERROR:  operator does not exist: integer ~~* unknown

The branch that used to handle it is still in the file, commented out with the note "these fields doesn't exists". That is true for fk_doc and fk_docdet, but piece_num does exist: it is declared integer NOT NULL in llx_accounting_bookkeeping.sql and the class treats it as an int everywhere (bookkeeping.class.php:292, :462, :1637).

Rather than restoring the plain equality, this uses natural_search in numeric mode, which is what t.credit and t.debit already use in the same file (list.php:746). Generated with the real function:

    "7"    -> (t.piece_num = 7)
    "<10"  -> (t.piece_num < 10)
    ">5"   -> (t.piece_num > 5)

and verified against PostgreSQL with rows 7, 17, 70:

    (t.piece_num = 7)    -> 7
    (t.piece_num < 10)   -> 7
    (t.piece_num > 5)    -> 7,17,70

One behaviour change worth flagging: on MySQL the LIKE currently works, and searching 7 returns 7, 17 and 70 because it matches substrings. After this it returns 7 only. I believe exact match is the right semantics for a movement number, and it is what the original commented-out code did, but it is a visible change for MySQL users so it should be a conscious choice rather than a silent one.

Only 22.0 and later are affected, 21.0 and 18.0 do not carry that commented block.

Reported by @RoL0NL in #40014.