### PR TITLE
QUAL: contrat/card.php - resolve origin object via fetchObjectByElement()

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -313,39 +313,6 @@ if (empty($reshook)) {
 
 			// If creation from another object of another module (Example: origin=propal, originid=1)
 			if (!empty($origin) && !empty($originid)) {
-				// Parse element/subelement (ex: project_task)
-				$element = $subelement = $origin;
-				$regs = array();
-				if (preg_match('/^([^_]+)_([^_]+)/i', $origin, $regs)) {
-					$element = $regs[1];
-					$subelement = $regs[2];
-				}
-
-				// For compatibility
-				$classname = '';
-				if ($element == 'order') {
-					$element = $subelement = 'commande';
-				}
-				if ($element == 'propal') {
-					$element = 'comm/propal';
-					$subelement = 'propal';
-				}
-				if ($element == 'invoice' || $element == 'facture') {
-					$element = 'compta/facture';
-					$subelement = 'facture';
-				}
-				if ($element == 'facturerec' || $element == 'facture_rec') {
-					// FactureRec lives in compta/facture/class/facture-rec.class.php (#34775)
-					$element = 'compta/facture';
-					$subelement = 'facture-rec';
-					$classname = 'FactureRec';
-				}
-				if ($element == 'facture_fourn_rec' || $element == 'invoice_supplier_rec') {
-					$element = 'fourn';
-					$subelement = 'fournisseur.facture-rec';
-					$classname = 'FactureFournisseurRec';
-				}
-
 				$object->origin    = $origin;
 				$object->origin_id = $originid;
 
@@ -357,17 +324,13 @@ if (empty($reshook)) {
 
 				$id = $object->create($user);
 				if ($id > 0) {
-					dol_include_once('/'.$element.'/class/'.$subelement.'.class.php');
-
-					if (empty($classname)) {
-						$classname = ucfirst($subelement);
-					}
-					$srcobject = new $classname($db);
-					'@phan-var-force Commande|Propal|Facture $srcobject';  // Can be other class, but CommonObject is too Generic
-
 					dol_syslog("Try to find source object origin=".$object->origin." originid=".$object->origin_id." to add lines");
-					$result = $srcobject->fetch($object->origin_id);
-					if ($result > 0) {
+
+					// Resolve and load the source object from its element type (propal, commande, facture, facture_rec, invoice_supplier_rec, ...)
+					$srcobject = fetchObjectByElement($object->origin_id, $origin);
+
+					if (is_object($srcobject) && $srcobject->id > 0) {
+						'@phan-var-force Commande|Propal|Facture $srcobject';  // Can be other class, but CommonObject is too Generic
 						$srcobject->fetch_thirdparty();
 						$lines = $srcobject->lines;
 						if (empty($lines) && method_exists($srcobject, 'fetch_lines')) {
@@ -458,12 +421,18 @@ if (empty($reshook)) {
 							}
 						}
 					} else {
-						setEventMessages($srcobject->error, $srcobject->errors, 'errors');
+						if (is_object($srcobject) && !empty($srcobject->error)) {
+							$srcobjecterror = $srcobject->error;
+						} else {
+							$langs->load("errors");
+							$srcobjecterror = $langs->trans("ErrorRecordNotFound");
+						}
+						setEventMessages($srcobjecterror, (is_object($srcobject) ? $srcobject->errors : null), 'errors');
 						$error++;
 					}
 
 					// Hooks
-					$parameters = array('objFrom' => $srcobject);
+					$parameters = array('objFrom' => (is_object($srcobject) ? $srcobject : null));
 					$reshook = $hookmanager->executeHooks('createFrom', $parameters, $object, $action); // Note that $action and $object may have been
 					// modified by hook
 					if ($reshook < 0) {
@@ -1182,6 +1151,7 @@ if ($result > 0) {
 // Create
 if ($action == 'create') {
 	$objectsrc = null;
+	$projectid = GETPOSTINT('projectid');
 	print load_fiche_titre($langs->trans('NewContract'), '', 'contract');
 
 	$soc = new Societe($db);
@@ -1190,67 +1160,42 @@ if ($action == 'create') {
 	}
 
 	if (GETPOST('origin') && GETPOSTINT('originid')) {
-		// Parse element/subelement (ex: project_task)
+		// Parse element (ex: project_task -> project) just to detect the 'project' origin handled below
 		$regs = array();
-		$element = $subelement = GETPOST('origin');
+		$element = GETPOST('origin');
 		if (preg_match('/^([^_]+)_([^_]+)/i', GETPOST('origin'), $regs)) {
 			$element = $regs[1];
-			$subelement = $regs[2];
 		}
 
 		if ($element == 'project') {
 			$projectid = GETPOSTINT('originid');
 		} else {
-			// For compatibility
-			if ($element == 'order' || $element == 'commande') {
-				$element = $subelement = 'commande';
-			}
-			if ($element == 'propal') {
-				$element = 'comm/propal';
-				$subelement = 'propal';
-			}
-			if ($element == 'invoice' || $element == 'facture') {
-				$element = 'compta/facture';
-				$subelement = 'facture';
-			}
-			$classname = '';
-			if ($element == 'facturerec' || $element == 'facture_rec') {
-				$element = 'compta/facture';
-				$subelement = 'facture-rec';
-				$classname = 'FactureRec';
-			}
-			if ($element == 'facture_fourn_rec' || $element == 'invoice_supplier_rec') {
-				$element = 'fourn';
-				$subelement = 'fournisseur.facture-rec';
-				$classname = 'FactureFournisseurRec';
-			}
+			// Resolve and load the source object from its element type (propal, commande, facture, facture_rec, invoice_supplier_rec, ...)
+			$objectsrc = fetchObjectByElement($originid, $origin);
 
-			dol_include_once('/'.$element.'/class/'.$subelement.'.class.php');
+			if (is_object($objectsrc) && $objectsrc->id > 0) {
+				'@phan-var-force Commande|Propal|Facture $objectsrc';
+				if (empty($objectsrc->lines) && method_exists($objectsrc, 'fetch_lines')) {
+					$objectsrc->fetch_lines();
+				}
+				$objectsrc->fetch_thirdparty();
 
-			if (empty($classname)) {
-				$classname = ucfirst($subelement);
+				// Replicate extrafields
+				$objectsrc->fetch_optionals();
+				$object->array_options = $objectsrc->array_options;
+
+				$projectid = (int) $objectsrc->fk_project;
+
+				$soc = $objectsrc->thirdparty;
+
+				$note_private = (!empty($objectsrc->note_private) ? $objectsrc->note_private : '');
+				$note_public = (!empty($objectsrc->note_public) ? $objectsrc->note_public : '');
+
+				// Object source contacts list
+				$srccontactslist = $objectsrc->liste_contact(-1, 'external', 1);
+			} else {
+				$objectsrc = null;
 			}
-			$objectsrc = new $classname($db);
-			'@phan-var-force Commande|Propal|Facture $objectsrc';
-			$objectsrc->fetch($originid);
-			if (empty($objectsrc->lines) && method_exists($objectsrc, 'fetch_lines')) {
-				$objectsrc->fetch_lines();
-			}
-			$objectsrc->fetch_thirdparty();
-
-			// Replicate extrafields
-			$objectsrc->fetch_optionals();
-			$object->array_options = $objectsrc->array_options;
-
-			$projectid = (int) $objectsrc->fk_project;
-
-			$soc = $objectsrc->thirdparty;
-
-			$note_private = (!empty($objectsrc->note_private) ? $objectsrc->note_private : '');
-			$note_public = (!empty($objectsrc->note_public) ? $objectsrc->note_public : '');
-
-			// Object source contacts list
-			$srccontactslist = $objectsrc->liste_contact(-1, 'external', 1);
 		}
 	} else {
 		$projectid = GETPOSTINT('projectid');

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -10679,6 +10679,14 @@ function getElementProperties($elementType)
 		$subelement = '';
 		$classname = 'FactureFournisseur';
 		$table_element = 'facture_fourn';
+	} elseif ($elementType == 'invoice_supplier_rec' || $elementType == 'supplier_invoice_rec' || $elementType == 'facture_fourn_rec') {
+		$classpath = 'fourn/class';
+		$module = 'fournisseur';
+		$classfile = 'fournisseur.facture-rec';
+		$element = 'invoice_supplier_rec';
+		$subelement = '';
+		$classname = 'FactureFournisseurRec';
+		$table_element = 'facture_fourn_rec';
 	} elseif ($elementType == 'facture_fourn_det') {
 		$classpath = 'fourn/class';
 		$module = 'fournisseur';


### PR DESCRIPTION
## Description

`contrat/card.php` had **two** near-identical *"For compatibility"* blocks (create action + create view) that mapped an `origin` element string (`propal`, `order`, `facture`, `facture_rec`, `invoice_supplier_rec`, …) to a class path / file / name by hand, then did `dol_include_once` + `new $classname` + `fetch()`.

That is exactly what `fetchObjectByElement($id, $element_type)` / `getElementProperties()` in `functions.lib.php` already do. Both blocks are replaced by a single `fetchObjectByElement()` call. Net **-91 / +44** lines.

The same duplicated block also lives in `fichinter/card.php`, `commande/card.php`, `supplier_proposal/card.php` — this PR does only `contrat/` to keep it reviewable; the others can follow.

## Behaviour changes

- **`getElementProperties()`** gains an `invoice_supplier_rec` / `supplier_invoice_rec` / `facture_fourn_rec` entry (it was missing) → resolves to `FactureFournisseurRec` (`fourn/class/fournisseur.facture-rec.class.php`).
- **`facture_rec` / `invoice_supplier_rec` origins now load their real recurring class.** The old blocks ran `preg_match('/^([^_]+)_([^_]+)/')` first, so `facture_rec` became `element = 'facture'` *before* the compat tests and matched the plain-invoice branch — the `FactureRec` / `FactureFournisseurRec` branches were effectively dead code. `getElementProperties()` matches on the full element type, so it now does the right thing.
- **Origin module must be enabled**: `fetchObjectByElement()` gates on `isModEnabled()`. An unresolved / disabled origin now sets an error (`ErrorRecordNotFound`, create action) or leaves the form unfilled (create view) instead of fataling on an unknown class.
- `$projectid` is now initialised once at the top of the create view (`GETPOSTINT('projectid')`) so it is always defined (PHPStan).

## Tests

- `getElementProperties()` resolution verified for `propal`, `order`, `commande`, `facture`, `invoice`, `facture_rec`, `facturerec`, `invoice_supplier_rec`, `facture_fourn_rec`.
- PHPStan (level 9) + Phan: clean on the changed files.
- Manual test still recommended: create a contract from a proposal / sales order / customer invoice / recurring customer invoice / recurring supplier invoice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
