### PR TITLE
FIX Vendor area: draft supplier invoices show a PHP warning instead of the reference

### DIFF
--- a/htdocs/fourn/index.php
+++ b/htdocs/fourn/index.php
@@ -168,7 +168,7 @@ if (isModEnabled("supplier_order")) {
 
 // Draft invoices
 if (isModEnabled("supplier_invoice") && ($user->hasRight('fournisseur', 'facture', 'lire') || $user->hasRight('supplier_invoice', 'read'))) {
-	$sql = "SELECT ff.ref_supplier, ff.rowid, ff.total_ttc, ff.type";
+	$sql = "SELECT ff.ref, ff.ref_supplier, ff.rowid, ff.total_ttc, ff.type";
 	$sql .= ", s.nom as name, s.rowid as socid";
 	$sql .= " FROM ".MAIN_DB_PREFIX."facture_fourn as ff";
 	$sql .= ", ".MAIN_DB_PREFIX."societe as s";


### PR DESCRIPTION
# FIX Vendor area: draft supplier invoices show a PHP warning instead of the reference

The "Draft invoices" block on the Vendor area page (`htdocs/fourn/index.php`) builds its query as:

```php
$sql = "SELECT ff.ref_supplier, ff.rowid, ff.total_ttc, ff.type";
```

but the loop below reads a column that was never selected:

```php
$facturestatic->ref = $obj->ref;
```

So every row emits `Warning: Undefined property: stdClass::$ref in .../fourn/index.php on line 204`, and because `$facturestatic->ref` ends up empty, `getNomUrl()` renders a link with no label.

Adding `ff.ref` to the SELECT matches the sibling **Draft orders** block ~50 lines above, which already selects `cf.ref` and assigns it the same way — so the two blocks now behave identically.

**Why it has gone unnoticed:** it only appears when at least one *draft* supplier invoice exists. Validated ones go through a different block.

**Affected versions:** reproduced in 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0 and develop. Targeting 22.0 per the N-2 guidance in CONTRIBUTING.

**Reproduction**
1. Enable the Supplier invoice module.
2. Create a supplier invoice and leave it as a draft.
3. Open **Vendor area** (`/fourn/index.php`).

**Before** — three draft supplier invoices, each showing the warning where the reference link belongs. Note the *Draft orders* block above rendering correctly, for contrast:

![before](https://raw.githubusercontent.com/AKhalid-projects/dolibarr/de3f008f8858a1a543c96a334cefc9d9b1043b44/before-fourn-index.png)

**After** — the same page with `ff.ref` selected:

![after](https://raw.githubusercontent.com/AKhalid-projects/dolibarr/de3f008f8858a1a543c96a334cefc9d9b1043b44/after-fourn-index.png)

Screenshots taken with the `eldy` theme on an instance running the develop branch; the block is byte-identical in 22.0.

<sub>Found while adding draft supplier invoices to a test fixture set; reproduced and verified before and after on a running instance.</sub>
