### PR TITLE
FIX : Fix empty option on extrafields sellist when MAIN_EXTRAFIELDS_ENABLE_NEW_SELECT2 is activated who is displayed has raw text '&nbsp;' and not a space character

### DIFF
--- a/htdocs/core/ajax/ajaxextrafield.php
+++ b/htdocs/core/ajax/ajaxextrafield.php
@@ -101,7 +101,7 @@ $data = [
 if ($page == 1) {
 	$data['results'][] = [
 		'id' => -1,
-		'text' => '&nbsp;',
+		'text' => "\u{00A0}",	// Real non-breaking space (U+00A0), not the HTML entity '&nbsp;' which Select2 would escape and display as raw text
 	];
 }
 $i = 0;


### PR DESCRIPTION
Fix empty option on extrafields sellist when MAIN_EXTRAFIELDS_ENABLE_NEW_SELECT2 is activated who is displayed has raw text '&nbsp;' and not a space character