### PR TITLE
Fix #40031 post the confirm box when a value contains a double quote

### DIFF
--- a/htdocs/core/js/lib_head.js.php
+++ b/htdocs/core/js/lib_head.js.php
@@ -1210,12 +1210,17 @@ function getParameterByName(name, valueifnotfound)
  */
 function dolSubmitConfirmForm(urljump, page, options, maxurllength)
 {
-	if (urljump.length <= maxurllength) {
+	// A double quote in a GET parameter is always refused by the WAF (waf.inc.php, type 1),
+	// while a POST body is checked with type 0 which does not apply that rule. So a value
+	// containing a double quote must be posted, whatever the url length is.
+	var hasquote = urljump.indexOf('%22') >= 0 || urljump.indexOf('"') >= 0;
+
+	if (urljump.length <= maxurllength && !hasquote) {
 		location.href = urljump;
 		return;
 	}
 
-	console.log("dolSubmitConfirmForm: url is "+urljump.length+" chars long, we submit a POST form instead of a GET");
+	console.log("dolSubmitConfirmForm: url is "+urljump.length+" chars long"+(hasquote ? " or contains a double quote" : "")+", we submit a POST form instead of a GET");
 
 	var form = document.createElement("form");
 	form.method = "POST";


### PR DESCRIPTION
Confirmed the whole chain in the issue, and verified the fix by running the WAF checker on the reported value:

    value: new offer with "XY"
    GET  (type 1)  inj=1  -> REFUSED (403)
    POST (type 0)  inj=0  -> accepted

The two behaviours that collide are both real:

    html.form.class.php:6340   $postconfirmas = 'GET';                  hardcoded
    waf.inc.php:236            refuses any " when type is 1 or 3        $_GET
    waf.inc.php:338            analyseVarsForSqlAndScriptsInjection($_POST, 0)

so a free-text field travels through a channel that rejects a character ordinary text contains, while the same value is accepted in a POST body.

As @wagmatthias1802 points out, dolSubmitConfirmForm() already builds a POST form, it just triggers on url length only. This extends the condition to a double quote, encoded or not, since the value reaches the function encoded in urljump.

Checked the routing decision:

    note=hello                          -> GET
    note=new%20offer%20with%20%22XY%22  -> POST
    note=say%20"hi"                     -> POST
    note=aaa... (3000 chars)            -> POST

and that the POST path carries the value intact rather than mangling it:

    note_private posted as: "new offer with \"XY\""
    quote preserved? yes
    token carried?   yes

Both call sites, yes and no, go through the same function (html.form.class.php:6920 and :6952), so both are covered.

Targeting develop because dolSubmitConfirmForm() only exists there, it came with #39700. 23.0 and earlier have no POST fallback at all, so fixing it there would mean backporting that helper first, which is a bigger change than a bug fix should carry.

On the SECURITY_WAF_ALLOW_QUOTES_IN_GET note in the issue: that is accurate and worth its own decision. main.inc.php:56 loads waf.inc.php but filefunc.inc.php only at :74, so a define() in conf.php runs after the WAF has already exited. The constant is effectively unreachable from conf.php today.

Reported by @wagmatthias1802 in #40031.