### PR TITLE
FIX Product statistics crash (TypeError) when year filter is set to all years

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4470,7 +4470,9 @@ class Product extends CommonObject
 			}
 			if ($month == 0) {
 				$month = 12;
-				$year -= 1;
+				if ($year !== '') { // $year is '' when we want stats for all years
+					$year -= 1;
+				}
 			}
 		}
 


### PR DESCRIPTION
## Bug

On the product **Statistics** tab (`product/stats/card.php`), selecting the empty entry of the year selector sends `search_year=-1` (all years).

In `Product::_get_stats()`, `$year` is then set to `''`, and the 12-month loop executes `$year -= 1;` on that empty string:

- PHP 7.x: `Warning: A non-numeric value encountered in .../product/class/product.class.php on line 4441` (22.0.4)
- PHP 8.x: `PHP Fatal error: Uncaught TypeError: Unsupported operand types: string - int in .../product/class/product.class.php` — the page stops right after the tabs, no graph is displayed.

```
#0 product/class/product.class.php: Product->_get_stats()
#1 product/class/product.class.php: Product->get_nb_propal()
#2 product/stats/card.php: {main}
```

Same code from 22.0 up to develop.

## Fix

Skip the year decrement when `$year` is `''`. In "all years" mode the keys of `$tab` are the 2-digit month only, so the decremented value was never used anyway: no functional change for the other modes.

Tested on 22.0 and 23.0.2 / PHP 8.2: all-years, current-year and past-year stats pages all render their graphs, no warning or error in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lgi979JFst5TgbH2ydewzv
