### PR TITLE
Fix #40017 set last_main_doc when generating a document from an ODT template

### DIFF
--- a/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
+++ b/htdocs/core/modules/commande/doc/doc_generic_order_odt.modules.php
@@ -68,6 +68,7 @@ class doc_generic_order_odt extends ModelePDFCommandes
 		$this->db = $db;
 		$this->name = "ODT templates";
 		$this->description = $langs->trans("DocumentModelOdt");
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
 		$this->scandir = 'COMMANDE_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
 
 		// Page size for A4 format

--- a/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
+++ b/htdocs/core/modules/contract/doc/doc_generic_contract_odt.modules.php
@@ -65,6 +65,7 @@ class doc_generic_contract_odt extends ModelePDFContract
 		$this->db = $db;
 		$this->name = "ODT templates";
 		$this->description = $langs->trans("DocumentModelOdt");
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
 		$this->scandir = 'CONTRACT_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
 
 		// Page size for A4 format

--- a/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
+++ b/htdocs/core/modules/expedition/doc/doc_generic_shipment_odt.modules.php
@@ -68,6 +68,7 @@ class doc_generic_shipment_odt extends ModelePdfExpedition
 		$this->db = $db;
 		$this->name = "ODT templates";
 		$this->description = $langs->trans("DocumentModelOdt");
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
 		$this->scandir = 'EXPEDITION_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
 
 		// Page size for A4 format

--- a/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
+++ b/htdocs/core/modules/facture/doc/doc_generic_invoice_odt.modules.php
@@ -67,6 +67,7 @@ class doc_generic_invoice_odt extends ModelePDFFactures
 		$this->db = $db;
 		$this->name = "ODT/ODS templates";
 		$this->description = $langs->trans("DocumentModelOdt");
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
 		$this->scandir = 'FACTURE_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
 
 		// Page size for A4 format

--- a/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
+++ b/htdocs/core/modules/mrp/doc/doc_generic_mo_odt.modules.php
@@ -67,6 +67,7 @@ class doc_generic_mo_odt extends ModelePDFMo
 		$this->db = $db;
 		$this->name = "ODT templates";
 		$this->description = $langs->trans("DocumentModelOdt");
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
 		$this->scandir = 'MRP_MO_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
 
 		// Page size for A4 format

--- a/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
+++ b/htdocs/core/modules/project/doc/doc_generic_project_odt.modules.php
@@ -105,6 +105,7 @@ class doc_generic_project_odt extends ModelePDFProjects
 		$this->db = $db;
 		$this->name = "ODT templates";
 		$this->description = $langs->trans("DocumentModelOdt");
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
 		$this->scandir = 'PROJECT_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
 
 		// Page size for A4 format

--- a/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
+++ b/htdocs/core/modules/supplier_invoice/doc/doc_generic_supplier_invoice_odt.modules.php
@@ -68,6 +68,7 @@ class doc_generic_supplier_invoice_odt extends ModelePDFSuppliersInvoices
 		$this->db = $db;
 		$this->name = "ODT templates";
 		$this->description = $langs->trans("DocumentModelOdt");
+		$this->update_main_doc_field = 1; // Save the name of generated file as the main doc when generating a doc with this template
 		$this->scandir = 'SUPPLIER_INVOICE_ADDON_PDF_ODT_PATH'; // Name of constant that is used to save list of directories to scan
 		// Page size for A4 format
 		$this->type = 'odt';


### PR DESCRIPTION
The ODT generators did not set update_main_doc_field, so when one of them produced a document, commonobject.class.php:5575 read the flag as empty and called indexFile() without updating last_main_doc on the object, which is the side effect on sending an email described in the issue.

What makes this clearly an oversight rather than a design choice: the proposal ODT generator already sets it, with the same comment, and every PDF sibling sets it too.

    propale/doc/doc_generic_proposal_odt.modules.php:68   sets it
    commande/doc/pdf_einstein.modules.php                 sets it
    facture/doc/pdf_crabe.modules.php                     sets it
    ... 26 generators in total

so the ODT models of order, invoice, contract, shipment, mo, project, reception and supplier invoice were the odd ones out. The line is placed exactly where the proposal one has it, right after the description assignment.

Verified the property is inherited rather than invented locally: each of these extends a ModelePDF* abstract that itself extends CommonDocGenerator, where $update_main_doc_field is declared (commondocgenerator.class.php:66).

Scope note: the issue also lists two further ideas, excluding .xml files from the automatic selection and adding a file selector. Both are behaviour changes rather than this bug, so I left them out to keep the patch reviewable. @mdeweerd if you want either of them, they are worth their own issue.

I deliberately did not touch the other generators that lack the flag, such as the label sheets, the bank RIB and SEPA mandate ones, since those do not produce a main document for an object and setting it there would change behaviour rather than restore it.

Reported by @mdeweerd in #40017.