### PR TITLE
QUAL: Align "SQL inside loops" wording in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -137,7 +137,7 @@ If possible:
 
 ## Performance
 
-- Avoid SQL queries inside loops (N+1 problem)
+- Never run SQL queries inside loops (N+1 problem)
 - Use JOINs or batch queries instead of multiple sequential queries
 - Apply `LIMIT` and proper indexes on list queries
 - Cache repeated calls to `getDolGlobalString()` or `$conf->global->` in local variables


### PR DESCRIPTION
Same rule stated with different strength in `.agents/AGENTS.md`:

- Database section: *"Never run SQL queries inside loops"*
- Performance section: *"Avoid SQL queries inside loops"*

Use "Never" in both.

Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>