### PR TITLE
QUAL: List all commit/PR types in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -160,7 +160,7 @@ If possible:
     - `develop` branch for both fixes and new features
 - Never commit directly to `main` or `develop` or any branch name matching regex `^\d+\.\d+$` but use a Pull Request.
 - Commit message format: `TYPE: #issueNumber Short description`
-    - Types: `NEW`, `FIX` or `CLOSE`
+    - Types: `NEW`, `FIX`, `CLOSE`, `QUAL`, `PERF`, `UIUX` (uppercase, so it appears in the ChangeLog)
     - Example: `FIX: #1234 Correct VAT calculation on credit notes`
 - Do not update the `ChangeLog` file (this file will be generated before the release from all commit titles)
 - When commiting, keep your commit comment short and add a line "Co-authored-by:" to mention the AI agent name


### PR DESCRIPTION
`.agents/AGENTS.md` lists only `NEW`, `FIX`, `CLOSE` as commit/PR types.

`.github/PULL_REQUEST_TEMPLATE.md` in the same repo lists `FIX`, `CLOSE`, `NEW`, `UIUX`, `PERF`, `QUAL`, and `QUAL` is the 2nd most used prefix on `develop` (33 of the last ~300 commits). This aligns AGENTS.md with the PR template.

Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>