### PR TITLE
Fix #36750 report a missing ctype extension in the installer

### DIFF
--- a/htdocs/install/check.php
+++ b/htdocs/install/check.php
@@ -193,6 +193,15 @@ if (!function_exists("simplexml_load_string")) {
 	print '<img src="../theme/eldy/img/tick.png" alt="Ok" class="valignmiddle paddingright"> '.$langs->trans("PHPSupport", "Xml")."<br>\n";
 }
 
+// Check if Ctype is supported. Dolibarr uses ctype_* on several pages, without any fallback.
+if (!extension_loaded("ctype")) {
+	$langs->load("errors");
+	print '<img src="../theme/eldy/img/warning.png" alt="Error" class="valignmiddle paddingright"> '.$langs->trans("ErrorPHPDoesNotSupport", "Ctype")."<br>\n";
+	// $checksok = 0;	// If ko, just warning. So check must still be 1 (otherwise no way to install)
+} else {
+	print '<img src="../theme/eldy/img/tick.png" alt="Ok" class="valignmiddle paddingright"> '.$langs->trans("PHPSupport", "Ctype")."<br>\n";
+}
+
 // Check if UTF8 is supported
 if (!function_exists("utf8_encode")) {
 	$langs->load("errors");


### PR DESCRIPTION
Companion to #40010, same reporter, same gap: install/check.php verifies mbstring, json, gd, curl, calendar, simplexml, utf8, intl and imap, but never ctype, so an install on a PHP built without it completes with no warning.

The extension is used without any guard, over 70 ctype_* calls in the tree, including on document cards:

    compta/facture/card.php:3444   ctype_alpha($fromElement)

so those pages die once the extension is absent.

One difference from the dom case in #40010 worth stating: ctype is not on the path of every single page. Nothing in the main.inc.php chain calls it, so the login page still renders. It is the proposal, order and invoice cards and a few libraries that break, which matches the title of the issue, mandatory to draw some pages after authentication rather than all of them.

    with ctype     tick    PHPSupport(Ctype)
    without ctype  warning ErrorPHPDoesNotSupport(Ctype)

Reported as a warning rather than blocking, following every other extension check in that file, which all carry the same commented-out $checksok = 0 and the note that a blocking check would leave no way to install. Both translation keys already exist in install.lang, verified by rendering them.

Reported by @Zulgrib in #36750.