### PR TITLE
Fix misleading dolDecrypt log message when the key does not match

### DIFF
--- a/htdocs/blockedlog/lib/securitycore.lib.php
+++ b/htdocs/blockedlog/lib/securitycore.lib.php
@@ -196,7 +196,7 @@ function dolDecrypt($chain, $key = '', $patterntotest = '')
 			//if (!ascii_check($newchain)) {
 			if (!ascii_check($newchain) && !utf8_check($newchain)) {
 				if (empty($savkey)) {
-					dol_syslog("Error dolDecrypt failed: The key dolibarr_main_dolcrypt or dolibarr_main_instance_unique_id, found in conf.php file, seems the one used to encrypt the encrypted string", LOG_ERR);
+					dol_syslog("Error dolDecrypt failed: The key dolibarr_main_dolcrypt or dolibarr_main_instance_unique_id, found in conf.php file, seems not to be the one used to encrypt the encrypted string", LOG_ERR);
 				} else {
 					dol_syslog("Error dolDecrypt failed: The string decoded with the key return a non valid value (not ascii)", LOG_ERR);
 				}


### PR DESCRIPTION
The message states the opposite of what the branch means.

    if (!ascii_check($newchain) && !utf8_check($newchain)) {
        if (empty($savkey)) {
            dol_syslog("... seems the one used to encrypt the encrypted string", LOG_ERR);

The condition is reached when the decoded string is neither ascii nor utf8, so when decryption failed. But the text tells the reader the key in conf.php seems to be the right one, which sends an admin looking somewhere else entirely.

Found while helping on #39154, where the reporter's stripeipn log is full of this line on every Stripe IPN call. Reading it literally, the key is fine and something else is wrong, when in fact the key does not decrypt the stored value.

Text only, no behaviour change. The sibling message a few lines below is already correct, so this only aligns the first one.

Note 23.0 carries an older variant of the same line with a doubled word, "is the the one used to encrypt", in core/lib/security.lib.php:237. Same confusion, different file, since the function moved to blockedlog/lib/securitycore.lib.php on develop. Happy to send that one separately against 23.0 if wanted, I kept this PR to a single branch and a single line.