### PR TITLE
QUAL: Recommend dolBuildUrl() for URL building in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -132,6 +132,7 @@ If possible:
   - GET links with a modifying `action`: `...&token='.newToken().'`
   - Ajax calls: use `currentToken()` instead of `newToken()`, and set `NOTOKENRENEWAL` on the called ajax endpoint
 - Public endpoints called without a session (e.g. webhooks) are exempt via `NOCSRFCHECK` (page-level constant) or, exceptionally, `$dolibarr_nocsrfcheck` (global conf.php override)
+- Build internal URLs (links, `header("Location: ...")` redirects) with `dolBuildUrl($url, $params, $addtoken)` instead of concatenating a query string by hand: it `http_build_query()`-encodes the parameters and, with `$addtoken = true`, appends the CSRF `token`
 
 ---
 


### PR DESCRIPTION
Same spirit as the `$user->hasRight()` guidance: point contributors at an existing helper instead of an error-prone manual pattern.

`dolBuildUrl($url, $params, $addtoken)` (`htdocs/core/lib/functions.lib.php`, ~1460 call sites, added in #35549):
- `http_build_query()`-encodes the parameters (no manual `urlencode`, no unencoded value slipping in);
- with `$addtoken = true`, appends the CSRF `token` (`newToken()`);
- keeps the `mainmenu` / `leftmenu` context and runs the `buildurl` hook.

Adds one bullet in the Security section recommending it over hand-built query strings for internal links and `header("Location: …")` redirects.

Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>