### PR TITLE
QUAL: Recommend getDolGlobal*() and isModEnabled() in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -19,6 +19,8 @@ Every modification must respect:
 -  Use Dolibarr hooks whenever possible
 -  Respect existing naming conventions
 -  All database table names must use the `llx_` prefix
+-  Read configuration with `getDolGlobalString()` / `getDolGlobalInt()` / `getDolGlobalBool()`, not `$conf->global->XXX`
+-  Check module activation with `isModEnabled('module')`, not `!empty($conf->module->enabled)`
 
 ---
 


### PR DESCRIPTION
Same spirit as the `$user->hasRight()` guidance. Both accessors are the current standard and the target of an ongoing repo-wide migration:
- `getDolGlobalString()` ~13800 calls, `getDolGlobalInt()` ~4400, vs ~1000 remaining `$conf->global->` accesses;
- `isModEnabled()` ~5700 calls.

Adds two bullets in Critical Rules. Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>