### PR TITLE
QUAL: Document trans() vs transnoentities() in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -91,9 +91,9 @@ Before writing any code, the agent **must**:
 ## Internationalisation
 
 - Never hardcode user-facing strings — always use `$langs->trans('Key')`
-- Use `$langs->trans()` for direct HTML output; use `$langs->transnoentities()` when the result is placed where it will be HTML-escaped again (tag attributes, JS strings, `dol_escape_htmltag()` arguments) to avoid double-encoding
+- Use `$langs->trans()` for direct HTML output; use `$langs->transnoentities()` when the result is used into HTMLescaped functions
 - Language files must be placed in `mymodule/langs/en_US/` (and other locales as needed)
-- All code comments and variables or functions names must be in English.
+- All code comments and variables or functions names must be in English
 - Language key names must use PascalCase (e.g., `MyModuleLabel`, not `monLibelléModule`)
 - Load the language file at the top of the page: `$langs->load('mymodule@mymodule')`
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -91,6 +91,7 @@ Before writing any code, the agent **must**:
 ## Internationalisation
 
 - Never hardcode user-facing strings — always use `$langs->trans('Key')`
+- Use `$langs->trans()` for direct HTML output; use `$langs->transnoentities()` when the result is placed where it will be HTML-escaped again (tag attributes, JS strings, `dol_escape_htmltag()` arguments) to avoid double-encoding
 - Language files must be placed in `mymodule/langs/en_US/` (and other locales as needed)
 - All code comments and variables or functions names must be in English.
 - Language key names must use PascalCase (e.g., `MyModuleLabel`, not `monLibelléModule`)


### PR DESCRIPTION
Same spirit as the `$user->hasRight()` guidance. `transnoentities()` (~3000 calls) vs `trans()` is a recurring double-encoding pitfall not covered by AGENTS.md. Adds one bullet in Internationalisation. Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>