### PR TITLE
QUAL: Recommend Dolibarr file helpers in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -132,6 +132,7 @@ If possible:
   - GET links with a modifying `action`: `...&token='.newToken().'`
   - Ajax calls: use `currentToken()` instead of `newToken()`, and set `NOTOKENRENEWAL` on the called ajax endpoint
 - Public endpoints called without a session (e.g. webhooks) are exempt via `NOCSRFCHECK` (page-level constant) or, exceptionally, `$dolibarr_nocsrfcheck` (global conf.php override)
+- Use the Dolibarr filesystem wrappers (`dol_mkdir()`, `dol_delete_file()`, `dol_copy()`, `dol_is_file()`, `dol_is_dir()`) and sanitize any user-provided name with `dol_sanitizeFileName()` / `dol_sanitizePathName()`, never raw PHP `mkdir()` / `unlink()` / `file_exists()`
 
 ---
 


### PR DESCRIPTION
Same spirit as the `$user->hasRight()` guidance. `dol_sanitizeFileName()` ~800 calls (path-traversal protection), `dol_mkdir()` ~350, `dol_delete_file()` ~180. Adds one bullet in the Security section. Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>