### PR TITLE
QUAL: Mention declare(strict_types=1) for new modules in AGENTS.md

### DIFF
--- a/.agents/skills/skill-doli-devmodule/SKILL.md
+++ b/.agents/skills/skill-doli-devmodule/SKILL.md
@@ -32,7 +32,7 @@ These principles must be followed even before reviewing specific task details. V
     Do not apply rules 1-3 to existing code in backports (i.e., non-functional changes not applied to a (fork of) the develop branch.
 
 ### Workflow & Architecture
-1.  **PHP version:** 7.1+
+1.  **PHP version:** 7.1+ for core and bug-fix code. New external modules should target PHP 8.1+ and start every PHP file with `declare(strict_types=1)`.
 2.  **Action/View Separation:** Always clearly separate page action logic (executed on POST) from pure rendering (the HTML view).
 3.  **Hooks First:** Before implementing any logic that runs on a core lifecycle event (e.g., form save, object update), check if an existing Dolibarr hook can be used. Use the standard calling pattern: `$hookmanager->executeHooks('actionName', $parameters, $object, $action);`.
 


### PR DESCRIPTION
Same spirit as the `$user->hasRight()` guidance. The repo's own `CLAUDE.md` states "PHP 8.1+ with \`declare(strict_types=1)\` for new external modules" but AGENTS.md omits the `strict_types` part. Adds one bullet in PHP Best Practices. Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>