### PR TITLE
QUAL: Recommend natural_search() for list filters in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -69,6 +69,7 @@ Before writing any code, the agent **must**:
 -  SQL scripts for table and index creation must be placed in `htdocs/install/mysql/tables/` (see existing files for examples)
 -  Never run SQL queries inside loops (avoid N+1 problem — use JOINs or batch queries instead)
 -  Always use `LIMIT` on list queries for performance
+-  Build list-filter `WHERE` clauses with `natural_search($fields, $value, $mode)` rather than assembling `LIKE` conditions by hand
 
 ---
 


### PR DESCRIPTION
Same spirit as the `$user->hasRight()` guidance. `natural_search()` (~900 calls) is the standard helper for list search filters and handles escaping, multi-field and numeric/date modes. Adds one bullet in Database. Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>