### PR TITLE
QUAL: Recommend price2num() / price() for amounts in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -56,6 +56,7 @@ Before writing any code, the agent **must**:
 - Write short, readable, and testable functions
 - Avoid side effects
 - Prefer typed properties and return types when PHP version allows
+- Parse user-entered amounts with `price2num()` and format amounts for display with `price()`; do not use `number_format()` or a raw cast
 
 ---
 


### PR DESCRIPTION
Same spirit as the `$user->hasRight()` guidance. `price2num()` (~2800 calls) / `price()` are the standard money parse/format helpers (locale decimal and thousand separators, rounding rules). Adds one bullet in PHP Best Practices. Doc-only.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>