### PR TITLE
Fix: disable action buttons while editing a line

### DIFF
--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -3768,7 +3768,7 @@ if ($action == 'create' && $usercancreate) {
 	 *    Boutons actions
 	 */
 
-	if (($user->socid == 0) && ($action != 'presend')) {
+	if (($user->socid == 0) && ($action != 'presend') && ($action != 'editline')) {
 		print '<div class="tabsAction">';
 
 		$parameters = array();

--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -2026,7 +2026,7 @@ if ($action == 'create') {
 	if (empty($reshook)) {
 		$params = array();
 		if ($user->socid == 0) {
-			if ($action != 'editdescription' && ($action != 'presend')) {
+			if ($action != 'editdescription' && $action != 'presend' && $action != 'editline') {
 				// Subtotal
 				if ($object->status == Fichinter::STATUS_DRAFT && isModEnabled('subtotals')
 					&& (getDolGlobalString('SUBTOTAL_TITLE_'.strtoupper($object->element)) || getDolGlobalString('SUBTOTAL_'.strtoupper($object->element)) || getDolGlobalString('SUBTOTAL_TEXT_'.strtoupper($object->element)))) {

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -778,7 +778,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	print dol_get_fiche_end();
 
 
-	if (!in_array($action, array('consumeorproduce', 'consumeandproduceall'))) {
+	if (!in_array($action, array('consumeorproduce', 'consumeandproduceall', 'editline'))) {
 		print '<div class="tabsAction">';
 
 		$parameters = array();

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -2931,7 +2931,7 @@ if ($action == 'create' && $permissiontoadd) {
 	 *    Button actions
 	 */
 
-	if (($user->socid == 0) && ($action != 'presend')) {
+	if (($user->socid == 0) && ($action != 'presend') && ($action != 'editline')) {
 		print '<div class="tabsAction">';
 
 		$parameters = array();


### PR DESCRIPTION
Validate/Clone/Delete buttons stay active while editing a line (action=editline) on fichinter, expedition, reception
  and mo_production cards. Aligns with the existing convention (action != editline) already used in asset, contrat,
  expensereport and webhook cards.