### PR TITLE
FIX Wrong margin calculation on situation invoices due to cumulative situation_percent (backport of #39090 to 23.0)

### DIFF
--- a/htdocs/accountancy/customer/index.php
+++ b/htdocs/accountancy/customer/index.php
@@ -602,6 +602,9 @@ if (getDolGlobalString('SHOW_TOTAL_OF_PREVIOUS_LISTS_IN_LIN_PAGE')) { // This pa
 	$sql .= "  SUM(fd.total_ht) as total";
 	$sql .= " FROM ".MAIN_DB_PREFIX."facturedet as fd";
 	$sql .= "  LEFT JOIN ".MAIN_DB_PREFIX."facture as f ON f.rowid = fd.fk_facture";
+	if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."facturedet AS prev_fd ON prev_fd.rowid = fd.fk_prev_id";
+	}
 	$sql .= " WHERE f.datef >= '".$db->idate($search_date_start)."'";
 	$sql .= "  AND f.datef <= '".$db->idate($search_date_end)."'";
 	// Define begin binding date
@@ -663,16 +666,16 @@ if (getDolGlobalString('SHOW_TOTAL_OF_PREVIOUS_LISTS_IN_LIN_PAGE')) { // This pa
 					"MONTH(f.datef) = ".((int) $j),
 					" (".$db->ifsql(
 						"fd.total_ht < 0",
-						" (-1 * (abs(fd.total_ht) - (fd.buy_price_ht * fd.qty * (fd.situation_percent / 100))))",	// TODO This is bugged, we must use the percent for the invoice and fd.situation_percent is cumulated percent !
-						"  (fd.total_ht - (fd.buy_price_ht * fd.qty * (fd.situation_percent / 100)))"
+						" (-1 * (abs(fd.total_ht * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / fd.situation_percent)) - (fd.buy_price_ht * fd.qty * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / 100))))",
+						"  (fd.total_ht * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / fd.situation_percent) - (fd.buy_price_ht * fd.qty * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / 100)))"
 					).")",
 					'0'
 				).") AS month".str_pad((string) $j, 2, '0', STR_PAD_LEFT).",";
 			}
 			$sql .= "  SUM(".$db->ifsql(
 				"fd.total_ht < 0",
-				" (-1 * (abs(fd.total_ht) - (fd.buy_price_ht * fd.qty * (fd.situation_percent / 100))))",	// TODO This is bugged, we must use the percent for the invoice and fd.situation_percent is cumulated percent !
-				"  (fd.total_ht - (fd.buy_price_ht * fd.qty * (fd.situation_percent / 100)))"
+				" (-1 * (abs(fd.total_ht * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / fd.situation_percent)) - (fd.buy_price_ht * fd.qty * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / 100))))",
+				"  (fd.total_ht * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / fd.situation_percent) - (fd.buy_price_ht * fd.qty * ((fd.situation_percent - COALESCE(prev_fd.situation_percent, 0)) / 100)))"
 			).") as total";
 		} else {
 			$sql = "SELECT '".$db->escape($langs->trans("Vide"))."' AS marge,";

--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -112,8 +112,14 @@ class FormMargin
 				/** @var Facture $object */
 				if (($object->element == 'facture' && $object->type == $object::TYPE_SITUATION)
 					|| ($object->element == 'facture' && $object->type == $object::TYPE_CREDIT_NOTE && getDolGlobalInt('INVOICE_USE_SITUATION_CREDIT_NOTE') && $object->situation_counter > 0)) {
-					// We need a compensation relative to $line->situation_percent
-					$pa = $line->qty * $pa_ht * ($line->situation_percent / 100);
+					// We need only the delta between this situation and the previous one to avoid cumulating margins across situation invoices
+					// total_ht is stored cumulatively (e.g. 60% of full price), so we extract only this invoice's share using the delta percent
+					$prevPercent = $line->get_prev_progress($object->id);
+					$deltaPercent = $line->situation_percent - $prevPercent;
+					if ($line->situation_percent > 0) {
+						$pv *= ($deltaPercent / $line->situation_percent);
+					}
+					$pa = $line->qty * $pa_ht * ($deltaPercent / 100);
 				} else {
 					$pa = $line->qty * $pa_ht;
 				}

--- a/htdocs/margin/agentMargins.php
+++ b/htdocs/margin/agentMargins.php
@@ -160,16 +160,28 @@ $invoice_status_except_list = array(Facture::STATUS_DRAFT, Facture::STATUS_ABAND
 $sql = "SELECT";
 $sql .= " s.rowid as socid, s.nom as name, s.code_client, s.client,";
 $sql .= " u.rowid as agent, u.login, u.lastname, u.firstname,";
-$sql .= " sum(d.total_ht) as selling_price,";
-// Note: qty and buy_price_ht is always positive (if not your database may be corrupted, you can update this)
-
-$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * d.qty * d.buy_price_ht * (d.situation_percent / 100)', 'd.qty * d.buy_price_ht * (d.situation_percent / 100)').") as buying_price,";
-$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * (abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100)))', 'd.total_ht - (d.buy_price_ht * d.qty * (d.situation_percent / 100))').") as marge";
+// Special case for old situation mode: total_ht is stored cumulatively, use delta percent to avoid cumulating margins
+if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+	$delta_pct = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN (d.situation_percent - COALESCE(prev_d.situation_percent, 0)) ELSE d.situation_percent END';
+	$delta_ht = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN d.total_ht * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / d.situation_percent) ELSE d.total_ht END';
+	$sql .= " sum($delta_ht) as selling_price,";
+	// Note: qty and buy_price_ht is always positive (if not your database may be corrupted, you can update this)
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', "-1 * d.qty * d.buy_price_ht * ($delta_pct / 100)", "d.qty * d.buy_price_ht * ($delta_pct / 100)").") as buying_price,";
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', "-1 * (abs($delta_ht) - (d.buy_price_ht * d.qty * ($delta_pct / 100)))", "$delta_ht - (d.buy_price_ht * d.qty * ($delta_pct / 100))").") as marge";
+} else {
+	$sql .= " sum(d.total_ht) as selling_price,";
+	// Note: qty and buy_price_ht is always positive (if not your database may be corrupted, you can update this)
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * d.qty * d.buy_price_ht * (d.situation_percent / 100)', 'd.qty * d.buy_price_ht * (d.situation_percent / 100)').") as buying_price,";
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * (abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100)))', 'd.total_ht - (d.buy_price_ht * d.qty * (d.situation_percent / 100))').") as marge";
+}
 
 $sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 $sql .= ", ".MAIN_DB_PREFIX."facture as f";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."element_contact e ON e.element_id = f.rowid and e.statut = 4 and e.fk_c_type_contact = ".(!getDolGlobalString('AGENT_CONTACT_TYPE') ? -1 : $conf->global->AGENT_CONTACT_TYPE);
 $sql .= ", ".MAIN_DB_PREFIX."facturedet as d";
+if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."facturedet AS prev_d ON prev_d.rowid = d.fk_prev_id";
+}
 $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 $sql .= ", ".MAIN_DB_PREFIX."user as u";
 $sql .= " WHERE f.fk_soc = s.rowid";

--- a/htdocs/margin/customerMargins.php
+++ b/htdocs/margin/customerMargins.php
@@ -228,15 +228,27 @@ $sql .= " s.rowid as socid, s.nom as name, s.code_client, s.client,";
 if ($client) {
 	$sql .= " f.rowid as facid, f.ref, f.total_ht, f.datef, f.paye, f.type, f.fk_statut as statut,";
 }
-$sql .= " sum(d.total_ht) as selling_price,";
-// Note: qty and buy_price_ht is always positive (if not, your database may be corrupted, you can update this)
-
-$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * d.qty * d.buy_price_ht * (d.situation_percent / 100)', 'd.qty * d.buy_price_ht * (d.situation_percent / 100)').") as buying_price,";
-$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * (abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100)))', 'd.total_ht - (d.buy_price_ht * d.qty * (d.situation_percent / 100))').") as marge";
+// Special case for old situation mode: total_ht is stored cumulatively, use delta percent to avoid cumulating margins
+if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+	$delta_pct = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN (d.situation_percent - COALESCE(prev_d.situation_percent, 0)) ELSE d.situation_percent END';
+	$delta_ht = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN d.total_ht * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / d.situation_percent) ELSE d.total_ht END';
+	$sql .= " sum($delta_ht) as selling_price,";
+	// Note: qty and buy_price_ht is always positive (if not, your database may be corrupted, you can update this)
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', "-1 * d.qty * d.buy_price_ht * ($delta_pct / 100)", "d.qty * d.buy_price_ht * ($delta_pct / 100)").") as buying_price,";
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', "-1 * (abs($delta_ht) - (d.buy_price_ht * d.qty * ($delta_pct / 100)))", "$delta_ht - (d.buy_price_ht * d.qty * ($delta_pct / 100))").") as marge";
+} else {
+	$sql .= " sum(d.total_ht) as selling_price,";
+	// Note: qty and buy_price_ht is always positive (if not, your database may be corrupted, you can update this)
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * d.qty * d.buy_price_ht * (d.situation_percent / 100)', 'd.qty * d.buy_price_ht * (d.situation_percent / 100)').") as buying_price,";
+	$sql .= " sum(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * (abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100)))', 'd.total_ht - (d.buy_price_ht * d.qty * (d.situation_percent / 100))').") as marge";
+}
 
 $sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 $sql .= ", ".MAIN_DB_PREFIX."facture as f";
 $sql .= ", ".MAIN_DB_PREFIX."facturedet as d";
+if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."facturedet AS prev_d ON prev_d.rowid = d.fk_prev_id";
+}
 if (!empty($TSelectedCats)) {
 	$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'categorie_product as cp ON cp.fk_product=d.fk_product';
 }

--- a/htdocs/margin/productMargins.php
+++ b/htdocs/margin/productMargins.php
@@ -194,17 +194,30 @@ if ($id > 0) {
 if ($id > 0) {
 	$sql .= " f.rowid as facid, f.ref, f.total_ht, f.datef, f.paye, f.fk_statut as statut,";
 }
-$sql .= " SUM(d.total_ht) as selling_price,";
-$sql .= " SUM(d.qty) as product_qty,";
-
-// Note: qty and buy_price_ht is always positive (if not your database may be corrupted, you can update this)
-$sql .= " SUM(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * d.qty * d.buy_price_ht * (d.situation_percent / 100)', 'd.qty * d.buy_price_ht * (d.situation_percent / 100)').") as buying_price,";
-$sql .= " SUM(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * (abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100)))', 'd.total_ht - (d.buy_price_ht * d.qty * (d.situation_percent / 100))').") as marge";
+// Special case for old situation mode: total_ht is stored cumulatively, use delta percent to avoid cumulating margins
+if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+	$delta_pct = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN (d.situation_percent - COALESCE(prev_d.situation_percent, 0)) ELSE d.situation_percent END';
+	$delta_ht = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN d.total_ht * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / d.situation_percent) ELSE d.total_ht END';
+	$sql .= " SUM($delta_ht) as selling_price,";
+	$sql .= " SUM(d.qty) as product_qty,";
+	// Note: qty and buy_price_ht is always positive (if not your database may be corrupted, you can update this)
+	$sql .= " SUM(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', "-1 * d.qty * d.buy_price_ht * ($delta_pct / 100)", "d.qty * d.buy_price_ht * ($delta_pct / 100)").") as buying_price,";
+	$sql .= " SUM(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', "-1 * (abs($delta_ht) - (d.buy_price_ht * d.qty * ($delta_pct / 100)))", "$delta_ht - (d.buy_price_ht * d.qty * ($delta_pct / 100))").") as marge";
+} else {
+	$sql .= " SUM(d.total_ht) as selling_price,";
+	$sql .= " SUM(d.qty) as product_qty,";
+	// Note: qty and buy_price_ht is always positive (if not your database may be corrupted, you can update this)
+	$sql .= " SUM(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * d.qty * d.buy_price_ht * (d.situation_percent / 100)', 'd.qty * d.buy_price_ht * (d.situation_percent / 100)').") as buying_price,";
+	$sql .= " SUM(".$db->ifsql('(d.total_ht < 0 OR (d.total_ht = 0 AND f.type = 2))', '-1 * (abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100)))', 'd.total_ht - (d.buy_price_ht * d.qty * (d.situation_percent / 100))').") as marge";
+}
 
 $sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 $sql .= ", ".MAIN_DB_PREFIX."facture as f";
 $sql .= ", ".MAIN_DB_PREFIX."facturedet as d";
 $sql .= " LEFT JOIN ".MAIN_DB_PREFIX."product as p ON p.rowid = d.fk_product";
+if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+	$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."facturedet AS prev_d ON prev_d.rowid = d.fk_prev_id";
+}
 if (!empty($TSelectedCats)) {
 	$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX.'categorie_product as cp ON cp.fk_product=p.rowid';
 }

--- a/htdocs/margin/tabs/productMargins.php
+++ b/htdocs/margin/tabs/productMargins.php
@@ -213,13 +213,26 @@ if ($id > 0 || !empty($ref)) {
 			if (!$user->hasRight('societe', 'client', 'voir')) {
 				$sql .= " sc.fk_soc, sc.fk_user,";
 			}
-			$sql .= " sum(d.total_ht) as selling_price,"; // may be negative or positive
-			$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(d.qty) as qty,"; // not always positive in case of Credit note
-			$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(d.qty * d.buy_price_ht * (d.situation_percent / 100)) as buying_price,"; // not always positive in case of Credit note
-			$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100))) as marge"; // not always positive in case of Credit note
+			// Special case for old situation mode: total_ht is stored cumulatively, use delta percent to avoid cumulating margins
+			if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+				$delta_pct = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN (d.situation_percent - COALESCE(prev_d.situation_percent, 0)) ELSE d.situation_percent END';
+				$delta_ht = 'CASE WHEN f.type = '.Facture::TYPE_SITUATION.' AND d.situation_percent > 0 THEN d.total_ht * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / d.situation_percent) ELSE d.total_ht END';
+				$sql .= " sum($delta_ht) as selling_price,"; // may be negative or positive
+				$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(d.qty) as qty,"; // not always positive in case of Credit note
+				$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(d.qty * d.buy_price_ht * ($delta_pct / 100)) as buying_price,"; // not always positive in case of Credit note
+				$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(abs($delta_ht) - (d.buy_price_ht * d.qty * ($delta_pct / 100))) as marge"; // not always positive in case of Credit note
+			} else {
+				$sql .= " sum(d.total_ht) as selling_price,"; // may be negative or positive
+				$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(d.qty) as qty,"; // not always positive in case of Credit note
+				$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(d.qty * d.buy_price_ht * (d.situation_percent / 100)) as buying_price,"; // not always positive in case of Credit note
+				$sql .= " ".$db->ifsql('f.type = 2', '-1', '1')." * sum(abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100))) as marge"; // not always positive in case of Credit note
+			}
 			$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 			$sql .= ", ".MAIN_DB_PREFIX."facture as f";
 			$sql .= ", ".MAIN_DB_PREFIX."facturedet as d";
+			if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+				$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."facturedet AS prev_d ON prev_d.rowid = d.fk_prev_id";
+			}
 			if (!$user->hasRight('societe', 'client', 'voir')) {
 				$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 			}

--- a/htdocs/margin/tabs/thirdpartyMargins.php
+++ b/htdocs/margin/tabs/thirdpartyMargins.php
@@ -237,12 +237,22 @@ if ($socid > 0) {
 	$sql = "SELECT DISTINCT s.nom, s.rowid as socid, s.code_client,";
 	$sql .= " f.rowid as facid, f.ref, f.total_ht,";
 	$sql .= " f.datef, f.paye, f.fk_statut as statut, f.type,";
-	$sql .= " sum(d.total_ht) as selling_price,"; // may be negative or positive
-	$sql .= " sum(d.qty * d.buy_price_ht * (d.situation_percent / 100)) as buying_price,"; // always positive
-	$sql .= " sum(abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100))) as marge"; // always positive
+	// Special case for old situation mode: total_ht is stored cumulatively, use delta percent to avoid cumulating margins
+	if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+		$sql .= " sum(CASE WHEN f.type = ".Facture::TYPE_SITUATION." AND d.situation_percent > 0 THEN d.total_ht * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / d.situation_percent) ELSE d.total_ht END) as selling_price,"; // may be negative or positive
+		$sql .= " sum(CASE WHEN f.type = ".Facture::TYPE_SITUATION." AND d.situation_percent > 0 THEN d.qty * d.buy_price_ht * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / 100) ELSE d.qty * d.buy_price_ht * (d.situation_percent / 100) END) as buying_price,"; // always positive
+		$sql .= " sum(CASE WHEN f.type = ".Facture::TYPE_SITUATION." AND d.situation_percent > 0 THEN (d.total_ht * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / d.situation_percent)) - (d.buy_price_ht * d.qty * ((d.situation_percent - COALESCE(prev_d.situation_percent, 0)) / 100)) ELSE abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100)) END) as marge"; // always positive
+	} else {
+		$sql .= " sum(d.total_ht) as selling_price,"; // may be negative or positive
+		$sql .= " sum(d.qty * d.buy_price_ht * (d.situation_percent / 100)) as buying_price,"; // always positive
+		$sql .= " sum(abs(d.total_ht) - (d.buy_price_ht * d.qty * (d.situation_percent / 100))) as marge"; // always positive
+	}
 	$sql .= " FROM ".MAIN_DB_PREFIX."societe as s";
 	$sql .= ", ".MAIN_DB_PREFIX."facture as f";
 	$sql .= ", ".MAIN_DB_PREFIX."facturedet as d";
+	if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {
+		$sql .= " LEFT JOIN ".MAIN_DB_PREFIX."facturedet AS prev_d ON prev_d.rowid = d.fk_prev_id";
+	}
 	$sql .= " WHERE f.fk_soc = s.rowid";
 	$sql .= " AND f.fk_statut > 0";
 	$sql .= " AND f.entity IN (".getEntity('invoice').")";


### PR DESCRIPTION
Backport of #39090 to the 23.0 maintenance branch.

## What
Fixes the margin computation for situation invoices in the **old** situation mode (`INVOICE_USE_SITUATION = 1`), where `situation_percent` is cumulative and `total_ht` stores the cumulated amount. The margin queries/report used the raw cumulative percent, which cumulated margins across successive situations. They now use only the delta between the current situation and the previous one (via `fd.fk_prev_id`), guarded by `INVOICE_USE_SITUATION == 1` so the standard (non-situation) path is left unchanged.

## Files
Same 7 files as #39090:
`accountancy/customer/index.php`, `core/class/html.formmargin.class.php`, `margin/agentMargins.php`, `margin/customerMargins.php`, `margin/productMargins.php`, `margin/tabs/productMargins.php`, `margin/tabs/thirdpartyMargins.php`.

## Notes
- The change is identical to #39090 except `htdocs/margin/tabs/thirdpartyMargins.php`, whose 23.0 version still uses `SELECT DISTINCT ...` (the `DISTINCT` was removed later on develop). The same guarded change was applied there by hand.
- No functional change for the new situation mode (`INVOICE_USE_SITUATION = 2`), which stores per-invoice deltas and already fell into the unchanged branch.
