### PR TITLE
FIX Margin (buy cost not scaled to delta) on situation invoices in new mode (INVOICE_USE_SITUATION = 2)

### DIFF
--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -123,6 +123,17 @@ class FormMargin
 				} else {
 					$pa = $line->qty * $pa_ht;
 				}
+			} elseif (getDolGlobalInt('INVOICE_USE_SITUATION') == 2) {	// New situation mode
+				'@phan-var-force Facture $object';
+				/** @var Facture $object */
+				if (($object->element == 'facture' && $object->type == $object::TYPE_SITUATION)
+					|| ($object->element == 'facture' && $object->type == $object::TYPE_CREDIT_NOTE && getDolGlobalInt('INVOICE_USE_SITUATION_CREDIT_NOTE') && $object->situation_counter > 0)) {
+					// In new situation mode, situation_percent and total_ht already store only this invoice's share (the delta).
+					// Selling price ($pv = total_ht) is therefore already correct; we only need to scale the buy price to the same percent.
+					$pa = $line->qty * $pa_ht * ($line->situation_percent / 100);
+				} else {
+					$pa = $line->qty * $pa_ht;
+				}
 			} else {
 				$pa = $line->qty * $pa_ht;
 			}


### PR DESCRIPTION
## What
In the invoice **Margin** tab (`FormMargin::getMarginInfosArray()`), situation invoices in the **new** situation mode (`INVOICE_USE_SITUATION = 2`) fell into the generic branch and computed the buy cost as `qty * pa_ht` (full quantity) while the selling price (`$pv = total_ht`) is only this invoice's **delta** share. This overstated the cost and understated (or turned negative) the margin for situation invoice lines.

## Why
In new situation mode, `situation_percent` and `total_ht` already store only the current invoice's delta (see `Facture::update_percent()`), so the selling price is already correct; only the buy cost must be scaled by `situation_percent / 100`. This is consistent with the margin **list** pages (`margin/*.php`), which already scale the buy cost by `situation_percent / 100`.

## Related
Complements #39090 (which covered the old cumulative mode, `INVOICE_USE_SITUATION = 1`). This addresses the new mode on the invoice Margin tab.
