### PR TITLE
QUAL: fix phpstan iterable type on extrafields_list_search_sql tpl

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_sql.tpl.php
@@ -32,7 +32,7 @@
  * @var string $extrafieldsobjectkey
  * @var string $search_options_pattern
  * @var string $extrafieldsobjectprefix
- * @var array $search_array_options
+ * @var array<string,mixed> $search_array_options
  */
 '
 @phan-var-force CommonObject $object


### PR DESCRIPTION
## Summary

PHPStan (level 10) currently fails on `develop`:

> PHPDoc tag @var for variable $search_array_options has no value type
> specified in iterable type array.

in `htdocs/core/tpl/extrafields_list_search_sql.tpl.php`. The untyped `@var array $search_array_options` was added in commit 373ffc8.

## Change

Declare the value type, matching the two sibling templates that already do so (`extrafields_list_search_input.tpl.php`, `extrafields_list_search_param.tpl.php`):

```diff
- * @var array $search_array_options
+ * @var array<string,mixed> $search_array_option