### PR TITLE
FIX: Replace time() with dol_now() for consistent time handling

### DIFF
--- a/htdocs/adherents/subscription.php
+++ b/htdocs/adherents/subscription.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2018-2025  Frédéric France				<frederic.france@free.fr>
  * Copyright (C) 2019		Thibault FOUCART			<support@ptibogxiv.net>
  * Copyright (C) 2023		Waël Almoman				<info@almoman.com>
- * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1058,7 +1058,7 @@ if (($action == 'createsubscription' || $action == 'create_thirdparty') && $user
 		print '<tr><td>'.$langs->trans("Note").'</td>';
 		print '<td><input name="label" type="text" size="32" value="';
 		if (!getDolGlobalString('MEMBER_NO_DEFAULT_LABEL')) {
-			print $langs->trans("Subscription").' '.dol_print_date(($datefrom ? $datefrom : time()), "%Y");
+			print $langs->trans("Subscription").' '.dol_print_date(($datefrom ? $datefrom : dol_now()), "%Y");
 		}
 		print '"></td></tr>';
 

--- a/htdocs/admin/oauthlogintokens.php
+++ b/htdocs/admin/oauthlogintokens.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2013-2016  Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2014-2024	Frédéric France      <frederic.france@free.fr>
  * Copyright (C) 2020		Nicolas ZABOURI      <info@inovea-conseil.com>
- * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -152,6 +152,7 @@ if ($action == 'refreshtoken' && $user->admin) {
 		dol_syslog("oauthlogintokens.php: Read token for service ".$OAUTH_SERVICENAME);
 		$tokenobj = $storage->retrieveAccessToken($OAUTH_SERVICENAME);
 
+		// tokenobj uses time() @phan-suppress-next-line DolibarrForbiddenFunctionPlugin
 		$expire = ($tokenobj->getEndOfLife() !== -9002 && $tokenobj->getEndOfLife() !== -9001 && time() > ($tokenobj->getEndOfLife() - 30));
 		// We have to save the refresh token in a memory variable because Google give it only once
 		$refreshtoken = $tokenobj->getRefreshToken();
@@ -358,6 +359,7 @@ if ($mode == 'setup' && $user->admin) {
 			$expire = false;
 			// Is token expired or will token expire in the next 30 seconds
 			if (is_object($tokenobj)) {
+				// tokenobj uses time() @phan-suppress-next-line DolibarrForbiddenFunctionPlugin
 				$expire = ($tokenobj->getEndOfLife() !== $tokenobj::EOL_NEVER_EXPIRES && $tokenobj->getEndOfLife() !== $tokenobj::EOL_UNKNOWN && time() > ($tokenobj->getEndOfLife() - 30));
 			}
 			if ($key[1] != '' && $key[2] != '') {

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -2651,7 +2651,7 @@ if ($action == 'create') {
 		print '<td class="valuefieldcreate">';
 		print img_picto('', 'action', 'class="pictofixedwidth"');
 		if (is_numeric(getDolGlobalString('DATE_LIVRAISON_WEEK_DELAY'))) {	// If value set to 0 or a num, not empty
-			$tmpdte = time() + (7 * getDolGlobalInt('DATE_LIVRAISON_WEEK_DELAY') * 24 * 60 * 60);
+			$tmpdte = dol_now() + (7 * getDolGlobalInt('DATE_LIVRAISON_WEEK_DELAY') * 24 * 60 * 60);
 			$syear = date("Y", $tmpdte);
 			$smonth = date("m", $tmpdte);
 			$sday = date("d", $tmpdte);

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -3662,7 +3662,7 @@ class Propal extends CommonObject
 		$this->ref_client = 'NEMICEPS';
 		$this->specimen = 1;
 		$this->socid = 1;
-		$this->date = time();
+		$this->date = dol_now();
 		$this->fin_validite = $this->date + 3600 * 24 * 30;
 		$this->cond_reglement_id   = 1;
 		$this->cond_reglement_code = 'RECEP';

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -4128,7 +4128,7 @@ class Commande extends CommonOrder
 		$this->specimen = 1;
 		$this->entity = $conf->entity;
 		$this->socid = 1;
-		$this->date = time();
+		$this->date = dol_now();
 		$this->date_lim_reglement = $this->date + 3600 * 24 * 30;
 		$this->cond_reglement_code = 'RECEP';
 		$this->mode_reglement_code = 'CHQ';

--- a/htdocs/compta/bank/annuel.php
+++ b/htdocs/compta/bank/annuel.php
@@ -61,7 +61,7 @@ $result = restrictedArea($user, 'banque', $fieldvalue, 'bank_account&bank_accoun
 
 $year_start = GETPOST('year_start');
 //$year_current = strftime("%Y", time());
-$year_current = (int) dol_print_date(time(), "%Y");
+$year_current = (int) dol_print_date(dol_now(), "%Y");
 if (!$year_start) {
 	$year_start = $year_current - 2;
 	$year_end = $year_current;

--- a/htdocs/compta/bank/class/api_bankaccounts.class.php
+++ b/htdocs/compta/bank/class/api_bankaccounts.class.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Copyright (C) 2016 Xebax Christy 			<xebax@wanadoo.fr>
- * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2025  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2025       Charlene Benke      <charlene@patas-monkey.com>
  *
@@ -166,7 +166,7 @@ class BankAccounts extends DolibarrApi
 
 		$account = new Account($this->db);
 		// Date of the initial balance (required to create an account).
-		$account->date_solde = time();
+		$account->date_solde = dol_now();
 		foreach ($request_data as $field => $value) {
 			if ($field === 'caller') {
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller

--- a/htdocs/compta/charges/index.php
+++ b/htdocs/compta/charges/index.php
@@ -65,7 +65,7 @@ $mode = GETPOST("mode", 'alpha');
 $year = GETPOSTINT("year");
 $filtre = GETPOST("filtre", 'alpha');
 if (!$year) {
-	$year = date("Y", time());
+	$year = (int) dol_print_date(dol_now(), "%Y");
 }
 $optioncss = GETPOST('optioncss', 'aZ'); // Option for the css output (always '' except when 'print')
 

--- a/htdocs/compta/paiement/rapport.php
+++ b/htdocs/compta/paiement/rapport.php
@@ -126,9 +126,9 @@ print load_fiche_titre($titre, '', 'bill');
 print '<form method="post" action="rapport.php?year='.$year.'">';
 print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="action" value="builddoc">';
-$cday = GETPOST("cday") ? GETPOST("cday") : date("d", time());
-$cmonth = GETPOST("remonth") ? GETPOST("remonth") : date("n", time());
-$syear = GETPOST("reyear") ? GETPOST("reyear") : date("Y", time());
+$cday = GETPOST("cday") ? GETPOST("cday") : (int) dol_print_date(dol_now(), "%d");
+$cmonth = GETPOST("remonth") ? GETPOST("remonth") : (int) dol_print_date(dol_now(), "%m");
+$syear = GETPOST("reyear") ? GETPOST("reyear") : (int) dol_print_date(dol_now(), "%Y");
 
 print $formother->selectDay($cday, 'cday', 1);
 

--- a/htdocs/compta/tva/payments.php
+++ b/htdocs/compta/tva/payments.php
@@ -54,7 +54,7 @@ $year = GETPOSTINT("year");
 $filtre = GETPOST("filtre", 'alpha');
 $optioncss = GETPOST('optioncss', 'alpha');
 if (!$year && $mode != 'tvaonly') {
-	$year = date("Y", time());
+	$year = (int) dol_print_date(dol_now(), "%Y");
 }
 
 $limit = GETPOSTINT('limit') ? GETPOSTINT('limit') : $conf->liste_limit;

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -12,7 +12,7 @@
  * Copyright (C) 2018-2026	Frédéric France				<frederic.france@free.fr>
  * Copyright (C) 2023-2026	Charlene Benke				<charlene@patas-monkey.com>
  * Copyright (C) 2023		Nick Fragoulis
- * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2026	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2025		William Mead				<william@m34d.com>
  * Copyright (C) 2026		Lionel Vessiller			<lvessiller@open-dsi.fr>
@@ -2208,7 +2208,7 @@ if ($action == 'create') {
 					if (GETPOST('remonth')) {
 						$dateactstart = dol_mktime(12, 0, 0, GETPOSTINT('remonth'), GETPOSTINT('reday'), GETPOSTINT('reyear'));
 					} elseif (!$dateactstart) {
-						$dateactstart = time();
+						$dateactstart = dol_now();
 					}
 
 					$dateactend = $objp->date_end;
@@ -2219,7 +2219,7 @@ if ($action == 'create') {
 							$product = new Product($db);
 							$product->fetch($objp->fk_product);
 							if (!empty($product->duration_value) && !empty($product->duration_unit)) {
-								$dateactend = dol_time_plus_duree(time(), $product->duration_value, $product->duration_unit);
+								$dateactend = dol_time_plus_duree(dol_now(), $product->duration_value, $product->duration_unit);
 							}
 						}
 					}
@@ -2265,7 +2265,7 @@ if ($action == 'create') {
 					if (GETPOST('remonth')) {
 						$dateactstart = dol_mktime(12, 0, 0, GETPOSTINT('remonth'), GETPOSTINT('reday'), GETPOSTINT('reyear'));
 					} elseif (!$dateactstart) {
-						$dateactstart = time();
+						$dateactstart = dol_now();
 					}
 
 					$dateactend = $objp->date_end_real;
@@ -2275,7 +2275,7 @@ if ($action == 'create') {
 						if ($objp->fk_product > 0) {
 							$product = new Product($db);
 							$product->fetch($objp->fk_product);
-							$dateactend = dol_time_plus_duree(time(), $product->duration_value, $product->duration_unit);
+							$dateactend = dol_time_plus_duree(dol_now(), $product->duration_value, $product->duration_unit);
 						}
 					}
 					$now = dol_now();

--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -1162,6 +1162,7 @@ class CMailFile
 						$expire = false;
 						// Is token expired or will token expire in the next 30 seconds
 						if (is_object($tokenobj)) {
+							// time() is used in tokenobj @phan-suppress-next-line DolibarrForbiddenFunctionPlugin
 							$expire = ($tokenobj->getEndOfLife() !== -9002 && $tokenobj->getEndOfLife() !== -9001 && time() > ($tokenobj->getEndOfLife() - 30));
 						}
 						// Token expired so we refresh it
@@ -1350,6 +1351,7 @@ class CMailFile
 						$expire = false;
 						// Is token expired or will token expire in the next 30 seconds
 						if (is_object($tokenobj)) {
+							// time() is used in tokenobj @phan-suppress-next-line DolibarrForbiddenFunctionPlugin
 							$expire = ($tokenobj->getEndOfLife() !== -9002 && $tokenobj->getEndOfLife() !== -9001 && time() > ($tokenobj->getEndOfLife() - 30));
 						}
 						// Token expired so we refresh it

--- a/htdocs/core/class/events.class.php
+++ b/htdocs/core/class/events.class.php
@@ -318,9 +318,9 @@ class Events // extends CommonObject
 	{
 		$this->id = 0;
 
-		$this->tms = time();
+		$this->tms = dol_now();
 		$this->type = '';
-		$this->dateevent = time();
+		$this->dateevent = dol_now();
 		$this->description = 'This is a specimen event';
 		$this->ip = '1.2.3.4';
 		$this->user_agent = 'Mozilla specimen User Agent X.Y';

--- a/htdocs/core/lib/agenda.lib.php
+++ b/htdocs/core/lib/agenda.lib.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2005-2009 Regis Houssin        <regis.houssin@inodbox.com>
  * Copyright (C) 2011	   Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2022-2026  Frédéric France		<frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -259,16 +259,16 @@ function show_array_actions_to_do($max = 5)
 			// Date
 			print '<td width="100" class="right tddate">'.dol_print_date($datep, 'day').'&nbsp;';
 			$late = 0;
-			if ($obj->percent == 0 && $datep && $datep < time()) {
+			if ($obj->percent == 0 && $datep && $datep < dol_now()) {
 				$late = 1;
 			}
-			if ($obj->percent == 0 && !$datep && $datep2 && $datep2 < time()) {
+			if ($obj->percent == 0 && !$datep && $datep2 && $datep2 < dol_now()) {
 				$late = 1;
 			}
-			if ($obj->percent > 0 && $obj->percent < 100 && $datep2 && $datep2 < time()) {
+			if ($obj->percent > 0 && $obj->percent < 100 && $datep2 && $datep2 < dol_now()) {
 				$late = 1;
 			}
-			if ($obj->percent > 0 && $obj->percent < 100 && !$datep2 && $datep && $datep < time()) {
+			if ($obj->percent > 0 && $obj->percent < 100 && !$datep2 && $datep && $datep < dol_now()) {
 				$late = 1;
 			}
 			if ($late) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -2545,7 +2545,7 @@ function dol_syslog($message, $level = LOG_INFO, $ident = 0, $suffixinfilename =
 			$ospid = sprintf("%7s", dol_trunc((string) getmypid(), 7, 'right', 'UTF-8', 1));
 			$osuser = " " . sprintf("%6s", dol_trunc(function_exists('posix_getuid') ? posix_getuid() : '', 6, 'right', 'UTF-8', 1));
 
-			$conf->logbuffer[] = dol_print_date(time(), "%Y-%m-%d %H:%M:%S") . " " . sprintf("%-7s", $logLevels[$level]) . " " . $ospid . " " . $osuser . " " . $message;
+			$conf->logbuffer[] = dol_print_date(dol_now(), "%Y-%m-%d %H:%M:%S") . " " . sprintf("%-7s", $logLevels[$level]) . " " . $ospid . " " . $osuser . " " . $message;
 		}
 
 		//TODO: Remove this. MAIN_ENABLE_LOG_INLINE_HTML should be deprecated and use a log handler dedicated to HTML output

--- a/htdocs/core/lib/html.lib.php
+++ b/htdocs/core/lib/html.lib.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur			<eldy@users.sourceforge.net>
  * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -2574,7 +2575,7 @@ function dol_print_error($db = null, $error = '', $errors = null)
 		}
 		$out .= $langs->trans("InformationToHelpDiagnose") . ":<br>\n";
 
-		$out .= "<b>" . $langs->trans("Date") . ":</b> " . dol_print_date(time(), 'dayhourlog') . "<br>\n";
+		$out .= "<b>" . $langs->trans("Date") . ":</b> " . dol_print_date(dol_now(), 'dayhourlog') . "<br>\n";
 		$out .= "<b>" . $langs->trans("Dolibarr") . ":</b> " . DOL_VERSION . " - https://www.dolibarr.org<br>\n";
 		if (isset($conf->global->MAIN_FEATURES_LEVEL)) {
 			$out .= "<b>" . $langs->trans("LevelOfFeature") . ":</b> " . getDolGlobalInt('MAIN_FEATURES_LEVEL') . "<br>\n";

--- a/htdocs/core/modules/action/doc/pdf_standard_actions.class.php
+++ b/htdocs/core/modules/action/doc/pdf_standard_actions.class.php
@@ -154,7 +154,7 @@ class pdf_standard_actions
 
 		$this->db = $db;
 		$this->description = "";
-		$this->date_edition = time();
+		$this->date_edition = dol_now();
 		$this->month = $month;
 		$this->year = $year;
 		$this->corner_radius = getDolGlobalInt('MAIN_PDF_FRAME_CORNER_RADIUS', 0);

--- a/htdocs/core/modules/printing/printgcp.modules.php
+++ b/htdocs/core/modules/printing/printgcp.modules.php
@@ -142,6 +142,7 @@ class printing_printgcp extends PrintingDriver
 			$expire = false;
 			// Is token expired or will token expire in the next 30 seconds
 			if ($token !== null) {
+				// time() is used internally in token @phan-suppress-next-line DolibarrForbiddenFunctionPlugin
 				$expire = ($token->getEndOfLife() !== -9002 && $token->getEndOfLife() !== -9001 && time() > ($token->getEndOfLife() - 30));
 			}
 

--- a/htdocs/core/modules/propale/mod_propale_marbre.php
+++ b/htdocs/core/modules/propale/mod_propale_marbre.php
@@ -153,7 +153,7 @@ class mod_propale_marbre extends ModeleNumRefPropales
 			return -1;
 		}
 
-		$date = time();
+		$date = dol_now();
 		$yymm = dol_print_date($date, "%y%m");
 
 		if ($max >= (pow(10, 4) - 1)) {

--- a/htdocs/core/modules/rapport/pdf_paiement.class.php
+++ b/htdocs/core/modules/rapport/pdf_paiement.class.php
@@ -478,7 +478,7 @@ class pdf_paiement extends CommonDocGenerator
 		$pdf->SetFont('', '', $default_font_size);
 
 		$pdf->SetXY($this->posxdate, 16);
-		$pdf->MultiCell(80, 2, $outputlangs->transnoentities("DateBuild")." : ".dol_print_date(time(), "day", false, $outputlangs, true), 0, 'L');
+		$pdf->MultiCell(80, 2, $outputlangs->transnoentities("DateBuild")." : ".dol_print_date(dol_now(), "day", false, $outputlangs, true), 0, 'L');
 
 		$pdf->SetXY($this->posxdate + 100, 16);
 		$pdf->MultiCell(80, 2, $outputlangs->transnoentities("Page")." : ".$page, 0, 'R');

--- a/htdocs/core/modules/reception/mod_reception_beryl.php
+++ b/htdocs/core/modules/reception/mod_reception_beryl.php
@@ -132,7 +132,7 @@ class mod_reception_beryl extends ModelNumRefReception
 			return -1;
 		}
 
-		$date = time();
+		$date = dol_now();
 		$yymm = dol_print_date($date, "%y%m");
 
 		if ($max >= (pow(10, 4) - 1)) {

--- a/htdocs/core/modules/supplier_proposal/mod_supplier_proposal_marbre.php
+++ b/htdocs/core/modules/supplier_proposal/mod_supplier_proposal_marbre.php
@@ -155,7 +155,7 @@ class mod_supplier_proposal_marbre extends ModeleNumRefSupplierProposal
 			return -1;
 		}
 
-		$date = time();
+		$date = dol_now();
 		$yymm = dol_print_date($date, "%y%m");
 
 		if ($max >= (pow(10, 4) - 1)) {

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -1238,6 +1238,7 @@ class EmailCollector extends CommonObject
 					$expire = false;
 					if (is_object($tokenobj) && method_exists($tokenobj, 'getEndOfLife')) {
 						$endOfLife = $tokenobj->getEndOfLife();
+						// time() is used internally in token @phan-suppress-next-line DolibarrForbiddenFunctionPlugin
 						if ($endOfLife !== -9002 && $endOfLife !== -9001 && time() > ($endOfLife - 30)) {
 							$expire = true;
 						}

--- a/htdocs/fourn/facture/rapport.php
+++ b/htdocs/fourn/facture/rapport.php
@@ -133,8 +133,8 @@ print load_fiche_titre($titre, '', 'supplier_invoice');
 print '<form method="post" action="rapport.php?year='.$year.'">';
 print '<input type="hidden" name="token" value="'.newToken().'">';
 print '<input type="hidden" name="action" value="builddoc">';
-$cmonth = GETPOST("remonth") ? GETPOST("remonth") : date("n", time());
-$syear = GETPOST("reyear") ? GETPOST("reyear") : date("Y", time());
+$cmonth = GETPOST("remonth") ? GETPOST("remonth") : dol_print_date(dol_now(), '%m');
+$syear = GETPOST("reyear") ? GETPOST("reyear") : dol_print_date(dol_now(), '%Y');
 
 print $formother->select_month($cmonth, 'remonth');
 

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -4599,8 +4599,8 @@ class Product extends CommonObject
 		}
 
 		if (empty($year)) {
-			$year = dol_print_date(time(), '%Y');
-			$month = dol_print_date(time(), '%m');
+			$year = dol_print_date(dol_now(), '%Y');
+			$month = dol_print_date(dol_now(), '%m');
 		} elseif ($year == -1) {
 			$year = '';
 			$month = 12; // We imagine we are at end of year, so we get last 12 month before, so all correct year.

--- a/htdocs/product/index.php
+++ b/htdocs/product/index.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2019       Pierre Ardoin           <mapiolca@me.com>
  * Copyright (C) 2019-2025  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2019       Nicolas ZABOURI         <info@inovea-conseil.com>
- * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -730,7 +730,7 @@ function activitytrim($product_type)
 	global $conf, $langs, $db;
 
 	// We display the last 3 years
-	$yearofbegindate = (int) date('Y', dol_time_plus_duree(time(), -3, "y"));
+	$yearofbegindate = (int) date('Y', dol_time_plus_duree(dol_now(), -3, "y"));
 	$out = '';
 	// breakdown by quarter
 	$sql = "SELECT DATE_FORMAT(p.datep,'%Y') as annee, DATE_FORMAT(p.datep,'%m') as mois, SUM(fd.total_ht) as mnttot";

--- a/htdocs/product/stock/movement_list.php
+++ b/htdocs/product/stock/movement_list.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2015		Juanjo Menent			<jmenent@2byte.es>
  * Copyright (C) 2018-2022	Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2019-2026  Frédéric France         <frederic.france@free.fr>
- * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -1758,8 +1758,8 @@ if (count($arrayofuniqueproduct) == 1 && !empty($search_date_startyear) && is_nu
 		$productidselected = $key;
 		$productlabelselected = $val;
 	}
-	$datebefore = dol_get_first_day($search_date_startyear ? $search_date_startyear : dol_print_date(time(), "%Y"), $search_date_startmonth ? $search_date_startmonth : 1, true);
-	$dateafter = dol_get_last_day($search_date_endyear ? $search_date_endyear : dol_print_date(time(), "%Y"), $search_date_endmonth ? $search_date_endmonth : 12, true);
+	$datebefore = dol_get_first_day($search_date_startyear ? $search_date_startyear : dol_print_date(dol_now(), "%Y"), $search_date_startmonth ? $search_date_startmonth : 1, true);
+	$dateafter = dol_get_last_day($search_date_endyear ? $search_date_endyear : dol_print_date(dol_now(), "%Y"), $search_date_endmonth ? $search_date_endmonth : 12, true);
 	$balancebefore = $object->calculateBalanceForProductBefore($productidselected, $datebefore);
 	$balanceafter = $object->calculateBalanceForProductBefore($productidselected, $dateafter);
 

--- a/htdocs/supplier_proposal/card.php
+++ b/htdocs/supplier_proposal/card.php
@@ -1731,10 +1731,10 @@ if ($action == 'create') {
 		print img_picto('', 'action', 'class="pictofixedwidth"');
 		$datedelivery = dol_mktime(0, 0, 0, GETPOSTINT('liv_month'), GETPOSTINT('liv_day'), GETPOSTINT('liv_year'));
 		if (is_numeric(getDolGlobalString('DATE_LIVRAISON_WEEK_DELAY'))) {	// If value set to 0 or a num, not empty
-			$tmpdte = time() + (7 * getDolGlobalInt('DATE_LIVRAISON_WEEK_DELAY') * 24 * 60 * 60);
-			$syear = date("Y", $tmpdte);
-			$smonth = date("m", $tmpdte);
-			$sday = date("d", $tmpdte);
+			$tmpdte = dol_now() + (7 * getDolGlobalInt('DATE_LIVRAISON_WEEK_DELAY') * 24 * 60 * 60);
+			$syear = dol_print_date($tmpdte, "Y");
+			$smonth = dol_print_date($tmpdte, "m");
+			$sday = dol_print_date($tmpdte, "d");
 			print $form->selectDate($syear."-".$smonth."-".$sday, 'liv_', 0, 0, 0, "addask");
 		} else {
 			print $form->selectDate($datedelivery ? $datedelivery : -1, 'liv_', 0, 0, 0, "addask", 1, 1);

--- a/htdocs/supplier_proposal/class/supplier_proposal.class.php
+++ b/htdocs/supplier_proposal/class/supplier_proposal.class.php
@@ -2379,7 +2379,7 @@ class SupplierProposal extends CommonObject
 		$this->ref_supplier = 'NEMICEPS';
 		$this->specimen = 1;
 		$this->socid = 1;
-		$this->date = time();
+		$this->date = dol_now();
 		$this->cond_reglement_id   = 1;
 		$this->cond_reglement_code = 'RECEP';
 		$this->mode_reglement_id   = 7;

--- a/htdocs/user/class/usergroup.class.php
+++ b/htdocs/user/class/usergroup.class.php
@@ -1013,8 +1013,8 @@ class UserGroup extends CommonObject
 
 		$this->name = 'DOLIBARR GROUP SPECIMEN';
 		$this->note = 'This is a note';
-		$this->datec = time();
-		$this->tms = time();
+		$this->datec = dol_now();
+		$this->tms = dol_now();
 
 		// Members of this group is just me
 		$this->members = array(


### PR DESCRIPTION
Replace all instances of time() with dol_now() to ensure consistent time handling across the codebase. This change affects multiple files and functions to maintain uniformity in time-related operations.