### PR TITLE
Fix #40057 include blockedlog.lib.php in blockedlog.class.php

### DIFF
--- a/htdocs/blockedlog/class/blockedlog.class.php
+++ b/htdocs/blockedlog/class/blockedlog.class.php
@@ -23,6 +23,7 @@
 
 include_once DOL_DOCUMENT_ROOT.'/blockedlog/versionmod.inc.php';
 include_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/securitycore.lib.php';
+include_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php';
 
 
 /**


### PR DESCRIPTION
Confirmed the analysis and reproduced the fatal.

isALNERunningVersion() is defined in blockedlog/lib/blockedlog.lib.php:245 but called twice in the class with no include covering either call:

    blockedlog.class.php:1552   inside create()
    blockedlog.class.php:1824   inside buildFinalSignatureHash()

The include_once calls that do exist sit at :1603, :1953, :2384 and later, so all after those two. And main.inc.php only loads the lib for index.php or a forced ping:

    main.inc.php:4043   if (($_SERVER["PHP_SELF"] == DOL_URL_ROOT.'/index.php') || $forceping) {
    main.inc.php:4044       require_once DOL_DOCUMENT_ROOT.'/blockedlog/lib/blockedlog.lib.php';

Reproduced with PHP_SELF set to /document.php:

    after master.inc.php              isALNERunningVersion defined? NO
    after blockedlog.class.php too    isALNERunningVersion defined? NO

so the call is a guaranteed fatal on any page other than index.php, which matches the report.

Fixed by adding the include at the top of the class, next to the securitycore.lib.php one that is already there, as suggested in the issue. Verified after the change:

    isALNERunningVersion defined? YES
    BlockedLog class still loads? yes

I put it at file level rather than just before the call at :1824, because :1552 has the same problem and a single top-level include covers both without repeating it.

Reported by @ALD42220 in #40057.