### PR TITLE
Fix #40056 initialise the order rights before forcing them in the workflow trigger

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -80,6 +80,10 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				if (!empty($object->context['closedfromonlinesignature'])) {
 					// If signature was done from the online signature page,
 					// we must force permission to create order so the workflow action will work.
+					// The technical user of that page has no rights loaded, so initialise the object first.
+					if (empty($user->rights->commande)) {
+						$user->rights->commande = new stdClass();
+					}
 					$user->rights->commande->creer = 1;
 				}
 				$object->fetchObjectLinked();


### PR DESCRIPTION
Confirmed and reproduced on PHP 8.2.33, the version in the report.

core/ajax/onlineSign.php builds a technical user with new User($db) and never fetches its rights, so:

    fresh User: rights is object
    rights->commande is NOT SET
    $u->rights->commande->creer = 1
    FATAL Error: Attempt to assign property "creer" on null

which is the line at interface_20_modWorkflow_WorkflowManager.class.php:83, reached only when WORKFLOW_PROPAL_AUTOCREATE_ORDER is on and the signature came from the online page. That explains the whole symptom chain in the issue: the PDF is written before the trigger runs, the fatal kills the request with a 500, and the open transaction is rolled back so the proposal stays unsigned.

Fixed with the pattern already used for the same kind of anonymous user in public/payment/paymentok.php:542:

    if (empty($user->rights->commande)) {
        $user->rights->commande = new stdClass();
    }
    $user->rights->commande->creer = 1;

Checked both paths after the change:

    anonymous user   -> creer=1, no fatal
    existing rights  -> lire=1 preserved, creer=1

so a user who already carries loaded rights is not wiped by the guard.

Note this was harmless before PHP 8, where assigning a property on null only raised a warning and auto-vivified. It became fatal with PHP 8.0, which is likely why it went unnoticed.

Reported by @davidflipo-a11y in #40056.