### PR TITLE
NEW: TakePOS - allow to disable a terminal without removing it

### DIFF
--- a/htdocs/core/lib/takepos.lib.php
+++ b/htdocs/core/lib/takepos.lib.php
@@ -2,6 +2,7 @@
 /* Copyright (C) 2009       Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2022       Alexandre Spangaro  <aspangaro@open-dsi.fr>
  * Copyright (C) 2024		MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026       Jose Martinez       <jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,8 +58,13 @@ function takepos_admin_prepare_head()
 
 	$numterminals = max(1, getDolGlobalInt('TAKEPOS_NUM_TERMINALS', 1));
 	for ($i = 1; $i <= $numterminals; $i++) {
+		$label = getDolGlobalString('TAKEPOS_TERMINAL_NAME_'.$i, $langs->trans("TerminalName", $i));
+		if (!takeposTerminalIsEnabled($i)) {
+			// A disabled terminal is greyed out but still listed, so it can be enabled again
+			$label = '<span class="opacitymedium">'.$label.' ('.$langs->trans("Disabled").')</span>';
+		}
 		$head[$h][0] = DOL_URL_ROOT.'/takepos/admin/terminal.php?terminal='.$i;
-		$head[$h][1] = getDolGlobalString('TAKEPOS_TERMINAL_NAME_'.$i, $langs->trans("TerminalName", $i));
+		$head[$h][1] = $label;
 		$head[$h][2] = 'terminal'.$i;
 		$h++;
 	}
@@ -75,4 +81,37 @@ function takepos_admin_prepare_head()
 	complete_head_from_modules($conf, $langs, null, $head, $h, 'takepos_admin', 'remove');
 
 	return $head;
+}
+
+/**
+ * Tell if a TakePOS terminal can be used.
+ *
+ * A terminal is enabled by default: the constant is only recorded when the terminal is
+ * explicitly disabled, so existing setups keep all their terminals available.
+ * Disabling a terminal only hides it from the terminal selection: its past invoices
+ * and its reference counter are left untouched.
+ *
+ * @param	int		$terminal	Terminal number (1 to TAKEPOS_NUM_TERMINALS)
+ * @return	bool				True if the terminal can be used
+ */
+function takeposTerminalIsEnabled($terminal)
+{
+	return !getDolGlobalInt('TAKEPOS_TERMINAL_DISABLED_'.((int) $terminal));
+}
+
+/**
+ * Return the list of the TakePOS terminals that can be used.
+ *
+ * @return	int[]	Array of terminal numbers that are not disabled
+ */
+function takeposEnabledTerminals()
+{
+	$result = array();
+	$numterminals = max(1, getDolGlobalInt('TAKEPOS_NUM_TERMINALS', 1));
+	for ($i = 1; $i <= $numterminals; $i++) {
+		if (takeposTerminalIsEnabled($i)) {
+			$result[] = $i;
+		}
+	}
+	return $result;
 }

--- a/htdocs/langs/en_US/cashdesk.lang
+++ b/htdocs/langs/en_US/cashdesk.lang
@@ -202,3 +202,5 @@ DefaultCashPOSLabel=Cash account for POS
 
 TakeposValidateCreditNoteOnCreation=Validate credit note on creation
 TakeposValidateCreditNoteOnCreationDesc=If enabled, credit notes created in TakePOS will be validated immediately. If disabled, they will remain as drafts to allow editing quantities before payment.
+TakeposTerminalDisabled=Terminal disabled
+TakeposTerminalDisabledHelp=If set, this terminal is no longer proposed on the terminal selection screen. Its existing invoices and its numbering counter are not modified.

--- a/htdocs/takepos/admin/terminal.php
+++ b/htdocs/takepos/admin/terminal.php
@@ -5,6 +5,7 @@
  * Copyright (C) 2022      Alexandre Spangaro   <aspangaro@open-dsi.fr>
  * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026      Jose Martinez        <jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -202,6 +203,15 @@ print "</tr>\n";
 print '<tr class="oddeven"><td class="fieldrequired">'.$langs->trans("TerminalNameDesc").'</td>';
 print '<td>';
 print '<input type="text" name="terminalname'.$terminal.'" value="'.getDolGlobalString("TAKEPOS_TERMINAL_NAME_".$terminal, $langs->trans("TerminalName", $terminal)).'" >';
+print '</td></tr>';
+
+// A disabled terminal is hidden from the terminal selection screen. Its invoices and its
+// reference counter are kept, so it can be enabled again later without losing anything.
+print '<tr class="oddeven"><td>';
+print $form->textwithpicto($langs->trans("TakeposTerminalDisabled"), $langs->trans("TakeposTerminalDisabledHelp"));
+print '</td>';
+print '<td>';
+print ajax_constantonoff("TAKEPOS_TERMINAL_DISABLED_".$terminal, array(), $conf->entity, 0, 0, 1, 0);
 print '</td></tr>';
 
 print '<tr class="oddeven"><td>'.$langs->trans("ForbidSalesToTheDefaultCustomer").'</td>';

--- a/htdocs/takepos/index.php
+++ b/htdocs/takepos/index.php
@@ -55,6 +55,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formother.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/hookmanager.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/takepos.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
 require_once DOL_DOCUMENT_ROOT.'/compta/facture/class/facture.class.php';
 require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
@@ -69,8 +70,9 @@ $setcurrency = GETPOST('setcurrency', 'aZ09');
 
 $hookmanager->initHooks(array('takeposfrontend'));
 if (empty($_SESSION["takeposterminal"])) {
-	if (getDolGlobalInt('TAKEPOS_NUM_TERMINALS') == 1) {
-		$_SESSION["takeposterminal"] = 1; // Use terminal 1 if there is only 1 terminal
+	$enabledterminals = takeposEnabledTerminals();
+	if (count($enabledterminals) == 1) {
+		$_SESSION["takeposterminal"] = (int) $enabledterminals[0]; // Use the only usable terminal
 	} elseif (!empty($_COOKIE["takeposterminal"])) {
 		$_SESSION["takeposterminal"] = preg_replace('/[^a-zA-Z0-9_\-]/', '', $_COOKIE["takeposterminal"]); // Restore takeposterminal from previous session
 	}
@@ -1368,10 +1370,8 @@ if (!getDolGlobalString('TAKEPOS_HIDE_HEAD_BAR')) {
 		<h3><?php print $langs->trans("TerminalSelect"); ?></h3>
 	</div>
 	<div class="modal-body">
-		<button type="button" class="block" onclick="location.href='index.php?setterminal=1'"><?php print getDolGlobalString("TAKEPOS_TERMINAL_NAME_1", $langs->trans("TerminalName", 1)); ?></button>
 		<?php
-		$nbloop = getDolGlobalInt('TAKEPOS_NUM_TERMINALS');
-		for ($i = 2; $i <= $nbloop; $i++) {
+		foreach (takeposEnabledTerminals() as $i) {
 			print '<button type="button" class="block" onclick="location.href=\'index.php?setterminal='.$i.'\'">'.getDolGlobalString("TAKEPOS_TERMINAL_NAME_".$i, $langs->trans("TerminalName", $i)).'</button>';
 		}
 		?>


### PR DESCRIPTION
## Description

TakePOS currently has no way to retire a cash register. The only setting is `TAKEPOS_NUM_TERMINALS`, a count: terminals are always 1..N, so the only way to remove one is to lower the count — which drops the *last* terminal, not the one you actually stopped using, and there is no way at all to retire a terminal in the middle of the list.

This is a problem for shops that reorganise their tills over the years: closed registers keep showing up on the terminal selection screen, and staff can still open a sale on them by mistake.

This PR adds a real enabled/disabled state per terminal, in the same spirit as the active/inactive flag on users or third parties.

**A disabled terminal is only hidden from the terminal selection screen.** Its invoices, its history and its numbering counter (`mod_takepos_ref_simple` computes the counter from the existing references) are left strictly untouched, so a terminal can be disabled and enabled again later without losing anything, and the per-terminal sales history stays readable.

## Backward compatibility

A terminal is enabled by default: `TAKEPOS_TERMINAL_DISABLED_{n}` is only recorded when a terminal is explicitly disabled, so existing setups keep every terminal available and behave exactly as before.

## Changes

- `htdocs/core/lib/takepos.lib.php` — two helpers, `takeposTerminalIsEnabled($terminal)` and `takeposEnabledTerminals()`. `takepos_admin_prepare_head()` greys a disabled terminal out in the setup tabs **without removing it**, so you can see at a glance which terminals are off and click straight through to enable one again.
- `htdocs/takepos/admin/terminal.php` — the per-terminal on/off switch.
- `htdocs/takepos/index.php` — the terminal selection modal lists the enabled terminals only, and the "auto-select when there is a single terminal" shortcut now considers the enabled ones. This also removes the duplicated hard-coded button for terminal 1 (the loop used to start at 2).
- `htdocs/langs/en_US/cashdesk.lang` — 2 new keys.

## How it was tested

Tested on a live TakePOS install with 6 terminals:

| Scenario | Usable terminals |
|---|---|
| Nothing disabled | 1, 2, 3, 4, 5, 6 |
| Terminal 6 disabled | 1, 2, 3, 4, 5 |
| + terminal 3 disabled | 1, 2, 4, 5 |
| All re-enabled | 1, 2, 3, 4, 5, 6 |

The third scenario is the point of the PR: disabling a terminal in the middle of the list, which lowering `TAKEPOS_NUM_TERMINALS` cannot do. Invoice references and history of the disabled terminals were unchanged throughout. Enabling a terminal again from its greyed-out tab was checked in the browser.

Only `en_US` is modified; other languages are left to Transifex.

## Review

Thanks @eldy — the `TAKEPOS_ALLOW_TERMINAL_DISABLING` option has been dropped, the feature is now available to everybody by default as you suggested.
