### PR TITLE
FIX Untranslated error shown when the antivirus refuses an uploaded file

### DIFF
--- a/htdocs/admin/company.php
+++ b/htdocs/admin/company.php
@@ -7,7 +7,7 @@
  * Copyright (C) 2015-2025	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2017		Rui Strecht					<rui.strecht@aliartalentos.com>
  * Copyright (C) 2023		Nick Fragoulis
- * Copyright (C) 2024-2025	Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2024-2025	MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -214,14 +214,10 @@ if (($action == 'update' && !GETPOST("cancel", 'alpha'))
 					} else {
 						dol_syslog("ErrorImageFormatNotSupported", LOG_WARNING);
 					}
-				} elseif (preg_match('/^ErrorFileIsInfectedWithAVirus/', $result)) {
+				} elseif (!is_numeric($result)) {	// $result is a translation key
 					$error++;
 					$langs->load("errors");
-					$tmparray = explode(':', $result);
-					setEventMessages($langs->trans('ErrorFileIsInfectedWithAVirus', $tmparray[1]), null, 'errors');
-				} elseif (preg_match('/^ErrorFileSizeTooLarge/', $result)) {
-					$error++;
-					setEventMessages($langs->trans("ErrorFileSizeTooLarge"), null, 'errors');
+					setEventMessages($langs->trans($result), null, 'errors');
 				} else {
 					$error++;
 					setEventMessages($langs->trans("ErrorFailedToSaveFile"), null, 'errors');

--- a/htdocs/admin/ihm.php
+++ b/htdocs/admin/ihm.php
@@ -8,7 +8,7 @@
  * Copyright (C) 2021-2023	Anthony Berton				<anthony.berton@bb2a.fr>
  * Copyright (C) 2023		Eric Seigne					<eric.seigne@cap-rel.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025	Frédéric France				<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France				<frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -310,13 +310,13 @@ if ($action == 'update') {
 						dol_mkdir($dirforimage);
 					}
 					$result = dol_move_uploaded_file($_FILES[$varforimage]["tmp_name"], $dirforimage . $original_file, 1, 0, $_FILES[$varforimage]['error']);
-					if ($result > 0) {
+					// Note: a refused file is reported with a string, and in PHP 8 such a string is > 0, so we must test is_numeric() first
+					if (is_numeric($result) && $result > 0) {
 						dolibarr_set_const($db, "MAIN_LOGIN_BACKGROUND", $original_file, 'chaine', 0, '', $conf->entity);
-					} elseif (preg_match('/^ErrorFileIsInfectedWithAVirus/', $result)) {
+					} elseif (!is_numeric($result)) {	// $result is a translation key
 						$error++;
 						$langs->load("errors");
-						$tmparray = explode(':', $result);
-						setEventMessages($langs->trans('ErrorFileIsInfectedWithAVirus', $tmparray[1]), null, 'errors');
+						setEventMessages($langs->trans($result), null, 'errors');
 					} else {
 						$error++;
 						setEventMessages($langs->trans("ErrorFailedToSaveFile"), null, 'errors');

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -1429,7 +1429,7 @@ function dol_unescapefile($filename)
  *
  * @param   string      $src_file       Source file to check
  * @param   string      $dest_file      Destination file name (to know the expected type)
- * @return  string[]                    Array of errors, or empty array if not virus found
+ * @return  string[]                    Array of errors (the translation key of the error is used as array key when the check has one), or empty array if not virus found
  */
 function dolCheckVirus($src_file, $dest_file = '')
 {
@@ -1459,7 +1459,7 @@ function dolCheckVirus($src_file, $dest_file = '')
  *
  * @param   string      $src_file       Source file to check
  * @param   string      $dest_file      Destination file name (to know the expected type)
- * @return  string[]                    Array of errors, or empty array if not virus found
+ * @return  string[]                    Array of errors (the translation key of the error is used as array key when the check has one), or empty array if not virus found
  */
 function dolCheckOnFileName($src_file, $dest_file = '')
 {
@@ -1469,7 +1469,7 @@ function dolCheckOnFileName($src_file, $dest_file = '')
 
 			$tmp = file_get_contents(trim($src_file));
 			if (preg_match('/[\n\s]+\/JavaScript[\n\s]+/m', $tmp)) {
-				return array('File is a PDF with javascript inside');
+				return array('ErrorFileIsAnInfectedPDFWithJSInside' => 'File is a PDF with javascript inside');
 			}
 		} else {
 			dol_syslog("dolCheckOnFileName Check js into pdf disabled");
@@ -1544,7 +1544,14 @@ function dol_move_uploaded_file($src_file, $dest_file, $allowoverwrite, $disable
 			$checkvirusarray = dolCheckVirus($src_file, $dest_file);
 			if (count($checkvirusarray)) {
 				dol_syslog('Files.lib::dol_move_uploaded_file File "'.$src_file.'" (target name "'.$dest_file.'") KO with antivirus: errors='.implode(',', $checkvirusarray), LOG_WARNING);
-				return 'ErrorFileIsInfectedWithAVirus: '.implode(',', $checkvirusarray);
+				// We return a translation key alone, so the caller can translate it. The technical message of the
+				// antivirus is not appended to it (that would break the translation), it is kept into the log only.
+				foreach (array_keys($checkvirusarray) as $errorkey) {
+					if (is_string($errorkey)) {	// A check that knows its own error key returns it as array key
+						return $errorkey;
+					}
+				}
+				return 'ErrorFileIsInfectedWithAVirus';
 			}
 		}
 
@@ -2195,7 +2202,7 @@ function dol_add_file_process($upload_dir, $allowoverwrite = 0, $updatesessionor
 				// Move file from source directory to final destination. Check for virus is also embedded and a .noexe may also be appended on file name.
 				$resupload = dol_move_uploaded_file($TFile['tmp_name'][$i], $destfull, $allowoverwrite, 0, $TFile['error'][$i], 0, $keyforsourcefile, $upload_dir, $mode);
 
-				if (is_numeric($resupload) && $resupload > 0) {   // $resupload can be 'ErrorFileAlreadyExists', 'ErrorFileIsInfectedWithAVirus...'
+				if (is_numeric($resupload) && $resupload > 0) {   // $resupload can be 'ErrorFileAlreadyExists', 'ErrorFileIsInfectedWithAVirus'
 					include_once DOL_DOCUMENT_ROOT.'/core/lib/images.lib.php';
 
 					$tmparraysize = getDefaultImageSizes();
@@ -2255,13 +2262,7 @@ function dol_add_file_process($upload_dir, $allowoverwrite = 0, $updatesessionor
 					$langs->load("errors");
 					if (is_numeric($resupload) && $resupload < 0) {	// Unknown error
 						setEventMessages($langs->trans("ErrorFileNotUploaded"), null, 'errors');
-					} elseif (preg_match('/ErrorFileIsInfectedWithAVirus/', $resupload)) {	// Files infected by a virus
-						if (preg_match('/File is a PDF with javascript inside/', $resupload)) {
-							setEventMessages($langs->trans("ErrorFileIsAnInfectedPDFWithJSInside"), null, 'errors');
-						} else {
-							setEventMessages($langs->trans("ErrorFileIsInfectedWithAVirus").'<br>'.dolGetFirstLineOfText($resupload), null, 'errors');
-						}
-					} else { // Known error
+					} else { // Known error, $resupload is a translation key
 						setEventMessages($langs->trans($resupload), null, 'errors');
 					}
 				}

--- a/htdocs/core/modules/mailings/xinputfile.modules.php
+++ b/htdocs/core/modules/mailings/xinputfile.modules.php
@@ -215,9 +215,7 @@ class mailing_xinputfile extends MailingTargets
 				$langs->load("errors");
 				if ($resupload < 0) {	// Unknown error
 					$this->error = '<div class="error">'.$langs->trans("ErrorFileNotUploaded").'</div>';
-				} elseif (preg_match('/ErrorFileIsInfectedWithAVirus/', $resupload)) {	// Files infected by a virus
-					$this->error = '<div class="error">'.$langs->trans("ErrorFileIsInfectedWithAVirus").'</div>';
-				} else { // Known error
+				} else { // Known error, $resupload is a translation key
 					$this->error = '<div class="error">'.$langs->trans($resupload).'</div>';
 				}
 			}

--- a/htdocs/ecm/dir_card.php
+++ b/htdocs/ecm/dir_card.php
@@ -132,10 +132,7 @@ if (GETPOST("sendit") && getDolGlobalString('MAIN_UPLOAD_DOC') && $permissiontou
 			$langs->load("errors");
 			if ($resupload < 0) {	// Unknown error
 				setEventMessages($langs->trans("ErrorFileNotUploaded"), null, 'errors');
-			} elseif (preg_match('/ErrorFileIsInfectedWithAVirus/', $resupload)) {
-				// Files infected by a virus
-				setEventMessages($langs->trans("ErrorFileIsInfectedWithAVirus"), null, 'errors');
-			} else { // Known error
+			} else { // Known error, $resupload is a translation key
 				setEventMessages($langs->trans($resupload), null, 'errors');
 			}
 		}

--- a/test/phpunit/FilesLibTest.php
+++ b/test/phpunit/FilesLibTest.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2012		Regis Houssin		<regis.houssin@inodbox.com>
  * Copyright (C) 2023		Alexandre Janniaux   <alexandre.janniaux@gmail.com>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -594,6 +594,40 @@ class FilesLibTest extends CommonClassTest
 		$result = dol_move_dir($dirsrcpath, $dirdestpath, 1, 1, 1);
 		print __METHOD__." result=".$result."\n";
 		$this->assertTrue($result, 'move of directory with directory without rename needed in directory');
+	}
+
+	/**
+	 * dol_move_uploaded_file() returns a translation key when it refuses a file, so the caller can
+	 * translate it. The virus branch must return a key alone: a key with the technical message of the
+	 * antivirus appended matches no entry of errors.lang and is shown untranslated to the user.
+	 *
+	 * @return void
+	 */
+	public function testDolMoveUploadedFileReturnsATranslationKeyOnVirus()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$langs->load("errors");
+
+		// A jpg renamed as a pdf, holding javascript: dolCheckOnFileName() refuses it
+		$srcfile = $conf->admin->dir_temp.'/uploadedvirus.tmp';
+		dol_copy(dirname(__FILE__).'/file_pdf_with_js.pdf.jpg', $srcfile, '0', 1);
+
+		$destfile = $conf->admin->dir_temp.'/uploadedvirus.pdf';
+		dol_delete_file($destfile, 0, 1);
+
+		$result = dol_move_uploaded_file($srcfile, $destfile, 1, 0, 0, 1);
+		print __METHOD__." result=".$result."\n";
+
+		$this->assertSame('ErrorFileIsAnInfectedPDFWithJSInside', $result, 'A pdf with js inside must be refused with its own translation key');
+		$this->assertNotSame($result, $langs->trans($result), 'The returned code must be a key that can be translated');
+		$this->assertFalse(file_exists($destfile), 'The refused file must not have been moved to its destination');
+
+		dol_delete_file($srcfile, 0, 1);
 	}
 
 	/**


### PR DESCRIPTION
# FIX Untranslated error shown to the user when the antivirus refuses an uploaded file

`dol_move_uploaded_file()` has no `$langs`, so it reports a refusal by returning a **translation key** (`ErrorFileSizeTooLarge`, `ErrorPartialFile`, `ErrorNoTmpDir`...) that the caller translates.

The virus branch broke that contract: it appended the technical message of the antivirus to the key.

```php
return 'ErrorFileIsInfectedWithAVirus: '.implode(',', $checkvirusarray);
```

`ErrorFileIsInfectedWithAVirus: File is a PDF with javascript inside` matches no entry of `errors.lang`, so `$langs->trans()` returns it unchanged and the raw English string is shown to the user. It is visible in `admin/geoipmaxmind.php`, which translates the returned code like any other one.

The other callers worked around it by parsing the string with `preg_match()` / `explode(':')`, each in its own way, and one of them (`admin/ihm.php`) passed the parsed detail as a parameter to a translation that has no `%s`.

## What this PR does

* `dol_move_uploaded_file()` returns the translation key alone. The technical message of the antivirus stays in `dol_syslog()`, where it already was.
* `dolCheckOnFileName()` reports its own error key (`ErrorFileIsAnInfectedPDFWithJSInside`, already in `errors.lang`) as the **array key** of the error it returns, so a caller can tell the PDF-with-JS case from a plain antivirus hit without matching on the message text. `count()` and `implode()` on that array behave as before, so `dol_copy()`, `dol_move()` and the `RestException` of `api_documents.class.php` are unchanged — the REST API keeps its detailed message.
* The five places that parsed the returned string now simply call `$langs->trans($resupload)`: `dol_add_file_process()`, `ecm/dir_card.php`, `core/modules/mailings/xinputfile.modules.php`, `admin/ihm.php`, `admin/company.php`. They now also translate the other error codes (file too large, partial file...) instead of falling back to a generic message.
* In `admin/ihm.php`, the test for success was `if ($result > 0)` while `$result` can be a string. In PHP 8 a non-numeric string compares as greater than `0` (`'ErrorFileIsInfectedWithAVirus' > 0` is `true`), so every error branch below it was dead code: a refused file was reported as saved and `MAIN_LOGIN_BACKGROUND` was set anyway. Fixed with an `is_numeric()` guard.

## Test

A unit test is added to `test/phpunit/FilesLibTest.php`, using the `file_pdf_with_js.pdf.jpg` fixture already in the suite: it checks that the refused upload returns a code that `$langs->trans()` can actually translate, and that the file was not moved.

```
FilesLibTest::testDolMoveUploadedFileReturnsATranslationKeyOnVirus result=ErrorFileIsAnInfectedPDFWithJSInside
OK (1 test, 3 assertions)
```

`FilesLibTest`, `FilesLibMoveDirTest` and `FileUploadTest` pass (the pre-existing failure of `testDolCheckSecureAccessDocument` is unrelated and also fails without this PR). PHPStan level 10 reports no error on the changed files.

## Note

The same PHP 8 comparison problem as in `admin/ihm.php` exists in other callers of `dol_move_uploaded_file()` (`user/card.php`, `societe/card.php`, `contact/card.php`, `contact/perso.php`, `adherents/card.php`, `imports/import.php`, `core/ajax/flowjs-server.php`), where a refused upload is reported to the user as a success. It is a different bug and it is left to a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
