### PR TITLE
FIX An upload refused by dol_move_uploaded_file() is reported as a success

### DIFF
--- a/htdocs/contact/card.php
+++ b/htdocs/contact/card.php
@@ -8,7 +8,7 @@
  * Copyright (C) 2013-2024	Alexandre Spangaro			<alexandre@inovea-conseil.com>
  * Copyright (C) 2014		Juanjo Menent				<jmenent@2byte.es>
  * Copyright (C) 2015		Jean-François Ferry			<jfefe@aternatik.fr>
- * Copyright (C) 2018-2024	Frédéric France				<frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France				<frederic.france@free.fr>
  * Copyright (C) 2019		Josep Lluís Amador			<joseplluis@lliuretic.cat>
  * Copyright (C) 2020		Open-Dsi					<support@open-dsi.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
@@ -389,7 +389,8 @@ if (empty($reshook)) {
 						$newfile = $dir.'/'.dol_sanitizeFileName($_FILES['photo']['name']);
 						$result = dol_move_uploaded_file($_FILES['photo']['tmp_name'], $newfile, 1);
 
-						if (!($result > 0)) {
+						// Note: $result is a string when the file was refused and, in PHP 8, such a string compares as greater than 0
+						if (!is_numeric($result) || $result <= 0) {
 							$errors[] = "ErrorFailedToSaveFile";
 						} else {
 							$object->photo = dol_sanitizeFileName($_FILES['photo']['name']);

--- a/htdocs/core/ajax/flowjs-server.php
+++ b/htdocs/core/ajax/flowjs-server.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2023 Laurent Destailleur <eldy@users.sourceforge.net>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -129,7 +129,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
 			}
 
 			// move the temporary file
-			if (!dol_move_uploaded_file($file['tmp_name'], $dest_file, 0)) {
+			// Note: the returned value is a string when the file was refused and, in PHP 8, such a string compares as greater than 0
+			$resultupload = dol_move_uploaded_file($file['tmp_name'], $dest_file, 0);
+			if (!is_numeric($resultupload) || $resultupload <= 0) {
 				dol_syslog('Error saving (move_uploaded_file) chunk '.$flowChunkNumber.' for file '.$flowFilename);
 			} else {
 				// check if all the parts present, and create the final destination file

--- a/htdocs/imports/import.php
+++ b/htdocs/imports/import.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2012      Christophe Battarel	<christophe.battarel@altairis.fr>
  * Copyright (C) 2022      Charlene Benke		<charlene@patas-monkey.com>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024       Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -239,7 +239,9 @@ if ($step == 3 && $datatoimport) {
 		$nowyearmonth = dol_print_date(dol_now(), '%Y%m%d%H%M%S');
 
 		$fullpath = $conf->import->dir_temp."/".$nowyearmonth.'-'.$_FILES['userfile']['name'];
-		if (dol_move_uploaded_file($_FILES['userfile']['tmp_name'], $fullpath, 1) > 0) {
+		// Note: the returned value is a string when the file was refused and, in PHP 8, such a string compares as greater than 0
+		$resultupload = dol_move_uploaded_file($_FILES['userfile']['tmp_name'], $fullpath, 1);
+		if (is_numeric($resultupload) && $resultupload > 0) {
 			dol_syslog("File ".$fullpath." was added for import");
 		} else {
 			$langs->load("errors");

--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -12,7 +12,7 @@
  * Copyright (C) 2015       Raphaël Doursenaud      <rdoursenaud@gpcsolutions.fr>
  * Copyright (C) 2018       Nicolas ZABOURI         <info@inovea-conseil.com>
  * Copyright (C) 2018       Ferran Marcet           <fmarcet@2byte.es.com>
- * Copyright (C) 2018-2024	Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2022-2023  George Gkantinas        <info@geowv.eu>
  * Copyright (C) 2023       Nick Fragoulis
  * Copyright (C) 2023       Alexandre Janniaux      <alexandre.janniaux@gmail.com>
@@ -593,7 +593,8 @@ if (empty($reshook)) {
 								$newfile = $dir.'/'.dol_sanitizeFileName($_FILES['photo']['name']);
 								$result = dol_move_uploaded_file($_FILES['photo']['tmp_name'], $newfile, 1);
 
-								if (!($result > 0)) {
+								// Note: $result is a string when the file was refused and, in PHP 8, such a string compares as greater than 0
+								if (!is_numeric($result) || $result <= 0) {
 									$errors[] = "ErrorFailedToSaveFile";
 								} else {
 									// Create thumbs
@@ -773,7 +774,8 @@ if (empty($reshook)) {
 							$newfile = $dir.'/'.dol_sanitizeFileName($_FILES['photo']['name']);
 							$result = dol_move_uploaded_file($_FILES['photo']['tmp_name'], $newfile, 1);
 
-							if (!($result > 0)) {
+							// Note: $result is a string when the file was refused and, in PHP 8, such a string compares as greater than 0
+							if (!is_numeric($result) || $result <= 0) {
 								$errors[] = "ErrorFailedToSaveFile";
 							} else {
 								// Create thumbs
@@ -1171,7 +1173,8 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 					$newfile = $dir.'/'.dol_sanitizeFileName($_FILES['photo']['name']);
 					$result = dol_move_uploaded_file($_FILES['photo']['tmp_name'], $newfile, 1);
 
-					if (!($result > 0)) {
+					// Note: $result is a string when the file was refused and, in PHP 8, such a string compares as greater than 0
+					if (!is_numeric($result) || $result <= 0) {
 						$errors[] = "ErrorFailedToSaveFile";
 					} else {
 						// Create thumbs

--- a/htdocs/user/card.php
+++ b/htdocs/user/card.php
@@ -13,7 +13,7 @@
  * Copyright (C) 2015		Ari Elbaz (elarifr)			<github@accedinfo.com>
  * Copyright (C) 2015-2018	Charlene Benke				<charlie@patas-monkey.com>
  * Copyright (C) 2016		Raphaël Doursenaud			<rdoursenaud@gpcsolutions.fr>
- * Copyright (C) 2018-2024	Frédéric France				<frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France				<frederic.france@free.fr>
  * Copyright (C) 2018		David Beniamine				<David.Beniamine@Tetras-Libre.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
@@ -670,7 +670,8 @@ if (empty($reshook)) {
 							$newfile = $dir.'/'.dol_sanitizeFileName($_FILES['photo']['name']);
 							$result = dol_move_uploaded_file($_FILES['photo']['tmp_name'], $newfile, 1, 0, $_FILES['photo']['error']);
 
-							if (!($result > 0)) {
+							// Note: $result is a string when the file was refused and, in PHP 8, such a string compares as greater than 0
+							if (!is_numeric($result) || $result <= 0) {
 								setEventMessages($langs->trans("ErrorFailedToSaveFile"), null, 'errors');
 							} else {
 								// Create thumbs


### PR DESCRIPTION
# FIX An upload refused by `dol_move_uploaded_file()` is reported to the user as a success

`dol_move_uploaded_file()` returns:

* a positive number on success (`1`, or `2` when `.noexe` was appended),
* a negative number on an unknown error,
* **a string** (a translation key: `ErrorFileIsInfectedWithAVirus`, `ErrorFileSizeTooLarge`, `ErrorPartialFile`, `ErrorNoTmpDir`, `ErrorFailedToWriteInDir`, `ErrorUploadBlockedByAddon`) when it refuses the file.

Several callers test that result with `$result > 0`. In PHP 8, comparing a non-numeric string to a number casts the **number to a string**, so:

```php
var_dump('ErrorFileIsInfectedWithAVirus' > 0);	// bool(true)
```

A refused file therefore takes the success path, and the error branch is dead code.

## Consequences

On the photo/logo upload pages (`user/card.php`, `societe/card.php` ×3, `contact/card.php`), a file rejected by the antivirus or too large for `upload_max_filesize`:

* is reported to the user as saved — no error message at all,
* makes `addThumbs()` run on a file that was never written,
* is recorded on the object as its photo, and indexed into `llx_ecm_files` when `*_ALLOW_EXTERNAL_DOWNLOAD` is set,

while nothing was stored on disk.

In `imports/import.php` the file is logged as "added for import" and the import goes on with a missing file. In `core/ajax/flowjs-server.php` the returned string is truthy, so `!dol_move_uploaded_file(...)` is false and a failed chunk is treated as written.

## Fix

The test is guarded with `is_numeric()`, exactly as it already is in `admin/company.php` and `product/stock/massstockmove.php`:

```php
if (!is_numeric($result) || $result <= 0) {
```

No behaviour changes for the nominal case; only a genuinely refused upload now reaches the error branch that was already written for it.

Targeting 21.0 as the oldest maintained branch where the code is identical.

*Related but separate: #40085 fixes the untranslated message returned by that same function for the antivirus case, on `develop`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
