### PR TITLE
FIX: API setup, the switch to enable the count of API calls had no effect

### DIFF
--- a/htdocs/api/admin/index.php
+++ b/htdocs/api/admin/index.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2012-2018	Regis Houssin			<regis.houssin@inodbox.com>
  * Copyright (C) 2015		Jean-François Ferry		<jfefe@aternatik.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -94,8 +94,8 @@ if ($action == 'setdisablecompression') {
 	}
 }
 
-// Disable compression mode
-if ($action == 'setenablecount' && !empty($dolibarr_api_count_always_enabled)) {
+// Enable/disable the counting of API calls (only when not forced from conf.php)
+if ($action == 'setenablecount' && empty($dolibarr_api_count_always_enabled)) {
 	if (dolibarr_set_const($db, 'API_ENABLE_COUNT_CALLS', GETPOSTINT('status'), 'chaine', 0, '', 0) <= 0) {
 		dol_print_error($db);
 	}


### PR DESCRIPTION
## Bug

On **Home > Setup > Modules > API REST**, the switch for `API_ENABLE_COUNT_CALLS` ("Enable counting of API calls") cannot be turned on. Clicking it reloads the page on the same state, with no error, and the constant is never written.

## Root cause

The action handler and the view disagree on the meaning of the `$dolibarr_api_count_always_enabled` conf.php variable:

- the **view** prints a clickable switch only when that variable is **empty** (otherwise it prints a static "AlwaysEnabled" switch);
- the **action** was guarded by `!empty($dolibarr_api_count_always_enabled)`, i.e. exactly the case where the switch is *not* clickable.

The two conditions never overlap, so `dolibarr_set_const()` was never reached from the UI.

```php
// before
if ($action == 'setenablecount' && !empty($dolibarr_api_count_always_enabled)) {
```

Introduced with the option itself in 61f907c ("NEW Add option API_ENABLE_COUNT_CALLS"), so 23.0, 24.0 and develop are all affected.

## Fix

Invert the guard so the constant is saved when the toggle is actually usable, and still ignore the action (crafted URL) when the count is forced from `conf.php`. The copy-pasted `// Disable compression mode` comment above the block is corrected as well.

Cherry-picks for 24.0 and develop are ready if you prefer separate PRs rather than a merge forward.