### PR TITLE
Fix #39760 refuse a link extrafield whose class file does not exist

### DIFF
--- a/htdocs/core/actions_extrafields.inc.php
+++ b/htdocs/core/actions_extrafields.inc.php
@@ -134,6 +134,17 @@ if ($action == 'add') {
 			$mesgs[] = $langs->trans("ErrorNoValueForLinkType");
 			$action = 'create';
 		}
+		if ($type == 'link' && $param) {
+			// $param is 'ObjectName:classPath'. Check the class file really exists, a wrong path
+			// makes the link render as a raw id later, with nothing shown to the user.
+			$tmplink = explode(':', $param);
+			if (empty($tmplink[1]) || !file_exists(dol_buildpath($tmplink[1]))) {
+				$error++;
+				$langs->load("errors");
+				$mesgs[] = $langs->trans("ErrorFileNotFound", empty($tmplink[1]) ? $param : $tmplink[1]);
+				$action = 'create';
+			}
+		}
 		if ($type == 'radio' && !$param) {
 			$error++;
 			$langs->load("errors");
@@ -321,6 +332,17 @@ if ($action == 'update') {
 			$langs->load("errors");
 			$mesgs[] = $langs->trans("ErrorNoValueForRadioType");
 			$action = 'edit';
+		}
+		if ($type == 'link' && $param) {
+			// $param is 'ObjectName:classPath'. Check the class file really exists, a wrong path
+			// makes the link render as a raw id later, with nothing shown to the user.
+			$tmplink = explode(':', $param);
+			if (empty($tmplink[1]) || !file_exists(dol_buildpath($tmplink[1]))) {
+				$error++;
+				$langs->load("errors");
+				$mesgs[] = $langs->trans("ErrorFileNotFound", empty($tmplink[1]) ? $param : $tmplink[1]);
+				$action = 'edit';
+			}
 		}
 		if ((($type == 'radio') || ($type == 'checkbox')) && $param) {
 			// Construct array for parameter (value of select list)


### PR DESCRIPTION
A link extrafield stores 'ObjectName:classPath'. The setup form only checked that the param was non-empty, so a wrong path was saved happily and the field then rendered as a raw numeric id on the object cards, with nothing shown to explain why.

That is what happened in #39760: the stored value was

    Propal:propal/class/propal.class.php        <- saved, does not exist
    Propal:comm/propal/class/propal.class.php   <- the real location

and showOutputField discards the loader result (extrafields.class.php:2626):

    if (!empty($classpath)) {
        dol_include_once($InfoFieldList[1]);        <- returns false, ignored
        if ($classname && class_exists($classname)) {

so the block is skipped and $value stays the id.

This checks the file resolves through dol_buildpath before accepting the definition. Tested:

    Propal:comm/propal/class/propal.class.php     accepted
    Propal:propal/class/propal.class.php          refused    <- the reported case
    Societe:societe/class/societe.class.php       accepted
    Contrat:contrat/class/contrat.class.php       accepted
    Propal                                        refused
    Propal:                                       refused

and the extended form documented in the code is not broken by it, since explode keeps the path in position 1 whatever follows:

    Societe:societe/class/societe.class.php:1:(status:=:1)   accepted
    Propal:comm/propal/class/propal.class.php:1              accepted

Applied to both the add and the update blocks. Worth noting the update block had no link validation at all, not even the existing empty-param one, so a definition could be edited into an invalid state even before this change.

Used ErrorFileNotFound, which exists in errors.lang and takes the path as %s. Incidentally ErrorNoValueForLinkType, used by the pre-existing check just above, has no translation in any lang file, so it currently prints as its own key. I left that alone rather than widen this PR.

@JonBendtsen asked for the runtime guard to be kept separate, so this PR is only the save-time validation. Reported by @JonBendtsen in #39760.