### PR TITLE
Log when a link extrafield cannot load its target class

### DIFF
--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -2397,6 +2397,11 @@ class ExtraFields
 				$classpath = $InfoFieldList[1];
 				if (!empty($classpath)) {
 					dol_include_once($InfoFieldList[1]);
+					if (!$classname || !class_exists($classname)) {
+						// Without this, the raw id is printed with nothing telling why, which is very
+						// hard to diagnose. Most often the class path stored in the definition is wrong.
+						dol_syslog('Extrafields::showOutputField the class '.$classname.' of the link field '.$key.' could not be loaded from '.$classpath.', check the extrafield definition', LOG_WARNING);
+					}
 					if ($classname && class_exists($classname)) {
 						$tmpobject = new $classname($this->db);
 						'@phan-var-force CommonObject $tmpobject';


### PR DESCRIPTION
Follow-up to #40094, kept separate at the reporter's request.

#40094 stops a bad class path from being saved. This one makes an already-stored bad definition diagnosable, which no save-time check can do.

Today, when the path is wrong, dol_include_once() fails and its result is discarded:

    if (!empty($classpath)) {
        dol_include_once($InfoFieldList[1]);        <- returns false, ignored
        if ($classname && class_exists($classname)) {

so class_exists is false, the block is skipped, and the raw numeric id is printed with nothing shown or logged from here. In #39760 that cost eight rounds of investigation to find a single wrong path in one definition.

This adds a LOG_WARNING naming the class, the field and the path that failed. Rendering is untouched: the added block only calls dol_syslog, and the original condition below it is unchanged.

    bad path   class_exists=false  -> logs a warning, then falls through exactly as before
    good path  class_exists=true   -> silent, resolves normally

Note dol_include_once already logs "Tried to load unexisting file" for the same event, but without naming the extrafield, so the message is hard to connect to a field definition when it appears among unrelated log lines. This one names the field.

Targeting 22.0 like #40094, since the behaviour is identical from 18.0 onwards and the forward merge carries it up.

Related to #39760 reported by @JonBendtsen.