### PR TITLE
FIX #40083 Use URL root for generated links

### DIFF
--- a/htdocs/quickmemo/lib/quickmemo.lib.php
+++ b/htdocs/quickmemo/lib/quickmemo.lib.php
@@ -40,7 +40,7 @@ function quickmemoAdminPrepareHead()
 	$h = 0;
 	$head = array();
 
-	$head[$h][0] = dolBuildUrl(DOL_DOCUMENT_ROOT."/quickmemo/admin/setup.php");
+	$head[$h][0] = dolBuildUrl(DOL_URL_ROOT."/quickmemo/admin/setup.php");
 	$head[$h][1] = $langs->trans("Settings");
 	$head[$h][2] = 'settings';
 	$h++;

--- a/htdocs/webhook/lib/webhook_triggerhistory.lib.php
+++ b/htdocs/webhook/lib/webhook_triggerhistory.lib.php
@@ -37,7 +37,7 @@ function triggerhistoryPrepareHead($object)
 	$h = 0;
 	$head = array();
 
-	$head[$h][0] = dolBuildUrl(DOL_DOCUMENT_ROOT.'/webhook/triggerhistory_card.php', ['id' => $object->id]);
+	$head[$h][0] = dolBuildUrl(DOL_URL_ROOT.'/webhook/triggerhistory_card.php', ['id' => $object->id]);
 	$head[$h][1] = $langs->trans("Card");
 	$head[$h][2] = 'card';
 	$h++;
@@ -50,7 +50,7 @@ function triggerhistoryPrepareHead($object)
 		if (!empty($object->note_public)) {
 			$nbNote++;
 		}
-		$head[$h][0] = dolBuildUrl(DOL_DOCUMENT_ROOT.'/webhook/triggerhistory_note.php', ['id' => $object->id]);
+		$head[$h][0] = dolBuildUrl(DOL_URL_ROOT.'/webhook/triggerhistory_note.php', ['id' => $object->id]);
 		$head[$h][1] = $langs->trans('Notes');
 		if ($nbNote > 0) {
 			$head[$h][1] .= (!getDolGlobalInt('MAIN_OPTIMIZEFORTEXTBROWSER') ? '<span class="badge marginleftonlyshort">'.$nbNote.'</span>' : '');

--- a/htdocs/webhook/target_card.php
+++ b/htdocs/webhook/target_card.php
@@ -340,7 +340,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
 	// Object card
 	// ------------------------------------------------------------
-	$linkback = '<a href="'.dolBuildUrl(DOL_DOCUMENT_ROOT.'/webhook/target_list.php', ['restore_lastsearch_values' => 1]).'">'.$langs->trans("BackToList").'</a>';
+	$linkback = '<a href="'.dolBuildUrl(DOL_URL_ROOT.'/webhook/target_list.php', ['restore_lastsearch_values' => 1]).'">'.$langs->trans("BackToList").'</a>';
 
 	$morehtmlref = '<div class="refidno">';
 	/*


### PR DESCRIPTION
## Summary

- build the QuickMemo admin link from `DOL_URL_ROOT`
- build Webhook tab and back links from `DOL_URL_ROOT`
- prevent server filesystem paths from leaking into generated URLs

## Root cause

Four links introduced in `24.0` pass `DOL_DOCUMENT_ROOT` to
`dolBuildUrl()`. That constant contains the server filesystem path, while
these browser links require the application URL root.

`24.0` is the oldest affected maintained branch. This patch changes only
those four URL roots and preserves their paths and query parameters.

## Verification

- PHP syntax check on all three changed files
- focused scan confirms no `dolBuildUrl(DOL_DOCUMENT_ROOT` calls remain in
  QuickMemo or Webhook
- changed-file allowlist and patch comparison after rebasing onto current
  `24.0`
- `git diff --check`

Fix #40083
