### PR TITLE
Update github templates in order to redirect einvoicing issues to the community module project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,7 @@ body:
     attributes:
       value: |
         This is a template to help you report good issues. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.
+        If your issue is related to einvoicing please fill in an issue on the [Dolibarr community modules project](https://github.com/Dolibarr/dolibarr-community-modules/issues)
 
   - type: textarea
     id: bug

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,6 +7,7 @@ body:
     attributes:
       value: |
         This is a template to help you report good issues. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.
+        If your issue is related to einvoicing please fill in an issue on the [Dolibarr community modules project](https://github.com/Dolibarr/dolibarr-community-modules/issues)
 
   - type: textarea
     id: feature-request


### PR DESCRIPTION
We're starting to get einvoicing related issues on the dolibarr project
I updated the templates in order to redirect the user to the community module project