### PR TITLE
NEW Allow agenda event reminders to also notify the customer by email

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -80,6 +80,7 @@ $offsetvalue = GETPOSTINT('offsetvalue');
 $offsetunit = GETPOST('offsetunittype_duration', 'aZ09');
 $remindertype = GETPOST('selectremindertype', 'aZ09');
 $modelmail = GETPOSTINT('actioncommsendmodel_mail');
+$remindcustomer = GETPOST('remindcustomer', 'alpha');
 $complete = GETPOST('complete', 'alpha');	// 'na' must be allowed
 $private = GETPOST('private', 'alphanohtml');
 if ($complete == 'na' || $complete == -2) {
@@ -730,6 +731,28 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 							break;
 						}
 					}
+
+					// Also create a reminder by email for the linked customer, if requested
+					if (!$error && $remindcustomer == 'on' && $object->socid > 0) {
+						$actionCommReminderCustomer = new ActionCommReminder($db);
+						$actionCommReminderCustomer->dateremind = $dateremind;
+						$actionCommReminderCustomer->typeremind = 'email';
+						$actionCommReminderCustomer->offsetunit = $offsetunit;
+						$actionCommReminderCustomer->offsetvalue = $offsetvalue;
+						$actionCommReminderCustomer->status = $actionCommReminderCustomer::STATUS_TODO;
+						$actionCommReminderCustomer->fk_actioncomm = $object->id;
+						$actionCommReminderCustomer->fk_soc = $object->socid;
+						$actionCommReminderCustomer->fk_email_template = $modelmail;
+						$res = $actionCommReminderCustomer->create($user);
+
+						if ($res <= 0) {
+							$langs->load("errors");
+							$error++;
+							setEventMessages($langs->trans('ErrorReminderActionCommCreation'), null, 'errors');
+							$action = 'create';
+							$donotclearsession = 1;
+						}
+					}
 				}
 
 				// Modify $moreparam so we are sure to see the event we have just created, whatever are the default value of filter on next page.
@@ -850,6 +873,28 @@ if (empty($reshook) && $action == 'add' && $usercancreate) {
 									$action = 'create';
 									$donotclearsession = 1;
 									break;
+								}
+							}
+
+							// Also create a reminder by email for the linked customer, if requested
+							if (!$error && $remindcustomer == 'on' && $finalobject->socid > 0) {
+								$actionCommReminderCustomer = new ActionCommReminder($db);
+								$actionCommReminderCustomer->dateremind = $dateremind;
+								$actionCommReminderCustomer->typeremind = 'email';
+								$actionCommReminderCustomer->offsetunit = $offsetunit;
+								$actionCommReminderCustomer->offsetvalue = $offsetvalue;
+								$actionCommReminderCustomer->status = $actionCommReminderCustomer::STATUS_TODO;
+								$actionCommReminderCustomer->fk_actioncomm = $finalobject->id;
+								$actionCommReminderCustomer->fk_soc = $finalobject->socid;
+								$actionCommReminderCustomer->fk_email_template = $modelmail;
+								$res = $actionCommReminderCustomer->create($user);
+
+								if ($res <= 0) {
+									$error++;
+									$langs->load("errors");
+									setEventMessages($langs->trans('ErrorReminderActionCommCreation'), null, 'errors');
+									$action = 'create';
+									$donotclearsession = 1;
 								}
 							}
 						}
@@ -1174,6 +1219,37 @@ if (empty($reshook) && $action == 'update' && $usercancreate) {
 							$action = 'create';
 							$donotclearsession = 1;
 							break;
+						}
+					}
+				}
+
+				// Also (re)create a reminder by email for the linked customer, if requested.
+				// This is independent of $remindertype (the assigned users' reminder channel), so we
+				// clean up any previous customer reminder for this event ourselves instead of relying
+				// on the loadReminders($remindertype, ...) cleanup above.
+				if (!$error) {
+					$sqldeletecustomer = "DELETE FROM ".MAIN_DB_PREFIX."actioncomm_reminder";
+					$sqldeletecustomer .= " WHERE fk_actioncomm = ".((int) $object->id)." AND typeremind = 'email' AND fk_soc IS NOT NULL AND status < 1";
+					$db->query($sqldeletecustomer);
+
+					if ($remindcustomer == 'on' && $object->socid > 0) {
+						$actionCommReminderCustomer = new ActionCommReminder($db);
+						$actionCommReminderCustomer->dateremind = dol_time_plus_duree($datep, -1 * $offsetvalue, $offsetunit);
+						$actionCommReminderCustomer->typeremind = 'email';
+						$actionCommReminderCustomer->offsetunit = $offsetunit;
+						$actionCommReminderCustomer->offsetvalue = $offsetvalue;
+						$actionCommReminderCustomer->status = $actionCommReminderCustomer::STATUS_TODO;
+						$actionCommReminderCustomer->fk_actioncomm = $object->id;
+						$actionCommReminderCustomer->fk_soc = $object->socid;
+						$actionCommReminderCustomer->fk_email_template = $modelmail;
+						$res = $actionCommReminderCustomer->create($user);
+
+						if ($res <= 0) {
+							$langs->load("errors");
+							$error = $langs->trans('ErrorReminderActionCommCreation');
+							setEventMessages($error, null, 'errors');
+							$action = 'create';
+							$donotclearsession = 1;
 						}
 					}
 				}
@@ -1904,6 +1980,13 @@ if ($action == 'create') {
 			print '</td></tr>';
 		}
 
+		// Also remind the customer by email
+		if (getDolGlobalString('AGENDA_REMINDER_EMAIL') && $socid > 0) {
+			print '<tr><td class="titlefieldcreate nowrap">'.$langs->trans("AlsoRemindCustomer").'</td><td colspan="3">';
+			print '<input type="checkbox" id="remindcustomer" name="remindcustomer"'.(empty(GETPOST('remindcustomer')) ? '' : ' checked').'>';
+			print '</td></tr>';
+		}
+
 		print '</table>';
 		print '</div>';
 
@@ -2502,6 +2585,18 @@ if ($id > 0 && $action != 'create') {
 			if (getDolGlobalString('AGENDA_REMINDER_EMAIL')) {
 				print '<tr '.$hide.'><td class="titlefieldcreate nowrap">'.$langs->trans("EMailTemplates").'</td><td colspan="3">';
 				print $form->selectModelMail('actioncommsend', 'actioncomm_send', 1, 1, (string) $actionCommReminder->fk_email_template);
+				print '</td></tr>';
+			}
+
+			// Also remind the customer by email
+			if (getDolGlobalString('AGENDA_REMINDER_EMAIL') && $object->socid > 0) {
+				$sqlcustomerreminder = "SELECT rowid FROM ".MAIN_DB_PREFIX."actioncomm_reminder";
+				$sqlcustomerreminder .= " WHERE fk_actioncomm = ".((int) $object->id)." AND typeremind = 'email' AND fk_soc IS NOT NULL";
+				$rescustomerreminder = $db->query($sqlcustomerreminder);
+				$remindcustomerchecked = ($rescustomerreminder && $db->num_rows($rescustomerreminder)) ? ' checked' : '';
+
+				print '<tr><td class="titlefieldcreate nowrap">'.$langs->trans("AlsoRemindCustomer").'</td><td colspan="3">';
+				print '<input type="checkbox" id="remindcustomer" name="remindcustomer"'.(GETPOSTISSET('remindcustomer') ? (GETPOST('remindcustomer') ? ' checked' : '') : $remindcustomerchecked).'>';
 				print '</td></tr>';
 			}
 

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -1983,7 +1983,7 @@ if ($action == 'create') {
 		// Also remind the customer by email
 		if (getDolGlobalString('AGENDA_REMINDER_EMAIL') && $socid > 0) {
 			print '<tr><td class="titlefieldcreate nowrap">'.$langs->trans("AlsoRemindCustomer").'</td><td colspan="3">';
-			print '<input type="checkbox" id="remindcustomer" name="remindcustomer"'.(empty(GETPOST('remindcustomer')) ? '' : ' checked').'>';
+			print '<input type="checkbox" id="remindcustomer" name="remindcustomer"'.(GETPOST('remindcustomer') ? ' checked' : '').'>';
 			print '</td></tr>';
 		}
 

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -2822,7 +2822,7 @@ class ActionComm extends CommonObject
 		$this->reminders = array();
 
 		//Select all action comm reminders for event
-		$sql = "SELECT rowid as id, typeremind, dateremind, status, offsetvalue, offsetunit, fk_user, fk_email_template, lasterror";
+		$sql = "SELECT rowid as id, typeremind, dateremind, status, offsetvalue, offsetunit, fk_user, fk_soc, fk_contact, fk_email_template, lasterror";
 		$sql .= " FROM ".MAIN_DB_PREFIX."actioncomm_reminder";
 		$sql .= " WHERE fk_actioncomm = ".((int) $this->id);
 		if ($onlypast) {
@@ -2854,6 +2854,8 @@ class ActionComm extends CommonObject
 				$tmpactioncommreminder->offsetunit = $obj->offsetunit;
 				$tmpactioncommreminder->status = $obj->status;
 				$tmpactioncommreminder->fk_user = $obj->fk_user;
+				$tmpactioncommreminder->fk_soc = $obj->fk_soc;
+				$tmpactioncommreminder->fk_contact = $obj->fk_contact;
 				$tmpactioncommreminder->fk_email_template = $obj->fk_email_template;
 				$tmpactioncommreminder->lasterror = $obj->lasterror;
 				$tmpactioncommreminder->fk_actioncomm = $this->id;
@@ -2948,18 +2950,50 @@ class ActionComm extends CommonObject
 						$sendTopic = make_substitutions($sendTopic, $substitutionarray);
 
 						// Recipient
-						$recipient = new User($this->db);
-						$res = $recipient->fetch($actionCommReminder->fk_user);
-						if ($res > 0) {
-							if (!empty($recipient->email)) {
-								$to = $recipient->email;
+						if (!empty($actionCommReminder->fk_soc)) {
+							require_once DOL_DOCUMENT_ROOT.'/societe/class/societe.class.php';
+							$recipient = new Societe($this->db);
+							$res = $recipient->fetch($actionCommReminder->fk_soc);
+							if ($res > 0) {
+								if (!empty($recipient->email)) {
+									$to = $recipient->email;
+								} else {
+									$errormesg = "Failed to send remind to thirdparty id=" . $actionCommReminder->fk_soc . ". No email defined for thirdparty.";
+									$error++;
+								}
 							} else {
-								$errormesg = "Failed to send remind to user id=" . $actionCommReminder->fk_user . ". No email defined for user.";
+								$errormesg = "Failed to load recipient with thirdparty id=" . $actionCommReminder->fk_soc;
+								$error++;
+							}
+						} elseif (!empty($actionCommReminder->fk_contact)) {
+							require_once DOL_DOCUMENT_ROOT.'/contact/class/contact.class.php';
+							$recipient = new Contact($this->db);
+							$res = $recipient->fetch($actionCommReminder->fk_contact);
+							if ($res > 0) {
+								if (!empty($recipient->email)) {
+									$to = $recipient->email;
+								} else {
+									$errormesg = "Failed to send remind to contact id=" . $actionCommReminder->fk_contact . ". No email defined for contact.";
+									$error++;
+								}
+							} else {
+								$errormesg = "Failed to load recipient with contact id=" . $actionCommReminder->fk_contact;
 								$error++;
 							}
 						} else {
-							$errormesg = "Failed to load recipient with user id=" . $actionCommReminder->fk_user;
-							$error++;
+							$recipient = new User($this->db);
+							$res = $recipient->fetch($actionCommReminder->fk_user);
+							if ($res > 0) {
+								if (!empty($recipient->email)) {
+									$to = $recipient->email;
+								} else {
+									$errormesg = "Failed to send remind to user id=" . $actionCommReminder->fk_user . ". No email defined for user.";
+									$error++;
+								}
+							} else {
+								$errormesg = "Failed to load recipient with user id=" . $actionCommReminder->fk_user;
+								$error++;
+							}
 						}
 
 						// Sender

--- a/htdocs/comm/action/class/actioncommreminder.class.php
+++ b/htdocs/comm/action/class/actioncommreminder.class.php
@@ -85,7 +85,9 @@ class ActionCommReminder extends CommonObject
 		'entity' => array('type' => 'integer', 'label' => 'Entity', 'visible' => 0, 'enabled' => 1, 'position' => 20, 'notnull' => 1, 'index' => 1,),
 		'dateremind' => array('type' => 'datetime', 'label' => 'DateRemind', 'visible' => 1, 'enabled' => 1, 'position' => 60, 'notnull' => 1, 'index' => 1,),
 		'typeremind' => array('type' => 'varchar(32)', 'label' => 'TypeRemind', 'visible' => -1, 'enabled' => 1, 'position' => 55, 'notnull' => 1, 'comment' => "email, browser, sms",),
-		'fk_user' => array('type' => 'integer:User:user/class/user.class.php', 'label' => 'User', 'visible' => -1, 'enabled' => 1, 'position' => 65, 'notnull' => 1, 'index' => 1,),
+		'fk_user' => array('type' => 'integer:User:user/class/user.class.php', 'label' => 'User', 'visible' => -1, 'enabled' => 1, 'position' => 65, 'notnull' => -1, 'index' => 1,),
+		'fk_soc' => array('type' => 'integer:Societe:societe/class/societe.class.php', 'label' => 'ThirdParty', 'visible' => -1, 'enabled' => 1, 'position' => 66, 'notnull' => -1, 'index' => 1,),
+		'fk_contact' => array('type' => 'integer:Contact:contact/class/contact.class.php', 'label' => 'Contact', 'visible' => -1, 'enabled' => 1, 'position' => 67, 'notnull' => -1, 'index' => 1,),
 		'offsetvalue' => array('type' => 'integer', 'label' => 'OffsetValue', 'visible' => 1, 'enabled' => 1, 'position' => 56, 'notnull' => 1,),
 		'offsetunit' => array('type' => 'varchar(1)', 'label' => 'OffsetUnit', 'visible' => 1, 'enabled' => 1, 'position' => 57, 'notnull' => 1, 'comment' => "y, m, d, w, h, i",),
 		'status' => array('type' => 'integer', 'label' => 'Status', 'visible' => 1, 'enabled' => 1, 'position' => 58, 'notnull' => 1, 'default' => '0', 'index' => 0, 'arrayofkeyval' => array('0' => 'ToDo', '1' => 'Done')),
@@ -113,6 +115,16 @@ class ActionCommReminder extends CommonObject
 	 * @var int User ID
 	 */
 	public $fk_user;
+
+	/**
+	 * @var int Thirdparty ID
+	 */
+	public $fk_soc;
+
+	/**
+	 * @var int Contact ID
+	 */
+	public $fk_contact;
 
 	/**
 	 * @var int offset value

--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -184,6 +184,7 @@ ReminderTime=Reminder period before the event
 TimeType=Duration type
 ReminderType=Callback type
 AddReminder=Create an automatic reminder notification for this event
+AlsoRemindCustomer=Also send a reminder by email to the customer
 ErrorReminderActionCommCreation=Error creating the reminder notification for this event
 BrowserPush=Browser Popup Notification
 Reminders=Reminders


### PR DESCRIPTION
ActionCommReminder already declared TYPE_USER/TYPE_CUSTOMER/TYPE_CONTACT constants and the DB table already had fk_soc/fk_contact columns (added by prior commits enhancing reminders create #36321 and enhance actioncomm reminder #36316), but neither was wired to anything: the class's $fields array only declared fk_user, so fk_soc/fk_contact were silently dropped on create even if set, every reminder-channel option in the UI was hardcoded to TYPE_USER, reminder creation only ever looped over assigned users, and sendEmailsReminder() unconditionally resolved the recipient as a User.

- Add fk_soc/fk_contact to ActionCommReminder's $fields/properties so they actually persist, and relax fk_user to nullable to match the DB schema (a reminder can now target a user OR a thirdparty OR a contact).
- Add an 'Also remind the customer by email' checkbox next to the existing reminder options in comm/action/card.php, shown when the event has a linked thirdparty. Wire it into all three reminder creation paths (create, recurring-event create, update), with its own cleanup-then-recreate step on update so edits don't accumulate duplicate customer reminders.
- Update ActionComm::loadReminders() to load fk_soc/fk_contact, and ActionComm::sendEmailsReminder() to resolve the recipient from Societe (or Contact) instead of assuming a User when those fields are set.

Scoped to the customer (thirdparty) case for the UI, since that is the common 'remind the customer about their appointment' request; the class-level fk_contact plumbing is in place for a follow-up to extend this to specific contacts.

Tested end-to-end against the dev instance: real HTTP form submission through comm/action/card.php confirms the checkbox creates a fk_soc-linked reminder row alongside the existing user reminder, correctly pre-checks on edit, and repeated saves neither duplicate nor drop it. Calling ActionComm::sendEmailsReminder() actually delivered the email to the thirdparty's address (verified in MailDev) with correct subject/content substitution, while a parallel fk_user reminder on the same run still correctly emailed the assigned user (no regression).

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# UIUX|Uiux [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

