### PR TITLE
Fix #36750 and #40050: Replace ctype_* functions with preg_match equivalents

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -907,7 +907,7 @@ if (empty($reshook)) {
 		$fromElementid = GETPOST('fromelementid');
 		$importLines = GETPOST('line_checkbox');
 
-		if (!empty($importLines) && is_array($importLines) && !empty($fromElement) && ctype_alpha($fromElement) && !empty($fromElementid)) {
+		if (!empty($importLines) && is_array($importLines) && !empty($fromElement) && preg_match('/^[a-zA-Z]+$/', $fromElement) && !empty($fromElementid)) {
 			if ($fromElement == 'commande') {
 				dol_include_once('/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'OrderLine';

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1990,7 +1990,7 @@ if (empty($reshook)) {
 		$fromElementid = GETPOST('fromelementid');
 		$importLines = GETPOST('line_checkbox');
 
-		if (!empty($importLines) && is_array($importLines) && !empty($fromElement) && ctype_alpha($fromElement) && !empty($fromElementid)) {
+		if (!empty($importLines) && is_array($importLines) && !empty($fromElement) && preg_match('/^[a-zA-Z]+$/', $fromElement) && !empty($fromElementid)) {
 			if ($fromElement == 'commande') {
 				dol_include_once('/'.$fromElement.'/class/'.$fromElement.'.class.php');
 				$lineClassName = 'OrderLine';

--- a/htdocs/core/class/lessc.class.php
+++ b/htdocs/core/class/lessc.class.php
@@ -3036,7 +3036,7 @@ class lessc_parser
 
 		while (true) {
 			$whiteBefore = isset($this->buffer[$this->count - 1]) &&
-				ctype_space($this->buffer[$this->count - 1]);
+				preg_match('/^\s$/', $this->buffer[$this->count - 1]);
 
 			// If there is whitespace before the operator, then we require
 			// whitespace after the operator for it to be an expression
@@ -3055,7 +3055,7 @@ class lessc_parser
 
 
 				$whiteAfter = isset($this->buffer[$this->count - 1]) &&
-					ctype_space($this->buffer[$this->count - 1]);
+					preg_match('/^\s$/', $this->buffer[$this->count - 1]);
 
 				if (!$this->value($rhs)) {
 					break;
@@ -3474,7 +3474,7 @@ class lessc_parser
 		// speed shortcut
 		if (isset($this->buffer[$this->count])) {
 			$char = $this->buffer[$this->count];
-			if (!ctype_digit($char) && $char != ".") {
+			if (!preg_match('/^[0-9]+$/', $char) && $char != ".") {
 				return false;
 			}
 		}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -14872,7 +14872,7 @@ function dolForgeSQLCriteriaCallback($matches)
 			$tmpelem = trim($tmpelem);
 			if (preg_match('/^\'(.*)\'$/', $tmpelem, $reg)) {
 				$tmpelemarray[$tmpkey] = "'".$db->escape($db->sanitize($reg[1], 2, 1, 1, 1))."'";
-			} elseif (ctype_digit((string) $tmpelem)) {	// if only 0-9 chars, no .
+			} elseif (preg_match('/^[0-9]+$/', (string) $tmpelem)) {	// if only 0-9 chars, no .
 				$tmpelemarray[$tmpkey] = (int) $tmpelem;
 			} elseif (is_numeric((string) $tmpelem)) {	// it can be a float with a .
 				$tmpelemarray[$tmpkey] = (float) $tmpelem;
@@ -14899,7 +14899,7 @@ function dolForgeSQLCriteriaCallback($matches)
 	} else {
 		if (strtoupper($tmpescaped) == 'NULL') {
 			$tmpescaped = 'NULL';
-		} elseif (ctype_digit((string) $tmpescaped)) {	// if only 0-9 chars, no .
+		} elseif (preg_match('/^[0-9]+$/', (string) $tmpescaped)) {	// if only 0-9 chars, no .
 			$tmpescaped = (int) $tmpescaped;
 		} elseif (is_numeric((string) $tmpescaped)) {	// it can be a float with a .
 			$tmpescaped = (float) $tmpescaped;

--- a/htdocs/core/lib/modulebuilder.lib.php
+++ b/htdocs/core/lib/modulebuilder.lib.php
@@ -73,7 +73,7 @@ function rebuildObjectClass($destdir, $module, $objectname, $newmask, $readdir =
 		// Check for type stars(NumberOfStars), NumberOfStars must be an integer between 1 and 10
 		$matches = array();
 		if (preg_match('/^stars\((.+)\)$/', $addfieldentry['type'], $matches)) {
-			if (!ctype_digit($matches[1]) || $matches[1] < 1 || $matches[1] > 10) {
+			if (!preg_match('/^[0-9]+$/', $matches[1]) || $matches[1] < 1 || $matches[1] > 10) {
 				setEventMessages($langs->trans('BadValueForType', $addfieldentry['type']), null, 'errors');
 				return -2;
 			}


### PR DESCRIPTION
## Description

Replace all usages of `ctype_*` functions (`ctype_alpha`, `ctype_digit`, `ctype_space`) with `preg_match` equivalents in the following files:

- `htdocs/comm/propal/card.php`
- `htdocs/commande/card.php`
- `htdocs/core/class/lessc.class.php`
- `htdocs/core/lib/functions.lib.php`
- `htdocs/core/lib/modulebuilder.lib.php`

## Motivation

The `ctype_*` functions can return unexpected results on some inputs (empty strings, integers, etc.) depending on PHP locale and version. Using `preg_match` provides more predictable and robust behavior.

## Equivalences

| `ctype_*` | `preg_match` replacement |
|---|---|
| `ctype_digit($s)` | `preg_match('/^[0-9]+$/', $s)` |
| `ctype_alpha($s)` | `preg_match('/^[a-zA-Z]+$/', $s)` |
| `ctype_space($s)` | `preg_match('/^\s$/', $s)` |

Fixes #36750
Fixes #40050