### PR TITLE
FIX: Cast price2num() result to float for mass payment remain to pay

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -543,7 +543,7 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 						$totaldeposits = $facture->getSumDepositsUsed();
 
 						$totalallpayments = $paiementAmount + $totalcreditnotes + $totaldeposits;
-						$remaintopay = price2num($facture->total_ttc - $totalallpayments);
+						$remaintopay = (float) price2num($facture->total_ttc - $totalallpayments);
 
 						// hook to finalize the remaining amount, considering e.g. cash discount agreements
 						$parameters = array('remaintopay' => $remaintopay);
@@ -558,7 +558,7 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 						}
 
 						// Remain to pay in the invoice currency (may differ from $remaintopay when multicurrency is used)
-						$multicurrency_remaintopay = price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
+						$multicurrency_remaintopay = (float) price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
 
 						if ($remaintopay != 0) {
 							$resultBank = $facture->setBankAccount($bankid);


### PR DESCRIPTION
## Summary
Cherry-pick of #40112 forward into 24.0.

- \`price2num()\` returns a numeric **string**, not a float (per its own docblock: "the best way to guarantee a numeric value is to add a cast (float) before the price2num()").
- In the customer invoice list's mass "Record Payment" action, \`$remaintopay\` and \`$multicurrency_remaintopay\` were assigned directly from \`price2num()\` without that cast, then stored into \`Paiement::amounts\` / \`Paiement::multicurrency_amounts\`.
- This adds the explicit \`(float)\` cast on both, matching the convention already used elsewhere in the codebase.

## Test plan
- [x] PHP syntax / PHPCS / PHPStan / Phan pass (pre-commit hooks)
- [x] Manually record a mass payment on a multicurrency invoice and confirm the payment amounts are stored correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)