### PR TITLE
FIX: Pass multicurrency remain to pay to finalizeAmountOfInvoice hook

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -545,20 +545,23 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 						$totalallpayments = $paiementAmount + $totalcreditnotes + $totaldeposits;
 						$remaintopay = price2num($facture->total_ttc - $totalallpayments);
 
+						// Remain to pay in the invoice currency (may differ from $remaintopay when multicurrency is used)
+						$multicurrency_remaintopay = price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
+
 						// hook to finalize the remaining amount, considering e.g. cash discount agreements
-						$parameters = array('remaintopay' => $remaintopay);
+						$parameters = array('remaintopay' => $remaintopay, 'multicurrency_remaintopay' => $multicurrency_remaintopay);
 						$reshook = $hookmanager->executeHooks('finalizeAmountOfInvoice', $parameters, $facture, $action); // Note that $action and $object may have been modified by some hooks
 						if ($reshook > 0) {
 							if (!empty($remain = $hookmanager->resArray['remaintopay'])) {
 								$remaintopay = $remain;
 							}
+							if (!empty($multicurrency_remain = $hookmanager->resArray['multicurrency_remaintopay'])) {
+								$multicurrency_remaintopay = $multicurrency_remain;
+							}
 						} elseif ($reshook < 0) {
 							$error++;
 							setEventMessages($facture->ref.' '.$langs->trans("ProcessingError"), $hookmanager->errors, 'errors');
 						}
-
-						// Remain to pay in the invoice currency (may differ from $remaintopay when multicurrency is used)
-						$multicurrency_remaintopay = price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
 
 						if ($remaintopay != 0) {
 							$resultBank = $facture->setBankAccount($bankid);

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -546,7 +546,7 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 						$remaintopay = (float) price2num($facture->total_ttc - $totalallpayments);
 
 						// Remain to pay in the invoice currency (may differ from $remaintopay when multicurrency is used)
-						$multicurrency_remaintopay = price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
+						$multicurrency_remaintopay = (float) price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
 
 						// hook to finalize the remaining amount, considering e.g. cash discount agreements
 						$parameters = array('remaintopay' => $remaintopay, 'multicurrency_remaintopay' => $multicurrency_remaintopay);
@@ -563,8 +563,6 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 							setEventMessages($facture->ref.' '.$langs->trans("ProcessingError"), $hookmanager->errors, 'errors');
 						}
 
-						// Remain to pay in the invoice currency (may differ from $remaintopay when multicurrency is used)
-						$multicurrency_remaintopay = (float) price2num($facture->multicurrency_total_ttc - $sommePaiement['alreadypaid_multicurrency']);
 
 						if ($remaintopay != 0) {
 							$resultBank = $facture->setBankAccount($bankid);


### PR DESCRIPTION
## Summary
- Compute `$multicurrency_remaintopay` in `compta/facture/list.php` (mass payment action) before the `finalizeAmountOfInvoice` hook call instead of after.
- Expose it in `$parameters` so hook implementations can also adjust the remain-to-pay amount expressed in the invoice currency, not just the base-currency `remaintopay`.
- Read back an overridden value from `$hookmanager->resArray['multicurrency_remaintopay']`, symmetrically to how `remaintopay` is already handled.

## Test plan
- [x] Code inspection: verified `$multicurrency_remaintopay` is set before `$parameters` is built and unchanged when no hook overrides it.
- [x] Manual test: with a module implementing `finalizeAmountOfInvoice` and overriding `multicurrency_remaintopay`, run "Enter payment" mass action on a multicurrency invoice and confirm the recorded payment uses the overridden amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)