### PR TITLE
FIX: Use escape() instead of sanitize() in ticket secure-access SQL

### DIFF
--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3777,13 +3777,13 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 			$sqlprotectagainstexternals .= ' LEFT JOIN '.MAIN_DB_PREFIX.'element_contact ec ON ec.element_id = t.rowid';
 			$sqlprotectagainstexternals .= ' LEFT JOIN '.MAIN_DB_PREFIX.'socpeople c ON c.rowid = ec.fk_socpeople';
 			$sqlprotectagainstexternals .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_type_contact tc ON tc.element = "ticket" AND tc.rowid = ec.fk_c_type_contact';
-			$sqlprotectagainstexternals .= ' WHERE t.ref LIKE "'.$db->sanitize($refname).'"';
+			$sqlprotectagainstexternals .= " WHERE t.ref LIKE '".$db->escape($refname)."'";
 			$sqlprotectagainstexternals .= ' AND (';
 			$sqlprotectagainstexternals .= '   (';
 			$sqlprotectagainstexternals .= '     tc.rowid IS NOT NULL';
-			$sqlprotectagainstexternals .= '     AND c.email = "'.$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1]).'"';
+			$sqlprotectagainstexternals .= "     AND c.email = '".$db->escape($email_split[0])."@".$db->escape($email_split[1])."'";
 			$sqlprotectagainstexternals .= '   )';
-			$sqlprotectagainstexternals .= '   OR t.origin_email = "'.$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1]).'"';
+			$sqlprotectagainstexternals .= "   OR t.origin_email = '".$db->escape($email_split[0])."@".$db->escape($email_split[1])."'";
 			$sqlprotectagainstexternals .= ' )';
 		}
 		$original_file = $conf->ticket->multidir_output[$entity].'/'.$original_file;

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3777,13 +3777,13 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 			$sqlprotectagainstexternals .= ' LEFT JOIN '.MAIN_DB_PREFIX.'element_contact ec ON ec.element_id = t.rowid';
 			$sqlprotectagainstexternals .= ' LEFT JOIN '.MAIN_DB_PREFIX.'socpeople c ON c.rowid = ec.fk_socpeople';
 			$sqlprotectagainstexternals .= ' LEFT JOIN '.MAIN_DB_PREFIX.'c_type_contact tc ON tc.element = "ticket" AND tc.rowid = ec.fk_c_type_contact';
-			$sqlprotectagainstexternals .= " WHERE t.ref LIKE '".$db->sanitize($refname)."'";
+			$sqlprotectagainstexternals .= ' WHERE t.ref LIKE "'.$db->sanitize($refname).'"';
 			$sqlprotectagainstexternals .= ' AND (';
 			$sqlprotectagainstexternals .= '   (';
 			$sqlprotectagainstexternals .= '     tc.rowid IS NOT NULL';
-			$sqlprotectagainstexternals .= "     AND c.email = '".$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1])."'";
+			$sqlprotectagainstexternals .= '     AND c.email = "'.$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1]).'"';
 			$sqlprotectagainstexternals .= '   )';
-			$sqlprotectagainstexternals .= "   OR t.origin_email = '".$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1])."'";
+			$sqlprotectagainstexternals .= '   OR t.origin_email = "'.$db->sanitize($email_split[0]).'@'.$db->sanitize($email_split[1]).'"';
 			$sqlprotectagainstexternals .= ' )';
 		}
 		$original_file = $conf->ticket->multidir_output[$entity].'/'.$original_file;

--- a/htdocs/core/lib/files.lib.php
+++ b/htdocs/core/lib/files.lib.php
@@ -3781,9 +3781,9 @@ function dol_check_secure_access_document($modulepart, $original_file, $entity, 
 			$sqlprotectagainstexternals .= ' AND (';
 			$sqlprotectagainstexternals .= '   (';
 			$sqlprotectagainstexternals .= '     tc.rowid IS NOT NULL';
-			$sqlprotectagainstexternals .= "     AND c.email = '".$db->escape($email_split[0])."@".$db->escape($email_split[1])."'";
+			$sqlprotectagainstexternals .= "     AND c.email = CONCAT('".$db->escape($email_split[0])."', '@', '".$db->escape($email_split[1])."')";
 			$sqlprotectagainstexternals .= '   )';
-			$sqlprotectagainstexternals .= "   OR t.origin_email = '".$db->escape($email_split[0])."@".$db->escape($email_split[1])."'";
+			$sqlprotectagainstexternals .= "   OR t.origin_email = CONCAT('".$db->escape($email_split[0])."', '@', '".$db->escape($email_split[1])."')";
 			$sqlprotectagainstexternals .= ' )';
 		}
 		$original_file = $conf->ticket->multidir_output[$entity].'/'.$original_file;


### PR DESCRIPTION
## Summary
- Travis CI is currently red on `24.0` (independent of any other PR — a plain push build on the branch fails identically): `CodingPhpTest::testPHP` flags `htdocs/core/lib/files.lib.php` for "Found non escaped string in building of a sql request (case 2)".
- The flagged line, in the public-ticket-file-access SQL guard inside `dol_check_secure_access_document()`, used `$db->sanitize()`, unlike every other case in the same function (invoice, order, contract, project, ...), which all use `$db->escape($refname)` wrapped in single SQL-quotes.
- Per review feedback from @mdeweerd, switched from `sanitize()` to `escape()` for all three values (ticket ref + both halves of the email) instead of just tweaking quote style, so this now matches the established convention.
- The first attempt joined the two escaped email halves with a literal `"@"`, which passed `CodingPhpTest` but tripped a different check — phan's `SqlInjectionPlugin` (`SqlInjectionUnquotedEscape`) — because `"@"` has no quote character in its value, so the second `escape()` call isn't directly bounded by a quote on its left. Follow-up commit builds the value with SQL `CONCAT('...', '@', '...')` instead, which keeps both `escape()` calls directly adjacent to a real quote character while still comparing against a single `local@domain` string.
- No functional/SQL change beyond the escaping function and how the email is assembled.

## Test plan
- [x] `php vendor/bin/phpunit test/phpunit/CodingPhpTest.php --filter testPHP` — passes (was failing on this file before the fix)
- [x] PHPCS / PHPStan / Phan / pre-commit hooks pass
- [x] Manually traced phan's `SqlInjectionPlugin` quoting logic against the two `SqlInjectionUnquotedEscape` warnings from the first CI run to confirm the `CONCAT()` restructuring resolves both (local phan is version-mismatched with CI's and didn't reproduce the plugin-specific warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)