### PR TITLE
FIX: #39658 Shorten transaction template FK constraint name (backport of #39659)

### DIFF
--- a/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
+++ b/htdocs/install/mysql/migration/23.0.0-24.0.0.sql
@@ -93,7 +93,7 @@ CREATE TABLE llx_accounting_transaction_template_det (
 ) ENGINE=innodb;
 
 ALTER TABLE llx_accounting_transaction_template_det ADD INDEX idx_accounting_transaction_template_det_rowid (rowid);
-ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT llx_accounting_transaction_template_det_fk_transaction_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
+ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT fk_accounting_transaction_template_det_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
 
 create table llx_categorie_mo
 (

--- a/htdocs/install/mysql/tables/llx_accounting_transaction_template_det-accounting.key.sql
+++ b/htdocs/install/mysql/tables/llx_accounting_transaction_template_det-accounting.key.sql
@@ -19,4 +19,4 @@
 -- ============================================================================
 
 ALTER TABLE llx_accounting_transaction_template_det ADD INDEX idx_accounting_transaction_template_det_rowid (rowid);
-ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT llx_accounting_transaction_template_det_fk_transaction_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);
+ALTER TABLE llx_accounting_transaction_template_det ADD CONSTRAINT fk_accounting_transaction_template_det_template FOREIGN KEY (fk_transaction_template) REFERENCES llx_accounting_transaction_template(rowid);


### PR DESCRIPTION
## Problem

The foreign-key constraint name `llx_accounting_transaction_template_det_fk_transaction_template` is 63 characters with the default 3-character `llx_` prefix — one below MySQL's 64-character identifier limit. Any custom `MAIN_DB_PREFIX` longer than three characters makes the v23→v24 migration fail at request 22 with `DB_ERROR_1059: Identifier name ... is too long`.

## Fix

Backport of #39659 (merged to `develop`) to the `24.0` branch, since the affected migration (`23.0.0-24.0.0.sql`) and table are the ones actually run when upgrading to v24. Renames the constraint to `fk_accounting_transaction_template_det_template`, matching the naming style already used elsewhere in the accounting module.

Cherry-picked cleanly from 99df2496e24a3b938706ad181140257d2257ec52, no changes needed.

Fixes #39658 on the 24.0 branch.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>