### PR TITLE
FIX #40120 Tell the administrator how to recover a table that refuses any new field

### DIFF
--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -947,6 +947,16 @@ class DoliDBMysqli extends DoliDB
 		if ($this->query($sql)) {
 			return 1;
 		}
+		// A table where columns were added and dropped many times refuses any new one with "Row size too
+		// large" (error 1118), because the space the dropped columns took in the physical record is only
+		// given back by a rebuild. Rebuild once and retry, so that deleting an extrafield cannot make the
+		// next one impossible to create.
+		if ($this->lasterrno == 'DB_ERROR_1118') {
+			dol_syslog(get_class($this)."::DDLAddField row size limit reached on ".$table.", rebuilding it", LOG_WARNING);
+			if ($this->query("ALTER TABLE ".$table." FORCE") && $this->query($sql)) {
+				return 1;
+			}
+		}
 		return -1;
 	}
 

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -949,13 +949,12 @@ class DoliDBMysqli extends DoliDB
 		}
 		// A table where columns were added and dropped many times refuses any new one with "Row size too
 		// large" (error 1118), because the space the dropped columns took in the physical record is only
-		// given back by a rebuild. Rebuild once and retry, so that deleting an extrafield cannot make the
-		// next one impossible to create.
+		// given back by a table rebuild. Rebuilding needs privileges the database user of the application
+		// may not have, so we only tell the administrator which command recovers the table.
 		if ($this->lasterrno == 'DB_ERROR_1118') {
-			dol_syslog(get_class($this)."::DDLAddField row size limit reached on ".$table.", rebuilding it", LOG_WARNING);
-			if ($this->query("ALTER TABLE ".$table." FORCE") && $this->query($sql)) {
-				return 1;
-			}
+			$hint = "Table ".$table." must be rebuilt by your database administrator with the command: ALTER TABLE ".$table." FORCE";
+			dol_syslog(get_class($this)."::DDLAddField ".$hint, LOG_WARNING);
+			$this->lasterror .= ' - '.$hint;
 		}
 		return -1;
 	}


### PR DESCRIPTION
# FIX|Fix #40120 Tell the administrator how to recover a table that refuses any new field

Creating and deleting an extrafield on the same object about thirty times makes **every further
extrafield creation impossible** on that object, with `Row size too large. The maximum row size for
the used table type, not counting BLOBs, is 8126`. The table looks innocent - `llx_societe_extrafields`
still shows only `rowid`, `tms`, `fk_object` and `import_key` - but the space the dropped columns took
in the InnoDB record is never given back, so the budget only ever goes down. Nothing in the interface
says why, or how to recover.

**Updated after review: the application does not rebuild anything by itself any more.** A rebuild needs
database privileges the application user may not have, so `DDLAddField()` only recognises error 1118,
logs a warning, and appends to the error message the command that gives the space back. The
administrator - or their DBA - decides to run it. The normal path is untouched, and only the mysqli
driver is concerned.

What the administrator now gets when creating the extrafield (measured on 18.0.10, real HTTP POST on
the setup page, red sticky message):

> Row size too large. The maximum row size for the used table type, not counting BLOBs, is 8126. This
> includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs -
> Table llx_societe_extrafields must be rebuilt by your database administrator with the command:
> ALTER TABLE llx_societe_extrafields FORCE

and in the log:

```
DoliDBMysqli::DDLAddField Table llx_societe_extrafields must be rebuilt by your database administrator
with the command: ALTER TABLE llx_societe_extrafields FORCE
```

Where the wall is, measured on seven instances of a same MariaDB 11.4 server, each starting from a
freshly rebuilt table and cycling `ExtraFields::delete()` then `addExtraField()`:

| Version | Creation of an extrafield fails at |
|---|---|
| 18.0.10 | cycle 33 |
| 19.0.4 | cycle 33 |
| 20.0.4 | cycle 33 |
| 21.0.4 | cycle 33 |
| 22.0.5 | cycle 33 |
| 23.0.4 | cycle 33 |
| 24.0.1 | cycle 33 |

What exhausts the budget is MariaDB's instant `DROP COLUMN`
([MDEV-15562](https://jira.mariadb.org/browse/MDEV-15562), 10.4+), working as designed
([MDEV-28760](https://jira.mariadb.org/browse/MDEV-28760), closed *Not a Bug*): the space a dropped
column took in the record is only given back by a rebuild. Raw SQL with the very statements the core
sends breaks at the same cycle 33 on MariaDB 10.11 / 11.4 / 11.8 / 12.1; MySQL 8.4 passes 120 cycles.
So the SQL sent is correct - what was missing is a way out for the admin who hits the wall, who today
only sees "Row size too large" on a table that shows four columns.

For the record, the three ways out, all measured: `ALTER TABLE ... FORCE` and `OPTIMIZE TABLE` both
recover the table immediately (MariaDB answers *"Table does not support optimize, doing recreate +
analyze instead"*), but each only buys 32 more create/delete cycles; `REPAIR TABLE` does nothing
(*"The storage engine for the table doesn't support repair"*); and an admin who wants to avoid the
wall for good can set `innodb_instant_alter_column_allowed=add_last` on the server (verified: 100
cycles without failure).

Targeting 18.0 as the oldest maintained branch where the bug occurs; the code of this function is
identical from 18.0 to develop.
