### PR TITLE
NEW: Add llx_deletion_log tombstone table

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -127,6 +127,19 @@ ALTER TABLE llx_inventory ADD COLUMN last_main_doc varchar(255) DEFAULT NULL AFT
 ALTER TABLE llx_facturedet ADD INDEX idx_facturedet_fk_prev_id (fk_prev_id);
 ALTER TABLE llx_facture ADD INDEX idx_facture_situation_cycle_ref (situation_cycle_ref);
 
+-- Short-lived tombstone log of deleted objects (see llx_deletion_log.sql).
+CREATE TABLE llx_deletion_log(
+	rowid			integer AUTO_INCREMENT PRIMARY KEY NOT NULL,
+	entity			integer NOT NULL DEFAULT 1,
+	element_type	varchar(64) NOT NULL,
+	fk_object		integer NOT NULL,
+	date_deletion	datetime NOT NULL,
+	fk_user			integer NULL
+) ENGINE=innodb;
+
+ALTER TABLE llx_deletion_log ADD INDEX idx_deletion_log_element (element_type, entity, date_deletion);
+ALTER TABLE llx_deletion_log ADD INDEX idx_deletion_log_date_deletion (date_deletion);
+
 
 
 

--- a/htdocs/install/mysql/tables/llx_deletion_log.key.sql
+++ b/htdocs/install/mysql/tables/llx_deletion_log.key.sql
@@ -1,0 +1,21 @@
+-- Copyright (C) 2026 Frédéric France      <frederic.france@free.fr>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+
+
+-- Lookup "which objects of this type were deleted since date X".
+ALTER TABLE llx_deletion_log ADD INDEX idx_deletion_log_element (element_type, entity, date_deletion);
+
+-- Used by the retention purge.
+ALTER TABLE llx_deletion_log ADD INDEX idx_deletion_log_date_deletion (date_deletion);

--- a/htdocs/install/mysql/tables/llx_deletion_log.sql
+++ b/htdocs/install/mysql/tables/llx_deletion_log.sql
@@ -1,0 +1,32 @@
+-- Copyright (C) 2026 Frédéric France      <frederic.france@free.fr>
+--
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see https://www.gnu.org/licenses/.
+--
+-- Table to keep a short-lived trace of deleted objects (tombstones), so that a
+-- page holding a partial view of a collection (e.g. an ajax-refreshed calendar)
+-- can learn which records disappeared without reloading the whole set. Rows are
+-- purged after MAIN_DELETION_LOG_RETENTION_DAYS days.
+
+
+CREATE TABLE llx_deletion_log(
+	rowid			integer AUTO_INCREMENT PRIMARY KEY NOT NULL,
+	-- entity of the deleted object, so a consumer only sees the deletions of
+	-- the company(ies) it is allowed to read (multi-company setups). It is part
+	-- of the "deleted since" index and of the retention purge filter.
+	entity			integer NOT NULL DEFAULT 1,
+	element_type	varchar(64) NOT NULL,
+	fk_object		integer NOT NULL,
+	date_deletion	datetime NOT NULL,
+	fk_user			integer NULL
+) ENGINE=innodb;


### PR DESCRIPTION
## Context

When an object is deleted in Dolibarr, nothing is left in the database. A
page holding a *partial* view of a collection — typically a calendar that
refreshes its events in ajax — has no way to know that a given record was
removed, so it must reload the whole set to stay consistent.

This PR adds the storage for a small, generic tombstone log so such a page
can ask "which objects of type X disappeared since timestamp T?".

## What this PR contains (SQL only)

- `htdocs/install/mysql/tables/llx_deletion_log.sql` — new table
  `{rowid, entity, element_type, fk_object, date_deletion, fk_user}`.
- `htdocs/install/mysql/tables/llx_deletion_log.key.sql` — one index for the
  "deleted since" lookup `(element_type, entity, date_deletion)` and one on
  `date_deletion` for the retention purge.
- `htdocs/install/mysql/migration/24.0.0-25.0.0.sql` — same `CREATE TABLE`
  for existing installs.

No PHP in this PR. The trigger that fills the table (on agenda event
deletion), the retention purge (cron + probabilistic fallback) and the
ajax endpoint that consumes it come in a follow-up PR.

## Tests

`test/phpunit/CodingSqlTest.php` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)