### PR TITLE
FIX: img_picto_common() common-icon override ignores module themes and builds a filesystem src

### DIFF
--- a/htdocs/core/lib/html.lib.php
+++ b/htdocs/core/lib/html.lib.php
@@ -1985,10 +1985,17 @@ function img_picto_common($titlealt, $picto, $moreatt = '', $pictoisfullpath = 0
 		$path = DOL_URL_ROOT . '/theme/common/' . $picto;
 
 		if (getDolGlobalInt('MAIN_MODULE_CAN_OVERWRITE_COMMONICONS')) {
-			$themepath = DOL_DOCUMENT_ROOT . '/theme/' . $conf->theme . '/img/' . $picto;
+			$themeimg = '/theme/' . $conf->theme . '/img/' . $picto;
 
-			if (file_exists($themepath)) {
-				$path = $themepath;
+			if (file_exists(DOL_DOCUMENT_ROOT . $themeimg)) {
+				$path = DOL_URL_ROOT . $themeimg;
+			} elseif (!empty($conf->modules_parts['theme'])) {	// Using this feature slow down application
+				foreach ($conf->modules_parts['theme'] as $reldir) {
+					if (file_exists(dol_buildpath($reldir . $themeimg, 0))) {
+						$path = dol_buildpath($reldir . $themeimg, 1);
+						break;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What

Fix `img_picto_common()` so a theme provided by an external module can override the common icons, and so the emitted `<img src>` is always a URL.

## Why

Follow-up to #40130 (same root cause, different mechanism — this one builds a URL, not an `include` path, so it needs its own fix).

When `MAIN_MODULE_CAN_OVERWRITE_COMMONICONS` is enabled:

```php
$themepath = DOL_DOCUMENT_ROOT . '/theme/' . $conf->theme . '/img/' . $picto;
if (file_exists($themepath)) {
    $path = $themepath;
}
```

- The overriding icon is looked for **only** under `DOL_DOCUMENT_ROOT/theme/<theme>/img/`. A theme shipped inside a module (registered in `$conf->modules_parts['theme']`, living under `custom/<module>/theme/<theme>/`) is never searched.
- On a match, a **filesystem path** (`DOL_DOCUMENT_ROOT...`) is assigned to `$path`, which is then handed to `img_picto(..., 1, ...)` as a full path and rendered as `<img src="/abs/path/to/htdocs/theme/...">` — broken over HTTP.

## How

- `DOL_DOCUMENT_ROOT` is used only for the `file_exists()` test; the emitted `src` is built from `DOL_URL_ROOT`.
- If the icon is not in the native theme dir, fall back to the module theme directories via `dol_buildpath()` (type 0 to test, type 1 for the URL) — the same resolution `img_picto()` already uses internally.

Default path (no override constant) is unchanged. `img_weather()` uses a similar hardcoded-theme pattern but its string-picto branch has no on-disk icons in any bundled theme and is not reached in practice, so it is left untouched here.

## Tests

`php -l`, PHPStan (level 10) and PHP_CodeSniffer clean on `htdocs/core/lib/html.lib.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
