### PR TITLE
FIX: box_lastlogin shows wrong "Last password change" date (1970)

### DIFF
--- a/htdocs/core/boxes/box_lastlogin.php
+++ b/htdocs/core/boxes/box_lastlogin.php
@@ -1,7 +1,7 @@
 <?php
 /* Copyright (C) 2012      Charles-François BENKE <charles.fr@benke.fr>
  * Copyright (C) 2005-2017 Laurent Destailleur    <eldy@users.sourceforge.net>
- * Copyright (C) 2014-2025  Frédéric France        <frederic.france@free.fr>
+ * Copyright (C) 2014-2026  Frédéric France        <frederic.france@free.fr>
  * Copyright (C) 2024		MDW							<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -81,8 +81,8 @@ class box_lastlogin extends ModeleBoxes
 			'td' => '',
 			'text' => $langs->trans("PreviousConnexion"),
 		);
-		if ($user->datepreviouslogin) {
-			$tmp = dol_print_date((int) $user->datepreviouslogin, "dayhour", 'tzuserrel').' - <span class="opacitymedium">'.$langs->trans("FromIP").' '.dol_print_ip($user->ippreviouslogin).'</span>';
+		if (isDolTms($user->datepreviouslogin)) {
+			$tmp = dol_print_date($user->datepreviouslogin, "dayhour", 'tzuserrel').' - <span class="opacitymedium">'.$langs->trans("FromIP").' '.dol_print_ip($user->ippreviouslogin).'</span>';
 		} else {
 			$tmp = '<span class="opacitymedium">'.$langs->trans("Unknown").'</span>';
 		}
@@ -97,8 +97,8 @@ class box_lastlogin extends ModeleBoxes
 			'td' => '',
 			'text' => $langs->trans("LastPasswordChange"),
 		);
-		if ($user->datelastpassvalidation) {
-			$tmp = dol_print_date((int) $user->datelastpassvalidation, "dayhour", 'tzuserrel');
+		if (isDolTms($user->datelastpassvalidation)) {
+			$tmp = dol_print_date($user->datelastpassvalidation, "dayhour", 'tzuserrel');
 		} else {
 			$tmp = '<span class="opacitymedium">'.$langs->trans("Unknown").'</span>';
 		}

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13,7 +13,7 @@
  * Copyright (C) 2014		Cédric GROSS				<c.gross@kreiz-it.fr>
  * Copyright (C) 2014-2015	Marcos García				<marcosgdf@gmail.com>
  * Copyright (C) 2015		Jean-François Ferry			<jfefe@aternatik.fr>
- * Copyright (C) 2018-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France             <frederic.france@free.fr>
  * Copyright (C) 2019-2023  Thibault Foucart            <support@ptibogxiv.net>
  * Copyright (C) 2020       Open-Dsi         			<support@open-dsi.fr>
  * Copyright (C) 2021       Gauthier VERDOL         	<gauthier.verdol@atm-consulting.fr>
@@ -518,7 +518,7 @@ function getWarningDelay($module, $parmlevel1, $parmlevel2 = '')
 function isDolTms($timestamp)
 {
 	if ($timestamp === '') {
-		dol_syslog('Using empty string for a timestamp is deprecated, prefer use of null when calling page ' . $_SERVER["PHP_SELF"] . getCallerInfoString(), LOG_NOTICE);
+		dol_syslog('Using empty string for a timestamp is deprecated, prefer use of null when calling page ' . $_SERVER["PHP_SELF"] . getCallerInfoString(), LOG_DEBUG);
 		return false;
 	}
 	if (is_null($timestamp) || !is_numeric($timestamp)) {

--- a/htdocs/user/class/user.class.php
+++ b/htdocs/user/class/user.class.php
@@ -12,7 +12,7 @@
  * Copyright (C) 2015		Marcos García			<marcosgdf@gmail.com>
  * Copyright (C) 2018		charlene Benke			<charlie@patas-monkey.com>
  * Copyright (C) 2018-2021	Nicolas ZABOURI			<info@inovea-conseil.com>
- * Copyright (C) 2019-2025  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2019-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2019		Abbes Bahfir			<dolipar@dolipar.org>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024		Lenin Rivas				<lenin.rivas777@gmail.com>
@@ -661,7 +661,7 @@ class User extends CommonObject
 				$this->pass_indatabase_crypted = $obj->pass_crypted;
 				$this->pass = $obj->pass;
 				$this->pass_temp = $obj->pass_temp;
-				$this->datelastpassvalidation = $obj->datelastpassvalidation;
+				$this->datelastpassvalidation = $this->db->jdate($obj->datelastpassvalidation);
 				$this->api_key = dolDecrypt($obj->api_key);
 
 				$this->address = $obj->address;


### PR DESCRIPTION
## What

`User::fetch()` assigned `datelastpassvalidation` as the **raw SQL datetime string** instead of a Unix timestamp, unlike every other date field of the class (`datelastlogin`, `datepreviouslogin`, `datestartvalidity`, …).

PR #37794 fixed the resulting `TypeError` in `box_lastlogin` by casting to `(int)`, but `(int) "2026-04-10 12:00:00"` is `2026`, so the *"Last password change"* line on the dashboard box shows **01/01/1970** instead of the real date.

## How

- `user/class/user.class.php` — convert the column with `$this->db->jdate()` in `fetch()`, like the neighbouring date fields.
- `core/boxes/box_lastlogin.php` — drop the now-useless `(int)` casts and guard both dates with `isDolTms()`.
- `core/lib/functions.lib.php` — lower the `isDolTms()` empty-string message from `LOG_NOTICE` to `LOG_DEBUG`, so the box no longer floods the syslog for users who never changed their password / never had a previous login.

## Tested

Dashboard box "Last login" now shows the correct password-change date; users without one still show "Unknown".

Forward-ports: #40135 (24.0), #40136 (develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)