### PR TITLE
FIX: cast trim() argument to string in societe.class.php

### DIFF
--- a/htdocs/societe/class/societe.class.php
+++ b/htdocs/societe/class/societe.class.php
@@ -1261,7 +1261,7 @@ class Societe extends CommonObject
 		$this->errors = array();
 
 		$result = 0;
-		$this->name = trim($this->name);
+		$this->name = trim((string) $this->name);
 		$this->nom = $this->name; // For backward compatibility
 
 		if (!$this->name) {
@@ -1524,8 +1524,8 @@ class Societe extends CommonObject
 		$this->localtax1_assuj = (int) trim((string) $this->localtax1_assuj);
 		$this->localtax2_assuj = (int) trim((string) $this->localtax2_assuj);
 
-		$this->localtax1_value = trim($this->localtax1_value);
-		$this->localtax2_value = trim($this->localtax2_value);
+		$this->localtax1_value = trim((string) $this->localtax1_value);
+		$this->localtax2_value = trim((string) $this->localtax2_value);
 
 		$this->capital = (!is_null($this->capital) && (string) $this->capital != '') ? (float) price2num(trim((string) $this->capital)) : null;
 
@@ -2800,7 +2800,7 @@ class Societe extends CommonObject
 		global $conf, $langs;
 
 		// Parameter cleaning
-		$note = trim($note);
+		$note = trim((string) $note);
 		if (!$note) {
 			$this->error = $langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("NoteReason"));
 			return -2;
@@ -2861,7 +2861,7 @@ class Societe extends CommonObject
 		global $conf, $langs;
 
 		// Parameter cleaning
-		$note = trim($note);
+		$note = trim((string) $note);
 		if (!$note) {
 			$this->error = $langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("NoteReason"));
 			return -2;
@@ -2926,7 +2926,7 @@ class Societe extends CommonObject
 
 		// Clean parameters
 		$remise = (float) price2num($remise);
-		$desc = trim($desc);
+		$desc = trim((string) $desc);
 
 		// Check parameters
 		if (!($remise > 0)) {


### PR DESCRIPTION
## Description

`Societe::$name`, `Societe::$localtax1_value` and `Societe::$localtax2_value` are declared without a type and default to `null`. Likewise `set_remise_client()`, `set_remise_supplier()` and `set_remise_except()` take `$note` / `$desc` parameters that are only typed as `string` in the docblock.

When these hold `null`, the `trim()` calls in the parameter-cleaning blocks emit on PHP 8.1+:

```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated
```

Every other `trim()` in the same blocks already casts its argument (`trim((string) $this->...)`); these six calls were missed. This change makes them consistent.

- `verify()` — `$this->name`
- `update()` — `$this->localtax1_value`, `$this->localtax2_value`
- `set_remise_client()` / `set_remise_supplier()` — `$note`
- `set_remise_except()` — `$desc`

No functional change: `trim((string) null)` returns `''`, same as the previous implicit coercion on PHP < 8.1.

## How to test

- PHP 8.1+, create a `Societe` object without setting `name` and call `verify()` — no deprecation notice is raised any more.
- Existing `SocieteTest` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)