### PR TITLE
FIX #40105 add a tiebreaker to the supplier payment list sort

### DIFF
--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -93,7 +93,9 @@ if (!$sortorder) {
 	$sortorder = "DESC";
 }
 if (!$sortfield) {
-	$sortfield = "p.datep";
+	// rowid is needed as a tiebreaker: many payments share the same date, and without it
+	// the order of those rows is undefined, so paging can repeat or skip records.
+	$sortfield = "p.datep,p.rowid";
 }
 
 $search_all = trim(GETPOST('search_all', 'alphanohtml'));


### PR DESCRIPTION
The list sorts on p.datep alone (fourn/paiement/list.php:96). With 1911 payments many share the same date, and SQL gives no guarantee about the relative order of rows that compare equal, so LIMIT/OFFSET can hand back overlapping sets.

Reproduced on MariaDB with 60 rows sharing one date:

    ORDER BY datep DESC LIMIT 25 OFFSET 0   -> rowid 2,3,4,5,6,7,8,...
    ORDER BY datep DESC LIMIT 25 OFFSET 25  -> rowid 2,3,4,5,6,7,8,...

the same records on both pages. With a tiebreaker the pages become disjoint and stable:

    ORDER BY datep DESC, rowid DESC LIMIT 25 OFFSET 0   -> 36,37,38,...
    ORDER BY datep DESC, rowid DESC LIMIT 25 OFFSET 25  -> 11,12,13,...

That also explains the asymmetry in the report, where DESC gives an empty first page while ASC does not: with an undefined order the engine is free to return anything, and it happens to differ per direction.

The fix follows what compta/bank/various_payment/list.php:115 already does for the same kind of list:

    $sortfield = "v.datep,v.rowid";

Checked that db->order() applies the single sortorder to both columns, in both directions:

    order("p.datep,p.rowid", DESC) = ORDER BY p.datep DESC, p.rowid DESC
    order("p.datep,p.rowid", ASC)  = ORDER BY p.datep ASC, p.rowid ASC

Only the default sort is changed, so a user who clicks a column header is unaffected. Those columns can still be ambiguous, but fixing the default is what addresses the reported case without changing behaviour elsewhere.

Reported by @mdeweerd in #40105.