### PR TITLE
Fix #39766 stop duplicating the subfolder on Google OAuth login return

### DIFF
--- a/htdocs/core/modules/oauth/google_oauthcallback.php
+++ b/htdocs/core/modules/oauth/google_oauthcallback.php
@@ -403,7 +403,10 @@ if (!GETPOST('code')) {
 			if ($forlogin) {
 				// _SESSION['googleoauth_receivedlogin'] has been set to the key to validate the next test by function_googleoauth(), so we can make the redirect
 				// $backtourl is a relative url like /mypage.php?param1=value1 but without param token and action. Part after the # should also have been removed when saving it.
-				$backtourl = DOL_MAIN_URL_ROOT.$backtourl;
+				// $backtourl comes from $_SERVER['REQUEST_URI'], so it already contains DOL_URL_ROOT.
+				// Prefixing it with DOL_MAIN_URL_ROOT, which also contains it, duplicated the
+				// subfolder on an install that is not at the root of the domain.
+				$backtourl = preg_replace('/'.preg_quote(DOL_URL_ROOT, '/').'$/i', '', rtrim(DOL_MAIN_URL_ROOT, '/')).$backtourl;
 				$backtourl .= (preg_match('/\?/', $backtourl) ? '&' : '?').'actionlogin=login&afteroauthloginreturn=google&mainmenu=home'.($username ? '&username='.urlencode($username) : '').'&token='.newToken();
 				if (!empty($tmparray['entity'])) {
 					$backtourl .= '&entity='.$tmparray['entity'];


### PR DESCRIPTION
The login flow puts $_SERVER['REQUEST_URI'] into backtourl (core/login/functions_googleoauth.php:85), which on a subfolder install already contains the subfolder. The callback then prefixes it with DOL_MAIN_URL_ROOT, which contains it as well (google_oauthcallback.php:406):

    $backtourl = DOL_MAIN_URL_ROOT.$backtourl;

Reproduced with the reporter's configuration:

    DOL_MAIN_URL_ROOT = https://mydomain.com/dolibarr
    backtourl         = /dolibarr/index.php          (from REQUEST_URI)
    result            = https://mydomain.com/dolibarr/dolibarr/index.php

and at the domain root, for contrast:

    result            = https://mydomain.com/index.php     correct

which is exactly why this only shows on a subfolder install, and why the reporter's conf.php is not at fault.

The fix strips DOL_URL_ROOT from the absolute root before concatenating. Checked against the cases that matter, including a trailing slash and an empty DOL_URL_ROOT:

    main=https://mydomain.com            root=""          -> https://mydomain.com/index.php
    main=https://mydomain.com/           root=""          -> https://mydomain.com/index.php
    main=https://mydomain.com/dolibarr/  root="/dolibarr" -> https://mydomain.com/dolibarr/index.php
    main=https://mydomain.com/erp        root="/erp"      -> https://mydomain.com/erp/user/card.php?id=3

Worth noting google_oauthcallback.php is the only one of the eight oauth callbacks that concatenates this way. generic, github, microsoft, microsoft2, microsoft3, stripelive and stripetest all redirect on backtourl as-is, so none of them has the problem and none is touched here.

The comment on the line above said backtourl is a relative url, which is what made the concatenation look correct. It is relative to the domain, not to the Dolibarr root, and that is the whole bug. I left an explanatory comment in place of the misleading one.

Reported by @shap4ever in #39766.