### PR TITLE
Fix #37842 enforce the read permission on the product lot note page

### DIFF
--- a/htdocs/product/stock/productlot_note.php
+++ b/htdocs/product/stock/productlot_note.php
@@ -57,15 +57,17 @@ if ($id > 0 || !empty($ref)) {
 	$upload_dir = $conf->productlot->multidir_output[!empty($object->entity) ? $object->entity : $conf->entity]."/".$object->id;
 }
 
-$permissionnote = $user->hasRight('produit', 'lire'); // Used by the include of actions_setnotes.inc.php
+$permissiontoread = $user->hasRight('produit', 'lire');
+$permissionnote = $user->hasRight('produit', 'creer'); // Used by the include of actions_setnotes.inc.php
 
 // Security check (enable the most restrictive one)
 //if ($user->socid > 0) accessforbidden();
 //if ($user->socid > 0) $socid = $user->socid;
 //$isdraft = (($object->status == $object::STATUS_DRAFT) ? 1 : 0);
 //restrictedArea($user, $object->element, $object->id, $object->table_element, '', 'fk_soc', 'rowid', $isdraft);
-//if (empty($conf->calibration->enabled)) accessforbidden();
-//if (!$permissiontoread) accessforbidden();
+if (!$permissiontoread) {
+	accessforbidden();
+}
 
 
 /*


### PR DESCRIPTION
The report is accurate for the maintenance branches. On 22.0, productlot_note.php has every security check commented out:

    //if ($user->socid > 0) accessforbidden();
    //restrictedArea($user, $object->element, ...);
    //if (empty($conf->calibration->enabled)) accessforbidden();
    //if (!$permissiontoread) accessforbidden();

so any authenticated user reaches the page and reads both notes of any lot. And $permissionnote was set from the read right:

    $permissionnote = $user->hasRight('produit', 'lire');

which actions_setnotes.inc.php uses as the gate for setnote_public and setnote_private, so a read-only user could also edit those notes.

This enables the read check and uses the create right for the note edition, mirroring what productlot_card.php:121-127 already does on the same branch:

    $usercanread = $user->hasRight('produit', 'lire');
    $permissionnote = $user->hasRight('produit', 'creer');

Resulting behaviour:

    full product rights   page allowed     can edit notes
    read-only user        page allowed     cannot edit notes
    no product rights     page forbidden   cannot edit notes

Scope note: 24.0 and develop already carry an equivalent fix, so this is only needed on the maintenance branches. I checked 21.0, 22.0 and 23.0 and all three have the checks commented out. Targeting 22.0 so the forward merge covers 23.0; 21.0 would need the same patch separately if it is still in scope for fixes.

I did not enable the restrictedArea or socid lines, since those were commented out on the card page too and enabling them would change behaviour beyond the reported problem.

Reported by @Vraj118 in #37842.