### PR TITLE
Keep the real error when a contract creation fails

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -1192,7 +1192,11 @@ class Contrat extends CommonObject
 				$this->db->commit();
 				return $this->id;
 			} else {
-				$this->error = "Failed to add contract";
+				// Keep the error reported by the failing step, it is the only actionable one.
+				// Only fall back to a generic message when nothing was set, as propal.class.php does.
+				if (empty($this->error) && empty($this->errors)) {
+					$this->error = "Failed to add contract";
+				}
 				dol_syslog(get_class($this)."::create - 20 - ".$this->error, LOG_ERR);
 				$this->db->rollback();
 				return -2;


### PR DESCRIPTION
Contrat::create() ends its transaction like this (contrat.class.php:1194):

    } else {
        $this->error = "Failed to add contract";
        dol_syslog(...);
        $this->db->rollback();
        return -2;
    }

The assignment discards whatever the failing step reported. There are seven places inside create() that increment $error, including insertExtraFields() and the two add_contact() calls for SALESREPSIGN and SALESREPFOLL, and several of them set a precise message first. All of it is thrown away.

The visible consequence is on the API, which returns array_merge(array($this->contract->error), $this->contract->errors) (api_contracts.class.php:244), so the client receives:

    "message": "Internal Server Error: Error creating contract"
    "0": "Failed to add contract"

and nothing about the actual cause. That is what #36949 has been stuck on since January: the reporter cannot tell which of the seven branches failed, and neither can anyone reading the report.

This only falls back to the generic text when nothing was set, matching what propal.class.php already does on the same path, where the rollback branch does not touch $this->error at all.

Checked the three cases:

    add_contact set a message   -> error="ErrorCommercialNotAllowedForThirdparty"
    only errors[] populated     -> errors kept, error stays empty
    nothing set                 -> error="Failed to add contract"   unchanged behaviour

This does not fix #36949 itself, it makes it diagnosable. The underlying regression looks like the sales representative check added to add_contact() between 21.0 and 22.0, but confirming that needs data from the reporter, which I have asked for on the issue.

Related to #36949.