### PR TITLE
Fix phan on 22.0, cast the multicurrency remain to pay to float

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -530,7 +530,7 @@ if ($action == 'makepayment_confirm' && $user->hasRight('facture', 'paiement')) 
 								$paiement = new Paiement($db);
 								$paiement->datepaye = $paiementdate;
 								$paiement->amounts[$facture->id] = $remaintopay; // Array with all payments dispatching with invoice id
-								$paiement->multicurrency_amounts[$facture->id] = $multicurrency_remaintopay;
+								$paiement->multicurrency_amounts[$facture->id] = (float) $multicurrency_remaintopay;
 								$paiement->paiementid = $paiementid;
 								$paiement_id = $paiement->create($user, 1, $facture->thirdparty);
 								if ($paiement_id < 0) {


### PR DESCRIPTION
The phan job currently fails on every PR opened against 22.0. The single reported violation is:

    htdocs/compta/facture/list.php:533
    PhanTypeMismatchProperty: Assigning ($multicurrency_remaintopay as a field) of type array<int,string> to property

It is not in dev/tools/phan/baseline.txt, and the job analyses the whole tree rather than the changed files, so it fails regardless of what a PR modifies.

Cause is a type mismatch between the two sibling properties of Paiement:

    /** @var array<float|string> */ public $amounts = array();              // string accepted
    /** @var float[] */            public $multicurrency_amounts = array(); // string refused

and :522 builds the value with price2num(), which returns a string. That is why the line just above it, assigning $remaintopay to $amounts, does not trigger anything: that property declares string as acceptable.

The cast matches what every other assignment to that property already does:

    paiement.class.php-adjacent callers:
      $multicurrency_amounts[$id] = (float) price2num(-1 * (float) $newvalue, 'MT');
      $multicurrency_amounts[$id] = (float) $newvalue;
      $multicurrency_amounts[$id] = (float) $amount;

Checked the cast does not alter values:

    price2num(120.5)    = '120.5'    -> 120.5
    price2num(0)        = '0'        -> 0.0
    price2num(-35.2)    = '-35.20'   -> -35.2
    price2num(1234.567) = '1234.567' -> 1234.567

and Paiement::create() consumes the property numerically, so nothing downstream changes.

Timing, for the record: PRs whose phan ran on 2026-09-01 and 2026-09-03 passed, ones running from 2026-09-07 fail, and compta/facture/list.php was last touched on 22.0 by the automated merges of 2026-09-05.

Noticed while investigating the phan failures on #40139 and #40141, neither of which touches this file.