### PR TITLE
FIX #40089 compare phone_code to an integer, not to an empty string

### DIFF
--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -1151,7 +1151,8 @@ class Form
 
 		$sql = "SELECT rowid, code, label, phone_code, favorite, trunk_prefix";
 		$sql .= " FROM ".$this->db->prefix()."c_country";
-		$sql .= " WHERE active > 0 AND phone_code IS NOT NULL AND phone_code != ''";
+		// phone_code is an integer column, comparing it to an empty string fails on PostgreSQL
+		$sql .= " WHERE active > 0 AND phone_code IS NOT NULL AND phone_code != 0";
 
 		dol_syslog(get_class($this)."::selectPhoneCode", LOG_DEBUG);
 		$resql = $this->db->query($sql);


### PR DESCRIPTION
phone_code was added as an integer column (commit 029a1fbc1bb, NEW #37727):

    llx_c_country.sql            phone_code integer,
    22.0.0-23.0.0.sql            ALTER TABLE llx_c_country ADD COLUMN phone_code integer;

but the country prefix query compares it to an empty string (html.form.class.php:1154):

    WHERE active > 0 AND phone_code IS NOT NULL AND phone_code != ''

MySQL casts silently, PostgreSQL refuses. Reproduced on PostgreSQL 16, same message as the report:

    ERROR: invalid input syntax for type integer: ""

That makes contact/card.php?action=edit fail outright on a pgsql instance, which is what the reporter hits.

The empty-string test only ever excluded a phone_code of 0, so comparing to 0 keeps the exact same semantics. Verified on both engines with the same dataset, including a NULL row, a 0 row and an inactive row:

    PostgreSQL, patched     -> FR,BE
    MariaDB, phone_code != ''  -> FR,BE
    MariaDB, phone_code != 0   -> FR,BE

No shipped country has a phone_code of 0, and 0 is not a valid dialling code, so nothing legitimate is filtered differently.

Only one occurrence of this comparison exists in the tree. 23.0 does not carry it, the column arrived after, so 24.0 is the earliest affected branch.

Reported by @b-riou in #40089.