### PR TITLE
Fix - Show product ref in qty exceeded error on shipment creation

### DIFF
--- a/htdocs/expedition/class/expeditionligne.class.php
+++ b/htdocs/expedition/class/expeditionligne.class.php
@@ -903,7 +903,8 @@ class ExpeditionLigne extends CommonObjectLine
 
 		if ($qty > $qty_remaining) {
 			$langs->load('errors');
-			$this->error = $langs->trans('ErrorExpeditionQtyTooHigh', $qty, max(0, $qty_remaining));
+			$product_ref = !empty($orderline->product_ref) ? $orderline->product_ref : $orderline->desc;
+			$this->error = $langs->trans('ErrorExpeditionQtyTooHigh', $qty, max(0, $qty_remaining), $product_ref);
 			return false;
 		}
 

--- a/htdocs/langs/en_US/errors.lang
+++ b/htdocs/langs/en_US/errors.lang
@@ -482,4 +482,4 @@ SomeShipmentExists=Error, there is some shipment linked to the order. Deletion r
 WarningEvaluationEmptyValidate=Can't validate evaluation, levels on skills not defined
 ErrorBadParametersForDirectDebitFileCreate=Can't create bank transfer file: expected format parameter is not provided.
 ErrorBadParametersForDirectDebitFileCreateDids=Can't create bank transfer file: IDs of existing payment requests are not provided.
-ErrorExpeditionQtyTooHigh=Shipped quantity (%s) exceeds the remaining quantity to deliver (%s).
+ErrorExpeditionQtyTooHigh=Shipped quantity (%s) exceeds the remaining quantity to deliver (%s) for product %s.

--- a/htdocs/langs/fr_FR/errors.lang
+++ b/htdocs/langs/fr_FR/errors.lang
@@ -479,4 +479,4 @@ SomeShipmentExists=Erreur : une expédition est liée à commande. Suppression 
 WarningEvaluationEmptyValidate=Impossible d'évaluer les niveaux de compétences non définis.
 ErrorBadParametersForDirectDebitFileCreate=Impossible de créer un virement bancaire fichier : le paramètre de format attendu n'est pas fourni.
 ErrorBadParametersForDirectDebitFileCreateDids=Impossible de créer un virement bancaire fichier : les identifiants des demandes de paiement existantes ne sont pas fournis.
-ErrorExpeditionQtyTooHigh=La quantité expédiée (%s) dépasse la quantité restante à livrer (%s).
+ErrorExpeditionQtyTooHigh=La quantité expédiée (%s) dépasse la quantité restante à livrer (%s) pour le produit %s.


### PR DESCRIPTION
# FIX|Fix - Show product ref in qty exceeded error on shipment creation

When `STOCK_EXPEDITION_NO_MORE_THAN_ORDER` is enabled and a shipment line exceeds the remaining quantity to deliver, the error message now includes the product reference (or line description for free-text lines), making it easier to identify which line is blocking the shipment creation.

- Before: `La quantité expédiée (1) dépasse la quantité restante à livrer (0).`
- After:  `La quantité expédiée (1) dépasse la quantité restante à livrer (0) pour le produit REF-123.`