### PR TITLE
Fix: Add a custom supplier ref on supplier order line's addform

### DIFF
--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -758,6 +758,9 @@ if (empty($reshook)) {
 				}
 
 				$ref_supplier = $productsupplier->ref_supplier;
+				if (empty($ref_supplier) && !empty(GETPOST('fourn_ref', 'alpha'))) {
+					$ref_supplier = GETPOST('fourn_ref', 'alpha');
+				}
 
 				// Get vat rate
 				$tva_npr = 0;


### PR DESCRIPTION
When trying to add a custom supplier ref on add line's form (when there is no supplier price for this product on the order's supplier), it's not kept.

