### PR TITLE
FIX: drop always-true left operand of && (phpstan booleanAnd.leftAlwaysTrue)

### DIFF
--- a/htdocs/admin/remotestore/class/externalModules.class.php
+++ b/htdocs/admin/remotestore/class/externalModules.class.php
@@ -640,7 +640,8 @@ class ExternalModules
 					$remoteModuleName = preg_replace('/-' . preg_quote($remoteVersion, '/') . '$/', '', $remoteModuleName);
 					if (!empty($installedModules[$remoteModuleName]) && $remoteVersion && $remoteVersion != 'unknown') {
 						$localVersion = $installedModules[$remoteModuleName];
-						if ($localVersion && $localVersion != 'unknown') {
+						// $localVersion is guaranteed non-empty here (see !empty() test above), so only the 'unknown' value must be excluded
+						if ($localVersion != 'unknown') {
 							$versionDiff = $this->versionCompare($localVersion, $remoteVersion);
 							if ($versionDiff < 0) {
 								$buttonLabel = $langs->trans("Upgrade");

--- a/htdocs/reception/card.php
+++ b/htdocs/reception/card.php
@@ -2692,7 +2692,8 @@ if ($action == 'create' && $permissiontoadd) {
 			print '</td>';
 
 			// Qty in other receptions (with reception and warehouse used)
-			if ($origin && $origin_id > 0) {
+			// Note: here $origin is always a non-empty string (normalized above), so only $origin_id needs to be tested
+			if ($origin_id > 0) {
 				print '<td class="center nowrap linecolqtyinotherreceptions">';
 				$htmltooltip = '';
 				$qtyalreadyreceived = 0;


### PR DESCRIPTION
## What

Two spots flagged by PHPStan as `booleanAnd.leftAlwaysTrue` — the left side of an `&&` is provably always true, so it is dead code.

### `htdocs/reception/card.php` (~line 2695)

```php
if ($origin && $origin_id > 0) {
```

A few lines above, `$origin` is normalized and can no longer be falsy:

```php
$origin = (string) $origin;
if (empty($origin) || $origin == 'order_supplier') {
    $origin = 'supplier_order';
}
if (!in_array($origin, array('supplier_proposal', 'supplier_order', /* ... */))) {
    dol_print_error($db, 'Bad value for parameter origin in reception/card.php');
    exit;
}
```

So `$origin` is always a non-empty string here. The condition is reduced to `if ($origin_id > 0)`, which also matches the sibling check a few lines above (`if ($origin_id > 0)` before the SQL query).

### `htdocs/admin/remotestore/class/externalModules.class.php` (~line 641)

```php
if (!empty($installedModules[$remoteModuleName]) && $remoteVersion && $remoteVersion != 'unknown') {
    $localVersion = $installedModules[$remoteModuleName];
    if ($localVersion && $localVersion != 'unknown') {
```

`$localVersion` is read straight from an entry already guarded by `!empty()`, so it cannot be falsy. Reduced to `if ($localVersion != 'unknown')`.

## Why

Removes two PHPStan errors. Both introducing commits (`db93aa739f4`, `973153bd784`) are present on `24.0`.

No behaviour change.