### PR TITLE
FIX: cast nullable key/table/label to string in natural_search() sellist subquery (phan PhanTypeMismatchArgumentNullable)

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -13685,7 +13685,7 @@ function natural_search($fields, $value, $mode = 0, $nofirstand = 0, $sqltoadd =
 						$tmps = '';
 
 						if ($isSellist && $key && $table && $label) {
-							$newres .= $field . " IN (SELECT t." . $db->sanitize($key) . " FROM " . $db->prefix() . $db->sanitize($table) . " AS t WHERE t." . $db->sanitize($label) . " LIKE '%" . $db->escape($tmpcrit2) . "%')";
+							$newres .= $field . " IN (SELECT t." . $db->sanitize((string) $key) . " FROM " . $db->prefix() . $db->sanitize((string) $table) . " AS t WHERE t." . $db->sanitize((string) $label) . " LIKE '%" . $db->escape($tmpcrit2) . "%')";
 						} else {
 							if (preg_match('/^!/', $tmpcrit)) {
 								$tmps .= $db->sanitize($field) . " NOT LIKE "; // ! as exclude character


### PR DESCRIPTION
## What

`htdocs/core/lib/functions.lib.php`, `natural_search()`, the `$isSellist` branch (~line 13688):

```php
$table = $label = $key = null;
// ...
list($table, $label, $key) = explode(':', $param);   // only on some paths
// ...
if ($isSellist && $key && $table && $label) {
    $newres .= $field . " IN (SELECT t." . $db->sanitize($key) . " FROM " . $db->prefix() . $db->sanitize($table) . " AS t WHERE t." . $db->sanitize($label) . " ...
```

phan (quick mode) does not narrow `?string` to `string` through the `&& $key && $table && $label` guard, so `DoliDB::sanitize()` (which takes a non-nullable `string`) is reported with `PhanTypeMismatchArgumentNullable` on the `$key` and `$label` arguments.

## Fix

Cast the three values to `string` at the call, the same way many other `$db->sanitize((string) ...)` call sites already do. No behaviour change — inside that branch the values are guaranteed non-empty strings.

## Why here

The `$db->sanitize()` calls were introduced on `24.0` by c100361cd25 ("Fix sanitize search_all parameter - reported by AlphaLab"). This is a follow-up static-analysis cleanup; it currently makes the phan job red on any PHP-touching PR against `24.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)