### PR TITLE
FIX: Undefined array key "imagebackground" in admin/ihm.php

### DIFF
--- a/htdocs/admin/ihm.php
+++ b/htdocs/admin/ihm.php
@@ -298,7 +298,7 @@ if ($action == 'update') {
 
 		$varforimage = 'imagebackground';
 		$dirforimage = $conf->mycompany->dir_output . '/logos/';
-		if ($_FILES[$varforimage]["tmp_name"]) {
+		if (!empty($_FILES[$varforimage]["tmp_name"])) {
 			$reg = array();
 			if (preg_match('/([^\\/:]+)$/i', $_FILES[$varforimage]["name"], $reg)) {
 				$original_file = $reg[1];


### PR DESCRIPTION
## Problem

Saving the **Home - Setup - Display** login screen setup raises:

```
Warning: Undefined array key "imagebackground" in htdocs/admin/ihm.php on line 301
```

When `ADD_UNSPLASH_LOGIN_BACKGROUND` is enabled, the background-image
file input is rendered `disabled` (further down the same page), so the
browser does not submit it and `$_FILES` has no `imagebackground` entry
when the `login` mode form is posted. The unconditional
`if ($_FILES[$varforimage]["tmp_name"])` then dereferences a missing key.

## Fix

Guard the upload block with `!empty()`. This is null-safe on the missing
key and also correctly skips the "form submitted without choosing a
file" case (`tmp_name === ''`), so behaviour is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)