### PR TITLE
FIX Add the missing translation key Direction

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -20,6 +20,7 @@ NewProduct=New product
 NewService=New service
 ProductVatMassChange=Global VAT Update
 ProductVatMassChangeDesc=This tool updates the VAT rate defined on <b><u>ALL</u></b> products and services!
+Direction=Direction
 MassBarcodeInit=Mass barcode init
 MassBarcodeInitDesc=This page can be used to initialize a barcode on objects that do not have a barcode defined. Check before that setup of module barcode is complete.
 ProductAccountancyBuyCode=Accounting code (purchase)


### PR DESCRIPTION
## Context

The translation key `Direction` is used by `htdocs/product/admin/product_tools.php:343` since 4acca63d889, but it was never added to the lang files.

## Summary

Adds `Direction=Direction` to `htdocs/langs/en_US/products.lang`, next to the other keys of that screen (`ProductVatMassChange`, `ProductVatMassChangeDesc`).

## Details

The `pre-commit` job runs the `check-translations` hook on the **whole project**, not only on the files of the pull request. So this single missing key currently fails the `pre-commit` job of every open pull request against `develop`, and short-circuits the `phan` and `phpstan` jobs that run after it.

```
htdocs/product/admin/product_tools.php:343:21: error - Missing translation; print '<td>'.$langs->trans("Direction").'</td>'."\n";
```

## Test

Open Home > Setup > Products/Services > `product/admin/product_tools.php`: the first column of the global VAT update table now displays *Direction* instead of the raw key.
