### PR TITLE
fix CI and Modernize script tags: drop obsolete language="javascript" attribute

### DIFF
--- a/htdocs/bom/bom_net_needs.php
+++ b/htdocs/bom/bom_net_needs.php
@@ -348,7 +348,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 	}
 	print '</div>'; ?>
 
-		<script type="text/javascript" language="javascript">
+		<script type="text/javascript">
 			$(document).ready(function() {
 
 				function folderManage(element) {

--- a/htdocs/bom/lib/bom.lib.php
+++ b/htdocs/bom/lib/bom.lib.php
@@ -165,7 +165,7 @@ function mrpCollapseBomManagement()
 {
 	?>
 
-	<script type="text/javascript" language="javascript">
+	<script type="text/javascript">
 
 		$(document).ready(function () {
 			function folderManage(element, onClose = 0) {

--- a/htdocs/core/boxes/box_graph_invoices_peryear.php
+++ b/htdocs/core/boxes/box_graph_invoices_peryear.php
@@ -176,7 +176,7 @@ class box_graph_invoices_peryear extends ModeleBoxes
 
 			if (!$mesg) {
 				$stringtoshow = '';
-				$stringtoshow .= '<script nonce="'.getNonce().'" type="text/javascript" language="javascript">
+				$stringtoshow .= '<script nonce="'.getNonce().'" type="text/javascript">
 					jQuery(document).ready(function() {
 						jQuery("#idsubimg'.$this->boxcode.'").click(function() {
 							jQuery("#idfilter'.$this->boxcode.'").toggle();

--- a/htdocs/expedition/dispatch.php
+++ b/htdocs/expedition/dispatch.php
@@ -1391,7 +1391,7 @@ if ($object->id > 0 || !empty($object->ref)) {
 				$out_js_line .= '}';
 				$out_js_line_list[] = $out_js_line;
 
-				$out_js = '<script type="text/javascript" language="javascript">';
+				$out_js = '<script type="text/javascript">';
 				$out_js .= 'jQuery(document).ready(function() {';
 				// when a warehouse is selected, only the lot/serial numbers that are available in it are offered
 				$out_js .= 'updateselectbatchbywarehouse();';

--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -2038,7 +2038,7 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 		print "</form>\n";
 	} ?>
 
-		<script  type="text/javascript" language="javascript">
+		<script type="text/javascript">
 
 			$(document).ready(function() {
 				//Consumption : When a warehouse is selected, only the lot/serial numbers that are available in it are offered

--- a/htdocs/partnership/admin/website.php
+++ b/htdocs/partnership/admin/website.php
@@ -110,7 +110,7 @@ print '<input type="hidden" name="token" value="'.newToken().'">';
 print dol_get_fiche_head($head, 'website', $langs->trans("Partnerships"), -1, 'partnership');
 
 if ($conf->use_javascript_ajax) {
-	print "\n".'<script type="text/javascript" language="javascript">';
+	print "\n".'<script type="text/javascript">';
 	print 'jQuery(document).ready(function () {
                 function initemail()
                 {

--- a/htdocs/product/stock/stocktransfer/stocktransfer_card.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_card.php
@@ -428,7 +428,7 @@ llxHeader('', $title, $help_url, '', 0, 0, '', '', '', 'mod-product page-stock-s
 
 
 // Example: Adding jQuery code
-print '<script type="text/javascript" language="javascript">
+print '<script type="text/javascript">
 jQuery(document).ready(function() {';
 
 // Show alert for planned departure date if the transfer is related

--- a/htdocs/takepos/invoice.php
+++ b/htdocs/takepos/invoice.php
@@ -3,7 +3,7 @@
  * Copyright (C) 2021    	Nicolas ZABOURI    		<info@inovea-conseil.com>
  * Copyright (C) 2022-2023	Christophe Battarel		<christophe.battarel@altairis.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2026       Jose Martinez           <jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -104,8 +104,8 @@ if (empty($takeposterminal)) {
 		$takeposterminal = $_SESSION["takeposterminal"];
 	} else {
 		print <<<SCRIPT
-<script language="javascript">
-	$( document ).ready(function() {
+<script type="text/javascript">
+	jQuery(function() {
 		ModalBox('ModalTerminal');
 	});
 </script>
@@ -1827,12 +1827,12 @@ function showPrintResultPopup(message, duration) {
 // Call url to generate a credit note (with same lines) from existing invoice
 var creditNoteParams="";
 function CreditNote() {
-    <?php
-    $parameters = array();
-    $reshook = $hookmanager->executeHooks('paramsForCreditNote', $parameters, $invoice, $action);?>
+	<?php
+	$parameters = array();
+	$reshook = $hookmanager->executeHooks('paramsForCreditNote', $parameters, $invoice, $action);?>
 	$("#poslines").load("<?php
-        print DOL_URL_ROOT; ?>/takepos/invoice.php?action=creditnote&token=<?php echo newToken() ?>&invoiceid="+placeid+creditNoteParams, function() {	});
-        return true;
+		print DOL_URL_ROOT; ?>/takepos/invoice.php?action=creditnote&token=<?php echo newToken() ?>&invoiceid="+placeid+creditNoteParams, function() {	});
+		return true;
 }
 
 // Call url to add notes


### PR DESCRIPTION
## What

The HTML `language` attribute on `<script>` has been obsolete for years
([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-language)).

- **`takepos/invoice.php`** — the inline `<script>` printed when TakePOS opens
  with no terminal selected had *only* `language="javascript"` (no `type`).
  It now gets `type="text/javascript"` like the rest of the file, and the
  verbose `$( document ).ready(function () { ... })` wrapper becomes the shorter
  `jQuery(function () { ... })` idiom (which also avoids any `$` interpolation
  ambiguity inside the PHP `<<<SCRIPT` heredoc).
- **`bom/`, `expedition/`, `mrp/`, `partnership/`, `product/stock/stocktransfer/`,
  `core/boxes/box_graph_invoices_peryear.php`** — these tags already carried
  `type="text/javascript"`, so the redundant `language="javascript"` is simply
  removed (plus a stray double space in `mo_production.php`).

It also converts some pre-existing space indentation to tabs in
`invoice.php` `CreditNote()` (what `phpcbf` produces), which the codesniffer
CI check otherwise reports for the whole touched file.

## Behaviour change

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)