### PR TITLE
FIX #40175 Email templates: restore the "Private" field removed from $tabfield[25]

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -142,7 +142,7 @@ $tabname[25] = MAIN_DB_PREFIX."c_email_templates";
 // Nom des champs en resultat de select pour affichage du dictionnaire
 // Names of fields in select results for dictionary display (AI translated)
 $tabfield = array();
-$tabfield[25] = "label,lang,type_template,fk_user,position,module,topic,joinfiles,defaultfortype,content";
+$tabfield[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfield[25] .= ',content_lines';
 }


### PR DESCRIPTION
# FIX #40175 Email templates: restore the "Private" field removed from $tabfield[25]

Since v23, the "Private" field of email templates (Setup → Emails → Email templates) is no longer displayed in the list nor in the create/edit form, so a template can no longer be declared private (visible by its owner only). The field is still stored (`llx_c_email_templates.private`), still in `$tabfieldinsert[25]`, still handled on POST, and still enforced when templates are proposed to users (`private = 0 OR fk_user = …`). Only the UI was lost, in commit 9e5043bed6 ("Restore view in one page without scrolling").

This PR puts `private` back in `$tabfield[25]`, between `fk_user` and `position` (one line, no other change).

Tested on a clean 24.0.0 (official Docker image): the "Private" column and the Yes/No selector are back in the create form, saving stores `private = 1`.

If the column was removed on purpose to keep the page narrow, an alternative would be to keep the field only in the create/edit form; happy to adjust.
