### PR TITLE
FIX Supplier order is not classified billed when documents use a foreign currency

### DIFF
--- a/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
+++ b/htdocs/core/triggers/interface_20_modWorkflow_WorkflowManager.class.php
@@ -284,13 +284,18 @@ class InterfaceWorkflowManager extends DolibarrTriggers
 				$object->fetchObjectLinked(0, 'order_supplier', $object->id, $object->element);
 				if (!empty($object->linkedObjects['order_supplier'])) {
 					$totalonlinkedelements = 0;
+					$totalonlinkedelements_multicurrency = 0;
+					$samemulticurrencycode = true;
 					foreach ($object->linkedObjects['order_supplier'] as $element) {
 						if ($element->statut == CommandeFournisseur::STATUS_ACCEPTED || $element->statut == CommandeFournisseur::STATUS_ORDERSENT || $element->statut == CommandeFournisseur::STATUS_RECEIVED_PARTIALLY || $element->statut == CommandeFournisseur::STATUS_RECEIVED_COMPLETELY) {
 							$totalonlinkedelements += $element->total_ht;
+							$totalonlinkedelements_multicurrency += $element->multicurrency_total_ht;
+							$samemulticurrencycode = $samemulticurrencycode && ($element->multicurrency_code == $object->multicurrency_code);
 						}
 					}
 					dol_syslog("Amount of linked orders = ".$totalonlinkedelements.", of invoice = ".$object->total_ht.", egality is ".json_encode($totalonlinkedelements == $object->total_ht));
-					if ($this->shouldClassify($conf, $totalonlinkedelements, $object->total_ht)) {
+					if ($this->shouldClassify($conf, $totalonlinkedelements, $object->total_ht)
+						|| ($samemulticurrencycode && !empty($object->multicurrency_total_ht) && $this->shouldClassify($conf, $totalonlinkedelements_multicurrency, $object->multicurrency_total_ht))) {
 						foreach ($object->linkedObjects['order_supplier'] as $element) {
 							$ret = $element->classifyBilled($user);
 							if ($ret < 0) {


### PR DESCRIPTION
# FIX Supplier order is not classified billed when documents use a foreign currency

When a supplier invoice is validated, the linked purchase order is classified as billed only if the amounts match. That comparison is made on the amounts converted into the currency of the company. An order and an invoice recorded in the same foreign currency but at different exchange rates end up a few cents apart once converted, so the order stays unbilled even though it is fully invoiced.

The amounts are now also compared in the currency of the documents, and that second comparison is used only when the order and the invoice share the same currency. The existing comparison runs first and is unchanged, so nothing moves for setups using a single currency.

Documents created before the multicurrency module was in use keep a zero amount in their own currency. The second comparison is therefore skipped when the invoice has no amount in its own currency, so orders whose amounts genuinely differ are still not classified.

Targeting 22.0 as the oldest maintained version affected. The same code is present from 20.0 up to develop.
