### PR TITLE
FIX: GeoIP country lookup fails when a City database is used as country datafile

### DIFF
--- a/htdocs/core/class/dolgeoip.class.php
+++ b/htdocs/core/class/dolgeoip.class.php
@@ -127,6 +127,34 @@ class DolGeoIP
 	}
 
 	/**
+	 * Return the ISO country code for an IP or a host name using the embedded GeoIP2 reader.
+	 * A Country database is read with country(), but a City database (which also embeds the
+	 * country record) is read with city(), so a City datafile configured as the country
+	 * datafile still resolves instead of failing with a BadMethodCallException.
+	 *
+	 * @param	string	$ipOrName	IP address or host name to look up
+	 * @return	string				Country code (two letters, upper case) or '' if not found
+	 */
+	private function getGeoIp2IsoCode($ipOrName)
+	{
+		try {
+			$databasetype = '';
+			if (is_object($this->gi) && method_exists($this->gi, 'metadata')) {
+				$databasetype = (string) $this->gi->metadata()->databaseType;
+			}
+			if (strpos($databasetype, 'Country') === false && strpos($databasetype, 'City') !== false) {
+				$record = $this->gi->city($ipOrName);
+			} else {
+				$record = $this->gi->country($ipOrName);
+			}
+			return (string) $record->country->isoCode;
+		} catch (Exception $e) {
+			//return $e->getMessage();
+			return '';
+		}
+	}
+
+	/**
 	 * Return in lower case the country code from an ip
 	 *
 	 * @param	string	$ip		IP to scan
@@ -148,13 +176,7 @@ class DolGeoIP
 		} else {
 			if (preg_match('/^[0-9]+.[0-9]+\.[0-9]+\.[0-9]+/', $ip)) {
 				if ($geoipversion == '2') {
-					try {
-						$record = $this->gi->country($ip);
-						return strtolower($record->country->isoCode);
-					} catch (Exception $e) {
-						//return $e->getMessage();
-						return '';
-					}
+					return strtolower($this->getGeoIp2IsoCode($ip));
 				} else {
 					if (!function_exists('geoip_country_code_by_addr')) {
 						return strtolower(geoip_country_code_by_name($ip));
@@ -163,13 +185,7 @@ class DolGeoIP
 				}
 			} else {
 				if ($geoipversion == '2') {
-					try {
-						$record = $this->gi->country($ip);
-						return strtolower($record->country->isoCode);
-					} catch (Exception $e) {
-						//return $e->getMessage();
-						return '';
-					}
+					return strtolower($this->getGeoIp2IsoCode($ip));
 				} else {
 					if (function_exists('geoip_country_code_by_addr_v6')) {
 						return strtolower(geoip_country_code_by_addr_v6($this->gi, $ip));
@@ -200,13 +216,7 @@ class DolGeoIP
 		}
 
 		if ($geoipversion == '2') {
-			try {
-				$record = $this->gi->country($name);
-				return $record->country->isoCode;
-			} catch (Exception $e) {
-				//return $e->getMessage();
-				return '';
-			}
+			return $this->getGeoIp2IsoCode($name);
 		} else {
 			return strtolower(geoip_country_code_by_name($name));
 		}


### PR DESCRIPTION
## Problem

`DolGeoIP::getCountryCodeFromIP()` and `getCountryCodeFromName()` always call `GeoIp2\Database\Reader::country()`.

When the configured datafile is a **City** database (e.g. `GeoLite2-City.mmdb`), that reader rejects `country()` with a `BadMethodCallException`:

```
The country method cannot be used to open a GeoLite2-City database
```

The exception is caught and turned into an empty string, so `admin/geoipmaxmind.php` just shows `Error` for the test IPs with no indication of the cause, and `dolGetCountryCodeFromIp()` silently returns `''` everywhere.

## Fix

A City database also embeds the country record, so:

- detect the database type from the reader metadata (`metadata()->databaseType`)
- call `city()` instead of `country()` when the file is a City database
- the `country()` path is unchanged for a Country database

The three duplicated `try { country() } catch` blocks (IPv4 + IPv6 in `getCountryCodeFromIP()`, plus `getCountryCodeFromName()`) are factored into a private `getGeoIp2IsoCode()` helper.

Also casts `isoCode` to string to avoid a `strtolower(null)` deprecation on PHP 8.1+.

## Test

Manually, embedded GeoIP v2, PHP 8.5:

| datafile | `24.24.24.24` | `8.8.8.8` | IPv6 | invalid IP | host name |
|---|---|---|---|---|---|
| `GeoLite2-City.mmdb` as country file | `us` | `us` | `fr` | `` | `US` |
| `GeoLite2-Country.mmdb` (unchanged) | `us` | `us` | `fr` | `` | `US` |

Before the patch, the City-file row returned `Error` for every lookup.

PHPStan (level 10) and PHP CodeSniffer: clean.