### PR TITLE
NEW Show a total per currency at the bottom of invoice lists

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -2959,26 +2959,33 @@ if ($num > 0) {
 					$totalarray['nbfield']++;
 				}
 			}
+			$currencykey = !empty($obj->multicurrency_code) ? $obj->multicurrency_code : $conf->currency;
 			// Amount HT
 			if (!empty($arrayfields['f.multicurrency_total_ht']['checked'])) {
 				print '<td class="right nowraponall amount">'.price($obj->multicurrency_total_ht)."</td>\n";
 				if (!$i) {
 					$totalarray['nbfield']++;
+					$totalarray['pospercurrency'][$totalarray['nbfield']] = 'f.multicurrency_total_ht';
 				}
+				$totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ht'] = ($totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ht'] ?? 0) + $obj->multicurrency_total_ht;
 			}
 			// Amount VAT
 			if (!empty($arrayfields['f.multicurrency_total_vat']['checked'])) {
 				print '<td class="right nowraponall amount">'.price($obj->multicurrency_total_vat)."</td>\n";
 				if (!$i) {
 					$totalarray['nbfield']++;
+					$totalarray['pospercurrency'][$totalarray['nbfield']] = 'f.multicurrency_total_vat';
 				}
+				$totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_vat'] = ($totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_vat'] ?? 0) + $obj->multicurrency_total_vat;
 			}
 			// Amount TTC
 			if (!empty($arrayfields['f.multicurrency_total_ttc']['checked'])) {
 				print '<td class="right nowraponall amount">'.price($obj->multicurrency_total_ttc)."</td>\n";
 				if (!$i) {
 					$totalarray['nbfield']++;
+					$totalarray['pospercurrency'][$totalarray['nbfield']] = 'f.multicurrency_total_ttc';
 				}
+				$totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ttc'] = ($totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ttc'] ?? 0) + $obj->multicurrency_total_ttc;
 			}
 			// Dyn amount
 			if (!empty($arrayfields['multicurrency_dynamount_payed']['checked'])) {

--- a/htdocs/core/tpl/list_print_total.tpl.php
+++ b/htdocs/core/tpl/list_print_total.tpl.php
@@ -30,10 +30,10 @@
  * @var string		$sql
  * @var string		$sqlfields
  * @var string		$moreinfoontotal
- * @var array{nbfield:int,type?:array<int,string>,pos?:array<int,string>,val?:array<int,float>} $totalarray
+ * @var array{nbfield:int,type?:array<int,string>,pos?:array<int,string>,val?:array<int,float>,pospercurrency?:array<int,string>,valpercurrency?:array<string,array<string,float>>} $totalarray
  */
 '
-@phan-var-force array{nbfield:int,type?:array<int,string>,pos?:array<int,string>,val?:array<int,float>} $totalarray
+@phan-var-force array{nbfield:int,type?:array<int,string>,pos?:array<int,string>,val?:array<int,float>,pospercurrency?:array<int,string>,valpercurrency?:array<string,array<string,float>>} $totalarray
 @phan-var-force string $sql
 @phan-var-force ?string $sqlfields
 @phan-var-force int	$num
@@ -121,6 +121,25 @@ if (isset($totalarray['pos'])) {
 		}
 	}
 	print '</tr>';
+
+	// Show one line per currency when the list holds documents in several currencies
+	if (!empty($totalarray['valpercurrency']) && count($totalarray['valpercurrency']) > 1) {
+		foreach ($totalarray['valpercurrency'] as $currencycode => $valpercurrency) {
+			print '<tr class="liste_total'.(empty($trforbreaknobg) ? '' : ' trforbreaknobg').'">';
+			$i = 0;
+			while ($i < $totalarray['nbfield']) {
+				$i++;
+				if (!empty($totalarray['pospercurrency'][$i]) && isset($valpercurrency[$totalarray['pospercurrency'][$i]])) {
+					printTotalValCell($totalarray['type'][$i] ?? '', (string) $valpercurrency[$totalarray['pospercurrency'][$i]]);
+				} elseif ($i == 1) {
+					print '<td>'.$langs->trans("Total").' '.dol_escape_htmltag($currencycode).'</td>';
+				} else {
+					print '<td></td>';
+				}
+			}
+			print '</tr>';
+		}
+	}
 
 	// Add grand total if necessary ie only if different of page total already printed above
 	if (getDolGlobalString('MAIN_GRANDTOTAL_LIST_SHOW') && (!(is_null($limit) || $num < $limit))) {

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -2202,26 +2202,33 @@ while ($i < $imaxinloop) {
 				$totalarray['nbfield']++;
 			}
 		}
+		$currencykey = !empty($obj->multicurrency_code) ? $obj->multicurrency_code : $conf->currency;
 		// Amount HT
 		if (!empty($arrayfields['f.multicurrency_total_ht']['checked'])) {
 			print '<td class="right nowrap"><span class="amount">'.price($obj->multicurrency_total_ht)."</span></td>\n";
 			if (!$i) {
 				$totalarray['nbfield']++;
+				$totalarray['pospercurrency'][$totalarray['nbfield']] = 'f.multicurrency_total_ht';
 			}
+			$totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ht'] = ($totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ht'] ?? 0) + $obj->multicurrency_total_ht;
 		}
 		// Amount VAT
 		if (!empty($arrayfields['f.multicurrency_total_vat']['checked'])) {
 			print '<td class="right nowrap"><span class="amount">'.price($obj->multicurrency_total_vat)."</span></td>\n";
 			if (!$i) {
 				$totalarray['nbfield']++;
+				$totalarray['pospercurrency'][$totalarray['nbfield']] = 'f.multicurrency_total_vat';
 			}
+			$totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_vat'] = ($totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_vat'] ?? 0) + $obj->multicurrency_total_vat;
 		}
 		// Amount TTC
 		if (!empty($arrayfields['f.multicurrency_total_ttc']['checked'])) {
 			print '<td class="right nowrap"><span class="amount">'.price($obj->multicurrency_total_ttc)."</span></td>\n";
 			if (!$i) {
 				$totalarray['nbfield']++;
+				$totalarray['pospercurrency'][$totalarray['nbfield']] = 'f.multicurrency_total_ttc';
 			}
+			$totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ttc'] = ($totalarray['valpercurrency'][$currencykey]['f.multicurrency_total_ttc'] ?? 0) + $obj->multicurrency_total_ttc;
 		}
 		// Dynamic amount paid
 		if (!empty($arrayfields['multicurrency_dynamount_payed']['checked'])) {


### PR DESCRIPTION
# NEW Show a total per currency at the bottom of invoice lists

On a company selling or buying in several currencies, the total at the bottom of the customer and supplier invoice lists is only available in the currency of the company. The amount column in the currency of the document is displayed row by row but has no total at all, so there is no way to read what a period represents in each currency, which is the figure people actually work with when most of the business is invoiced abroad.

A line per currency is now shown under the existing total, filling the columns holding amounts in the currency of the document. The existing total line does not move.

The lines appear only when the displayed invoices carry more than one currency, so nothing changes for a company working in a single currency. Documents with no currency of their own are counted under the currency of the company.

The rendering sits in the shared total template, so any other list can offer the same by feeding the two new keys of the total array. Related, for the list of bank accounts: #36922.
