### PR TITLE
FIX #40184 Order PDF eratosthene/proforma: sender block drawn over the logo with MAIN_PDF_USE_ISO_LOCATION

### DIFF
--- a/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
+++ b/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
@@ -1796,7 +1796,7 @@ class pdf_eratosthene extends ModelePDFCommandes
 			$carac_emetteur .= pdf_build_address($outputlangs, $this->emetteur, $object->thirdparty, '', 0, 'source', $object);
 
 			// Show sender
-			$posy = getDolGlobalInt('MAIN_PDF_USE_ISO_LOCATION') ? $this->marge_haute : $this->marge_haute + 32;
+			$posy = getDolGlobalInt('MAIN_PDF_USE_ISO_LOCATION') ? $this->marge_haute + 30 : $this->marge_haute + 32;
 			$posy += $top_shift;
 			$posx = $this->marge_gauche;
 			if (getDolGlobalInt('MAIN_INVERT_SENDER_RECIPIENT')) {


### PR DESCRIPTION
FIX #40184

Since v24, the "eratosthene" order template (and "proforma", which extends it) draws the sender frame at `$this->marge_haute` when `MAIN_PDF_USE_ISO_LOCATION` is enabled, i.e. at the very top of the page, over the company logo. Up to 23.0.x the value was 40 mm.

This uses `$this->marge_haute + 30`, consistent with the recipient block of the same template and with the sender block of pdf_sponge. One-line change, tested on 24.0.0 (frame back below the logo with the option enabled, no change with the option disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
