### PR TITLE
Fix #40186 add the CSRF token to the various payment clone button

### DIFF
--- a/htdocs/compta/bank/various_payment/card.php
+++ b/htdocs/compta/bank/various_payment/card.php
@@ -798,7 +798,7 @@ if ($id) {
 
 	// Clone
 	if ($permissiontoadd) {
-		print '<div class="inline-block divButAction"><a class="butAction butActionClone" href="' . dolBuildUrl(DOL_URL_ROOT."/compta/bank/various_payment/card.php", ['id' => $object->id, 'action' => 'clone']).'">'.$langs->trans("ToClone") . "</a></div>";
+		print '<div class="inline-block divButAction"><a class="butAction butActionClone" href="' . dolBuildUrl(DOL_URL_ROOT."/compta/bank/various_payment/card.php", ['id' => $object->id, 'action' => 'clone'], true).'">'.$langs->trans("ToClone") . "</a></div>";
 	}
 
 	// Delete


### PR DESCRIPTION
The clone link was built without a token (compta/bank/various_payment/card.php:801):

    dolBuildUrl(DOL_URL_ROOT."/compta/bank/various_payment/card.php", ['id' => $object->id, 'action' => 'clone'])

so with MAIN_SECURITY_CSRF_WITH_TOKEN enabled, main.inc.php:426 refuses any GET carrying an action parameter and prints the message from the report.

The fix uses dolBuildUrl's own $addtoken parameter rather than adding the key by hand:

    dolBuildUrl(..., ['id' => $object->id, 'action' => 'clone'], true)

which appends 'token' => newToken() internally (functions.lib.php). That is the established form, 248 calls in the tree already pass it.

Scope note, since the issue text suggests a wider problem: I checked every clone button built with dolBuildUrl and this is the only one missing it. bom/bom_card.php:783, salaries/card.php:1233 and webhook/target_card.php:483 all already pass true. My first grep suggested four candidates because it looked for a 'token' key in the array rather than the third argument, so the real count is one.

Also checked the other report about cloning, #40174 on mass mailing: that page does carry a token, both on its button (comm/mailing/card.php:1328) and through formconfirm, so it is a different problem and is not addressed here.

The suggested fix in the issue, adding 'token' => newToken() to the array, works too, but passing addtoken keeps it consistent with the rest of the codebase.

Reported by @JRFPlows in #40186.