### PR TITLE
Fix #40182 do not order from an unrelated supplier on replenishment

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -194,7 +194,15 @@ if ($action == 'order' && GETPOST('valid') && $user->hasRight('fournisseur', 'co
 				$supplierpriceid = GETPOSTINT('fourn'.$i);
 				//get all the parameters needed to create a line
 				$qty = GETPOSTFLOAT('tobuy'.$i);
-				$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);
+				// Resolve the product and the supplier of the selected price line first. Without them,
+				// get_buyprice() falls back to a search with no product and no supplier filter, and can
+				// return a price row of another supplier for another product (see #40182).
+				$tmpprodfourn = new ProductFournisseur($db);
+				if ($tmpprodfourn->fetch_product_fournisseur_price($supplierpriceid) > 0) {
+					$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty, $tmpprodfourn->product_id, 'none', $tmpprodfourn->fourn_id);
+				} else {
+					$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);
+				}
 				$res = $productsupplier->fetch($idprod);
 				if ($res && $idprod > 0) {
 					if ($qty) {
@@ -278,6 +286,7 @@ if ($action == 'order' && GETPOST('valid') && $user->hasRight('fournisseur', 'co
 				$order->fetch($obj->rowid);
 				$order->fetch_thirdparty();
 
+				$result = 0;	// Stays 0 when the supplier has no line, so the test below is not done on an undefined value
 				foreach ($supplier['lines'] as $line) {
 					if (empty($line->remise_percent)) {
 						$line->remise_percent = (float) $order->thirdparty->remise_supplier_percent;


### PR DESCRIPTION
The analysis in the issue is correct and I reproduced the mechanism.

replenish.php:197 calls get_buyprice() with only two arguments:

    $idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);

so product_id defaults to 0, fk_soc to 0 and fourn_ref to ''. When the ordered quantity is below the price tier minimum, the first lookup returns nothing and the fallback runs. With those defaults it builds:

    WHERE 1 = 1 AND pfp.ref_fourn = '' AND pfp.quantity <= 1 ORDER BY pfp.quantity DESC LIMIT 1

Note that '' != 'none' is true, so instead of disabling the reference filter it matches every price row with an empty supplier reference, with no product and no supplier constraint at all. Reproduced on MariaDB with two suppliers:

    rows: (product 100, supplier 1, ref REF-A, qty 5)
          (product 200, supplier 2, ref '',    qty 1)
    query returns: product 200, supplier 2

which is then used as fk_product, and the order supplier comes from $productsupplier->fourn_socid, hence the extra draft order for an unrelated supplier.

The fix resolves the product and supplier from the selected price line, which the page already has as $supplierpriceid, and passes them:

    $tmpprodfourn->fetch_product_fournisseur_price($supplierpriceid)
    get_buyprice($supplierpriceid, $qty, $tmpprodfourn->product_id, 'none', $tmpprodfourn->fourn_id)

'none' is the documented way to disable the reference filter, and it is what every other caller of get_buyprice() passes. After the change the same scenario returns no row, so the line is skipped by the existing if ($res && $idprod > 0) guard rather than producing a wrong order.

One design note: passing $fk_supplier from the page filter would not have been enough, since it is 0 when the user did not filter on a supplier, leaving the fallback unconstrained again. Resolving from the price line works in both cases.

Reported by @comaiteseb in #40182.