### PR TITLE
QUAL: Sync AGENTS.md and skill files on 23.0 with develop

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -170,12 +170,27 @@ Before any modification, verify:
 - User rights enforcement (`$user->hasRight("module", "permission")` or `$user->hasRight("module", "objectname", "permission")`)
 - Multi-entity compatibility (add ` AND entity IN ('.getEntity("tablename").')`)
 
-If you want to make an online test, you can find the URL of instance info file htdocs/conf/conf.php in parameter $dolibarr_main_url_root. You can ignore and bypass the warning about HTTPS certificate. 
+### If adding a unit test was explicitely requested
 
-If adding a unit test is requested:
+If you want to make an online test, you can find the URL of instance info file htdocs/conf/conf.php in parameter $dolibarr_main_url_root. 
+You can ignore and bypass the warning about HTTPS certificate when URL is localhost. Ask the password if you need one without trying to get it from database.
+
 - If modifying the Dolibarr code project, add a PHPUnit test file into `test/phpunit/` and add the entry into file `test/phpunit/AllTests.php`.
 - If you need to validate code change or if it is explicitely requested, you can check code and dev syntax rules by running the following command on modified files (it takes a long time):
 	`phan -k .phan/config.php -B dev/tools/phan/baseline.txt --analyze-twice --minimum-target-php-version 7.2 --exclude-directory-list=dev/tools,mymodule/test/,mymodule/vendor/ --output-mode=checkstyle filemodified1.php filemodified2.php ...`
+
+### Local Dolibarr Online test — Page Access
+
+You can find the URL of an online instance into file htdocs/conf/conf.php in parameter $dolibarr_main_url_root. 
+You can ignore and bypass the warning about HTTPS certificate. Ask the password if you need one without trying to get it from database.
+
+Dolibarr requires a CSRF token and a session cookie. To access any authenticated page:
+
+1. **GET the login page** (e.g. `index.php?mainmenu=home`) to obtain:
+   - The CSRF token: extract the `name="token" value="..."` field from the HTML.
+   - The session cookie: the `DOLSESSID_*` cookie set in the response headers.
+2. **POST the login form** to `index.php` with `token`, `username`, `password`, and `actionlogin=dologin`. Keep the cookie for subsequent requests.
+3. **Reuse the session cookie** on all subsequent page requests — the session is now authenticated.
 
 ---
 

--- a/.agents/skills/skill-doli-code-review/SKILL.md
+++ b/.agents/skills/skill-doli-code-review/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: skill-doli-code-review
-description: >
-  Reviews Dolibarr PHP code for compliance with coding standards and security best practices, and fixes identified issues. Use when the user asks to review, audit, fix, or update code for Dolibarr, or mentions code quality, security vulnerabilities, or PSR-12 compliance.
+description:
+  Reviews Dolibarr PHP code for compliance with coding standards and security best practices, and fixes identified issues. 
+  Use when the user asks to review, audit, fix, or update code for Dolibarr, or mentions code quality, security vulnerabilities, or PSR-12 compliance.
 license: MIT
 user-invocable: true
 allowed-tools:
@@ -15,6 +16,18 @@ allowed-tools:
 ## When to Use This Skill
 
 Use this skill whenever the user asks to review, audit, or fix Dolibarr code to match best practices.
+
+
+## Relationship with AGENTS.md
+
+The instructions in this file are **complementary to** the instructions defined in `AGENTS.md`.
+
+- `AGENTS.md` contains the general instructions and rules for the project.
+- `SKILLS.md` contains additional instructions specific to skills.
+- Unless explicitly stated otherwise, the instructions from both files apply.
+- `SKILLS.md` does not replace or override `AGENTS.md`.
+- If an instruction in `SKILLS.md` conflicts with `AGENTS.md`, follow the rules defined by `AGENTS.md`.
+
 
 ## Inputs
 
@@ -40,7 +53,7 @@ The user request should contain, when available:
 
 When generating code:
 
-- provide only the relevant PHP code
+- provide only the relevant PHP code 7.2+
 - preserve the existing file formatting, never change the copyright or licence header, never remove existing cast 
 - do not rewrite unrelated methods
 - explain briefly what is being fixed

--- a/.agents/skills/skill-doli-devmodule/SKILL.md
+++ b/.agents/skills/skill-doli-devmodule/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: skill-doli-dev
-description: Use when developing Dolibarr ERP/CRM code, working with database queries, or asking about Dolibarr best practices.
+name: skill-doli-devmodule
+description: Use when developing a Dolibarr ERP/CRM external module, working with database queries, or asking about Dolibarr best practices.
 license: MIT
 user-invocable: true
 allowed-tools:
@@ -29,14 +29,12 @@ The instructions in this file are **complementary to** the instructions defined 
 ## Core Principles: Non-Negotiable Mandatory Rules
 These principles must be followed even before reviewing specific task details. Violation of these principles results in failed suggestions.
 
-
 ### Security & Data Integrity
 1.  **Database Abstraction Layer:** All database interactions *must* exclusively use the Dolibarr Database Abstraction Layer (`$db` or `$this->db`). **Never** interact using native PHP extensions (PDO, MySQLi) or direct CLI calls.
 2.  **Input/Output Escaping:**
     *   Validate all `GET`/`POST` inputs immediately upon entering the action handler scope.
     *   **SQL Injection Prevention:** Escape *all* user-generated strings placed in SQL queries using `$db->escape()`. For integers, use explicit casting: `((int) $var)`; for floats, use `(float) $var`.
 3.  **Variable Safety Naming:** When constructing dynamic SQL, the resulting variable holding the entire query string MUST be clearly prefixed (e.g., `$sqlWhereClause`, `$queryParams`). This pattern helps static analysis tools detect unsafe assignments.
-
 
 ### Code Structure & Quality
 1.  **Coding Standard:** All new and modified committed code must strictly adhere to **PSR-12** (enforcable by using `phpcbf` and `phpcs`).All properties and all function arguments and return value need detailed PHPDoc (e.g., `array<string,array{key1?:?type,...}>`).Variables expected to exist in view files require both a PHPDoc declaration *and* the use of `'@phan-var-force';` declarations near the HEAD of the file for strict static analysis tracking.
@@ -45,17 +43,16 @@ These principles must be followed even before reviewing specific task details. V
 4.  **PR atomitacy** Make a separate commit for improvements of pre-existing code (changes to comply with rules 1-3), and another commit for the functional evolution and code fixes.
     Do not apply rules 1-3 to existing code in backports (i.e., non-functional changes not applied to a (fork of) the develop branch.
 
-
 ### Workflow & Architecture
-1.  **PHP version:** 7.2+
+1.  **PHP version:** 7.1+ for core and bug-fix code. New external modules should target PHP 8.1+ and start every PHP file with `declare(strict_types=1)`.
 2.  **Action/View Separation:** Always clearly separate page action logic (executed on POST) from pure rendering (the HTML view).
+3.  **Hooks First:** Before implementing any logic that runs on a core lifecycle event (e.g., form save, object update), check if an existing Dolibarr hook can be used. Use the standard calling pattern: `$hookmanager->executeHooks('actionName', $parameters, $object, $action);`.
 
 ---
 
 ## Workflow and Tasks Guidance
 
 This section guides the agent through common development tasks.
-
 
 ### Code Investigation / Searching / Database analysis
 *   Use `pre-commit` to run tools (`php-cbf`, `php-cs`, `shellcheck`, `php-lint` - example:`pre-commit run php-cbf --files RELATIVEFILEPATH`) when the git hook is installed as local direct installations differ accross systems.
@@ -81,18 +78,16 @@ This section guides the agent through common development tasks.
 
 
 ### Module Development
-*   **Module Template:** Use the structure found at `htdocs/modulebuilder/template/` as a definitive guide when initiating a new module or new pages.
-
+*   **Module Template:** Use the structure found at `htdocs/modulebuilder/template/` as a definitive guide when initiating a new module.
+*   **Hook Priority:** When adding functionality that interacts with core Dolibarr processes, check for existing hooks first to minimize architectural impact and maintain compatibility.
 
 ### Database Interaction Detail (Refined)
 This details the preferred mechanical steps:
 1.  **Read Operations:** Use `$db->query('SELECT ...')` followed by fetching results using methods like `$db->fetch_object()`.
 2.  **Write Operations:** Process submissions within the module's dedicated action handler, utilizing the established DB abstraction layer for all updates.
 
-
 ### Extrafields Best Practices
 **IMPORTANT**: When working with extrafields (custom fields), follow these patterns from the [Dolibarr Extrafields Wiki](https://wiki.dolibarr.org/index.php/Extrafields):
-
 
 #### Loading & Accessing Extrafields
 ```php
@@ -100,7 +95,6 @@ $object->fetch(); // CommonObject fetch loads its extrafields
 // Access extrafield values via:
 $field_copy = $object->array_options['options_FIELDNAME']
 ```
-
 
 #### Saving Extrafields
 Before calling `$object->create()` or `$object->update()`, ensure extrafields are set:
@@ -113,7 +107,6 @@ $object->array_options['options_FIELDNAME'] = $value;
 // Then call update() - it will automatically save extrafields via insertExtraFields()
 $result = $object->update($user);
 ```
-
 
 #### Displaying Extrafields
 In view pages:
@@ -129,7 +122,6 @@ if (empty($reshook) && !empty($extrafields->attribute_label)) {
 }
 ```
 
-
 #### Extrafields Table Structure
 Each CommonObject objecttype has its own extrafields table:
 ```sql
@@ -140,11 +132,9 @@ llx_{objecttype}_extrafields
 - import_key (varchar)
 ```
 
-
 #### Reference
 - [Dolibarr Extrafields Wiki](https://wiki.dolibarr.org/index.php/Extrafields)
 - [Forum: Little dev tips for extrafields](https://www.dolibarr.org/forum/t/little-dev-tips-for-extrafields/29860)
-
 
 ### Testing & Validation Flow
 Before proposing code:
@@ -157,24 +147,19 @@ Before proposing code:
 
 This section contains detailed standards and constants for reference only. Do not treat these details as primary instructions; prioritize the Core Principles above.
 
-
 ### Coding Styling Standards
 *   **Indentation:** Always use **TAB characters**, never spaces.
 *   **Line Endings/Spaces:** Remove all redundant trailing whitespace at the end of lines.
 *   **Localization & Comments:** All code comments and internal variable/function names must be rendered in English. Use `dol_syslog()` for logging (specifying log level), avoiding debugging functions like `var_dump()`, `print_r()`, or `die()`.
-
 
 ### Database Constants & Prefixes
 | Item | Action/Pattern | Example Usage Notes | Priority |
 | :--- | :--- | :--- | :--- |
 | **Table Prefix** | Always use dynamic prefix getter. | `$db->prefix() . 'tablename'` | Overrides reliance on legacy constants like `MAIN_DB_PREFIX`. |
 
-
 ### Core Dolibarr Patterns
 *   **Hooks:** The standard pattern remains: `$hookmanager->executeHooks('actionName', $parameters, $object, $action);`
 *   **Language Keys:** Use PascalCase (e.g., `MyModuleLabel`) for consistency across all locales.
-*   **Global variables**: Dolibarr uses globals like `$db`, `$conf`, `$lang`, `$user`. Do not remove these without understanding the architecture
-
 
 ### Input Handling Functions
 Dolibarr provides type-safe input handling functions. **Always use these instead of `$_GET`/`$_POST` directly:**
@@ -190,7 +175,6 @@ Dolibarr provides type-safe input handling functions. **Always use these instead
 - `GETPOST()` with type for other cases
 
 **Never use:** `$_GET['param']` or `$_POST['param']` directly - always use GETPOST functions for proper escaping and type conversion.
-
 
 ### Extrafields Best Practices (Continued)
 
@@ -260,7 +244,6 @@ foreach ($tracking_fields as $name => $config) {
 	}
 }
 ```
-
 
 #### Reference
 - [Dolibarr Extrafields Wiki](https://wiki.dolibarr.org/index.php/Extrafields)

--- a/.agents/skills/skill-doli-test-hurl/SKILL.md
+++ b/.agents/skills/skill-doli-test-hurl/SKILL.md
@@ -1,6 +1,12 @@
 ---
-name: skill-doli-hurl-test
+name: skill-doli-test-hurl
 description: Create and maintain Hurl tests for Dolibarr ERP/CRM. Use when asked to create, write, or fix hurl tests for Dolibarr, or when working with test/hurl directory. Covers Dolibarr-specific conventions for hurl testing including authentication, test file naming, and test structure.
+user-invocable: true
+allowed-tools:
+ - read_file
+ - write_file
+ - grep
+ - bash
 ---
 
 # Dolibarr Hurl Test Skill
@@ -12,12 +18,25 @@ Create and maintain Hurl tests for Dolibarr ERP/CRM. Use when asked to create, w
 
 **NOTE**: Hurl uses Rust regex syntax, which does not support negative lookaheads (`(?!...)`). Use character class exclusions like `[^X]` instead.
 
+
 ## When to Use
 - User asks to create hurl tests for Dolibarr
 - User asks to fix failing hurl tests
 - Working with test/hurl directory
 - Need to test Dolibarr GUI or API endpoints
 - User mentions "hurl test" or "hurl tests"
+
+
+## Relationship with AGENTS.md
+
+The instructions in this file are **complementary to** the instructions defined in `AGENTS.md`.
+
+- `AGENTS.md` contains the general instructions and rules for the project.
+- `SKILLS.md` contains additional instructions specific to skills.
+- Unless explicitly stated otherwise, the instructions from both files apply.
+- `SKILLS.md` does not replace or override `AGENTS.md`.
+- If an instruction in `SKILLS.md` conflicts with `AGENTS.md`, follow the rules defined by `AGENTS.md`.
+
 
 ## Dolibarr Hurl Test Conventions
 

--- a/.agents/skills/skill-doli-test-interactive/SKILL.md
+++ b/.agents/skills/skill-doli-test-interactive/SKILL.md
@@ -26,6 +26,18 @@ Use this skill when you need to create a PHP script that:
 - Allows users to tear down/clean up the test data
 - Uses Dolibarr's authentication and session system
 
+
+## Relationship with AGENTS.md
+
+The instructions in this file are **complementary to** the instructions defined in `AGENTS.md`.
+
+- `AGENTS.md` contains the general instructions and rules for the project.
+- `SKILLS.md` contains additional instructions specific to skills.
+- Unless explicitly stated otherwise, the instructions from both files apply.
+- `SKILLS.md` does not replace or override `AGENTS.md`.
+- If an instruction in `SKILLS.md` conflicts with `AGENTS.md`, follow the rules defined by `AGENTS.md`.
+
+
 ## Quick Start
 
 1. Read the Dolibarr issue to understand what data needs to be created
@@ -35,6 +47,9 @@ Use this skill when you need to create a PHP script that:
 5. Create test data with unique identifiers (use timestamps)
 6. Output direct links with `target="_blank"` to view data
 7. Add teardown logic that deletes in reverse order of creation
+
+If you want to make an online test, you can find the URL of instance info file htdocs/conf/conf.php in parameter $dolibarr_main_url_root. 
+You can ignore and bypass the warning about HTTPS certificate. Ask the password if you need one without trying to get it from database. 
 
 ## Required Files
 

--- a/.agents/skills/skill-doli-test-phpunit/SKILL.md
+++ b/.agents/skills/skill-doli-test-phpunit/SKILL.md
@@ -1,7 +1,8 @@
 ---
-name: skill-doli-phpunit
-description: >
-  Creates or modify PHP unit tests for Dolibarr ERP/CRM functions and methods. Use when the user asks to add, write, create, or complete a PHPUnit test for Dolibarr, or mentions testing a specific function, method, or class in the Dolibarr codebase.
+name: skill-doli-test-phpunit
+description:
+  Creates or modify PHP unit tests for Dolibarr ERP/CRM functions and methods. Use when the user asks to add, write, create, or complete a PHPUnit test for Dolibarr,
+  or mentions testing a specific function, method, or class in the Dolibarr codebase.
 license: MIT
 user-invocable: true
 allowed-tools:
@@ -15,8 +16,19 @@ allowed-tools:
 ## When to Use This Skill
 
 Use this skill whenever the user asks to create, modify, or complete a PHP unit test for the Dolibarr ERP/CRM project.
-
 The goal is to produce a unit test that follows Dolibarr conventions and integrates cleanly into the existing PHPUnit test suite.
+
+
+## Relationship with AGENTS.md
+
+The instructions in this file are **complementary to** the instructions defined in `AGENTS.md`.
+
+- `AGENTS.md` contains the general instructions and rules for the project.
+- `SKILLS.md` contains additional instructions specific to skills.
+- Unless explicitly stated otherwise, the instructions from both files apply.
+- `SKILLS.md` does not replace or override `AGENTS.md`.
+- If an instruction in `SKILLS.md` conflicts with `AGENTS.md`, follow the rules defined by `AGENTS.md`.
+
 
 ## Inputs
 
@@ -24,6 +36,7 @@ The user request should contain, when available:
 
 - a name of the function to test
 - or the class method name to test
+
 
 ## General Rules
 
@@ -34,11 +47,13 @@ The user request should contain, when available:
 - avoid dependencies on external services
 - clean up every object created during the test
 
+
 ## Test Location
 
 Locate the most appropriate existing PHPUnit test file in `test/phpunit/`.
 
 If no suitable test file exists, create one using the naming convention `FeatureTest.php`.
+
 
 ## Naming
 
@@ -52,6 +67,7 @@ public function testDeleteObject()
 public function testFetchReturnsExpectedValues()
 public function testInvalidInputThrowsException()
 ```
+
 
 ## Assertions
 
@@ -68,6 +84,7 @@ $this->assertNull($value);
 $this->assertNotNull($value);
 ```
 
+
 ## Output
 
 When generating code:
@@ -77,12 +94,13 @@ When generating code:
 - do not rewrite unrelated methods
 - explain briefly what is being tested
 
+
 ## Examples
 
 ### Input: "Add a unit test for the create() method of the Invoice class"
 
 **Action:**
-1. locate or create `test/phpunit/InvoiceTest.php`
+1. locate or create `test/phpunit/MyObjectTest.php`
 2. add test method following Dolibarr conventions
 
 ### Input: "Write tests for the calculateVAT() function in price.lib.php"
@@ -90,6 +108,8 @@ When generating code:
 **Action:**
 1. locate or create appropriate test file in `test/phpunit/`
 2. add test methods for various VAT calculation scenarios
+3. you can test or suggest to test it by running the command: `phpunit test/phpunit/TheTestFile.php`
+
 
 ## Error Handling
 

--- a/htdocs/modulebuilder/template/AGENTS.md
+++ b/htdocs/modulebuilder/template/AGENTS.md
@@ -1,0 +1,199 @@
+# AGENTS.md (English Version)
+
+## Objective
+
+This project contains the sources of a module of the Dolibarr ERP and CRM application.
+Every modification must respect:
+- Dolibarr's modular architecture
+- Compatibility with upstream updates
+- Modern PHP best practices
+
+---
+
+## Critical Rules (DO NOT VIOLATE)
+
+-  Do not break compatibility of PHP functions and methods
+-  Do not introduce external dependencies without validation
+-  Separate page actions in the `/* Actions */` section of the PHP code and the rendering part in the `/* Views */` section
+-  Never use PHP native curl functions to call a GET or POST URL, but use instead the Dolibarr function getURLContent()
+-  Use Dolibarr hooks whenever possible
+-  Respect existing naming conventions
+-  All database table names must use the `llx_` prefix
+
+---
+
+## Expected Architecture
+
+Module structure:
+`htdocs/mymodule`
+├── `admin/`
+├── `class/`
+├── `core/`
+├── `css/`
+├── `doc/`
+├── `js/`
+├── `langs/`
+├── `lib/`
+├── `sql/`
+├── `test/`
+└── `tpl/`
+
+A template of a module directory content can be found in the `htdocs/modulebuilder/template` folder of this project.
+
+---
+
+## Before Coding
+
+Before writing any code, the agent **must**:
+- Search for existing similar functions in `htdocs/core/lib/` and `htdocs/core/class/`
+- Check if the concerned object class extends `CommonObject` and use its built-in methods (fetch, create, update, delete, etc.)
+- Review the module's `modMyModule.class.php` for declared permissions and constants
+- Run a search to ensure no equivalent function already exists in the codebase
+
+---
+
+## PHP Best Practices
+
+- PHP >= 7.3 (minimum support); PHP 8.1+ recommended for new external modules
+-  When writing a **bug fix**, always target the lowest compatible PHP version
+  of the branch being patched — do not use PHP 8.x syntax on a fix targeting v19 or v20
+- Respect PSR-12, but **indentations must use Tabs, not Spaces**
+- Write short, readable, and testable functions
+- Avoid side effects
+- Prefer typed properties and return types when PHP version allows
+
+---
+
+## Database
+
+- Use Dolibarr database functions exclusively — never use PDO or MySQLi directly
+    - In pages: use global `$db`
+    - In classes: use `$this->db`
+-  SQL forged by PHP must escaped fields with `db->escape()`, `db->sanitize()`, or by casting values to `(int)` or `(float)`
+-  Always use `$db->query()` followed by `$db->fetch_object()` or `$db->fetch_array()` to retrieve results
+-  SQL scripts for table and index creation must be placed in `htdocs/install/mysql/tables/` (see existing files for examples)
+-  Never run SQL queries inside loops (avoid N+1 problem — use JOINs or batch queries instead)
+-  Always use `LIMIT` on list queries for performance
+
+---
+
+## Hooks & Extensions
+
+- Prioritize hooks over direct code overrides
+- Before creating a new hook, verify it does not already exist:
+  ```
+  grep -r "executeHooks" htdocs/ | grep 'hookName'
+  ```
+- Call hooks using the standard pattern:
+  ```php
+  $hookmanager->executeHooks('actionName', $parameters, $object, $action);
+  ```
+- Name hooks clearly and descriptively (e.g., `formObjectOptions`, `addMoreActionsButtons`)
+
+---
+
+## Internationalisation
+
+- Never hardcode user-facing strings — always use `$langs->trans('Key')`
+- Language files must be placed in `mymodule/langs/en_US/` (and other locales as needed)
+- All code comments and variables or functions names must be in English.
+- Language key names must use PascalCase (e.g., `MyModuleLabel`, not `monLibelléModule`)
+- Load the language file at the top of the page: `$langs->load('mymodule@mymodule')`
+
+---
+
+## Testing & Validation
+
+Before any modification, verify:
+- Creation / edition / deletion workflows
+- User rights enforcement (`$user->hasRights("module", "permission")` or `$user->hasRights("module", "objectname", "permission")`)
+- Multi-entity compatibility (add ` AND entity IN ('.getDolEntity("tablename").')`)
+
+If possible:
+- If doing an external module, add a PHPUnit test file in `yourmoduledir/test/phpunit/`
+- If modifying the Dolibarr code project, add a PHPUnit test file into `test/phpunit/` and add the entry into file `test/phpunit/AllTests.php`.
+
+
+---
+
+## UI / UX
+
+- Respect Dolibarr UI — no unsolicited redesigns
+- Reuse existing components (buttons, forms, tables) from `htdocs/core/tpl/`
+- No overly complex inline JS
+- Place JavaScript in separate files under `mymodule/js/`
+
+---
+
+## Security
+
+- Always validate user inputs (`GET`, `POST`) via `GETPOST()` with a type parameter
+- Prevent SQL injection (use `db->escape()` or cast into `(int)` or `(float)`)
+- Prevent XSS injection by escaping HTML output (use `dolPrintHTML()`, `dolPrintHTMLForAttribute()`)
+- Always include Dolibarr CSRF tokens in POST forms: `<input type="hidden" name="token" value="'.newToken().'">`
+
+---
+
+## Performance
+
+- Avoid SQL queries inside loops (N+1 problem)
+- Use JOINs or batch queries instead of multiple sequential queries
+- Apply `LIMIT` and proper indexes on list queries
+- Cache repeated calls to `getDolGlobalString()` or `$conf->global->` in local variables
+
+---
+
+## Logs & Debug
+
+- Use `dol_syslog()` for all logging (with appropriate log level: `LOG_DEBUG`, `LOG_WARNING`, `LOG_ERR`)
+- Do not leave `var_dump()`, `print_r()`, or `die()` in committed code
+- Use Dolibarr's `setEventMessages()` to display user-facing messages
+
+---
+
+## Git Workflow
+
+- Branch strategy:
+    - One branch per major version (bug fixes only)
+    - `develop` branch for both fixes and new features
+- Never commit directly to `main` or `develop` or any branch name matching regex `^\d+\.\d+$` but use a Pull Request.
+- Commit message format: `TYPE: #issueNumber Short description`
+    - Types: `NEW`, `FIX` or `CLOSE`
+    - Example: `FIX: #1234 Correct VAT calculation on credit notes`
+- Do not update the `ChangeLog` file (this file will be generated before the release from all commit titles)
+- Do not introduce new syntax or features unavailable in the branch's minimum PHP version
+- When committing, mention the AI agent name in the commit message (e.g. "Co-authored-by: AI Agent <ai-agent@dolibarr.org>")
+
+---
+
+## What the Agent MUST Do
+
+- Read this file before any modification
+- Check if an equivalent function already exists before writing new code
+- Minimize the impact of changes
+- Propose modular modifications that do not affect unrelated features
+
+---
+
+## What the Agent MUST NOT Do
+
+- Perform massive refactoring without an explicit request
+- Change the global architecture of existing modules
+- Delete dead code
+- Add external dependencies (Composer packages, JS libraries) without prior validation
+- Modify the `ChangeLog` file (this file is generated by the maintainer during the release process)
+
+---
+
+## Key Principle
+
+ Always prioritize:
+**extension > modification**
+
+---
+
+## In Case of Doubt
+
+- Keep it simple
+- Be conservative
+- Ask for confirmation before any critical or irreversible change


### PR DESCRIPTION
## Description

The `.agents/` agent-instruction files have drifted between `23.0` and `develop`. This PR makes them identical on both branches (backport direction: `develop` → `23.0`).

### Changes

- **Renamed test skill directories** to match `develop`:
  - `skill-doli-hurl-test/` → `skill-doli-test-hurl/`
  - `skill-doli-interactive-test/` → `skill-doli-test-interactive/`
  - `skill-doli-phpunit/` → `skill-doli-test-phpunit/`
- **Added** `.agents/skills/skill-doli-devmodule/SKILL.md` (present on `develop` only)
- **Wording updates** on `develop` pulled in: `.agents/AGENTS.md`, `.agents/skills/skill-doli-code-review/SKILL.md`, `.agents/skills/skill-doli-dev/SKILL.md`, and the three renamed skills
- **Added** `htdocs/modulebuilder/template/AGENTS.md` (present on `develop` only)

After this change, `git diff 23.0 develop -- .agents htdocs/modulebuilder/template/AGENTS.md` is empty.

Documentation only — no code, no runtime behaviour change.