### PR TITLE
FIX: PHPStan errors on develop (mailing require_admin covariance + PaymentVarious socid)

### DIFF
--- a/htdocs/compta/bank/various_payment/card.php
+++ b/htdocs/compta/bank/various_payment/card.php
@@ -660,7 +660,7 @@ if ($id) {
 				$morehtmlref .= '<input type="submit" class="button valignmiddle" value="'.$langs->trans("Modify").'">';
 				$morehtmlref .= '</form>';
 			} else {
-				$morehtmlref .= $form->form_project($_SERVER['PHP_SELF'].'?id='.$object->id, (property_exists($object, 'socid') ? $object->socid : 0), (string) $object->fk_project, ($action == 'classify' ? 'projectid' : 'none'), 0, 0, 0, 1, '', 'maxwidth300');
+				$morehtmlref .= $form->form_project($_SERVER['PHP_SELF'].'?id='.$object->id, (int) $object->socid, (string) $object->fk_project, ($action == 'classify' ? 'projectid' : 'none'), 0, 0, 0, 1, '', 'maxwidth300');
 			}
 		} else {
 			if (!empty($object->fk_project)) {

--- a/htdocs/core/modules/mailings/advthirdparties.modules.php
+++ b/htdocs/core/modules/mailings/advthirdparties.modules.php
@@ -38,7 +38,7 @@ class mailing_advthirdparties extends MailingTargets
 	public $desc = "Third parties";
 
 	/**
-	 * @var int
+	 * @var int<0,1>
 	 */
 	public $require_admin = 0;
 

--- a/htdocs/core/modules/mailings/eventorganization.modules.php
+++ b/htdocs/core/modules/mailings/eventorganization.modules.php
@@ -33,7 +33,7 @@ class mailing_eventorganization extends MailingTargets
 	public $desc = "Attendees of an organized event";
 
 	/**
-	 * @var int
+	 * @var int<0,1>
 	 */
 	public $require_admin = 0;
 

--- a/htdocs/core/modules/mailings/partnership.modules.php
+++ b/htdocs/core/modules/mailings/partnership.modules.php
@@ -39,7 +39,7 @@ class mailing_partnership extends MailingTargets
 	public $desc = "Thirdparties or members included into a partnership program";
 
 	/**
-	 * @var int
+	 * @var int<0,1>
 	 */
 	public $require_admin = 0;
 

--- a/htdocs/core/modules/mailings/pomme.modules.php
+++ b/htdocs/core/modules/mailings/pomme.modules.php
@@ -48,7 +48,7 @@ class mailing_pomme extends MailingTargets
 	public $require_module = array();
 
 	/**
-	 * @var int Module mailing actif pour user admin ou non
+	 * @var int<0,1> Module mailing actif pour user admin ou non
 	 */
 	public $require_admin = 1;
 

--- a/htdocs/core/modules/mailings/thirdparties_services_expired.modules.php
+++ b/htdocs/core/modules/mailings/thirdparties_services_expired.modules.php
@@ -35,7 +35,7 @@ class mailing_thirdparties_services_expired extends MailingTargets
 	public $desc = 'Third parties with expired contract\'s lines';
 
 	/**
-	 * @var int
+	 * @var int<0,1>
 	 */
 	public $require_admin = 0;
 


### PR DESCRIPTION
## Description

The full PHPStan run on `develop` is red with 6 errors, all introduced today:

### 1. `require_admin` property override not covariant (5×)

`MailingTargets::$require_admin` was narrowed to `@var int<0,1>`, but five mailing selectors still declared it as plain `@var int`:

```
PHPDoc type int of property mailing_advthirdparties::$require_admin is not covariant
with PHPDoc type int<0, 1> of overridden property MailingTargets::$require_admin.
```

- `advthirdparties.modules.php`
- `eventorganization.modules.php`
- `partnership.modules.php`
- `pomme.modules.php`
- `thirdparties_services_expired.modules.php`

Their PHPDoc is aligned with the parent (`int<0,1>`), exactly like the selectors that already pass (`xinputuser`, `xinputfile`, `contacts1`, `thirdparties`, `fraise`).

### 2. `PaymentVarious::$socid` makes a guard always true

`PaymentVarious` now declares a `$socid` property, so in `htdocs/compta/bank/various_payment/card.php`:

```
Call to function property_exists() with PaymentVarious and 'socid' will always evaluate to true.
```

```php
- (property_exists($object, 'socid') ? $object->socid : 0)
+ (int) $object->socid
```

`(int) null` is `0`, so the fallback is preserved.

## No functional change

PHPDoc-only for (1); (2) is an equivalent simplification.

## Test

Full PHPStan run (`phpstan analyse -a dev/build/phpstan/bootstrap_action.php`) is clean on the affected paths.