### PR TITLE
Fix phan on 24.0, drop an unreachable continue in the users API

### DIFF
--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -380,7 +380,6 @@ class Users extends DolibarrApi
 			if ($field == 'pass') {
 				if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'password')) {		// In creation, users is always a different user than the one who create it.
 					throw new RestException(403, 'You are not allowed to modify/set password of other users');
-					continue;
 				}
 				if (!DolibarrApiAccess::$user->admin) {		// Only admin can set a password and knowing it. Others can reset with correct rights user->self->password but without knowing it.
 					throw new RestException(403, 'As a non admin user, you are not allowed to set a password from this API. Use the /setPassword endpoint for this.');


### PR DESCRIPTION
The phan job currently fails on every PR opened against 24.0. The single reported violation is:

    htdocs/user/class/api_users.class.php:383
    PhanPluginUnreachableCode: Unreachable statement detected

The statement sits directly after a throw, so it can never execute:

    if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'password')) {
        throw new RestException(403, 'You are not allowed to modify/set password of other users');
        continue;      <- dead
    }

The file is not in dev/tools/phan/baseline.txt, and the job analyses the whole tree rather than the changed files, so it fails regardless of what a PR modifies.

Removing the dead line has no behavioural effect: the throw already leaves the loop iteration, and it was the only statement between the throw and the closing brace.

Checked it is the only instance of that pattern in the tree, a continue following a throw new RestException, so nothing else needs the same treatment.

Noticed while investigating the phan failures on #40189 and #40190, neither of which touches this file.