### PR TITLE
NEW Shipment PDF (espadon): show shipping method even without a tracking number

### DIFF
--- a/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
+++ b/htdocs/core/modules/expedition/doc/pdf_espadon.modules.php
@@ -345,7 +345,7 @@ class pdf_espadon extends ModelePdfExpedition
 					$notetoshow = dol_concatdesc($notetoshow, $extranote);
 				}
 
-				if (!empty($notetoshow) || !empty($object->tracking_number)) {
+				if (!empty($notetoshow) || !empty($object->tracking_number) || $object->shipping_method_id > 0) {
 					$tab_top -= 2;
 					$tab_topbeforetrackingnumber = $tab_top;
 					$height_trackingnumber = 0;
@@ -383,6 +383,14 @@ class pdf_espadon extends ModelePdfExpedition
 						if ($height_trackingnumber < 4) {
 							$height_trackingnumber = 4;
 						}
+					}
+
+					// Shipping method, even when no tracking number is set
+					if (empty($object->tracking_number) && $object->shipping_method_id > 0) {
+						$code = $outputlangs->getLabelFromKey($this->db, (string) $object->shipping_method_id, 'c_shipment_mode', 'rowid', 'code');
+						$pdf->SetFont('', 'B', $default_font_size - 2);
+						$pdf->writeHTMLCell(90, 4, $this->posxdesc - 1, $tab_top - 1, $outputlangs->trans("SendingMethod").": ".$outputlangs->trans("SendingMethod".strtoupper($code)), 0, 1, false, true, 'L');
+						$tab_top = $pdf->GetY();
 					}
 
 					// Notes


### PR DESCRIPTION
Fixes #40197

In the **espadon** shipment PDF template, the shipping method ("SendingMethod") is printed only inside the tracking-number block, and then only when a tracking URL is present. A shipment that has a shipping method set but no tracking number therefore never shows the shipping method on the PDF.

This adds the shipping method display when no tracking number is set (and a shipping method is defined), so it is shown in both cases.

Tested on 24.0.0 with a shipment using "Generic transport service" and no tracking number: before, the method was absent from the PDF; after, "Méthode d'expédition: Generic transport service" is shown above the lines table. No change when a tracking number/URL is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
