### PR TITLE
FIX: Resolve Phan static analysis errors in 3 files

### DIFF
--- a/htdocs/core/class/html.formcompany.class.php
+++ b/htdocs/core/class/html.formcompany.class.php
@@ -919,6 +919,8 @@ class FormCompany extends Form
 				}
 				if (count($newselected) > 0) {
 					$selected = $newselected;
+				} else {
+					$selected = array();
 				}
 			}
 			return $this->multiselectarray($htmlname, $contactType, $selected, 0, 0, $morecss, 0, '90%', '', '', $placeholder);

--- a/htdocs/core/class/utils_diff.class.php
+++ b/htdocs/core/class/utils_diff.class.php
@@ -154,7 +154,7 @@ class Diff
 	 * Returns the partial diff for the specified sequences, in reverse order.
 	 * The parameters are:
 	 *
-	 * @param	array<array{0:string,1:int<0,2>}>	$table     	the table returned by the computeTable function
+	 * @param	array<array<int>>	$table     	the table returned by the computeTable function
 	 * @param	string	$sequence1 	the first sequence
 	 * @param	string	$sequence2 	the second sequence
 	 * @param	int		$start     	the starting index

--- a/htdocs/core/db/mysqli.class.php
+++ b/htdocs/core/db/mysqli.class.php
@@ -35,7 +35,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/db/DoliDB.class.php';
  */
 class DoliDBMysqli extends DoliDB
 {
-	/** @var mysqli Database object */
+	/** @var false|mysqli Database object */
 	public $db;
 	//! Database type
 	public $type = 'mysqli';


### PR DESCRIPTION
## Summary

Fixes 3 Phan static analysis errors reported on `develop`:

| File | Line | Error | Fix |
|---|---|---|---|
| `htdocs/core/class/html.formcompany.class.php` | 924 | `Parameter #3 $selected of method Form::multiselectarray() expects array, array given` | Added `else { $selected = array(); }` so `$selected` is always a flat `string[]` when the `array<array{id:int}>`-to-flat-array conversion fails, matching `multiselectarray()`'s `@param string[] $selected` |
| `htdocs/core/class/utils_diff.class.php` | 71 | `Parameter #1 $table of static method Diff::generatePartialDiff() expects array, array given` | Corrected `@param` from `array<array{0:string,1:int<0,2>}>` to `array<array<int>>` to match the actual return type of `computeTable()` |
| `htdocs/core/db/mysqli.class.php` | 106 | `Property DoliDBMysqli::$db (mysqli) in empty() is not falsy` | Updated `@var` from `mysqli` to `false|mysqli` since `connect()` can return `false` |

## Changes

- **html.formcompany.class.php**: Added `else` branch to reset `$selected` to `array()` when the conversion loop breaks early, guaranteeing a flat array is passed to `multiselectarray()`.
- **utils_diff.class.php**: Fixed the `@param` annotation of `generatePartialDiff()` — `$table` is an LCS length table (`array<array<int>>`), not an array of diff entries.
- **mysqli.class.php**: Fixed the `@var` annotation of `$db` property to include `false`, making `empty($this->db)` a valid check for Phan.

## Testing

All three files pass `php -l` syntax validation.