### PR TITLE
Fix #40182: replenishment can create a purchase order for the wrong s…

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -170,9 +170,16 @@ if ($action == 'order' && GETPOST('valid')) {
 				$supplierpriceid = GETPOSTINT('fourn'.$i);
 				//get all the parameters needed to create a line
 				$qty = GETPOSTINT('tobuy'.$i);
-				$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);
+				// Pass fk_soc = $fk_supplier so that, if the exact price tier (id $supplierpriceid) does not match
+				// the requested qty (fallback search in get_buyprice()), the fallback stays restricted to the
+				// supplier selected in the replenishment filter instead of matching any product/supplier in base.
+				$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty, 0, 'none', $fk_supplier);
 				$res = $productsupplier->fetch($idprod);
-				if ($res && $idprod > 0) {
+				if ($res && $idprod > 0 && $fk_supplier > 0 && (int) $productsupplier->fourn_socid !== (int) $fk_supplier) {
+					// Safety net: never let a line be attached to a supplier different from the one filtered on.
+					dol_syslog("replenish.php: get_buyprice returned fk_soc=".$productsupplier->fourn_socid." for fk_product=".$idprod." instead of expected fk_supplier=".$fk_supplier." (line $i, product_fournisseur_price id $supplierpriceid, qty $qty)", LOG_WARNING);
+					$errorQty++;
+				} elseif ($res && $idprod > 0) {
 					if ($qty) {
 						//might need some value checks
 						$line = new CommandeFournisseurLigne($db);


### PR DESCRIPTION
…upplier

product/stock/replenish.php called Product::get_buyprice() with only $prodfournprice and $qty, omitting $product_id and $fk_soc. When the requested quantity is below the minimum order quantity of the selected price tier, get_buyprice()'s fallback search becomes unconstrained (no product nor supplier filter) and can return a price row belonging to a completely different product and supplier than the one selected in the replenishment filter, silently creating an extra draft purchase order for that unrelated supplier.

Pass the filtered supplier ($fk_supplier) to get_buyprice() so the fallback search stays scoped to it, and add a safety check that rejects (instead of silently accepting) any line whose resolved supplier does not match the filter.

Fixes #40182

# Instructions
*This is a template to help you make good pull requests. You may use [Github Markdown](https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github/) syntax to format your issue report.*
*Please:*
- *only keep the "FIX", "CLOSE", "NEW", "UIUX", PERF" or "QUAL" section* (use uppercase to have the PR appears into the ChangeLog, lowercase will not appears)
- *follow the project [contributing guidelines](/.github/CONTRIBUTING.md)*
- ***in particular, in case of a bugfix, please check that you are targetting the branch corresponding to the oldest version in which the bug occurs***
- *replace the bracket enclosed texts with meaningful information*


# FIX|Fix #[*issue_number Short description*]
[*Long description*]


# CLOSE|Close #[*issue_number Short description*]
[*Long description*]


# NEW|New [*Short description*]
[*Long description*]


# UIUX|Uiux [*Short description*]
[*Long description*]


# PERF|Perf #[*issue_number Short description*]
[*Long description*]


# QUAL|Qual #[*issue_number Short description*]
[*Long description*]

