### PR TITLE
Fix #40182: replenishment can create a purchase order for the wrong supplier

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -170,9 +170,16 @@ if ($action == 'order' && GETPOST('valid')) {
 				$supplierpriceid = GETPOSTINT('fourn'.$i);
 				//get all the parameters needed to create a line
 				$qty = GETPOSTINT('tobuy'.$i);
-				$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);
+				// Pass fk_soc = $fk_supplier so that, if the exact price tier (id $supplierpriceid) does not match
+				// the requested qty (fallback search in get_buyprice()), the fallback stays restricted to the
+				// supplier selected in the replenishment filter instead of matching any product/supplier in base.
+				$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty, 0, 'none', $fk_supplier);
 				$res = $productsupplier->fetch($idprod);
-				if ($res && $idprod > 0) {
+				if ($res && $idprod > 0 && $fk_supplier > 0 && (int) $productsupplier->fourn_socid !== (int) $fk_supplier) {
+					// Safety net: never let a line be attached to a supplier different from the one filtered on.
+					dol_syslog("replenish.php: get_buyprice returned fk_soc=".$productsupplier->fourn_socid." for fk_product=".$idprod." instead of expected fk_supplier=".$fk_supplier." (line $i, product_fournisseur_price id $supplierpriceid, qty $qty)", LOG_WARNING);
+					$errorQty++;
+				} elseif ($res && $idprod > 0) {
 					if ($qty) {
 						//might need some value checks
 						$line = new CommandeFournisseurLigne($db);

--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -177,7 +177,7 @@ if ($action == 'order' && GETPOST('valid')) {
 				$res = $productsupplier->fetch($idprod);
 				if ($res && $idprod > 0 && $fk_supplier > 0 && (int) $productsupplier->fourn_socid !== (int) $fk_supplier) {
 					// Safety net: never let a line be attached to a supplier different from the one filtered on.
-					dol_syslog("replenish.php: get_buyprice returned fk_soc=".$productsupplier->fourn_socid." for fk_product=".$idprod." instead of expected fk_supplier=".$fk_supplier." (line $i, product_fournisseur_price id $supplierpriceid, qty $qty)", LOG_WARNING);
+					dol_syslog("replenish.php: get_buyprice returned fourn_socid=".$productsupplier->fourn_socid." for fk_product=".$idprod." instead of expected fk_supplier=".$fk_supplier." (line $i, product_fournisseur_price id $supplierpriceid, qty $qty)", LOG_WARNING);
 					$errorQty++;
 				} elseif ($res && $idprod > 0) {
 					if ($qty) {


### PR DESCRIPTION
## Bug

Fixes #40182

(Supersedes #40183, which was opened from a branch accidentally based on a corrupted local copy of 20.0 mixed with develop history, producing a huge unrelated diff. This PR is built from the correct, current upstream `20.0`.)

When using the stock replenishment screen (`product/stock/replenish.php`) filtered on a specific supplier
(`fk_supplier`), validating the order can silently create an **extra draft purchase order for a completely
different, unrelated supplier**, containing a product that was never part of the filtered/displayed list.

## Root cause

`product/stock/replenish.php` calls:

```php
$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);
```

`Product::get_buyprice($prodfournprice, $qty, $product_id = 0, $fourn_ref = '', $fk_soc = 0)` first tries an
exact lookup by the submitted `product_fournisseur_price.rowid`, restricted to `pfp.quantity <= $qty`. If the
price tier's minimum order quantity (MOQ) is greater than the quantity being ordered, this lookup returns
nothing and the function falls back to a second, much looser search:

```php
$sql = "SELECT ... FROM llx_product_fournisseur_price as pfp WHERE 1 = 1";
if ($product_id > 0) { $sql .= " AND pfp.fk_product = ".((int) $product_id); }
if ($fourn_ref != 'none') { $sql .= " AND pfp.ref_fourn = '".$this->db->escape($fourn_ref)."'"; }
if ($fk_soc > 0) { $sql .= " AND pfp.fk_soc = ".((int) $fk_soc); }
if ($qty > 0) { $sql .= " AND pfp.quantity <= ".((float) $qty); }
$sql .= " ORDER BY pfp.quantity DESC LIMIT 1";
```

Because `replenish.php` calls `get_buyprice()` with only 2 arguments, `$product_id` and `$fk_soc` stay at `0`
(no filtering), so this fallback can match a price row belonging to **any product from any supplier** in the
database, unrelated to what the user actually selected. `replenish.php` then groups order lines strictly by
`$productsupplier->fourn_socid` with no check against the filtered supplier, so a foreign supplier match
silently creates a new draft purchase order.

Every other call site of `get_buyprice()` in core correctly passes `$product_id`, `'none'` and `$fk_soc`
(e.g. `fourn/class/fournisseur.commande.class.php`, `fourn/class/fournisseur.facture.class.php`,
`supplier_proposal/class/supplier_proposal.class.php`, `fourn/commande/card.php`). `replenish.php` was the
only core caller omitting them.

## Fix

- Pass the currently filtered supplier (`$fk_supplier`) and `'none'` for `$fourn_ref` to `get_buyprice()`, so
  the fallback search stays scoped to that supplier, consistent with the rest of the codebase.
- Add a safety check that rejects (increments `$errorQty`, same as the existing "quantity too low" case)
  instead of silently accepting any line whose resolved supplier does not match the filter.

## Testing

- `php -l` passes on the modified file.
- Manual code review against all other `get_buyprice()` call sites in core for consistency.