### PR TITLE
FIX PHP warning on undefined property when showing the currency rate in lists

### DIFF
--- a/htdocs/commande/list_det.php
+++ b/htdocs/commande/list_det.php
@@ -1911,7 +1911,7 @@ if ($resql) {
 		// Currency rate
 		if (!empty($arrayfields['c.multicurrency_tx']['checked'])) {
 			print '<td class="nowrap">';
-			$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$obj->rowid, $obj->multicurrency_tx, 'none', $obj->multicurrency_code);
+			$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$obj->c_rowid, $obj->multicurrency_tx, 'none', $obj->multicurrency_code);
 			print "</td>\n";
 			if (!$i) {
 				$totalarray['nbfield']++;

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -2805,7 +2805,7 @@ if ($num > 0) {
 			// Currency rate
 			if (!empty($arrayfields['f.multicurrency_tx']['checked'])) {
 				print '<td class="nowraponall">';
-				$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$obj->rowid, $obj->multicurrency_tx, 'none', $obj->multicurrency_code);
+				$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$obj->id, $obj->multicurrency_tx, 'none', $obj->multicurrency_code);
 				print "</td>\n";
 				if (!$i) {
 					$totalarray['nbfield']++;

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -1988,7 +1988,7 @@ while ($i < $imaxinloop) {
 		// Currency rate
 		if (!empty($arrayfields['f.multicurrency_tx']['checked'])) {
 			print '<td class="nowrap">';
-			$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$obj->rowid, $obj->multicurrency_tx, 'none', $obj->multicurrency_code);
+			$form->form_multicurrency_rate($_SERVER['PHP_SELF'].'?id='.$obj->facid, $obj->multicurrency_tx, 'none', $obj->multicurrency_code);
 			print "</td>\n";
 			if (!$i) {
 				$totalarray['nbfield']++;


### PR DESCRIPTION
# FIX PHP warning on undefined property when showing the currency rate in lists

Displaying the currency rate column raises "Undefined property: stdClass::$rowid" on the customer invoice list, the supplier invoice list and the order detail list. Those three queries give the identifier an alias, so the property read when building the link does not exist in the result set.

The other lists offering that column select their identifier without an alias, so they are not affected and are left untouched.

The link built here is never used, since the field is displayed read only, so the visible effect is limited to the warning itself and the noise it leaves in the logs.

Targeting 22.0. The same code is present at least from 21.0 up to develop.
