### PR TITLE
NEW Show a total per currency at the bottom of the list of bank entries

### DIFF
--- a/htdocs/compta/bank/bankentries_list.php
+++ b/htdocs/compta/bank/bankentries_list.php
@@ -581,7 +581,7 @@ if ($id > 0 || !empty($ref)) {
 	print dol_get_fiche_end();
 }
 
-$sql = "SELECT b.rowid, b.dateo as do, b.datev as dv, b.amount, b.label, b.rappro as conciliated, b.num_releve, b.num_chq,";
+$sql = "SELECT b.rowid, b.dateo as do, b.datev as dv, b.amount, b.amount_main_currency, b.label, b.rappro as conciliated, b.num_releve, b.num_chq,";
 $sql .= " b.fk_account, b.fk_type, b.fk_bordereau,";
 $sql .= " ba.rowid as bankid, ba.ref as bankref";
 // Add fields from extrafields
@@ -1785,12 +1785,19 @@ if ($resql) {
 			}
 		}
 
+		$currencykey = $bankaccount->currency_code;
+		if (!isset($totalarray['totalpercurrency'][$currencykey])) {
+			$totalarray['totalpercurrency'][$currencykey] = array('deb' => 0, 'cred' => 0);
+		}
+		$amountmaincurrency = empty($objp->amount_main_currency) ? $objp->amount : $objp->amount_main_currency;
+
 		// Debit
 		if (!empty($arrayfields['b.debit']['checked'])) {
 			print '<td class="nowraponall right"><span class="amount">';
 			if ($objp->amount < 0) {
 				print price($objp->amount * -1);
-				$totalarray['totaldeb'] += $objp->amount;
+				$totalarray['totaldeb'] += $amountmaincurrency;
+				$totalarray['totalpercurrency'][$currencykey]['deb'] += $objp->amount;
 			}
 			print "</span></td>\n";
 			if (!$i) {
@@ -1806,7 +1813,8 @@ if ($resql) {
 			print '<td class="nowraponall right"><span class="amount">';
 			if ($objp->amount > 0) {
 				print price($objp->amount);
-				$totalarray['totalcred'] += $objp->amount;
+				$totalarray['totalcred'] += $amountmaincurrency;
+				$totalarray['totalpercurrency'][$currencykey]['cred'] += $objp->amount;
 			}
 			print "</span></td>\n";
 			if (!$i) {
@@ -1969,6 +1977,27 @@ if ($resql) {
 			}
 		}
 		print '</tr>';
+
+		// Show one line per currency when the list holds accounts in several currencies
+		if (count($totalarray['totalpercurrency']) > 1) {
+			foreach ($totalarray['totalpercurrency'] as $currencycode => $totalpercurrency) {
+				print '<tr class="liste_total">';
+				$i = 0;
+				while ($i < $totalarray['nbfield']) {
+					$i++;
+					if ($i == 1) {
+						print '<td class="left">'.$langs->trans("Total").' '.dol_escape_htmltag($currencycode).'</td>';
+					} elseif (isset($totalarray['totaldebfield']) && $totalarray['totaldebfield'] == $i) {
+						print '<td class="right"><span class="amount">'.price(-1 * $totalpercurrency['deb']).'</span></td>';
+					} elseif (isset($totalarray['totalcredfield']) && $totalarray['totalcredfield'] == $i) {
+						print '<td class="right"><span class="amount">'.price($totalpercurrency['cred']).'</span></td>';
+					} else {
+						print '<td></td>';
+					}
+				}
+				print '</tr>';
+			}
+		}
 	}
 
 	// If no record found


### PR DESCRIPTION
# NEW Show a total per currency at the bottom of the list of bank entries

When the list of bank entries spans several accounts, the totals at the bottom add up amounts held in different currencies, since the amount of an entry is stored in the currency of its account. The figure that comes out corresponds to nothing, and nothing on screen says so.

Two things change, and they follow what is already done elsewhere.

The existing total now follows the currency of the company. Where an entry was recorded on an account in another currency, the conversion stored alongside it is used instead of the raw amount, which is the same rule the bank journal already applies. That conversion is only ever set when the currencies differ, so on an install where every account is in the currency of the company nothing is read differently and the total is unchanged.

A line per currency is then added underneath, holding the amounts as they stand in their own currency. Those lines appear only when the listed entries come from accounts in more than one currency.

The result reads like the totals of the invoice lists: the plain "Total" is the currency of the company, the named ones are the currencies of the accounts.

Companion of #40210, which adds the currency column to the same list. The two are independent and can be merged in any order.
