### PR TITLE
Fix #40004 make Microsoft Exchange OAuth prompt configurable (default select_account)

### DIFF
--- a/htdocs/core/modules/oauth/microsoft3_oauthcallback.php
+++ b/htdocs/core/modules/oauth/microsoft3_oauthcallback.php
@@ -191,7 +191,15 @@ if (GETPOST('code') || GETPOST('error')) {     // We are coming from oauth provi
 
 	// This may create record into oauth_state before the header redirect.
 	// Creation of record with state in this tables depend on the Provider used (see its constructor).
-	$params = array('prompt' => 'consent');
+	// Default prompt is 'select_account': it avoids the admin-consent infinite loop on Entra tenants
+	// where user consent is disabled, while offline_access (already requested) still returns a refresh
+	// token. Set OAUTH_MICROSOFT3_FORCE_PROMPT to 'consent' to force the consent screen, or to '' to
+	// omit the prompt parameter entirely.
+	$params = array();
+	$promptforauth = getDolGlobalString('OAUTH_MICROSOFT3_FORCE_PROMPT', 'select_account');
+	if ($promptforauth) {
+		$params['prompt'] = $promptforauth;
+	}
 	if ($state) {
 		$params['state'] = $state;
 	}


### PR DESCRIPTION
## Summary

The Microsoft Exchange Online (SMTP/IMAP) OAuth callback hard-coded `prompt=consent` in the authorization URL (`htdocs/core/modules/oauth/microsoft3_oauthcallback.php`).

On Entra tenants where *user consent for applications* is disabled (a common hardening baseline), this makes the token flow impossible to complete with a non-privileged account:

- Microsoft returns an "Approval required" screen instead of a consent button.
- Even after an admin approves the consent request, Dolibarr keeps sending `prompt=consent` on the next attempt, so the screen is shown again — an infinite loop.
- The only way to obtain a token is to run the flow with an account that can consent (an admin), which then stores a **privileged account's long-lived refresh token** in `llx_oauth_token`, instead of the intended dedicated, unprivileged mailbox token.

## Changes

- `htdocs/core/modules/oauth/microsoft3_oauthcallback.php`: the prompt is no longer hard-coded. It defaults to `select_account` and is configurable via a new constant `OAUTH_MICROSOFT3_FORCE_PROMPT`:
  - default `select_account` — completes when scopes are already covered by an existing (admin) consent grant, and forces the account chooser (avoids issuing the token under the wrong signed-in account);
  - set to `consent` to restore the previous behaviour;
  - set to empty to omit the `prompt` parameter entirely.

`offline_access` is already requested explicitly, so a refresh token is still returned without `prompt=consent`. First-time setups are unaffected: Entra still shows the consent screen when consent has not yet been granted.

This mirrors the existing configurable-prompt pattern used by the Google OAuth callback (`OAUTH_GOOGLE_FORCE_PROMPT_ON_LOGIN`).

## Test

The `select_account` value is the workaround verified by the reporter on 23.0.2 (returns a valid token with a non-null refresh token).

1. On an Entra tenant with user consent disabled and admin consent granted for `offline_access` + `SMTP.Send`, configure a `Microsoft Exchange Online [SMTP/IMAP]` OAuth service.
2. Token manager → "Get token", sign in with a standard (non-admin) account → the token is issued without the consent loop.
3. Set `OAUTH_MICROSOFT3_FORCE_PROMPT = consent` → previous behaviour is restored.

Fixes #40004
