### PR TITLE
FIX Rang of lines in contracts

### DIFF
--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -300,6 +300,7 @@ if (empty($reshook)) {
 
 						$fk_parent_line = 0;
 						$num = count($lines);
+						$rang = 1;
 
 						for ($i = 0; $i < $num; $i++) {
 							$product_type = ($lines[$i]->product_type ? $lines[$i]->product_type : 0);
@@ -369,7 +370,7 @@ if (empty($reshook)) {
 									$lines[$i]->pa_ht,
 									$array_options,
 									$lines[$i]->fk_unit,
-									$num+1
+									$rang++
 								);
 
 								if ($result < 0) {

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -1887,6 +1887,18 @@ class Contrat extends CommonObject
 				}
 			}
 
+			if (!$error) {
+				// Renumber remaining lines so rang stays a contiguous 1..N sequence.
+				// Without this, a deleted line leaves a permanent gap that breaks
+				// the up/down swap logic (updateLineUp/updateLineDown) for any pair
+				// of lines that no longer sit at an exact rang+/-1 from each other.
+				$result = $this->line_order(true, 'ASC', false);
+				if ($result < 0) {
+					$error++;
+					$this->error = "Error ".get_class($this)."::deleteline line_order error";
+				}
+			}
+
 			if (empty($error)) {
 				$this->db->commit();
 				return 1;


### PR DESCRIPTION
# FIX Order of lines in a contract

Bug : in some cases, you can't reorder lines of a contract.

Seen from **DLB 18.0 up to develop.**

To reproduce : 

- create a contract
- add 3 lines
- delete the middle line
- click "down" on the first line : **no change. Bug**
- click "down" again on the first line : this time the line goes down.

This is due to the `rang` of line  :

- add 3 lines (rang of lines => 1,2,3)
- delete the middle line (rang of lines => 1,3)
- click "down" on the first line : no change (rang of lines => 2,3 : the order does not change)
- click "down" again on the first line : this time the line goes down. (rang of lines => 3,2)

The fix recomputes the rang of lines each time a line is deleted.


