### PR TITLE
Fix #40153 re-encrypt a BLOCKEDLOG_HMAC_KEY left in clear by an old migration

### DIFF
--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -5789,6 +5789,20 @@ function migrate_blockedlog_add_hmac_key()
 		}
 
 		print $langs->trans('Done');
+	} elseif (!preg_match('/^(dolcrypt|dolobfuscation)/', $hmac_encoded_secret_key)) {
+		// The value is stored in clear, without any prefix. This happens on instances migrated from a
+		// version that stored it unencrypted. dolDecrypt() returns such a value unchanged, so the test
+		// below used to pass and the value was left in clear, which then breaks getClearHMACSecretKey().
+		// Store the same key again so it gets encrypted, without changing the key itself.
+		$result = dolibarr_set_const($db, 'BLOCKEDLOG_HMAC_KEY', $hmac_encoded_secret_key, 'chaine', 0, 'The secret key for HMAC used for blockedlog record', $conf->entity);
+		if ($result < 0) {
+			dol_print_error($db);
+			$db->rollback();
+
+			print '</td></tr>';
+			return -1;
+		}
+		print $langs->trans('Done')." (BLOCKEDLOG_HMAC_KEY was stored in clear, it has been encrypted)\n";
 	} else {
 		// Decode the HMAC key
 		$hmac_secret_key = dolDecrypt($hmac_encoded_secret_key);


### PR DESCRIPTION
Reported on #40153 after an in-place v19 to v24 upgrade: invoice validation fails with

    getClearHMACSecretKey Error: Failed to decode the crypted value of the parameter BLOCKEDLOG_HMAC_KEY

with the SIREN, $dolibarr_main_instance_unique_id and network access all verified unchanged by the reporter.

The stored value turned out to be a bare BLOCKEDLOGHMAC234f1..., with no dolcrypt or dolobfuscation prefix. getClearHMACSecretKey() branches on that prefix (blockedlog.class.php:2032 and :2040), so with neither present $hmac_secret_key is never assigned and the exception is thrown.

The migration should have re-encrypted it, and silently did not (install/upgrade2.php:5794):

    $hmac_secret_key = dolDecrypt($hmac_encoded_secret_key);
    if (! preg_match('/^BLOCKEDLOGHMAC/', $hmac_secret_key)) {

dolDecrypt() returns a value unchanged when it carries no known prefix, so a clear key decodes to itself, passes the BLOCKEDLOGHMAC test, and the migration prints NothingToDo. Verified:

    stored (clear)   BLOCKEDLOGHMAC234f1...
    after dolDecrypt BLOCKEDLOGHMAC234f1...   unchanged
    passes check     yes

This adds a branch that detects the missing prefix and stores the same value again through dolibarr_set_const(), which encrypts any constant whose name ends in _KEY (admin.lib.php:50-55). Verified with an instance key set:

    input      BLOCKEDLOGHMAC234f1abcdef
    stored     dolcrypt:AES-256-CTR:7dc39997bfa2e...
    round trip BLOCKEDLOGHMAC234f1abcdef      key preserved

The key value is unchanged, only its storage, so past blockedlog signatures remain valid. That matters: replacing the key would invalidate every existing record, which the module explicitly warns about.

Branch routing after the change:

    empty value                   creates a new key, unchanged behaviour
    clear value                   NEW, re-stored encrypted
    dolcrypt: prefix              decode and verify, unchanged
    dolobfuscation: prefix        decode and verify, unchanged

so no already-encrypted value goes through the new path.

Reported by @The-Guims in #40153.