### PR TITLE
Fix #40009 return HTTP 400 instead of a technical error page on missing fulltag

### DIFF
--- a/htdocs/public/payment/paymentko.php
+++ b/htdocs/public/payment/paymentko.php
@@ -110,7 +110,12 @@ if (preg_match('/PM=([^\.]+)/', $FULLTAG, $reg)) {
 	$paymentmethod = $reg[1];
 }
 if (empty($paymentmethod)) {
-	dol_print_error(null, 'The back url does not contain a parameter fulltag that should help us to find the payment method used');
+	// Missing/invalid fulltag is a malformed client request, not a server failure: answer 400
+	// with a plain message instead of dol_print_error (which implies an internal error and
+	// returns a misleading 202 status).
+	dol_syslog("***** paymentko.php was called with a non valid parameter FULLTAG=".$FULLTAG, LOG_WARNING, 0, '_payment');
+	http_response_code(400);
+	print 'Bad request: the back url does not contain a valid fulltag parameter, required to find the payment method used.';
 	exit;
 } else {
 	dol_syslog("paymentko.php: paymentmethod=".$paymentmethod, LOG_DEBUG, 0, '_payment');

--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -123,8 +123,12 @@ if (preg_match('/PM=([^\.]+)/', $FULLTAG, $reg)) {
 	$paymentmethod = $reg[1];
 }
 if (empty($paymentmethod)) {
-	dol_syslog("***** paymentok.php was called with a non valid parameter FULLTAG=".$FULLTAG, LOG_DEBUG, 0, '_payment');
-	dol_print_error(null, 'The callback url does not contain a parameter fulltag that should help us to find the payment method used');
+	// Missing/invalid fulltag is a malformed client request, not a server failure: answer 400
+	// with a plain message instead of dol_print_error (which implies an internal error and
+	// returns a misleading 202 status).
+	dol_syslog("***** paymentok.php was called with a non valid parameter FULLTAG=".$FULLTAG, LOG_WARNING, 0, '_payment');
+	http_response_code(400);
+	print 'Bad request: the callback url does not contain a valid fulltag parameter, required to find the payment method used.';
 	exit;
 }
 


### PR DESCRIPTION
## Summary

When `htdocs/public/payment/paymentok.php` (the online payment return page) is reached with a missing or malformed `fulltag` parameter, the payment method cannot be resolved (`PM=` is not found in the tag). The code then called `dol_print_error()`, which:

- renders the generic **"Dolibarr has detected a technical error"** page — alarming for a customer who has just paid, and misleading because nothing failed on the server;
- leaves the response status at **HTTP 202 (Accepted)**, so the request looks successful to browsers and monitoring, even though it is in fact a bad request that produced no result.

## Changes

A missing/invalid `fulltag` is a malformed client request, not a server failure. In both `paymentok.php` and its sibling `paymentko.php` (same pattern), when no payment method can be extracted:

- log a warning (`LOG_WARNING`) with the offending `FULLTAG`;
- send **HTTP 400 Bad Request** via `http_response_code(400)`;
- print a short, plain message instead of the internal-error page.

## Notes

- The HTTP status was chosen as `400` (malformed request). `422` was considered but `400` is the more standard fit for a required parameter that is missing/unparseable — happy to switch if maintainers prefer `422`.
- Behaviour of valid payment returns is unchanged; only the missing-`fulltag` error path is affected.

Fixes #40009
