### PR TITLE
NEW: Add conf param dolibarr_main_limit_sessions_per_user

### DIFF
--- a/htdocs/conf/conf.php.example
+++ b/htdocs/conf/conf.php.example
@@ -506,6 +506,16 @@ $dolibarr_cron_allow_cli='0';
 // Examples:
 // $dolibarr_main_limit_users='0';
 
+// dolibarr_main_limit_sessions_per_user
+// ====================================
+// Can set a limit on the number of concurrent sessions per user. Only effective when
+// sessions are stored in database ($php_session_save_handler='db'). When a user opens a
+// new session above this limit, its oldest sessions are removed, which logs those other
+// browsers out on their next request. Set it to 1 to allow a single session per user.
+// Default value: 0 (unlimited)
+// Examples:
+// $dolibarr_main_limit_sessions_per_user='0';
+
 // dolibarr_strict_mode
 // ====================
 // Set this to 1 to enable the PHP strict mode. For dev environment only.

--- a/htdocs/core/lib/admin.lib.php
+++ b/htdocs/core/lib/admin.lib.php
@@ -224,7 +224,7 @@ function run_sql($sqlfile, $silent = 1, $entity = 0, $usesavepoint = 1, $handler
 								$qualified = 0;
 							}
 						} else { // This is a test on a constant. For example when we have -- VMYSQLUTF8UNICODE, we test constant $conf->global->UTF8UNICODE
-							$dbcollation = strtoupper(preg_replace('/_/', '', $conf->db->dolibarr_main_db_collation));
+							$dbcollation = strtoupper(preg_replace('/_/', '', (string) $conf->db->dolibarr_main_db_collation));
 							if (empty($conf->db->dolibarr_main_db_collation) || ($reg[2] != $dbcollation)) {
 								$qualified = 0;
 							}

--- a/htdocs/core/lib/phpsessionindb.lib.php
+++ b/htdocs/core/lib/phpsessionindb.lib.php
@@ -276,6 +276,74 @@ function dolSessionGC($max_lifetime)
 	}
 }
 
+/**
+ * Enforce a maximum number of concurrent database sessions for a given user.
+ *
+ * Called when a new authenticated session is being established. The existing rows
+ * of that user in llx_session are kept only for the ($keepcount - 1) most recently
+ * accessed ones, so that adding the session being established brings the total back
+ * to $keepcount. The other (older) sessions are deleted, which logs those browsers
+ * out on their next request (dolSessionRead() then finds no row).
+ *
+ * @param	int		$fk_user			Id of the user that just logged in
+ * @param	int		$keepcount			Max number of concurrent sessions for this user (<= 0 disables the feature)
+ * @param	string	$currentsessionid	Id of the session being established (never deleted)
+ * @return	int							Number of sessions that were evicted
+ */
+function dolSessionsLimitForUser($fk_user, $keepcount, $currentsessionid)
+{
+	global $dbsession;
+
+	$fk_user = (int) $fk_user;
+	$keepcount = (int) $keepcount;
+	if ($fk_user <= 0 || $keepcount <= 0) {
+		return 0;
+	}
+
+	// List the other sessions of this user, most recently accessed first.
+	$sql = "SELECT session_id FROM ".MAIN_DB_PREFIX."session";
+	$sql .= " WHERE fk_user = ".((int) $fk_user);
+	$sql .= " AND session_id <> '".$dbsession->escape($currentsessionid)."'";
+	$sql .= " ORDER BY last_accessed DESC, session_id DESC";
+
+	$resql = $dbsession->query($sql);
+	if (!$resql) {
+		dol_syslog("dolSessionsLimitForUser failed to list sessions: ".$dbsession->lasterror(), LOG_WARNING);
+		return 0;
+	}
+
+	$idstodelete = array();
+	$rank = 0;
+	while ($obj = $dbsession->fetch_object($resql)) {
+		$rank++;
+		if ($rank >= $keepcount) {	// Keep the ($keepcount - 1) most recent ones, evict the rest
+			$idstodelete[] = $obj->session_id;
+		}
+	}
+
+	if (empty($idstodelete)) {
+		return 0;
+	}
+
+	$sqldel = "DELETE FROM ".MAIN_DB_PREFIX."session WHERE session_id IN (";
+	$i = 0;
+	foreach ($idstodelete as $idtodelete) {
+		$sqldel .= ($i > 0 ? ", " : "")."'".$dbsession->escape($idtodelete)."'";
+		$i++;
+	}
+	$sqldel .= ")";
+
+	$resqldel = $dbsession->query($sqldel);
+	if (!$resqldel) {
+		dol_syslog("dolSessionsLimitForUser failed to purge sessions: ".$dbsession->lasterror(), LOG_WARNING);
+		return 0;
+	}
+
+	dol_syslog("dolSessionsLimitForUser evicted ".count($idstodelete)." session(s) for fk_user=".$fk_user." to enforce a limit of ".$keepcount, LOG_NOTICE);
+
+	return count($idstodelete);
+}
+
 // Call to register user call back functions.
 session_set_save_handler("dolSessionOpen", "dolSessionClose", "dolSessionRead", "dolSessionWrite", "dolSessionDestroy", "dolSessionGC"); // @phpstan-ignore-line
 

--- a/htdocs/filefunc.inc.php
+++ b/htdocs/filefunc.inc.php
@@ -10,7 +10,7 @@
  * Copyright (C) 2010      Juanjo Menent        <jmenent@2byte.es>
  * Copyright (C) 2015      Bahfir Abbes         <bafbes@gmail.com>
  * Copyright (C) 2024-2026	MDW					<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024      Frédéric France      <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France      <frederic.france@free.fr>
  * Copyright (C) 2026      Nathan Pixodeo       <nathan@pixodeo.net>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -159,6 +159,7 @@ $result = @include_once $conffile; // Keep @ because with some error reporting m
  * @var ?string $dolibarr_main_dolcrypt_key
  * @var ?string $dolibarr_main_force_https
  * @var ?string $dolibarr_main_limit_users
+ * @var ?string $dolibarr_main_limit_sessions_per_user
  * @var ?string $dolibarr_mailing_limit_sendbyweb
  * @var ?string $dolibarr_mailing_limit_sendbycli
  * @var ?string $dolibarr_mailing_limit_sendbyday
@@ -285,6 +286,9 @@ if (empty($dolibarr_main_db_cryptkey)) {
 }
 if (empty($dolibarr_main_limit_users)) {
 	$dolibarr_main_limit_users = 0;
+}
+if (empty($dolibarr_main_limit_sessions_per_user)) {
+	$dolibarr_main_limit_sessions_per_user = 0;
 }
 if (empty($dolibarr_mailing_limit_sendbyweb)) {
 	$dolibarr_mailing_limit_sendbyweb = 0;

--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1126,6 +1126,12 @@ if (!defined('NOLOGIN')) {
 
 		dol_syslog("This is a new started user session. _SESSION['dol_login']=".$_SESSION["dol_login"]." Session id=".session_id());
 
+		// Enforce the max number of concurrent sessions per user (only when sessions are stored in database).
+		// Opening this new session evicts the user's oldest sessions above the limit, logging those browsers out.
+		if (!empty($php_session_save_handler) && $php_session_save_handler == 'db' && !empty($conf->file->main_limit_sessions_per_user) && (int) $conf->file->main_limit_sessions_per_user > 0) {
+			dolSessionsLimitForUser($user->id, (int) $conf->file->main_limit_sessions_per_user, session_id());
+		}
+
 		$db->begin();
 
 		$user->update_last_login_date();

--- a/htdocs/master.inc.php
+++ b/htdocs/master.inc.php
@@ -51,6 +51,7 @@ require_once 'filefunc.inc.php';
  * @var string $dolibarr_main_db_cryptkey
  * @var string $dolibarr_main_document_root_alt
  * @var string $dolibarr_main_limit_users
+ * @var string $dolibarr_main_limit_sessions_per_user
  * @var string $dolibarr_mailing_limit_sendbyweb
  * @var string $dolibarr_mailing_limit_sendbycli
  * @var	string $dolibarr_mailing_limit_sendbyday
@@ -71,6 +72,7 @@ require_once 'filefunc.inc.php';
 @phan-var-force ?string $dolibarr_main_db_encryption
 @phan-var-force ?string $dolibarr_main_db_cryptkey
 @phan-var-force ?string $dolibarr_main_limit_users
+@phan-var-force ?string $dolibarr_main_limit_sessions_per_user
 @phan-var-force ?string $dolibarr_main_url_root_alt
 ';
 require_once DOL_DOCUMENT_ROOT.'/core/class/conf.class.php';
@@ -164,6 +166,7 @@ if (defined('TEST_DB_FORCE_TYPE')) {
 
 // Set properties specific to conf file
 $conf->file->main_limit_users = $dolibarr_main_limit_users;
+$conf->file->main_limit_sessions_per_user = empty($dolibarr_main_limit_sessions_per_user) ? 0 : $dolibarr_main_limit_sessions_per_user;
 $conf->file->mailing_limit_sendbyweb = empty($dolibarr_mailing_limit_sendbyweb) ? 0 : $dolibarr_mailing_limit_sendbyweb;
 $conf->file->mailing_limit_sendbycli = empty($dolibarr_mailing_limit_sendbycli) ? 0 : $dolibarr_mailing_limit_sendbycli;
 $conf->file->mailing_limit_sendbyday = empty($dolibarr_mailing_limit_sendbyday) ? 0 : $dolibarr_mailing_limit_sendbyday;

--- a/test/phpunit/AllTests.php
+++ b/test/phpunit/AllTests.php
@@ -150,6 +150,8 @@ class AllTests
 		$suite->addTestSuite('ProfidLibTest');
 		require_once dirname(__FILE__).'/XCalLibTest.php';
 		$suite->addTestSuite('XCalLibTest');
+		require_once dirname(__FILE__).'/PhpSessionInDbTest.php';
+		$suite->addTestSuite('PhpSessionInDbTest');
 
 		require_once dirname(__FILE__).'/SecurityTest.php';
 		$suite->addTestSuite('SecurityTest');

--- a/test/phpunit/PhpSessionInDbTest.php
+++ b/test/phpunit/PhpSessionInDbTest.php
@@ -1,0 +1,144 @@
+<?php
+/* Copyright (C) 2026  Frédéric France     <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/PhpSessionInDbTest.php
+ *      \ingroup    test
+ *      \brief      PHPUnit test for the database session handler helpers
+ *      \remarks    To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db;
+//define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
+//require_once 'PHPUnit/Autoload.php';
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/phpsessionindb.lib.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->loadRights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class PhpSessionInDbTest extends CommonClassTest
+{
+	/** @var int */
+	const FKUSER1 = 990001;
+	/** @var int */
+	const FKUSER2 = 990002;
+
+	/**
+	 * Insert a fake row into llx_session.
+	 *
+	 * @param	string	$sessionid		Session id to use
+	 * @param	int		$fk_user		Owner user id
+	 * @param	int		$secondsago		Age of last_accessed, in seconds before now
+	 * @return	void
+	 */
+	private function insertSession($sessionid, $fk_user, $secondsago)
+	{
+		global $db;
+
+		$now = dol_now();
+		$sql = "INSERT INTO ".MAIN_DB_PREFIX."session";
+		$sql .= "(session_id, session_variable, date_creation, last_accessed, fk_user, remote_ip, user_agent)";
+		$sql .= " VALUES ('".$db->escape($sessionid)."', '', '".$db->idate($now - $secondsago)."', '".$db->idate($now - $secondsago)."', ".((int) $fk_user).", '127.0.0.1', 'phpunit')";
+		$resql = $db->query($sql);
+		$this->assertNotFalse($resql, 'Failed to insert fake session '.$sessionid.': '.$db->lasterror());
+	}
+
+	/**
+	 * Return the list of session ids currently stored for a given user.
+	 *
+	 * @param	int		$fk_user	Owner user id
+	 * @return	string[]			Session ids, ordered by session_id
+	 */
+	private function sessionIdsForUser($fk_user)
+	{
+		global $db;
+
+		$ids = array();
+		$sql = "SELECT session_id FROM ".MAIN_DB_PREFIX."session WHERE fk_user = ".((int) $fk_user)." ORDER BY session_id";
+		$resql = $db->query($sql);
+		$this->assertNotFalse($resql, 'Failed to read sessions: '.$db->lasterror());
+		while ($obj = $db->fetch_object($resql)) {
+			$ids[] = $obj->session_id;
+		}
+		return $ids;
+	}
+
+	/**
+	 * testDolSessionsLimitForUser
+	 *
+	 * @return	void
+	 */
+	public function testDolSessionsLimitForUser()
+	{
+		global $db;
+
+		// The helper works on the global $dbsession connection, like the rest of phpsessionindb.lib.php.
+		$GLOBALS['dbsession'] = $db;
+
+		// --- Case 1: keepcount = 1 evicts every other session of that user, and never touches other users.
+		$this->insertSession('ut-sess-A', self::FKUSER1, 300);
+		$this->insertSession('ut-sess-B', self::FKUSER1, 200);
+		$this->insertSession('ut-sess-C', self::FKUSER1, 100);
+		$this->insertSession('ut-sess-X', self::FKUSER2, 100);
+
+		$nb = dolSessionsLimitForUser(self::FKUSER1, 1, 'ut-sess-CUR');
+		$this->assertEquals(3, $nb, 'keepcount=1 should evict the 3 existing sessions');
+		$this->assertEquals(array(), $this->sessionIdsForUser(self::FKUSER1), 'no session should remain for user 1');
+		$this->assertEquals(array('ut-sess-X'), $this->sessionIdsForUser(self::FKUSER2), 'sessions of other users must be left untouched');
+
+		// --- Case 2: keepcount = 2 keeps the single most recent session and evicts the rest.
+		$this->insertSession('ut-sess-A', self::FKUSER1, 300);
+		$this->insertSession('ut-sess-B', self::FKUSER1, 200);
+		$this->insertSession('ut-sess-C', self::FKUSER1, 100);
+
+		$nb = dolSessionsLimitForUser(self::FKUSER1, 2, 'ut-sess-CUR');
+		$this->assertEquals(2, $nb, 'keepcount=2 should evict the 2 oldest of the 3 existing sessions');
+		$this->assertEquals(array('ut-sess-C'), $this->sessionIdsForUser(self::FKUSER1), 'only the most recent session must survive');
+
+		// --- Case 3: the session being established is never evicted, even when it is the oldest row.
+		$db->query("DELETE FROM ".MAIN_DB_PREFIX."session WHERE fk_user = ".self::FKUSER1);
+		$this->insertSession('ut-sess-CUR', self::FKUSER1, 500);
+		$this->insertSession('ut-sess-D', self::FKUSER1, 100);
+
+		$nb = dolSessionsLimitForUser(self::FKUSER1, 1, 'ut-sess-CUR');
+		$this->assertEquals(1, $nb, 'only the other session must be evicted');
+		$this->assertEquals(array('ut-sess-CUR'), $this->sessionIdsForUser(self::FKUSER1), 'the current session must survive');
+
+		// --- Case 4: a non-positive keepcount is a no-op (feature disabled).
+		$db->query("DELETE FROM ".MAIN_DB_PREFIX."session WHERE fk_user = ".self::FKUSER1);
+		$this->insertSession('ut-sess-E', self::FKUSER1, 100);
+
+		$nb = dolSessionsLimitForUser(self::FKUSER1, 0, 'ut-sess-CUR');
+		$this->assertEquals(0, $nb, 'keepcount=0 must not evict anything');
+		$this->assertEquals(array('ut-sess-E'), $this->sessionIdsForUser(self::FKUSER1), 'keepcount=0 must leave every session in place');
+	}
+}


### PR DESCRIPTION
## What

New optional `conf.php` parameter `$dolibarr_main_limit_sessions_per_user` (default `0` = unlimited), sibling of `$dolibarr_main_limit_users`.

It caps the number of **concurrent sessions per user**, and is only effective when sessions are stored in database (`$php_session_save_handler='db'`).

When a user opens a new authenticated session above the limit, its oldest rows in `llx_session` are deleted. Those other browsers are logged out on their next request (`dolSessionRead()` then finds no row and redirects to the login page). Setting the value to `1` gives a strict "one session per user, a new login disconnects the previous one" behaviour.

## How

- `dolSessionsLimitForUser($fk_user, $keepcount, $currentsessionid)` added to `htdocs/core/lib/phpsessionindb.lib.php`: lists the user's other sessions most-recently-accessed first, keeps the `keepcount - 1` newest, deletes the rest. The session being established is always excluded. A `LOG_NOTICE` line records how many sessions were evicted. A non-positive `keepcount` is a no-op.
- Called from `htdocs/main.inc.php`, in the "new started user session" branch, guarded by the DB-session handler check and a positive limit.
- Config plumbing: `filefunc.inc.php` (default), `master.inc.php` (`$conf->file->main_limit_sessions_per_user`), `conf.php.example` (documentation).

## Tests

New `test/phpunit/PhpSessionInDbTest.php` (registered in `AllTests.php`), run against the DB:

- `keepcount=1` evicts every other session of that user and leaves other users untouched
- `keepcount=2` keeps only the most recently accessed session
- the session being established is never evicted, even when it is the oldest row
- `keepcount=0` is a no-op

`OK (1 test, 24 assertions)`. PHPStan (level 10) and phpcs are clean on the changed files.

## Notes

- No database schema change: `llx_session` already exists when the DB session handler is enabled.
- File-based sessions are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)