### PR TITLE
Fix #35575 do not let an over-reception lower the virtual stock

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -6621,9 +6621,9 @@ class Product extends CommonObject
 
 		// Stock Increase mode
 		if (getDolGlobalString('STOCK_CALCULATE_ON_RECEPTION') || getDolGlobalString('STOCK_CALCULATE_ON_RECEPTION_CLOSE')) {
-			$this->stock_theorique += ($stock_commande_fournisseur - $stock_reception_fournisseur);
+			$this->stock_theorique += max(0, $stock_commande_fournisseur - $stock_reception_fournisseur);
 		} elseif (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER')) {	// This option is similar to STOCK_CALCULATE_ON_RECEPTION_CLOSE but when module Reception is not enabled
-			$this->stock_theorique += ($stock_commande_fournisseur - $stock_reception_fournisseur);
+			$this->stock_theorique += max(0, $stock_commande_fournisseur - $stock_reception_fournisseur);
 		} elseif (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER')) {	// Warning: stock change "on approval", not on validation !
 			if (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER_INCLUDE_DRAFT')) {	// By default, draft means "does not exist", so we do not include them by default, except if option is on
 				$tmpnewprod = dol_clone($this, 1);
@@ -6634,7 +6634,7 @@ class Product extends CommonObject
 		} elseif (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_BILL') && $weBillOrderOrShipmentReception == 'order') {
 			$this->stock_theorique += $stock_commande_fournisseur;
 		} elseif (getDolGlobalString('STOCK_CALCULATE_ON_SUPPLIER_BILL') && $weBillOrderOrShipmentReception == 'shipmentreception') {
-			$this->stock_theorique += ($stock_commande_fournisseur - $stock_reception_fournisseur);
+			$this->stock_theorique += max(0, $stock_commande_fournisseur - $stock_reception_fournisseur);
 		}
 
 		$parameters = array('id' => $this->id, 'includedraftpoforvirtual' => $includedraftpoforvirtual);


### PR DESCRIPTION
The virtual stock adds the still-pending supplier quantity, computed as ordered minus received (product.class.php, load_virtual_stock):

    $this->stock_theorique += ($stock_commande_fournisseur - $stock_reception_fournisseur);

When more is received than was ordered that difference is negative, so it is subtracted from the theoretical stock:

    real stock 100, ordered 10, received 10  ->  virtual 100   correct
    real stock 100, ordered 10, received 15  ->  virtual  95   below the real stock

which is what the reporter describes: the virtual stock stops following the real one once a reception exceeds its order.

Flooring the pending quantity at zero fixes it, and only affects that case:

    nothing received yet    current 10   fixed 10   identical
    partially received      current  5   fixed  5   identical
    fully received          current  0   fixed  0   identical
    over-received           current -5   fixed  0   only this changes

Applied to the three branches that use that expression, STOCK_CALCULATE_ON_RECEPTION, STOCK_CALCULATE_ON_SUPPLIER_DISPATCH_ORDER and STOCK_CALCULATE_ON_SUPPLIER_BILL with shipmentreception.

Left untouched: the STOCK_CALCULATE_ON_SUPPLIER_VALIDATE_ORDER branch, which does $this->stock_theorique -= $stock_reception_fournisseur without pairing it with an ordered quantity. There the stock increases on approval, so subtracting the receptions is the intended behaviour and a floor would be wrong.

Reported by @midnightgard in #35575.