### PR TITLE
Fix #35107 use the curl client to refresh the OAuth2 mail token

### DIFF
--- a/htdocs/core/class/CMailFile.class.php
+++ b/htdocs/core/class/CMailFile.class.php
@@ -1173,6 +1173,10 @@ class CMailFile
 								getDolGlobalString('OAUTH_'.getDolGlobalString($keyforsmtpoauthservice).'_URLCALLBACK')
 							);
 							$serviceFactory = new \OAuth\ServiceFactory();
+							// Force the curl client, the default stream one uses file_get_contents() which
+							// fails to reach the token endpoint on many setups, so the token is never refreshed.
+							$httpClient = new \OAuth\Common\Http\Client\CurlClient();
+							$serviceFactory->setHttpClient($httpClient);
 							$oauthname = explode('-', $OAUTH_SERVICENAME);
 							// ex service is Google-Emails we need only the first part Google
 							$apiService = $serviceFactory->createService($oauthname[0], $credentials, $storage, array());
@@ -1343,6 +1347,10 @@ class CMailFile
 								getDolGlobalString('OAUTH_'.getDolGlobalString($keyforsmtpoauthservice).'_URLCALLBACK')
 							);
 							$serviceFactory = new \OAuth\ServiceFactory();
+							// Force the curl client, the default stream one uses file_get_contents() which
+							// fails to reach the token endpoint on many setups, so the token is never refreshed.
+							$httpClient = new \OAuth\Common\Http\Client\CurlClient();
+							$serviceFactory->setHttpClient($httpClient);
 							$oauthname = explode('-', $OAUTH_SERVICENAME);
 							// ex service is Google-Emails we need only the first part Google
 							$apiService = $serviceFactory->createService($oauthname[0], $credentials, $storage, array());


### PR DESCRIPTION
The OAuth2 mail token is never refreshed automatically on 22.0 and 23.0.

`CMailFile` builds the service factory without setting an HTTP client, so the library falls back to its stream one, which calls `file_get_contents()` on the token endpoint. Where that is not usable the refresh dies with "no suitable wrapper could be found" and sending mail stops as soon as the token expires. Refreshing by hand from the setup page still works, because the callback pages do set the curl client.

This backports 34ec74d3738, already on 24.0, to the two factory sites in `CMailFile`. `CurlClient` ships in `htdocs/includes/OAuth/` on this branch and curl is already required by the installer.
