### PR TITLE
Fix #40221 put the stock back when deleting a validated order

### DIFF
--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -215,7 +215,25 @@ if (empty($reshook)) {
 		}
 	} elseif ($action == 'confirm_delete' && $confirm == 'yes' && $usercandelete) {
 		// Remove order
-		$result = $object->delete($user);
+		$idwarehouse = GETPOST('idwarehouse');
+
+		$qualified_for_stock_change = 0;
+		if (empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
+			$qualified_for_stock_change = $object->hasProductsOrServices(2);
+		} else {
+			$qualified_for_stock_change = $object->hasProductsOrServices(1);
+		}
+
+		// Check parameters
+		if (isModEnabled('stock') && !empty($conf->global->STOCK_CALCULATE_ON_VALIDATE_ORDER) && $object->statut != Commande::STATUS_DRAFT && $qualified_for_stock_change) {
+			if (!$idwarehouse || $idwarehouse == -1) {
+				$error++;
+				setEventMessages($langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv("Warehouse")), null, 'errors');
+				$action = '';
+			}
+		}
+
+		$result = ($error ? -1 : $object->delete($user, 0, $idwarehouse));
 		if ($result > 0) {
 			header('Location: list.php?restore_lastsearch_values=1');
 			exit;
@@ -2141,11 +2159,6 @@ if ($action == 'create' && $usercancreate) {
 
 		$formconfirm = '';
 
-		// Confirmation to delete
-		if ($action == 'delete') {
-			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans('DeleteOrder'), $langs->trans('ConfirmDeleteOrder'), 'confirm_delete', '', 0, 1);
-		}
-
 		// Confirmation of validation
 		if ($action == 'validate') {
 			// We check that object has a temporary ref
@@ -2359,7 +2372,8 @@ if ($action == 'create' && $usercancreate) {
 		/*
 		 * Confirmation de l'annulation
 		 */
-		if ($action == 'cancel') {
+		// Both actions put the stock back, so they share the warehouse question
+		if ($action == 'cancel' || $action == 'delete') {
 			$qualified_for_stock_change = 0;
 			if (empty($conf->global->STOCK_SUPPORTS_SERVICES)) {
 				$qualified_for_stock_change = $object->hasProductsOrServices(2);
@@ -2367,9 +2381,19 @@ if ($action == 'create' && $usercancreate) {
 				$qualified_for_stock_change = $object->hasProductsOrServices(1);
 			}
 
-			$text = $langs->trans('ConfirmCancelOrder', $object->ref);
+			if ($action == 'cancel') {
+				$text = $langs->trans('ConfirmCancelOrder', $object->ref);
+				$title = $langs->trans("Cancel");
+				$confirmaction = 'confirm_cancel';
+			} else {
+				$text = $langs->trans('ConfirmDeleteOrder', $object->ref);
+				$title = $langs->trans('DeleteOrder');
+				$confirmaction = 'confirm_delete';
+			}
+
 			$formquestion = array();
-			if (isModEnabled('stock') && !empty($conf->global->STOCK_CALCULATE_ON_VALIDATE_ORDER) && $qualified_for_stock_change) {
+			// A draft was never validated, so its stock was never decreased and there is nothing to put back
+			if (isModEnabled('stock') && !empty($conf->global->STOCK_CALCULATE_ON_VALIDATE_ORDER) && $object->statut != Commande::STATUS_DRAFT && $qualified_for_stock_change) {
 				$langs->load("stocks");
 				require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
 				$formproduct = new FormProduct($db);
@@ -2385,7 +2409,7 @@ if ($action == 'create' && $usercancreate) {
 				);
 			}
 
-			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $langs->trans("Cancel"), $text, 'confirm_cancel', $formquestion, 0, 1);
+			$formconfirm = $form->formconfirm($_SERVER["PHP_SELF"].'?id='.$object->id, $title, $text, $confirmaction, $formquestion, 0, 1);
 		}
 
 		// Confirmation to delete line

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -3455,9 +3455,10 @@ class Commande extends CommonOrder
 	 *
 	 *	@param	User	$user		User object
 	 *	@param	int		$notrigger	1=Does not execute triggers, 0= execute triggers
+	 *	@param	int		$idwarehouse	Warehouse ID to move the stock back to (Used only if option STOCK_CALCULATE_ON_VALIDATE_ORDER is on). -1 = no stock change.
 	 * 	@return	int					<=0 if KO, >0 if OK
 	 */
-	public function delete($user, $notrigger = 0)
+	public function delete($user, $notrigger = 0, $idwarehouse = -1)
 	{
 		global $conf, $langs;
 		require_once DOL_DOCUMENT_ROOT.'/core/lib/files.lib.php';
@@ -3481,6 +3482,31 @@ class Commande extends CommonOrder
 		if ($this->countNbOfShipments() != 0) {
 			$this->errors[] = $langs->trans('SomeShipmentExists');
 			$error++;
+		}
+
+		// Restore stock, the validation had decreased it. Must be done before lines are deleted.
+		if (!$error && isModEnabled('stock') && !empty($conf->global->STOCK_CALCULATE_ON_VALIDATE_ORDER) && $conf->global->STOCK_CALCULATE_ON_VALIDATE_ORDER == 1 && $this->statut != self::STATUS_DRAFT && $idwarehouse != -1) {
+			require_once DOL_DOCUMENT_ROOT.'/product/stock/class/mouvementstock.class.php';
+			$langs->load("agenda");
+
+			$this->fetch_lines();
+
+			$num = count($this->lines);
+			for ($i = 0; $i < $num; $i++) {
+				if ($this->lines[$i]->fk_product > 0) {
+					$mouvP = new MouvementStock($this->db);
+					$mouvP->origin = &$this;
+					$mouvP->setOrigin($this->element, $this->id);
+					// We increment stock of product (and sub-products), we use 0 for price to not change the weighted average value
+					$result = $mouvP->reception($user, $this->lines[$i]->fk_product, $idwarehouse, $this->lines[$i]->qty, 0, $langs->trans("OrderDeletedInDolibarr", $this->ref));
+					if ($result < 0) {
+						$error++;
+						$this->error = $mouvP->error;
+						$this->errors = array_merge($this->errors, $mouvP->errors);
+						break;
+					}
+				}
+			}
 		}
 
 		// Delete extrafields of lines and lines

--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -74,6 +74,7 @@ OrderCreatedInDolibarr=Order %s created
 OrderValidatedInDolibarr=Order %s validated
 OrderDeliveredInDolibarr=Order %s classified delivered
 OrderCanceledInDolibarr=Order %s canceled
+OrderDeletedInDolibarr=Order %s deleted
 OrderBilledInDolibarr=Order %s classified billed
 OrderApprovedInDolibarr=Order %s approved
 OrderRefusedInDolibarr=Order %s refused


### PR DESCRIPTION
With STOCK_CALCULATE_ON_VALIDATE_ORDER, validating an order decreases the stock, but deleting that order never gave it back. The delete button shows for a validated order as long as no shipment exists, so the stock is silently wrong afterwards and no movement records it.

setDraft() and cancel() already restore the stock, and Facture::delete() does the same for invoices with an $idwarehouse argument, so delete() was the only path left without it. This adds the same third argument, restores the stock before the lines are deleted, and makes the confirmation ask for the warehouse exactly like the back-to-draft confirmation already does.

Measured on 18.0.10 through valid() then delete(): stock 100 -> 93 on validation -> 93 after delete before the change, 100 after. A draft order is untouched, and the existing two-argument call keeps its previous behaviour.
