### PR TITLE
Fix #40224 apply the alert filter on supplier orders waiting delivery

### DIFF
--- a/htdocs/fourn/commande/list.php
+++ b/htdocs/fourn/commande/list.php
@@ -897,6 +897,10 @@ if ($search_status != '' && $search_status != '-1') {
 if ($search_option == 'late') {
 	$sql .= " AND cf.date_commande < '".$db->idate(dol_now() - $conf->order->fournisseur->warning_delay)."'";
 }
+if ($search_option == 'recv_late') {
+	// Same rule as FournisseurCommande::hasDelay() for the ordered and partially received status
+	$sql .= " AND cf.date_livraison < '".$db->idate(dol_now() - $conf->order->fournisseur->warning_delay)."'";
+}
 if ($search_date_order_start) {
 	$sql .= " AND cf.date_commande >= '".$db->idate($search_date_order_start)."'";
 }


### PR DESCRIPTION
The Alert checkbox on the supplier order list has no effect once the status filter is on ordered or partially received. In that case it submits recv_late, which only narrows the status to 3,4 (list.php:161) while the only date condition in the query is guarded by search_option == 'late'. The box comes back checked, so it looks like it applied.

This adds the missing condition on date_livraison, which is the field FournisseurCommande::hasDelay() tests for those two status. Orders with no delivery date stay out of the result, as they do in hasDelay() too, since NULL fails the comparison.

Checked against a table of five rows: before, the filter returned every order in status 3,4 including one due in 2030 and one with no date; after, only the two genuinely overdue ones.

Targeted 22.0, the oldest branch where recv_late exists.
