### PR TITLE
Fix #39990 remove the dead and broken Holiday::createCPusers()

### DIFF
--- a/htdocs/holiday/class/holiday.class.php
+++ b/htdocs/holiday/class/holiday.class.php
@@ -1862,42 +1862,6 @@ class Holiday extends CommonObject
 	}
 
 	/**
-	 *  Create entries for each user at setup step
-	 *
-	 *  @param	boolean		$single		Single
-	 *  @param	int			$userid		Id user
-	 *  @return void
-	 */
-	public function createCPusers($single = false, $userid = 0)
-	{
-		// do we have to add balance for all users ?
-		if (!$single) {
-			dol_syslog(get_class($this).'::createCPusers');
-			$arrayofusers = $this->fetchUsers(false, true);
-
-			foreach ($arrayofusers as $users) {
-				$sql = "INSERT INTO ".MAIN_DB_PREFIX."holiday_users";
-				$sql .= " (fk_user, nb_holiday)";
-				$sql .= " VALUES (".((int) $users['rowid'])."', '0')";
-
-				$resql = $this->db->query($sql);
-				if (!$resql) {
-					dol_print_error($this->db);
-				}
-			}
-		} else {
-			$sql = "INSERT INTO ".MAIN_DB_PREFIX."holiday_users";
-			$sql .= " (fk_user, nb_holiday)";
-			$sql .= " VALUES (".((int) $userid)."', '0')";
-
-			$resql = $this->db->query($sql);
-			if (!$resql) {
-				dol_print_error($this->db);
-			}
-		}
-	}
-
-	/**
 	 *  Return the balance of annual leave of a user
 	 *
 	 *  @param	int		$user_id    User ID


### PR DESCRIPTION
createCPusers() cannot work. It inserts into llx_holiday_users without fk_type, which the table declares NOT NULL with no default, and the stray quote left by f57b4fd2fd3 in 2020 makes the statement a syntax error before the column even matters. Every call ends in dol_print_error() with nothing inserted.

Removing it rather than repairing it, because it has been dead for ten years: its last caller was dropped in 2016 by 9c89bc4095b, "Remove deprecated tables and code", and nothing in htdocs, scripts or dev has referenced it since. updateSoldeCP() already covers the same need properly, keyed on fk_type and doing update-or-insert.

It is a public method, so if you would rather keep the signature and fix the INSERT to loop over the active leave types, say so and I will send that instead.
