### PR TITLE
Fix #39909 count the whole fiscal period in the entry and movement columns

### DIFF
--- a/htdocs/accountancy/admin/fiscalyear.php
+++ b/htdocs/accountancy/admin/fiscalyear.php
@@ -152,8 +152,8 @@ if ($result) {
 			print '<td class="left">'.$obj->label.'</td>';
 			print '<td class="left">'.dol_print_date($db->jdate($obj->date_start), 'day').'</td>';
 			print '<td class="left">'.dol_print_date($db->jdate($obj->date_end), 'day').'</td>';
-			print '<td class="center">'.$object->getAccountancyEntriesByFiscalYear($obj->date_start, $obj->date_end).'</td>';
-			print '<td class="center">'.$object->getAccountancyMovementsByFiscalYear($obj->date_start, $obj->date_end).'</td>';
+			print '<td class="center">'.$object->getAccountancyEntriesByFiscalYear($db->jdate($obj->date_start), $db->jdate($obj->date_end)).'</td>';
+			print '<td class="center">'.$object->getAccountancyMovementsByFiscalYear($db->jdate($obj->date_start), $db->jdate($obj->date_end)).'</td>';
 			print '<td class="right">'.$fiscalyearstatic->LibStatut($obj->status, 5).'</td>';
 			print '</tr>';
 			$i++;


### PR DESCRIPTION
The Number of entries and Number of movements columns are given $obj->date_start and $obj->date_end straight from the query, but getAccountancyEntriesByFiscalYear() and getAccountancyMovementsByFiscalYear() feed them to idate(), which expects a timestamp. A date column yields the string "2026-01-01", which dol_print_date() handles in its legacy branch: parsed as UTC, rendered in the server timezone. Both bounds shift by the server offset.

Measured on a table of three rows dated 2026-01-01, 2026-06-15 and 2026-12-31:

    UTC              >= 2026-01-01 00:00:00   counts 3
    Europe/Paris     >= 2026-01-01 01:00:00   counts 2, first day dropped
    America/New_York >= 2025-12-31 19:00:00   counts 2, last day dropped

So it is invisible on a UTC server and loses one day either side elsewhere, which is what makes opening balances vanish. After the change all four timezones I tried produce 2026-01-01 00:00:00 and count 3.

The fix converts at the call site with jdate(), as the date display three lines above already does. The methods themselves are fine: fetch() stores real timestamps in $this->date_start, so idate() is correct there.
