### PR TITLE
Fix #40237 make the direct debit notification form work

### DIFF
--- a/htdocs/admin/paymentbybanktransfer.php
+++ b/htdocs/admin/paymentbybanktransfer.php
@@ -117,7 +117,7 @@ if ($action == "set") {
 
 if ($action == "addnotif") {
 	$bon = new BonPrelevement($db);
-	$bon->addNotification($db, GETPOST('user', 'int'), $action);
+	$bon->addNotification($db, GETPOST('user', 'int'), GETPOST('notifaction', 'int'));
 
 	header("Location: ".$_SERVER["PHP_SELF"]);
 	exit;
@@ -446,7 +446,7 @@ if (!empty($conf->global->MAIN_MODULE_NOTIFICATION))
 	print '</td>';
 
 	print '<td>';
-	print $form->selectarray('action',$actions);//  select_dolusers(0,'user',0);
+	print $form->selectarray('notifaction', $actions);
 	print '</td>';
 
 	print '<td class="right"><input type="submit" class="button button-add" value="'.$langs->trans("Add").'"></td></tr>';

--- a/htdocs/admin/prelevement.php
+++ b/htdocs/admin/prelevement.php
@@ -118,7 +118,7 @@ if ($action == "set") {
 
 if ($action == "addnotif") {
 	$bon = new BonPrelevement($db);
-	$bon->addNotification($db, GETPOST('user', 'int'), $action);
+	$bon->addNotification($db, GETPOST('user', 'int'), GETPOST('notifaction', 'int'));
 
 	header("Location: ".$_SERVER["PHP_SELF"]);
 	exit;
@@ -460,7 +460,7 @@ if (!empty($conf->global->MAIN_MODULE_NOTIFICATION))
 	print '</td>';
 
 	print '<td>';
-	print $form->selectarray('action',$actions);//  select_dolusers(0,'user',0);
+	print $form->selectarray('notifaction', $actions);
 	print '</td>';
 
 	print '<td class="right"><input type="submit" class="button button-add" value="'.$langs->trans("Add").'"></td></tr>';

--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -1439,7 +1439,7 @@ class BonPrelevement extends CommonObject
 		}
 
 		$sql = "DELETE FROM " . MAIN_DB_PREFIX . "notify_def";
-		$sql .= " WHERE fk_user=" . ((int) $userid) . " AND fk_action='" . $this->db->escape($action) . "'";
+		$sql .= " WHERE fk_user = " . ((int) $userid) . " AND fk_action = " . ((int) $action);
 
 		if ($this->db->query($sql)) {
 			return 0;
@@ -1471,8 +1471,8 @@ class BonPrelevement extends CommonObject
 		if ($this->deleteNotification($user, $action) == 0) {
 			$now = dol_now();
 
-			$sql = "INSERT INTO " . MAIN_DB_PREFIX . "notify_def (datec,fk_user, fk_soc, fk_contact, fk_action)";
-			$sql .= " VALUES ('" . $this->db->idate($now) . "', " . ((int) $userid) . ", 'NULL', 'NULL', '" . $this->db->escape($action) . "')";
+			$sql = "INSERT INTO " . MAIN_DB_PREFIX . "notify_def (datec, fk_user, fk_soc, fk_contact, fk_action)";
+			$sql .= " VALUES ('" . $this->db->idate($now) . "', " . ((int) $userid) . ", NULL, NULL, " . ((int) $action) . ")";
 
 			dol_syslog("adnotiff: " . $sql);
 			if ($this->db->query($sql)) {


### PR DESCRIPTION
Adding a notification on the direct debit and credit transfer setup screens never inserts anything, and the screen reports nothing.

The trigger selector is named action, but the form already posts to ?action=addnotif. GETPOST prefers the GET value, so $action holds the literal "addnotif" and the trigger id picked in the dropdown is thrown away. Renaming the field to notifaction and reading it fixes that half.

The INSERT then wrote the quoted string 'NULL' into fk_soc and fk_contact and the action name into fk_action, three integer columns, so it failed with "Incorrect integer value" under STRICT_TRANS_TABLES, which is the MariaDB default and is not changed by Dolibarr. deleteNotification() had the matching defect on fk_action. The failure was invisible because addNotification() returns 0 on its error branch and both callers ignore the return before redirecting.

Verified on a table matching the real schema: the original statement is rejected, the corrected one inserts and the row then joins to llx_c_action_trigger, which is what the list below the form needs to display it.
