### PR TITLE
Fix #40175 show the Private field of email templates on 24.0

### DIFF
--- a/htdocs/admin/mails_templates.php
+++ b/htdocs/admin/mails_templates.php
@@ -157,7 +157,7 @@ $tabname[25] = MAIN_DB_PREFIX."c_email_templates";
 // Nom des champs en resultat de select pour affichage du dictionnaire
 // Names of fields in select results for dictionary display (AI translated)
 $tabfield = array();
-$tabfield[25] = "label,lang,type_template,fk_user,position,module,topic,joinfiles,defaultfortype,content";
+$tabfield[25] = "label,lang,type_template,fk_user,private,position,module,topic,joinfiles,defaultfortype,content";
 if (getDolGlobalString('MAIN_EMAIL_TEMPLATES_FOR_OBJECT_LINES')) {
 	$tabfield[25] .= ',content_lines';
 }


### PR DESCRIPTION
9da40653d15 restored the Private field on 23.0, but the forward merge did not carry it to 24.0, so the regression is still live there and on develop.

The state on 24.0 is inconsistent: $tabfieldvalue[25] and $tabfieldinsert[25] both still list private, only $tabfield[25] lost it. So the column exists, the insert expects a value for it, and the list filter in html.formmail.class.php still honours it, but there is no longer any way to set it from the page.

Same one-line change as the 23.0 fix, putting private back between fk_user and position.
