### PR TITLE
Fix #40008 offer a way back from a closed task

### DIFF
--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -793,6 +793,9 @@ if ($id > 0 || !empty($ref)) {
 					print '<a class="butAction classfortooltip reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=reopen&token='.newToken().'&withproject='.((int) $withproject).'" title="'.$langs->trans("SetToDraft").'">'.$langs->trans('SetToDraft').'</a>';
 				} elseif ($object->status == $object::STATUS_DRAFT) {
 					print '<a class="butAction reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=valid&token='.newToken().'&withproject='.((int) $withproject).'">'.$langs->trans('Validate').'</a>';
+				} elseif ($object->status == $object::STATUS_CLOSED) {
+					// A closed task had no way back, the reopen action above already accepts it
+					print '<a class="butAction reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=reopen&token='.newToken().'&withproject='.((int) $withproject).'">'.$langs->trans('ReOpen').'</a>';
 				}
 				//if ($object->status != $object::STATUS_CLOSED) {
 				print '<a class="butAction reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=edit&token='.newToken().'&withproject='.((int) $withproject).'">'.$langs->trans('Modify').'</a>';


### PR DESCRIPTION
A closed task has no button to come back. The action block only handles VALIDATED and ONGOING (Back to draft) and DRAFT (Validate), so STATUS_CLOSED falls through and shows neither, which is why the only way out today is to edit the progress field.

The reopen handler already accepts a closed task, it just was not reachable. Verified through the real code: a task created, closed with setStatusCommon(STATUS_CLOSED), then reopened with setStatusCommon(STATUS_DRAFT) goes 0 -> 3 -> 0 and returns 1.

Uses the existing ReOpen label, matching what fiscalyear_card.php, asset and bom already do after a close.

Targeted 22.0, the oldest branch with task statuses; 18.0 and 21.0 have neither the status nor the reopen action.
