### PR TITLE
Fix #40184 keep the sender block off the logo on develop

### DIFF
--- a/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
+++ b/htdocs/core/modules/commande/doc/pdf_eratosthene.modules.php
@@ -1777,7 +1777,7 @@ class pdf_eratosthene extends ModelePDFCommandes
 			$carac_emetteur .= pdf_build_address($outputlangs, $this->emetteur, $object->thirdparty, '', 0, 'source', $object);
 
 			// Show sender
-			$posy = getDolGlobalInt('MAIN_PDF_USE_ISO_LOCATION') ? $this->marge_haute : $this->marge_haute + 32;
+			$posy = getDolGlobalInt('MAIN_PDF_USE_ISO_LOCATION') ? $this->marge_haute + 30 : $this->marge_haute + 32;
 			$posy += $top_shift;
 			$posx = $this->marge_gauche;
 			if (getDolGlobalInt('MAIN_INVERT_SENDER_RECIPIENT')) {


### PR DESCRIPTION
ab7dcb7c667 fixed this on 24.0 (#40185) but the forward merge did not carry it, so develop still draws the sender block at the top margin when MAIN_PDF_USE_ISO_LOCATION is on, which puts it over the logo.

The line is now identical to the merged 24.0 one, so the next forward merge lands clean. The recipient block 65 lines below already uses marge_haute + 30, and pdf_sponge does the same for its own sender block, so this is consistent with both. With the default 10 mm top margin it gives 40 mm, which is the constant 23.0 used.

pdf_proforma extends pdf_eratosthene, so both templates are covered.
