### PR TITLE
Fix #39561 test the cleanup delete in Expedition::manageStockMvtOnEvt

### DIFF
--- a/htdocs/expedition/class/expedition.class.php
+++ b/htdocs/expedition/class/expedition.class.php
@@ -3133,7 +3133,17 @@ class Expedition extends CommonObject
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sqldelete = "DELETE FROM ".$this->db->prefix()."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".$this->db->prefix()."product_batch as pb)";
 				$resqldelete = $this->db->query($sqldelete);
-				// We do not test error, it can fails if there is child in batch details
+				// The NOT IN clause already excludes the rows still referenced by product_batch (the only child FK on
+				// product_stock), so this DELETE can not fail on a child constraint. Any failure is a real error, in
+				// particular a deadlock (1213) that rolls back the whole transaction including the stock movements just
+				// recorded; if we swallowed it, the caller would commit an empty transaction and report a success while
+				// the movements were lost.
+				if (!$resqldelete) {
+					$this->error = $this->db->lasterror();
+					$this->errors[] = $this->db->lasterror();
+					$error++;
+					break;
+				}
 			}
 		} else {
 			$this->error = $this->db->lasterror();


### PR DESCRIPTION
Same change as #39694, retargeted to develop as you asked. I will close the 18.0 one.

The comment says the DELETE may fail because of a batch child, but the NOT IN clause already excludes every product_stock row referenced by product_batch, which is the only child FK on that table. Checked with the real foreign key in place: rows at zero that are referenced are kept, rows at zero that are not are deleted, and the statement succeeds. So the nominal path cannot reach the new error branch.

What can fail is a deadlock. That rolls back the whole transaction, including the stock movements written a few lines above, and with the result ignored the caller commits and reports success while the movements are gone. Hence testing it.
