### PR TITLE
Fix #39561 test the cleanup delete in MouvementStock::_create

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -665,7 +665,16 @@ class MouvementStock extends CommonObject
 				// having a lot1/qty=X and lot2/qty=-X, so 0 but we must not loose repartition of different lot.
 				$sql = "DELETE FROM ".$this->db->prefix()."product_stock WHERE reel = 0 AND rowid NOT IN (SELECT fk_product_stock FROM ".$this->db->prefix()."product_batch as pb)";
 				$resql = $this->db->query($sql);
-				// We do not test error, it can fails if there is child in batch details
+				// The NOT IN clause already excludes rows still referenced by product_batch (the only child FK on
+				// product_stock), so this DELETE cannot fail on a child constraint. Any failure is therefore a real
+				// error, in particular a deadlock (1213) that rolls back the whole transaction including the movement
+				// just inserted; if we swallowed it, _create() would commit an empty transaction and return the
+				// movement id as a success, so the caller (and the REST API) would think the movement was saved while
+				// it was lost.
+				if (!$resql) {
+					$this->errors[] = $this->db->lasterror();
+					$error++;
+				}
 			}
 		}
 


### PR DESCRIPTION
Same change as #39593, retargeted to develop following your comment on #39694. I will close the 21.0 one.

This is the MouvementStock::_create() half of #39561; #40243 covers the Expedition one. The comment claims the DELETE may fail on a batch child, but the NOT IN clause already excludes every product_stock row referenced by product_batch, the only child FK on that table, so the nominal path cannot reach the new error branch.

A deadlock there rolls back the transaction including the movement inserted just above, and with the result ignored _create() commits and returns the movement id, so the caller and the REST API both see a success while the movement is gone. No break needed here, $error is tested a few lines below before the commit.
