### PR TITLE
Fix #40182 do not order from an unrelated supplier on replenishment

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -170,7 +170,15 @@ if ($action == 'order' && GETPOST('valid')) {
 				$supplierpriceid = GETPOST('fourn' . $i, 'int');
 				//get all the parameters needed to create a line
 				$qty = GETPOST('tobuy' . $i, 'int');
-				$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);
+				// Resolve the product and the supplier of the selected price line first. Without them,
+				// get_buyprice() falls back to a search with no product and no supplier filter, and can
+				// return a price row of another supplier for another product (see #40182).
+				$tmpprodfourn = new ProductFournisseur($db);
+				if ($tmpprodfourn->fetch_product_fournisseur_price($supplierpriceid) > 0) {
+					$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty, $tmpprodfourn->product_id, 'none', $tmpprodfourn->fourn_id);
+				} else {
+					$idprod = $productsupplier->get_buyprice($supplierpriceid, $qty);
+				}
 				$res = $productsupplier->fetch($idprod);
 				if ($res && $idprod > 0) {
 					if ($qty) {


### PR DESCRIPTION
Backport to 18.0 of the fix merged on 24.0 as #40190. @comaiteseb reported this on v20 and rightly pointed out that fixing only 24.0 does not close it: the call is unchanged on 18.0, 21.0, 22.0 and 23.0.

get_buyprice($supplierpriceid, $qty) leaves the product and supplier arguments at their defaults, so the fallback query runs unfiltered and an empty supplier reference matches any price line, which is how the order ends up against a different supplier than the one filtered on.

Same change as the 24.0 one: resolve the price line first, then pass its product and supplier. fetch_product_fournisseur_price() and the ProductFournisseur include both already exist on 18.0.

Not including the $result initialisation from #40190 here: that was a phpstan fix for a pre-existing defect unrelated to this bug, and 18.0 does not run phpstan.
