### PR TITLE
Fix #40186 add the CSRF token to the various payment clone link

### DIFF
--- a/htdocs/compta/bank/various_payment/card.php
+++ b/htdocs/compta/bank/various_payment/card.php
@@ -722,7 +722,7 @@ if ($id) {
 
 	// Clone
 	if ($permissiontoadd) {
-		print '<div class="inline-block divButAction"><a class="butAction" href="'.dol_buildpath("/compta/bank/various_payment/card.php", 1).'?id='.$object->id.'&amp;action=clone&amp;token='.newToken().'">'.$langs->trans("ToClone")."</a></div>";
+		print '<div class="inline-block divButAction"><a class="butAction" href="'.dol_buildpath("/compta/bank/various_payment/card.php", 1).'?id='.$object->id.'&action=clone&token='.newToken().'">'.$langs->trans("ToClone")."</a></div>";
 	}
 
 	// Delete

--- a/htdocs/compta/bank/various_payment/card.php
+++ b/htdocs/compta/bank/various_payment/card.php
@@ -722,7 +722,7 @@ if ($id) {
 
 	// Clone
 	if ($permissiontoadd) {
-		print '<div class="inline-block divButAction"><a class="butAction" href="'.dol_buildpath("/compta/bank/various_payment/card.php", 1).'?id='.$object->id.'&amp;action=clone">'.$langs->trans("ToClone")."</a></div>";
+		print '<div class="inline-block divButAction"><a class="butAction" href="'.dol_buildpath("/compta/bank/various_payment/card.php", 1).'?id='.$object->id.'&amp;action=clone&amp;token='.newToken().'">'.$langs->trans("ToClone")."</a></div>";
 	}
 
 	// Delete


### PR DESCRIPTION
Backport to 18.0 of the fix merged on 24.0 as #40189. The clone link is unfixed on 18.0, 21.0, 22.0 and 23.0, where it is written with dol_buildpath() rather than dolBuildUrl(), so the 24.0 change does not apply as is.

With MAIN_SECURITY_CSRF_WITH_TOKEN at 3, main.inc.php treats every GET action outside its exclusion list as sensitive and requires a token; clone is not in that list, so the request is refused. The link carried none.

Same token spelling as the sibling link at line 587 of the same file.
