### PR TITLE
Fix #40153 re-encrypt a BLOCKEDLOG_HMAC_KEY left in clear by an old migration

### DIFF
--- a/htdocs/install/upgrade2.php
+++ b/htdocs/install/upgrade2.php
@@ -5760,6 +5760,21 @@ function migrate_blockedlog_add_hmac_key()
 		}
 
 		print $langs->trans('Done');
+	} elseif (!preg_match('/^(dolcrypt|dolobfuscation)/', $hmac_encoded_secret_key)) {
+		// The value is stored in clear, without any prefix. This happens on instances migrated from a
+		// version that stored it unencrypted. dolDecrypt() returns such a value unchanged, so the test
+		// below used to pass and the value was left in clear, which then breaks getClearHMACSecretKey().
+		// Store the same key again so it gets encrypted, without changing the key itself.
+		$result = dolibarr_set_const($db, 'BLOCKEDLOG_HMAC_KEY', $hmac_encoded_secret_key, 'chaine', 0, 'The secret key for HMAC used for blockedlog record', $conf->entity);
+		if ($result < 0) {
+			dol_print_error($db);
+			$db->rollback();
+
+			print '</td></tr>';
+			return -1;
+		}
+
+		print $langs->trans('Done');
 	} else {
 		// Decode the HMAC key
 		$hmac_secret_key = dolDecrypt($hmac_encoded_secret_key);


### PR DESCRIPTION
Backport to 23.0 of the fix merged on 24.0 as #40227. 23.0 is the oldest branch carrying this migration block, 22.0 and below have no BLOCKEDLOG_HMAC_KEY handling in upgrade2.php at all.

The check tests the decrypted content with preg_match('/^BLOCKEDLOGHMAC/'), but dolDecrypt() returns a value with no prefix unchanged, so a key stored in clear passes it and is never re-encrypted. getClearHMACSecretKey() then refuses that value because it finds neither a dolcrypt nor a dolobfuscation prefix, which is the exception reported on the issue.

Testing the prefix instead routes only the clear case through the new branch:

    BLOCKEDLOGHMAC1234abcd                 -> re-encrypted
    dolcrypt:AES-256-CTR:...               -> untouched
    dolobfuscationv1-12345:...             -> untouched

so a correctly stored key on an existing install is not affected.
