### PR TITLE
Fix #40187 scope notification subscriptions to their entity

### DIFF
--- a/htdocs/core/class/notify.class.php
+++ b/htdocs/core/class/notify.class.php
@@ -285,6 +285,7 @@ class Notify
 		if (!$error) {
 			$sql = "DELETE FROM ".MAIN_DB_PREFIX."notify_def";
 			$sql .= " WHERE rowid = ".((int) $this->id);
+			$sql .= " AND entity IN (".getEntity('notify_def').")";
 
 			if (!$this->db->query($sql)) {
 				$error++;
@@ -310,6 +311,8 @@ class Notify
 	 */
 	public function create($user = null, $notrigger = 0)
 	{
+		global $conf;
+
 		$now = dol_now();
 
 		$error = 0;
@@ -327,8 +330,8 @@ class Notify
 
 		$this->db->begin();
 
-		$sql = "INSERT INTO ".MAIN_DB_PREFIX."notify_def (fk_soc, fk_action, fk_contact, type, datec)";
-		$sql .= " VALUES (".((int) $this->socid).", ".((int) $this->event).", ".((int) $this->contact_id).",";
+		$sql = "INSERT INTO ".MAIN_DB_PREFIX."notify_def (entity, fk_soc, fk_action, fk_contact, type, datec)";
+		$sql .= " VALUES (".((int) $conf->entity).", ".((int) $this->socid).", ".((int) $this->event).", ".((int) $this->contact_id).",";
 		$sql .= "'".$this->db->escape($this->type)."', '".$this->db->idate($this->datec)."')";
 
 		$resql = $this->db->query($sql);
@@ -432,6 +435,7 @@ class Notify
 		$sql .= ",fk_action = ".((int) $this->event);
 		$sql .= ",fk_contact = ".((int) $this->contact_id);
 		$sql .= " WHERE rowid = ".((int) $this->id);
+		$sql .= " AND entity IN (".getEntity('notify_def').")";
 
 		$result = $this->db->query($sql);
 		if (!$result) {
@@ -498,6 +502,7 @@ class Notify
 				$sql .= " AND n.fk_soc = s.rowid";
 				$sql .= $sqlnotifcode;
 				$sql .= " AND s.entity IN (".getEntity('societe').")";
+				$sql .= " AND n.entity IN (".getEntity('notify_def').")";
 				if ($socid > 0) {
 					$sql .= " AND s.rowid = ".((int) $socid);
 				}
@@ -538,6 +543,7 @@ class Notify
 				$sql .= " AND a.rowid = n.fk_action";
 				$sql .= $sqlnotifcode;
 				$sql .= " AND c.entity IN (".getEntity('user').")";
+				$sql .= " AND n.entity IN (".getEntity('notify_def').")";
 				if ($userid > 0) {
 					$sql .= " AND c.rowid = ".((int) $userid);
 				}
@@ -693,6 +699,7 @@ class Notify
 			$sql .= " ".$this->db->prefix()."notify_def as n,";
 			$sql .= " ".$this->db->prefix()."societe as s";
 			$sql .= " WHERE n.fk_contact = c.rowid AND a.rowid = n.fk_action";
+			$sql .= " AND n.entity IN (".getEntity('notify_def').")";
 			$sql .= " AND n.fk_soc = s.rowid";
 			$sql .= " AND c.statut = 1";
 			if (is_numeric($notifcode)) {
@@ -713,6 +720,7 @@ class Notify
 		$sql .= " ".$this->db->prefix()."c_action_trigger as a,";
 		$sql .= " ".$this->db->prefix()."notify_def as n";
 		$sql .= " WHERE n.fk_user = c.rowid AND a.rowid = n.fk_action";
+		$sql .= " AND n.entity IN (".getEntity('notify_def').")";
 		$sql .= " AND c.statut = 1";
 		if (is_numeric($notifcode)) {
 			$sql .= " AND n.fk_action = ".((int) $notifcode); // Old usage

--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -195,3 +195,8 @@ ALTER TABLE llx_product_attribute_combination2val ADD CONSTRAINT fk_product_att_
 ALTER TABLE llx_product_attribute_combination2val ADD CONSTRAINT fk_product_att_com2v_prod_attr_val FOREIGN KEY (fk_prod_attr_val) REFERENCES llx_product_attribute_value (rowid);
 ALTER TABLE llx_product_attribute_combination_price_level ADD CONSTRAINT fk_prod_att_comb_price_level_combination FOREIGN KEY (fk_product_attribute_combination) REFERENCES llx_product_attribute_combination (rowid);
 
+-- llx_notify_def.entity was never written, every row kept its DEFAULT 1, so filtering the
+-- notification queries on it would hide the existing subscriptions. Give each row the entity of the
+-- third party or the user it belongs to. Rows tied to neither keep their current value.
+UPDATE llx_notify_def n SET n.entity = (SELECT s.entity FROM llx_societe s WHERE s.rowid = n.fk_soc) WHERE n.fk_soc > 0 AND EXISTS (SELECT 1 FROM llx_societe s WHERE s.rowid = n.fk_soc);
+UPDATE llx_notify_def n SET n.entity = (SELECT u.entity FROM llx_user u WHERE u.rowid = n.fk_user) WHERE n.fk_user > 0 AND EXISTS (SELECT 1 FROM llx_user u WHERE u.rowid = n.fk_user);


### PR DESCRIPTION
Implements what you described on #40187: notify_def has its own entity, and the link to the third party stays as a second restriction on top of it.

llx_notify_def.entity was never written, so every row sat at DEFAULT 1, and update() and delete() keyed on rowid alone. The reads were scoped only through the joined societe or user, which is why a subscription created in one entity could fire for an action done in another when the third party is shared.

Changes:
- create() writes conf->entity
- update() and delete() add "AND entity IN (getEntity('notify_def'))"
- the four queries that pick recipients add "AND n.entity IN (getEntity('notify_def'))", keeping the existing s.entity / c.entity conditions

The column is unpopulated on existing installs, so filtering on it without a backfill would hide every current subscription. The migration gives each row the entity of its third party, or of its user for user subscriptions; rows tied to neither keep their value.

Checked without the multicompany module: getEntity('notify_def') returns the current entity, so the added conditions are inert on a single-entity install. Checked in SQL that a delete issued from the wrong entity matches no row while the same delete from the right one removes it.
