### PR TITLE
Fix #40008 offer a way back from a closed task

### DIFF
--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -778,6 +778,9 @@ if ($id > 0 || !empty($ref)) {
 					print '<a class="butAction classfortooltip reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=reopen&token='.newToken().'&withproject='.((int) $withproject).'" title="'.$langs->trans("SetToDraft").'">'.$langs->trans('SetToDraft').'</a>';
 				} elseif ($object->status == $object::STATUS_DRAFT) {
 					print '<a class="butAction reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=valid&token='.newToken().'&withproject='.((int) $withproject).'">'.$langs->trans('Validate').'</a>';
+				} elseif ($object->status == $object::STATUS_CLOSED) {
+					// A closed task had no way back, the reopen action above already accepts it
+					print '<a class="butAction reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=reopen&token='.newToken().'&withproject='.((int) $withproject).'">'.$langs->trans('ReOpen').'</a>';
 				}
 				//if ($object->status != $object::STATUS_CLOSED) {
 				print '<a class="butAction reposition" href="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'&action=edit&token='.newToken().'&withproject='.((int) $withproject).'">'.$langs->trans('Modify').'</a>';


### PR DESCRIPTION
Same change as #40240, retargeted to develop as you asked. I will close the 22.0 one.

A closed task shows no action button at all: the block covers VALIDATED and ONGOING (Back to draft) and DRAFT (Validate), so STATUS_CLOSED falls through both and the only way out is to edit the progress field, which is what the reporter described.

The reopen handler at task.php:278 already accepts a closed task and has no status restriction, so this only makes it reachable. Verified through the real code that the transition works: a task goes 0 -> 3 -> 0 with setStatusCommon() returning 1, and the progress field is untouched since setStatusCommon() only writes the status column.

Uses the existing ReOpen label, as fiscalyear_card.php, asset and bom already do after a close.
