### PR TITLE
Fix #39047 keep the foreign currency price on recurring supplier invoice lines

### DIFF
--- a/htdocs/fourn/facture/card-rec.php
+++ b/htdocs/fourn/facture/card-rec.php
@@ -698,7 +698,7 @@ if (empty($reshook)) {
 				setEventMessages($mesg, null, 'errors');
 			} else {
 				// Insert line
-				$result = $object->addline($idprod, (string) $ref_fournisseur, $label, $desc, $pu_ht, $pu_ttc, (float) $qty, $remise_percent, (string) $tva_tx, $localtax1_tx, $localtax2_tx, $price_base_type, $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1, $fk_unit);
+				$result = $object->addline($idprod, (string) $ref_fournisseur, $label, $desc, $pu_ht, $pu_ttc, (float) $qty, $remise_percent, (string) $tva_tx, $localtax1_tx, $localtax2_tx, $price_base_type, $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1, $fk_unit, (float) $price_ht_devise);
 
 				if ($result > 0) {
 					$object->fetch($object->id); // Reload lines
@@ -757,6 +757,7 @@ if (empty($reshook)) {
 		$description = dol_htmlcleanlastbr(GETPOST('product_desc', 'restricthtml') ? GETPOST('product_desc', 'restricthtml') : GETPOST('desc', 'restricthtml'));
 		$ref_fourn = GETPOST('fourn_ref', 'alpha');
 		$pu_ht = price2num(GETPOST('price_ht'), '', 2);
+		$price_ht_devise = price2num(GETPOST('multicurrency_price_ht'), 'CU', 2);
 		$vat_rate = (GETPOST('tva_tx') ? GETPOST('tva_tx') : 0);
 		$pu_ht_devise = price2num(GETPOST('multicurrency_subprice'), '', 2);
 
@@ -845,7 +846,7 @@ if (empty($reshook)) {
 
 		// Update line
 		if (! $error) {
-			$result = $object->updateline(GETPOSTINT('lineid'), GETPOSTINT('productid'), $ref_fourn, $label, $description, (float) $pu_ht, (float) $qty, (float) $remise_percent, $vat_rate, $localtax1_rate, $localtax1_rate, 'HT', $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1);
+			$result = $object->updateline(GETPOSTINT('lineid'), GETPOSTINT('productid'), $ref_fourn, $label, $description, (float) $pu_ht, (float) $qty, (float) $remise_percent, $vat_rate, $localtax1_rate, $localtax1_rate, 'HT', $type, $date_start_fill, $date_end_fill, $info_bits, $special_code, -1, '', (float) $price_ht_devise);
 			if ($result >= 0) {
 				$object->fetch($object->id); // Reload lines
 


### PR DESCRIPTION
card-rec.php reads multicurrency_price_ht at line 458 but never passes it on, so addline() and updateline() take their default of 0 for pu_ht_devise. With a product priced only as a supplier price in a foreign currency the base price is 0 as well, so calcul_price_total() has nothing to derive from and unit price, HT, VAT and TTC all come out at 0, which the generated invoices then inherit.

Measured with calcul_price_total() directly, quantity 1, rate 110:

    pu_ht_devise = 0     total_ht 0       multicurrency_total_ht 0
    pu_ht_devise = 100   total_ht 0.91    multicurrency_total_ht 100

The update block did not read the field at all, although it unsets it a few lines later, so it is added there too. fk_unit is not defined in that block, so updateline() gets its declared default rather than an undefined variable.

Targeted develop rather than a maintenance branch: the amounts on existing template lines would change after a minor upgrade, which is a visible behaviour change even though it is a fix.
