### PR TITLE
FIX: sqlfluff-lint failure on develop (24.0.0-25.0.0.sql notify_def entity backfill)

### DIFF
--- a/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
+++ b/htdocs/install/mysql/migration/24.0.0-25.0.0.sql
@@ -198,5 +198,5 @@ ALTER TABLE llx_product_attribute_combination_price_level ADD CONSTRAINT fk_prod
 -- llx_notify_def.entity was never written, every row kept its DEFAULT 1, so filtering the
 -- notification queries on it would hide the existing subscriptions. Give each row the entity of the
 -- third party or the user it belongs to. Rows tied to neither keep their current value.
-UPDATE llx_notify_def n SET n.entity = (SELECT s.entity FROM llx_societe s WHERE s.rowid = n.fk_soc) WHERE n.fk_soc > 0 AND EXISTS (SELECT 1 FROM llx_societe s WHERE s.rowid = n.fk_soc);
-UPDATE llx_notify_def n SET n.entity = (SELECT u.entity FROM llx_user u WHERE u.rowid = n.fk_user) WHERE n.fk_user > 0 AND EXISTS (SELECT 1 FROM llx_user u WHERE u.rowid = n.fk_user);
+UPDATE llx_notify_def INNER JOIN llx_societe ON llx_notify_def.fk_soc = llx_societe.rowid SET llx_notify_def.entity = llx_societe.entity WHERE llx_notify_def.fk_soc > 0;
+UPDATE llx_notify_def INNER JOIN llx_user ON llx_notify_def.fk_user = llx_user.rowid SET llx_notify_def.entity = llx_user.entity WHERE llx_notify_def.fk_user > 0;


### PR DESCRIPTION
## What

`develop` is red on the `CI-PUSH` → `pre-commit / pre-commit` job (hook `sqlfluff-lint`, run over all files on push to main branches).

Failing file: `htdocs/install/mysql/migration/24.0.0-25.0.0.sql`, the two `UPDATE llx_notify_def` statements added in #40248 (Fix #40187) to backfill `llx_notify_def.entity`:

```
L: 201 | AL01 | Implicit/explicit aliasing of table. [aliasing.table]   (x3)
L: 201 | RF01 | Reference 'n.fk_soc' refers to table/view not found ... [references.from]   (x2)
L: 202 | AL01 ... (x3)   /   L: 202 | RF01 Reference 'n.fk_user' ...  (x2)
```

Cause: implicit table aliases (`llx_notify_def n`, `llx_societe s`, `llx_user u`) plus correlated subqueries whose alias sqlfluff cannot resolve back to the `UPDATE` target.

## Fix

Rewrite the two statements as alias-free multi-table `UPDATE ... INNER JOIN`:

```sql
UPDATE llx_notify_def INNER JOIN llx_societe ON llx_notify_def.fk_soc = llx_societe.rowid SET llx_notify_def.entity = llx_societe.entity WHERE llx_notify_def.fk_soc > 0;
UPDATE llx_notify_def INNER JOIN llx_user    ON llx_notify_def.fk_user = llx_user.rowid   SET llx_notify_def.entity = llx_user.entity    WHERE llx_notify_def.fk_user > 0;
```

Behaviour is unchanged: the `INNER JOIN` on `fk_soc` / `fk_user` = `rowid` plays the role of the previous `EXISTS (...)` guard, so rows linked to neither a third party nor a user keep their current `entity`. Statement order is preserved (a row carrying both keys ends up with the user entity, as before).

## Test

- `sqlfluff-lint` (v4.2.0, repo `pyproject.toml` config) on `24.0.0-25.0.0.sql`: **Passed** (was Failed).
- Other `pre-commit` hooks touching the file: Passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
