### PR TITLE
NEW Option BOM_STATUS_OF_PRODUCT_TO_SHOW to filter the products offered on BOM lines

### DIFF
--- a/htdocs/bom/tpl/objectline_create.tpl.php
+++ b/htdocs/bom/tpl/objectline_create.tpl.php
@@ -10,6 +10,7 @@
  * Copyright (C) 2018		Ferran Marcet			<fmarcet@2byte.es>
  * Copyright (C) 2024		Vincent Maury			<vmaury@timgroup.fr>
  * Copyright (C) 2024-2025	MDW						<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		José MARTINEZ			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -140,7 +141,10 @@ if (isModEnabled("product") || isModEnabled("service")) {
 
 	echo '<span class="prod_entry_mode_predef nowraponall">';
 
-	$statustoshow = -1;
+	// By default, show all products whatever their "on sale" status, because a BOM may legitimately use raw
+	// materials that are only bought and never sold. Set BOM_STATUS_OF_PRODUCT_TO_SHOW to 1 to list only the
+	// products on sale (like the sale documents do), or to 0 to list only the products not on sale.
+	$statustoshow = getDolGlobalInt('BOM_STATUS_OF_PRODUCT_TO_SHOW', -1);
 	if (getDolGlobalString('ENTREPOT_EXTRA_STATUS')) {
 		// hide products in closed warehouse, but show products for internal transfer
 		print $form->select_produits(GETPOSTINT('idprod'), (($filtertype == 1) ? 'idprodservice' : 'idprod'), $filtertype, getDolGlobalInt('PRODUIT_LIMIT_SIZE'), 0, $statustoshow, 2, '', 1, array(), 0, '1', 0, 'maxwidth500 widthcentpercentminusx', 0, 'warehouseopen,warehouseinternal', GETPOST('combinations', 'array:alphanohtml'), 1);


### PR DESCRIPTION
## Problem

On the BOM line creation form, the product combo lists **every** product whatever its "on sale" status, and there is no way to change it:

```php
$statustoshow = -1;
```
<sub>`htdocs/bom/tpl/objectline_create.tpl.php`</sub>

The equivalent template used by the sale documents does the opposite and restricts the same combo to the products on sale:

```php
$statustoshow = 1;
```
<sub>`htdocs/core/tpl/objectline_create.tpl.php`</sub>

Both behaviours are legitimate, and which one is right depends on the site:

- a BOM often uses raw materials that are only bought and never sold, so filtering on "on sale" would hide exactly what the user needs — this is why the current default must stay;
- but on a site whose BOM components are all regular sellable products, the combo also offers the discontinued ones, and users pick them by mistake.

## Change

One line, plus a comment:

```php
$statustoshow = getDolGlobalInt('BOM_STATUS_OF_PRODUCT_TO_SHOW', -1);
```

- unset (the default) → `-1`, all products: **behaviour is strictly unchanged**;
- `1` → only the products on sale, like the sale documents;
- `0` → only the products not on sale.

No new page, no setup screen, no database change.

## Test

- Without the constant: the combo lists the same products as before.
- With `BOM_STATUS_OF_PRODUCT_TO_SHOW = 1`: only products whose "on sale" flag is set are offered; the rest of the form is unaffected.

Running in production on a 24.0 site with the constant set to `1`.

I am happy to switch to a plain boolean name such as `BOM_SHOW_ONLY_PRODUCTS_ON_SELL` if you prefer that over the numeric form — the numeric one was chosen only because it maps directly onto the parameter of `select_produits()`.
