### PR TITLE
Fix #40004 backport to 23.0: make Microsoft Exchange OAuth prompt configurable

### DIFF
--- a/htdocs/core/modules/oauth/microsoft3_oauthcallback.php
+++ b/htdocs/core/modules/oauth/microsoft3_oauthcallback.php
@@ -185,7 +185,15 @@ if (GETPOST('code') || GETPOST('error')) {     // We are coming from oauth provi
 
 	// This may create record into oauth_state before the header redirect.
 	// Creation of record with state in this tables depend on the Provider used (see its constructor).
-	$params = array('prompt' => 'consent');
+	// Default prompt is 'select_account': it avoids the admin-consent infinite loop on Entra tenants
+	// where user consent is disabled, while offline_access (already requested) still returns a refresh
+	// token. Set OAUTH_MICROSOFT3_FORCE_PROMPT to 'consent' to force the consent screen, or to '' to
+	// omit the prompt parameter entirely.
+	$params = array();
+	$promptforauth = getDolGlobalString('OAUTH_MICROSOFT3_FORCE_PROMPT', 'select_account');
+	if ($promptforauth) {
+		$params['prompt'] = $promptforauth;
+	}
 	if ($state) {
 		$params['state'] = $state;
 	}


### PR DESCRIPTION
Backport of #40217 (commit 57316cf) to the 23.0 maintenance branch.

The fix for #40004 landed on `develop` only. On 23.0, `htdocs/core/modules/oauth/microsoft3_oauthcallback.php:188` still hard-codes `prompt=consent`, so v23 installs remain exposed: on Entra tenants where user consent is disabled, every token generation re-displays the consent screen that a non-privileged account cannot clear, even once admin consent has been granted.

There is no configuration workaround on 23.0 — `OAUTH_MICROSOFT3_FORCE_PROMPT` does not exist on that branch — so a v23 install can only patch the file or run the flow with a privileged account, which stores a privileged refresh token in `llx_oauth_token` instead of the intended dedicated mailbox token.

Cherry-picked with `-x`, no adaptation needed: the commit applies cleanly on 23.0 (single file, 9 insertions, 1 deletion). Original authorship preserved.
