### PR TITLE
Fix #39428 cache the reception and lot fetched per dispatch line

### DIFF
--- a/htdocs/fourn/commande/dispatch.php
+++ b/htdocs/fourn/commande/dispatch.php
@@ -1229,8 +1229,14 @@ if ($id > 0 || !empty($ref)) {
 				if (isModEnabled("reception")) {
 					print '<td class="nowraponall">';
 					if (!empty($objp->fk_reception)) {
-						$reception = new Reception($db);
-						$reception->fetch($objp->fk_reception);
+						// Same per request cache as the product below, several lines usually share a reception
+						if (empty($conf->cache['reception'][$objp->fk_reception])) {
+							$reception = new Reception($db);
+							$reception->fetch($objp->fk_reception);
+							$conf->cache['reception'][$objp->fk_reception] = $reception;
+						} else {
+							$reception = $conf->cache['reception'][$objp->fk_reception];
+						}
 						print $reception->getNomUrl(1);
 					}
 
@@ -1260,8 +1266,15 @@ if ($id > 0 || !empty($ref)) {
 				if (isModEnabled('productbatch')) {
 					if ($objp->batch) {
 						include_once DOL_DOCUMENT_ROOT.'/product/stock/class/productlot.class.php';
-						$lot = new Productlot($db);
-						$lot->fetch(0, $objp->pid, $objp->batch);
+						// Same per request cache, several lines usually share a product and batch couple
+						$keyforlot = $objp->pid.'_'.$objp->batch;
+						if (empty($conf->cache['productlot'][$keyforlot])) {
+							$lot = new Productlot($db);
+							$lot->fetch(0, $objp->pid, $objp->batch);
+							$conf->cache['productlot'][$keyforlot] = $lot;
+						} else {
+							$lot = $conf->cache['productlot'][$keyforlot];
+						}
 						print '<td class="dispatch_batch_number">'.$lot->getNomUrl(1).'</td>';
 						if (empty($conf->global->PRODUCT_DISABLE_SELLBY)) {
 							print '<td class="dispatch_dlc">'.dol_print_date($lot->sellby, 'day').'</td>';


### PR DESCRIPTION
The already dispatched table fetches a Reception per row, and a Productlot per row when batches are used, while the Product a few lines above in the same loop is already cached in $conf->cache for the request. Dispatch lines usually share a handful of receptions and lot couples, so the query count followed the number of lines rather than the number of distinct objects.

Same cache applied to both, keyed on fk_reception and on the product and batch couple. Counting the fetches on 60 dispatch lines spread over 4 receptions and 6 product+batch couples: 120 before, 10 after.

No behaviour change, the cached objects are the same instances the page already used, and empty() on a missing index raises nothing in PHP 8 so the arrays need no initialisation, exactly as the existing product cache does.

Targeted 18.0, the call is identical from there through develop.
