### PR TITLE
Fix #38930 delete the odt source before the download block

### DIFF
--- a/htdocs/includes/odtphp/odf.php
+++ b/htdocs/includes/odtphp/odf.php
@@ -917,6 +917,12 @@ IMG;
 			dol_syslog(get_class($this).'::exportAsAttachedPDF $ret_val='.$retval, LOG_DEBUG);
 			$filename=''; $linenum=0;
 
+			// The pdf is already written at this point, so remove the odt source before the download block:
+			// that block may throw when headers are already sent, and it also strips the extension from $name.
+			if (!empty($conf->global->MAIN_ODT_AS_PDF_DEL_SOURCE)) {
+				unlink($name);
+			}
+
 			if (php_sapi_name() != 'cli') {	// If we are in a web context (not into CLI context)
 				if (headers_sent($filename, $linenum)) {
 					throw new OdfException("headers already sent ($filename at $linenum)");
@@ -928,10 +934,6 @@ IMG;
 					header('Content-Disposition: attachment; filename="'.$name.'.pdf"');
 					readfile($name.".pdf");
 				}
-			}
-
-			if (!empty($conf->global->MAIN_ODT_AS_PDF_DEL_SOURCE)) {
-				unlink($name);
 			}
 		} else {
 			dol_syslog(get_class($this).'::exportAsAttachedPDF $ret_val='.$retval, LOG_DEBUG);


### PR DESCRIPTION
The unlink for MAIN_ODT_AS_PDF_DEL_SOURCE sits after the block that sends the pdf, and the odt survives in two different ways.

The one reported: that block throws OdfException when headers are already sent, so the unlink below is never reached.

A second one not in the report: when the block does run with MAIN_DISABLE_PDF_AUTOUPDATE, it rewrites $name through preg_replace('/\.od(x|t)/i', '', $name) before building the download headers. The unlink afterwards therefore targets the path without the extension, which does not exist, and the odt stays on disk too.

Both reproduce:

    old order, headers already sent   odt left on disk
    old order, download block ran     odt left on disk

The pdf is already written by then, so moving the unlink before the block fixes both. Verified that the download still works after the source is gone: the pdf remains readable and readfile() returns its content, the two files being independent.

Targeted 18.0, the block is identical from there through develop. Note this file is under htdocs/includes/ but it is maintained in-tree, #39106 fixed it in July.
