### PR TITLE
Fix #38926 offer the extrafield mass action on the invoice list

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -1495,6 +1495,9 @@ if (isModEnabled('prelevement') && $user->hasRight('prelevement', 'bons', 'creer
 	$langs->load("withdrawals");
 	$arrayofmassactions['withdrawrequest'] = img_picto('', 'payment', 'class="pictofixedwidth"').$langs->trans("MakeWithdrawRequest");
 }
+if ($user->hasRight('facture', 'creer')) {
+	$arrayofmassactions['edit_extrafields'] = img_picto('', 'edit', 'class="pictofixedwidth"').$langs->trans("ModifyValueExtrafields");
+}
 if ($user->hasRight('facture', 'supprimer')) {
 	if (!getDolGlobalString('INVOICE_DIABLE_MASS_DELETION_ON_DRAFT_INVOICES')) {
 		$arrayofmassactions['predeletedraft'] = img_picto('', 'delete', 'class="pictofixedwidth"').$langs->trans("Deletedraft");
@@ -1505,7 +1508,7 @@ if ($user->hasRight("facture", "creer")) {
 		$arrayofmassactions['precreatecreditnote'] = img_picto('', 'undo', 'class="pictofixedwidth"').$langs->trans("cancelByCreditNote");
 	}
 }
-if (in_array($massaction, array('presend', 'predelete', 'makepayment'))) {
+if (in_array($massaction, array('presend', 'predelete', 'makepayment', 'edit_extrafields'))) {
 	$arrayofmassactions = array();
 }
 $massactionbutton = $form->selectMassAction('', $arrayofmassactions);


### PR DESCRIPTION
The edit_extrafields mass action is only wired on the product list, although everything behind it is generic: massactions_pre.tpl.php builds the form from $objecttmp->element, and the handler in actions_massactions.inc.php works from $objectclass and $permissiontoadd. The invoice list already sets both ($objectclass = 'Facture', $permissiontoadd = facture/creer) and already includes the two files, so only the two declaration lines were missing.

Verified the chain end to end rather than by reading: created a temporary extrafield on facture, checked the template resolves it through $objecttmp->element, then wrote and read back a value on a real invoice through insertExtraFields(). Removed the test extrafield afterwards.

The label needs no new key, ModifyValueExtrafields lives in products.lang which this page already loads.

Targeted develop since this adds an entry to a menu, which is a visible change rather than a silent fix.

One correction to the issue: the report says orders support this action. They do not - product/list.php is the only list that wires it today.
