### PR TITLE
Fix #38177 use the BOM quantity for frozen lines on 23.0

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -819,7 +819,7 @@ class Mo extends CommonObject
 
 		$quantity /= $bom->qty;
 		foreach ($bom->lines as $line) {
-			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : 1;
+			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : $line->qty;
 
 			$tmpproduct = new Product($this->db);
 			$tmpproduct->fetch($line->fk_product);


### PR DESCRIPTION
Backport to 23.0 of 2a42fc86f0a, merged on 24.0 as #39941. Forward merges only go upward, so 23.0 will never receive it on its own, and the issue reports the bug on 23.0.

A frozen BOM line consumed 1 whatever quantity the line carried, because the ternary returned the literal 1. Frozen means the quantity does not scale with the manufactured volume, not that it equals one, so the line quantity is what should be used.

    bom qty=5 frozen=1 mo qty=10   before 1    after 5
    bom qty=2 frozen=1 mo qty=3    before 1    after 2
    bom qty=5 frozen=0 mo qty=10   before 50   after 50    unchanged

Same single line as the merged 24.0 change, so the next forward merge from 23.0 lands clean.
