### PR TITLE
FIX Mo::processBOM() ignores qty value for qty_frozen BOM lines

### DIFF
--- a/htdocs/mrp/class/mo.class.php
+++ b/htdocs/mrp/class/mo.class.php
@@ -819,7 +819,7 @@ class Mo extends CommonObject
 
 		$quantity /= $bom->qty;
 		foreach ($bom->lines as $line) {
-			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : 1;
+			$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : $line->qty;
 
 			$tmpproduct = new Product($this->db);
 			$tmpproduct->fetch($line->fk_product);


### PR DESCRIPTION
Backport of #39941 to `23.0`.

On `23.0` a BOM line marked as a fixed quantity (`qty_frozen`) is booked into
the manufacturing order with quantity **1** instead of the quantity entered on
the line:

```php
$quantity_line = !$line->qty_frozen ? $line->qty * $quantity / (!empty($line->efficiency) ? $line->efficiency : 1) : 1;
```

`20.0` to `22.0` are not affected: there the expansion was still inline in
`Mo::createProduction()` and used `$line->qty`. The value was lost when the
loop moved into `processBOM()`, and #39941 restored it on `24.0` — but the fix
was never applied to `23.0`, which is the only maintained branch still showing
the behaviour.

**Steps to reproduce on 23.0**

1. Create a bill of materials with a component line of quantity 5 and tick the
   fixed quantity flag on it.
2. Create a manufacturing order from that bill of materials, for any quantity.
3. The line to consume shows 1 instead of 5.

Same one-line change as #39941.
