### PR TITLE
Fix #37790 keep the declared amounts of cash fences closed before 23.0

### DIFF
--- a/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
+++ b/htdocs/install/mysql/migration/22.0.0-23.0.0.sql
@@ -420,6 +420,13 @@ ALTER TABLE llx_pos_cash_fence ADD COLUMN cash_declared double(24,8) DEFAULT nul
 ALTER TABLE llx_pos_cash_fence ADD COLUMN card_declared double(24,8) DEFAULT null;
 ALTER TABLE llx_pos_cash_fence ADD COLUMN cheque_declared double(24,8) DEFAULT null;
 
+-- The declared amounts were stored in cash, card and cheque before this version, and the cash fence
+-- card now reads the _declared columns to show the final balance. Without this, every record closed
+-- before the upgrade shows 0. Rows already carrying a declared value are left untouched.
+UPDATE llx_pos_cash_fence SET cash_declared = cash WHERE cash_declared IS NULL;
+UPDATE llx_pos_cash_fence SET card_declared = card WHERE card_declared IS NULL;
+UPDATE llx_pos_cash_fence SET cheque_declared = cheque WHERE cheque_declared IS NULL;
+
 ALTER TABLE llx_pos_cash_fence ADD COLUMN cash_lifetime double(24,8) DEFAULT null;
 ALTER TABLE llx_pos_cash_fence ADD COLUMN card_lifetime double(24,8) DEFAULT null;
 ALTER TABLE llx_pos_cash_fence ADD COLUMN cheque_lifetime double(24,8) DEFAULT null;


### PR DESCRIPTION
The 22 to 23 migration adds cash_declared, card_declared and cheque_declared with DEFAULT null and never populates them, while cashcontrol_card.php now reads $object->{key}_declared to display the final balance. Every cash fence closed before the upgrade therefore shows 0, as reported.

The same amounts already exist in the old cash, card and cheque columns: on 22.0 the card stored GETPOST('cash_amount') into $object->cash, and on 23.0 it stores the same field into $object->cash_declared, so copying across is a rename rather than a guess.

Restricted to rows where the new column is still null, which matters twice:

    a record created after the upgrade keeps its declared value    verified, 99.00 stays 99.00
    replaying the migration on a minor upgrade changes nothing     verified over three runs

A cash fence genuinely closed at zero also stays at zero, since the copy preserves whatever the old column held.

The _lifetime columns are deliberately not backfilled: they have no predecessor on 22.0 and are not used by the final balance display.
