### PR TITLE
Fix #37517 send the ticket confirmation to the email collector sender on 21.0

### DIFF
--- a/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
+++ b/htdocs/core/triggers/interface_50_modTicket_TicketEmail.class.php
@@ -220,6 +220,8 @@ class InterfaceTicketEmail extends DolibarrTriggers
 					} elseif (!empty($object->fk_soc)) {
 						$object->fetch_thirdparty();
 						$sendto = $object->thirdparty->email;
+					} elseif (!empty($object->origin_email)) {
+						$sendto = $object->origin_email;
 					}
 
 					if ($sendto) {

--- a/htdocs/emailcollector/class/emailcollector.class.php
+++ b/htdocs/emailcollector/class/emailcollector.class.php
@@ -3430,7 +3430,7 @@ class EmailCollector extends CommonObject
 										$sender_contact = new Contact($this->db);
 										$sender_contact->fetch(0, null, '', $from);
 										if (!empty($sender_contact->id)) {
-											$tickettocreate->context['contactid'] = $sender_contact->id;
+											$tickettocreate->context['contact_id'] = $sender_contact->id;
 										}
 
 										$result = $tickettocreate->create($user);


### PR DESCRIPTION
Both defects reported in #37517 are already fixed on 22.0 and above but not on 21.0, which is still maintained. Forward merges only go upward, so 21.0 will not receive them.

The key mismatch: the collector wrote context['contactid'] while the trigger reads context['contact_id'], so the contact was never resolved and no confirmation went out.

The missing fallback: even with the key fixed, a sender who is neither a known contact nor attached to a third party ends with no recipient at all. The two lines added mirror what 22.0 already does.

Recipient resolution, before and after:

    contact + soc + origin   c@x.fr  ->  c@x.fr    unchanged
    soc + origin             s@x.fr  ->  s@x.fr    unchanged
    origin only              none    ->  o@x.fr    the case being fixed
    nothing                  none    ->  none      unchanged

so only the unknown-sender case changes.

Both hunks are identical to the 22.0 ones, so the next forward merge from 21.0 lands clean.
