### PR TITLE
NEW Split an over-sized available credit when it is used to reduce the amount of an invoice

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -688,9 +688,41 @@ if (empty($reshook)) {
 		if (GETPOSTINT("remise_id") > 0) {
 			$ret = $object->fetch($id);
 			if ($ret > 0) {
-				$result = $object->insert_discount(GETPOSTINT("remise_id"));
-				if ($result < 0) {
-					setEventMessages($object->error, $object->errors, 'errors');
+				$idremise = GETPOSTINT("remise_id");
+
+				// If the available credit is larger than what the invoice can still absorb, split it automatically:
+				// only the required part is inserted as a line, the rest stays available for another invoice.
+				$discount = new DiscountAbsolute($db);
+				if ($discount->fetch($idremise) > 0) {
+					$maxtoabsorb = (float) price2num($object->getRemainToPay(0), 'MT');
+					if ((float) price2num($discount->amount_ttc, 'MT') > $maxtoabsorb) {
+						if ($maxtoabsorb <= 0) {
+							// Nothing left to absorb: the credit cannot be used on this invoice at all
+							$error++;
+							setEventMessages($langs->trans("ErrorDiscountLargerThanRemainToPaySplitItBefore"), null, 'errors');
+						} else {
+							$splitparts = $discount->splitAmount($maxtoabsorb, (float) price2num((float) $discount->amount_ttc - $maxtoabsorb, 'MT'));
+							$discount->fk_facture_source = 0;
+							$discount->fk_invoice_supplier_source = 0;
+							$resdelete = $discount->delete($user);
+							$newidapply = $splitparts[0]->create($user);
+							$newidremain = $splitparts[1]->create($user);
+							if ($resdelete > 0 && $newidapply > 0 && $newidremain > 0) {
+								$idremise = $newidapply;
+								setEventMessages($langs->trans('DepositSplitAutomaticallyApplied', price($maxtoabsorb, 0, $langs, 1, -1, -1, $conf->currency), price((float) price2num((float) $discount->amount_ttc - $maxtoabsorb, 'MT'), 0, $langs, 1, -1, -1, $conf->currency)), null, 'warnings');
+							} else {
+								$error++;
+								setEventMessages($langs->trans("Error"), null, 'errors');
+							}
+						}
+					}
+				}
+
+				if (!$error) {
+					$result = $object->insert_discount($idremise);
+					if ($result < 0) {
+						setEventMessages($object->error, $object->errors, 'errors');
+					}
 				}
 			} else {
 				$error++;

--- a/htdocs/core/tpl/object_discounts.tpl.php
+++ b/htdocs/core/tpl/object_discounts.tpl.php
@@ -3,6 +3,7 @@
 /* Copyright (C) 2018		ATM Consulting		<support@atm-consulting.fr>
  * Copyright (C) 2021-2024  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2025-2026	MDW					<mdeweerd@users.noreply.github.com>
+ * Copyright (C) 2026		José MARTINEZ		<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -118,8 +119,9 @@ if ($absolute_discount > 0) {
 		// Discount available of type fixed amount (not credit note)
 		$more = $addabsolutediscount;
 		$filter = $filterabsolutediscount;  // Fix PhanPluginSuspiciousParamPosition as filterabsolutescount is other argument name in form_remise_dispo
-		// TODO: Check $resteapayer - is '$maxvalue' in form_remise_dispo()
-		$form->form_remise_dispo($_SERVER["PHP_SELF"].'?facid='.$object->id, GETPOSTINT('discountid'), 'remise_id', $thirdparty->id, $absolute_discount, $filter, $resteapayer, $more, 0, $discount_type, 1);
+		// No max value: a credit larger than the remaining amount is now split automatically when it is applied,
+		// only the required part being used. This mirrors what is already done for the credit notes below.
+		$form->form_remise_dispo($_SERVER["PHP_SELF"].'?facid='.$object->id, GETPOSTINT('discountid'), 'remise_id', $thirdparty->id, $absolute_discount, $filter, 0, $more, 0, $discount_type, 1);
 	}
 }
 

--- a/htdocs/fourn/facture/card.php
+++ b/htdocs/fourn/facture/card.php
@@ -563,9 +563,41 @@ if (empty($reshook)) {
 		if (GETPOSTINT("remise_id")) {
 			$ret = $object->fetch($id);
 			if ($ret > 0) {
-				$result = $object->insert_discount(GETPOSTINT("remise_id"));
-				if ($result < 0) {
-					setEventMessages($object->error, $object->errors, 'errors');
+				$idremise = GETPOSTINT("remise_id");
+
+				// If the available credit is larger than what the invoice can still absorb, split it automatically:
+				// only the required part is inserted as a line, the rest stays available for another invoice.
+				$discount = new DiscountAbsolute($db);
+				if ($discount->fetch($idremise) > 0) {
+					$maxtoabsorb = (float) price2num($object->getRemainToPay(0), 'MT');
+					if ((float) price2num($discount->amount_ttc, 'MT') > $maxtoabsorb) {
+						if ($maxtoabsorb <= 0) {
+							// Nothing left to absorb: the credit cannot be used on this invoice at all
+							$error++;
+							setEventMessages($langs->trans("ErrorDiscountLargerThanRemainToPaySplitItBefore"), null, 'errors');
+						} else {
+							$splitparts = $discount->splitAmount($maxtoabsorb, (float) price2num((float) $discount->amount_ttc - $maxtoabsorb, 'MT'));
+							$discount->fk_facture_source = 0;
+							$discount->fk_invoice_supplier_source = 0;
+							$resdelete = $discount->delete($user);
+							$newidapply = $splitparts[0]->create($user);
+							$newidremain = $splitparts[1]->create($user);
+							if ($resdelete > 0 && $newidapply > 0 && $newidremain > 0) {
+								$idremise = $newidapply;
+								setEventMessages($langs->trans('DepositSplitAutomaticallyApplied', price($maxtoabsorb, 0, $langs, 1, -1, -1, $conf->currency), price((float) price2num((float) $discount->amount_ttc - $maxtoabsorb, 'MT'), 0, $langs, 1, -1, -1, $conf->currency)), null, 'warnings');
+							} else {
+								$error++;
+								setEventMessages($langs->trans("Error"), null, 'errors');
+							}
+						}
+					}
+				}
+
+				if (!$error) {
+					$result = $object->insert_discount($idremise);
+					if ($result < 0) {
+						setEventMessages($object->error, $object->errors, 'errors');
+					}
 				}
 			} else {
 				dol_print_error($db, $object->error);

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -753,3 +753,5 @@ CreditNoteNotCreatedErrorOnDiscount=Credit note for <b>%s</b> not created: error
 CreditNoteNotCreatedAlreadyConverted=Credit note for <b>%s</b> not created: invoice already converted
 CreditNotesCreated=%s credit note(s) created
 ThisMassActionIsOnlyForInvoices=This mass action is only available for invoices
+# A credit larger than what the invoice can absorb is split automatically when applied
+DepositSplitAutomaticallyApplied=The available credit was larger than the remaining amount to pay and was split automatically: %s applied to this invoice, %s kept as an available credit for later use.


### PR DESCRIPTION
## Problem

Applying an available credit to an invoice goes through two different paths, and they do not treat an over-sized credit the same way.

**Credit notes** are offered whatever their amount — `object_discounts.tpl.php` calls `form_remise_dispo()` with no max value, with the explicit comment *"We allow credit note even if amount is higher"*.

**The other credits** (commercial discounts and down payments) get `$maxvalue = $resteapayer`, so `select_remises()` renders every credit larger than the remaining amount as `disabled`:

```php
if ($maxvalue > 0 && $obj->amount_ttc > $maxvalue) {
    $qualifiedlines--;
    $disabled = ' disabled';
}
```

The user then sees the credit announced on the card — *"You have discounts (commercial, down payments) for X"* — with nothing selectable in front of it. To use it, they have to leave the invoice, open the third party discount page, split the credit by hand, come back, and apply the right part. On a supplier with three down payments and a small invoice, none of them can be used without that round trip.

The line just above the call has been carrying a `// TODO: Check $resteapayer - is '$maxvalue' in form_remise_dispo()` for a while.

## Change

Offer those credits like the credit notes, and split on application instead of forbidding the selection:

- `core/tpl/object_discounts.tpl.php` — no max value on the selector any more;
- `compta/facture/card.php` and `fourn/facture/card.php` — before `insert_discount()`, if the credit exceeds what the invoice can still absorb, `splitAmount()` cuts it in two: the required part is inserted as a line, the remainder is recreated as an available credit, and a warning message states both amounts.

The invoice can therefore still never be over-absorbed — which is exactly what the max value was protecting against — but the user stays on the invoice.

The split reuses the existing `DiscountAbsolute::splitAmount()`, already used by `comm/remx.php` for the manual split.

## Test

- Third party with a 4,063.83 credit, invoice of 1,428: before, the credit was greyed out; now it is selectable, 1,428 is applied as a line and 2,635.83 stays available.
- Credit smaller than the remaining amount: unchanged, no split, no message.
- Invoice already fully absorbed: unchanged, nothing is split.
- Both customer and supplier sides.

## Notes for reviewers

- The `DepositSplitAutomaticallyApplied` message is the one introduced by #39682 (now merged), which does the same thing for the credits applied as a **payment** on a validated invoice. This PR reuses it, so no language key is added.
- #39666 makes `splitAmount()` carry the currency and rate of the original credit, so the parts keep their foreign-currency value. Without it the split is still correct in the company currency; with it, it is correct in both.
- The branch name carries `phan_full` because the CI needs the full analysis for a changed `.tpl.php`.