### PR TITLE
Fix stock movement origin never displayed for Class@module origins on 18.0

### DIFF
--- a/htdocs/product/stock/class/mouvementstock.class.php
+++ b/htdocs/product/stock/class/mouvementstock.class.php
@@ -997,7 +997,9 @@ class MouvementStock extends CommonObject
 					$classname = $origin_type_array[0];
 					$modulename = empty($origin_type_array[1]) ? strtolower($classname) : $origin_type_array[1];
 
-					$result = dol_include_once('/'.$modulename.'/class/'.$classname.'.class.php');
+					// Dolibarr names its class files in lowercase, so use a lowercase file name whatever
+					// the case of the class name (class names themselves are case insensitive in PHP).
+					$result = dol_include_once('/'.$modulename.'/class/'.strtolower($classname).'.class.php');
 
 					if ($result) {
 						$classname = ucfirst($classname);


### PR DESCRIPTION
Backport to 18.0 of a7b4efef233 by @Pichinov-Jose, merged on 23.0 as #39794. The same include is still present on 18.0, 21.0 and 22.0, and forward merges only go upward so those branches will not receive it.

The include builds the file name from the class name as written, but Dolibarr stores class files in lowercase. An origin declared as MyObject@mymodule therefore looks for MyObject.class.php, which does not exist on a case sensitive filesystem, and the origin column stays empty.

Scale of it: 287 tracked files under htdocs/*/class/ hold a class whose name differs from their file name, so every one of those would fail the include as written.

Worth noting my bench could not reproduce it directly: both the Docker mount and macOS are case insensitive, so the CamelCase path resolves there even though git only stores the lowercase name. On a Linux server with ext4 it does not, which is where the bug shows.
