### PR TITLE
FIX: Multiprice export drops products priced in a shared entity

### DIFF
--- a/htdocs/core/modules/modProduct.class.php
+++ b/htdocs/core/modules/modProduct.class.php
@@ -355,9 +355,10 @@ class modProduct extends DolibarrModules
 				'pr.date_price' => "product");
 			$this->export_sql_start[$r] = 'SELECT DISTINCT ';
 			$this->export_sql_end[$r]  = ' FROM '.MAIN_DB_PREFIX.'product as p';
-			$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_price as pr ON p.rowid = pr.fk_product AND pr.entity = '.$conf->entity; // export prices only for the current entity
+			// Entity scope must be identical in the JOIN and in the MAX() subquery, else products whose latest price is in a shared entity are dropped
+			$this->export_sql_end[$r] .= ' LEFT JOIN '.MAIN_DB_PREFIX.'product_price as pr ON p.rowid = pr.fk_product AND pr.entity IN ('.getEntity('productprice').')';
 			$this->export_sql_end[$r] .= ' WHERE p.entity IN ('.getEntity('product').')'; // For product and service profile
-			$this->export_sql_end[$r] .= ' AND pr.date_price = (SELECT MAX(pr2.date_price) FROM '.MAIN_DB_PREFIX.'product_price as pr2 WHERE pr2.fk_product = pr.fk_product AND pr2.price_level = pr.price_level AND pr2.entity IN ('.getEntity('product').'))'; // export only latest prices not full history
+			$this->export_sql_end[$r] .= ' AND pr.date_price = (SELECT MAX(pr2.date_price) FROM '.MAIN_DB_PREFIX.'product_price as pr2 WHERE pr2.fk_product = pr.fk_product AND pr2.price_level = pr.price_level AND pr2.entity IN ('.getEntity('productprice').'))'; // export only latest prices not full history
 			$this->export_sql_end[$r] .= ' ORDER BY p.ref, pr.price_level';
 		}
 


### PR DESCRIPTION
# FIX Multiprice export drops products priced in a shared entity

The export dataset "Products and prices for each price level" (`ProductsMultiPrice` in `htdocs/core/modules/modProduct.class.php`) mixes two entity scopes:

- the `LEFT JOIN llx_product_price pr` is restricted to `pr.entity = $conf->entity` (current entity only)
- the "latest price only" subquery `pr.date_price = (SELECT MAX(pr2.date_price) ... AND pr2.entity IN (getEntity('product')))` spans all shared entities

With the multicompany module and product + price sharing enabled, a product whose latest price for a level was set from another entity gets a `MAX(date_price)` that matches no row of the current entity. The product is then silently dropped from the export: no line at all, for any level.

This PR uses `getEntity('productprice')` on both sides. It is the scope `Product::fetch()` already uses to load price levels, so the export now returns the same prices as the product card.

- Without multicompany: `getEntity('productprice')` resolves to `$conf->entity`, behaviour unchanged.
- Multicompany, price sharing disabled: both sides resolve to the current entity, the original intent ("export prices of the current entity") is preserved.
- Multicompany, price sharing enabled: both sides use the shared scope.

Verified on a 2-entity instance with bidirectional product/price sharing and 1391 products: before the fix, 77 products were missing from the export run from entity 1 and 1295 from entity 2. After the fix, all 1391 products are exported from both entities, with the latest price per level.

The inconsistency was introduced with the `MAX(date_price)` subquery in 2021 and exists on every maintained branch, hence the target 21.0 (N-2).
