### PR TITLE
FIX #36232 Backport to 20.0: drop reference to non-existent fk_user_done in upcoming-events box

### DIFF
--- a/htdocs/core/boxes/box_actions_future.php
+++ b/htdocs/core/boxes/box_actions_future.php
@@ -99,7 +99,7 @@ class box_actions_future extends ModeleBoxes
 				$sql .= " AND s.rowid = ".((int) $user->socid);
 			}
 			if (!$user->hasRight('agenda', 'allactions', 'read')) {
-				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id)." OR a.fk_user_done = ".((int) $user->id).")";
+				$sql .= " AND (a.fk_user_author = ".((int) $user->id)." OR a.fk_user_action = ".((int) $user->id).")";
 			}
 			$sql .= " AND a.datep > '".$this->db->idate($now)."'";
 			$sql .= " ORDER BY a.datep ASC";


### PR DESCRIPTION
Same one-line fix as the one already on 23.0 and develop, retargeted to 20.0, the oldest affected branch, so that pullmerge.sh propagates it to 21.0 and 22.0.

`llx_actioncomm` lost its `fk_user_done` column in 71e7adac7fa (2024-03-14), which is in 20.0 and later. 18.0 and 19.0 still declare the column in `htdocs/install/mysql/tables/llx_actioncomm.sql`, so they are not affected despite carrying the same PHP line.

On an installation created from 20.0 or later, the query of the box fails with `Unknown column`, so the box shows nothing at all to a user without the `agenda->allactions->read` permission. The removed predicate could never match a row, and `fk_user_action` holds what `fk_user_done` used to hold (see `migration/3.5.0-3.6.0.sql:1704`), so this restores the box rather than widening what it shows. `box_actions.php` already carries this exact two-predicate form.

Supersedes #39686, which targeted 22.0 only.