### PR TITLE
FIX Proposal list user filter no longer defaults to the current user

### DIFF
--- a/htdocs/comm/propal/list.php
+++ b/htdocs/comm/propal/list.php
@@ -1268,7 +1268,7 @@ if ($user->hasRight('user', 'user', 'lire')) {
 if ($user->hasRight('user', 'user', 'lire')) {
 	$moreforfilter .= '<div class="divsearchfield">';
 	$tmptitle = $langs->trans('LinkedToSpecificUsers');
-	$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers($search_user, 'search_user', $tmptitle, null, 0, '', '', '0', 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');
+	$moreforfilter .= img_picto($tmptitle, 'user', 'class="pictofixedwidth"').$form->select_dolusers(($search_user > 0 ? $search_user : -2), 'search_user', $tmptitle, null, 0, '', '', '0', 0, 0, '', 0, '', 'maxwidth250 widthcentpercentminusx');
 	$moreforfilter .= '</div>';
 }
 // If the user can view products


### PR DESCRIPTION
Fixes #40274

Since **24.0.1**, opening the proposal list with no filter pre-selects the current user in the "Linked to a specific user contact" dropdown. The list then silently hides every proposal not linked to them, and users think the filters are broken.

Commit e7da5b4d (PR #39921) replaced `(empty($search_user) ? -2 : 0)` with `$search_user`. As `$search_user` is read with `GETPOSTINT()` (`htdocs/comm/propal/list.php:91`), it is `0` when no filter is set, and `select_dolusers()` treats `0` as "no preselected user defined" and falls back to `$user->id`. The `-2` that was removed is exactly what prevented that fallback.

Passing `-2` only when nothing is selected keeps what #39921 fixed.

Measured on a clean instance, restarted between each state:

| line 1267 | no filter | `?search_user=2` |
|---|---|---|
| 24.0.0 — `(empty($search_user) ? -2 : 0)` | nothing selected ✔ | user 1 ✘ (the bug #39921 fixed) |
| 24.0.1 — `$search_user` | **user 1 ✘ (regression)** | user 2 ✔ |
| this PR — `($search_user > 0 ? $search_user : -2)` | nothing selected ✔ | user 2 ✔ |

`commande/list.php` and `compta/facture/list.php` are not affected: they read the parameter with `GETPOST()`, which returns `''`.

One file, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
