### PR TITLE
QUAL|Qual Fix Phan undeclared property PaymentVAT->label

### DIFF
--- a/htdocs/compta/tva/class/paymentvat.class.php
+++ b/htdocs/compta/tva/class/paymentvat.class.php
@@ -127,6 +127,11 @@ class PaymentVAT extends CommonObject
 	public $lib;
 
 	/**
+	 * @var string      Label of the VAT payment
+	 */
+	public $label;
+
+	/**
 	 * @var int|string datepaye
 	 */
 	public $datepaye;


### PR DESCRIPTION
# QUAL|Qual Fix Phan undeclared property PaymentVAT->label

The `PaymentVAT` class (htdocs/compta/tva/class/paymentvat.class.php) uses
`$this->label` in `getNomUrl()` but never declared the property, which raises
`PhanUndeclaredProperty` warnings in the Phan technical debt report
(https://cti.dolibarr.org/ - Technical debt (Phan) section).

This change declares the `public $label` property (with its PHPDoc) right after
the deprecated `$lib` property, which is already annotated `@see $label`.

No functional change: the property was already being read with a
`!empty($this->label)` guard in `getNomUrl()`.

Follows `.agents/AGENTS.md`: tabs for indentation, English comments, PSR-12,
no blank lines removed, no existing function/variable renamed.