### PR TITLE
FIX Third-party autocomplete broken by a LIMIT placed before ORDER BY

### DIFF
--- a/htdocs/societe/ajax/ajaxcompanies.php
+++ b/htdocs/societe/ajax/ajaxcompanies.php
@@ -140,9 +140,8 @@ if ($user->socid > 0) {
 //if (GETPOST("filter")) $sql.= " AND (".GETPOST("filter", "alpha").")"; // Add other filters
 
 $limit = getDolGlobalInt('SEARCH_LIMIT_AJAX') ?: 1000;		// SEARCH_LIMIT_AJAX is a hidden option that has priority on option THIRDPARTY_LIMIT_SIZE if set.
-$sql .= $db->plimit($limit, 0);
-
 $sql .= " ORDER BY s.nom ASC";
+$sql .= $db->plimit($limit, 0);
 
 //dol_syslog("ajaxcompanies", LOG_DEBUG);
 $resql = $db->query($sql);


### PR DESCRIPTION
Fixes #40277

On the **Contacts/addresses** tab of any document, the third-party search field shows a dropdown of empty rows and no third party can be selected. 23.0 is fine; 24.0.0, 24.0.1, `24.0` and `develop` are affected.

`htdocs/societe/ajax/ajaxcompanies.php` appended the limit before the `ORDER BY`:

```sql
... AND (s.nom LIKE '%commune de%' OR ...) LIMIT 1000 OFFSET 0 ORDER BY s.nom ASC
```

```
ERROR 1064 (42000): ... check the manual ... near 'ORDER BY s.nom ASC' at line 1
```

The query therefore always failed and the endpoint answered with its error object `{"nom":"Error","label":"Error","key":"Error","value":"Error"}`. Being an object rather than an array, `$.map()` in `ajax_autocompleter()` iterates its four properties and produces four entries whose `label` is `undefined`; jQuery UI then reclassifies the text-less items as `ui-menu-divider`, which is why users see thin empty lines.

Verified on a clean 24.0.0 instance, MariaDB, default theme:

| | endpoint response | dropdown |
|---|---|---|
| before | `{"nom":"Error","label":"Error",…}` | 4 empty rows |
| after | `[{"label":"<strong>Commune de</strong> Colmar","key":"105",…}, …]` | the 3 matching third parties |

The `plimit()` call came from 5728e44c ("NEW Introduce THIRDPARTY_LIMIT_SIZE for a limit on thirdparty in select"); only its position is wrong, so the limit itself is preserved.

One file, two lines swapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
