### PR TITLE
FIX Quadratic update_price when creating an invoice from an origin

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2030,7 +2030,7 @@ if (empty($reshook)) {
 											$lines[$i]->fk_unit,
 											0,
 											'',
-											0
+											1  // noupdateafterinsertline: update_price() is called once after the loop, calling it per line is quadratic
 										);
 
 										if ($result > 0) {


### PR DESCRIPTION
## Bug

Creating an invoice from an order (or a proposal, or a contract) with a few hundred lines fails with `PHP Fatal error: Maximum execution time of 30 seconds exceeded`, referer `compta/facture/card.php?action=create&origin=commande&originid=...`.

## Cause

In `htdocs/compta/facture/card.php` the origin lines are copied one by one with `Facture::addline()`. The last argument, `$noupdateafterinsertline`, is passed as `0`, so every single line triggers a full `update_price()` that re-reads all the lines already inserted. The cost is quadratic.

This is a regression. Commit 30bb2c5c2f2 (2022-05-03, *"FIX Too many requets. On large order, fix n(n+1) sql into a n sql."*) had set this argument to `1`, together with the single `update_price()` that still follows the loop. Commit 1301cd36a1e (*"NEW Subtotal module"*, #33502, 2025-05-10) set it back to `0`, in the same hunk that adds the `extraparams` copy loop:

```diff
 											$lines[$i]->fk_unit,
 											0,
 											'',
-											1
+											0
 										);
 
 										if ($result > 0) {
+											foreach ($object->lines as $line) {
```

Value of that argument per branch: `1` in 21.0, `0` in 22.0, 23.0, 24.0 and develop.

## Why setting it back to `1` is safe

- In `Facture::addline()`, `$this->lines[] = $this->line;` is **outside** the `if (empty($noupdateafterinsertline))` guard, which only wraps the `update_price()` call. `$object->lines` is therefore populated either way, and the `extraparams` loop added by #33502 keeps working — verified at runtime. The guard was already shaped like this before #33502, so the flip was not needed by it.
- `CommonObject::update_price()` never touches `$this->lines` (it re-reads the lines with its own SQL), and it is idempotent: totals are reset and fully recomputed on each call.
- `$object->update_price(1, 'auto', 0, $mysoc);` right after the loop is unconditional as soon as `create()` succeeded, and is followed by `line_order(true, 'DESC')`. The rank handling and the child-line ordering inside `addline()` are outside the guard too, so they are unchanged.
- The other `addline()` loop in the same file (invoice created from a product list) already passes `1` with a single `update_price()` after it.

## Measurements

On a real 402-line order, inside a rolled-back transaction:

| | duration | total_ht |
|---|---|---|
| before | 402 s | 28982.48 |
| after | 25.4 s | 28982.48 |

Equivalence test: both invoices were compared line by line on 31 business columns of `llx_facturedet` (`total_*`, `tva_tx`, `rang`, `fk_parent_line`, `special_code`, `situation_percent`, `fk_prev_id`, `extraparams`, multicurrency…) plus the totals of `llx_facture`. **402 lines, 0 difference.**

## Scope

One value changed. Deliberately kept atomic — the same pattern exists in other loops (`commande/card.php`, `comm/propal/card.php`, `commande/list.php`, `expedition/list.php`, `import_lines_from_object`), but those also need the post-loop `update_price()` to be added, so they belong in separate PRs.

Happy to drop the inline comment if you prefer a strictly one-character diff.

## Additional check: Subtotal lines

Since the flip came from the Subtotal module, a second equivalence run was made on an order mixing regular product and service lines with 4 Subtotal lines (`special_code = 81`, `product_type = 9`, title and subtotal at depth 1/-1), which also exercises the `$fk_parent_line` chaining of the loop. Both invoices are identical on the same 31 columns, and so are the totals.

What the equivalence runs cover: product and service lines, VAT, percentage discounts, ranks, Subtotal title/subtotal lines and parent-line chaining. What they do not exercise: situation invoices (`fk_prev_id`), real multicurrency, and negative-amount lines — the latter go through the `insert_discount()` branch of `card.php`, which is not touched by this diff. Deposits (`TYPE_DEPOSIT`) use a different `addline()` loop in the same file, also untouched.

## Known limitation, deliberately left out

The return value of the post-loop `update_price()` is not tested, so a failure there is no longer surfaced by `addline()`. This is not introduced by this PR: the return value was already untested between 2022 and #33502, when the argument was `1`, and the sibling loop in the same file has the same shape. Handling it would make this diff non-atomic — happy to open a follow-up PR.