### PR TITLE
FIX security: restore restrictedArea() on payment_vat, donation payment and stocktransfer note pages

### DIFF
--- a/htdocs/compta/payment_vat/card.php
+++ b/htdocs/compta/payment_vat/card.php
@@ -56,8 +56,6 @@ $confirm = GETPOST('confirm');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-// TODO ajouter regle pour restreindre access paiement
-//restrictedArea($user, 'facture', $id,'');
 
 $object = new PaymentVAT($db);
 if ($id > 0) {
@@ -66,6 +64,8 @@ if ($id > 0) {
 		dol_print_error($db, 'Failed to get payment id '.$id);
 	}
 }
+
+restrictedArea($user, 'payment_vat', $object, '');
 
 
 /*

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -260,6 +260,10 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
 		$tableandshare = 'paiementcharge';
 		$parentfortableentity = 'fk_charge@chargesociales';
 	}
+	if ($features == 'payment_vat') {
+		$tableandshare = 'payment_vat';
+		$parentfortableentity = 'fk_tva@tva';
+	}
 
 	// if commonObjectLine : Using many2one related commonObject
 	// @see commonObjectLine::parentElement
@@ -398,6 +402,11 @@ function restrictedArea(User $user, $features, $object = 0, $tableandshare = '',
 				$nbko++;
 			}
 		} elseif ($feature == 'payment_sc') {
+			if (!$user->hasRight('tax', 'charges', 'lire')) {
+				$readok = 0;
+				$nbko++;
+			}
+		} elseif ($feature == 'payment_vat') {
 			if (!$user->hasRight('tax', 'charges', 'lire')) {
 				$readok = 0;
 				$nbko++;

--- a/htdocs/don/payment/card.php
+++ b/htdocs/don/payment/card.php
@@ -52,8 +52,6 @@ $confirm = GETPOST('confirm', 'alpha');
 if ($user->socid) {
 	$socid = $user->socid;
 }
-// TODO Add rule to restrict access payment
-//restrictedArea($user, 'facture', $id,'');
 
 $object = new PaymentDonation($db);
 if ($id > 0) {
@@ -62,6 +60,8 @@ if ($id > 0) {
 		dol_print_error($db, 'Failed to get payment id '.$id);
 	}
 }
+
+restrictedArea($user, 'don', $object->id, 'payment_donation', '', '', 'rowid');
 
 $permissiontoread = $user->hasRight('don', 'lire');
 $permissiontoadd = $user->hasRight('don', 'creer');

--- a/htdocs/product/stock/stocktransfer/stocktransfer_note.php
+++ b/htdocs/product/stock/stocktransfer/stocktransfer_note.php
@@ -54,19 +54,21 @@ $hookmanager->initHooks(array('stocktransfernote', 'globalcard')); // Note that 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
-// Security check - Protection if external user
-//if ($user->socid > 0) accessforbidden();
-//if ($user->socid > 0) $socid = $user->socid;
-//restrictedArea($user, 'stocktransfer', $id);
-
 // Load object
 include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be 'include', not 'include_once'. Include fetch and fetch_thirdparty but not fetch_optionals
 if ($id > 0 || !empty($ref)) {
 	$upload_dir = $conf->stocktransfer->multidir_output[$object->entity ?? $conf->entity]."/".$object->id;
 }
 
+$permissiontoread = $user->hasRight('stocktransfer', 'stocktransfer', 'read');
 $permissionnote = $user->hasRight('stocktransfer', 'stocktransfer', 'write'); // Used by the include of actions_setnotes.inc.php
 $permissiontoadd = $user->hasRight('stocktransfer', 'stocktransfer', 'write'); // Used by the include of actions_addupdatedelete.inc.php
+
+// Security check - Protection if external user
+restrictedArea($user, 'stocktransfer', $object->id, 'stocktransfer_stocktransfer', 'stocktransfer', 'fk_soc', 'rowid');
+if (!$permissiontoread) {
+	accessforbidden();
+}
 
 
 


### PR DESCRIPTION
## Fix security: restore restrictedArea() on 3 pages with commented-out permission checks

### Vulnerability

Three pages had their `restrictedArea()` call commented out and never replaced, so none of them tested any permission before loading and printing a record. Any authenticated account — including an external customer or vendor login — could read arbitrary VAT payments, donation payments and stock-transfer private notes by walking the `id` parameter.

### Root cause

- `htdocs/compta/payment_vat/card.php` — lines 59-60 had `//restrictedArea($user, 'facture', $id,'')` commented out, nothing replaced it
- `htdocs/don/payment/card.php` — lines 55-56 had `//restrictedArea($user, 'facture', $id,'')` commented out, nothing replaced it
- `htdocs/product/stock/stocktransfer/stocktransfer_note.php` — lines 57-60 had the entire security block commented out, nothing replaced it

The comparable pages (`compta/payment_sc/card.php:68`, `compta/paiement/card.php:73`) do have active `restrictedArea()` calls.

### Changes

| File | Change |
|------|--------|
| `htdocs/core/lib/security.lib.php` | Added `payment_vat` feature mapping in `restrictedArea()` (mirrors `payment_sc`): table mapping + `tax/charges/lire` permission check |
| `htdocs/compta/payment_vat/card.php` | Removed commented-out lines, added `restrictedArea($user, 'payment_vat', $object, '')` after fetch |
| `htdocs/don/payment/card.php` | Removed commented-out lines, added `restrictedArea($user, 'don', $object->id, 'payment_donation', '', '', 'rowid')` after fetch |
| `htdocs/product/stock/stocktransfer/stocktransfer_note.php` | Removed commented-out block, added `restrictedArea()` + `$permissiontoread` check after object load |

### How the fix works

`restrictedArea()` enforces two layers:
1. **Module read permission** — `tax/charges/lire`, `don/lire`, `stocktransfer/stocktransfer/read`
2. **External-user gate** — if `MAIN_MODULES_FOR_EXTERNAL` is set, external users (`socid > 0`) are denied unless the module is explicitly listed. For stock transfers, it additionally checks the record's `fk_soc` against the external user's `socid`.

### Severity

Medium (CVSS: AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N) — confidential financial data readable by any authenticated user.

### Credit

Vulnerability found by Google's security automation tooling. Please credit Google and Ada Logics in any advisories.

### Testing

All four files pass `php -l` syntax check. Manual verification recommended: confirm that an external user (socid > 0) gets `accessforbidden()` on all three pages, and that an internal user without `tax/charges/lire` (or `don/lire`, or `stocktransfer/stocktransfer/read`) is also blocked.