### PR TITLE
NEW: Add img_fa() FontAwesome-only helper next to img_picto()

### DIFF
--- a/htdocs/core/lib/html.lib.php
+++ b/htdocs/core/lib/html.lib.php
@@ -1697,6 +1697,43 @@ function img_picto($titlealt, $picto, $moreatt = '', $pictoisfullpath = 0, $srco
 }
 
 /**
+ *	Show a FontAwesome icon whatever its name (generic function).
+ *
+ *	This is img_picto() restricted to FontAwesome output. It accepts the same $picto
+ *	values as img_picto() does for icons (a Dolibarr picto key such as 'user', 'bill'
+ *	or 'project', or a FontAwesome code such as 'fa-user', 'fontawesome_user' or
+ *	'fa-star_far_#888_1.3em' with the 'fa-<name>_<style>_<color>_<size>' syntax) and
+ *	returns the very same <span> tag. Everything img_picto() does to load a png/gif/svg
+ *	file from disk is left out: a $picto that looks like an image path (it is not a
+ *	'fa-'/'fontawesome_' code and contains a '.', '/' or '@') is not supported and
+ *	returns an empty string.
+ *
+ *	@param      string		$titlealt         		Text on title tag for tooltip. Not used if param $notitle is set to 1.
+ *	@param      string		$picto       			Icon name: a Dolibarr picto key ('user', 'bill', ...) or a FontAwesome code
+ *													('fa-user', 'fontawesome_user', or 'fa-<name>_<style>_<color>_<size>').
+ *	@param		string		$moreatt				Add more attributes on the tag (For example 'class="pictofixedwidth"')
+ *  @param		int<0,1>	$notitle				1=Disable tag title. Use it if you add js tooltip, to avoid duplicate tooltip.
+ *  @param		string		$morecss				Add more class css on the tag (For example 'myclascss').
+ *  @param		int<0,2>	$marginleftonlyshort	1=Add a short left margin on picto, 2=Add a larger left margin on picto, 0=No margin left.
+ *  @return     string       				    	Return the <span> tag of the FontAwesome icon, or '' if $picto is not a supported icon name
+ *  @see        img_picto()
+ */
+function img_fa($titlealt, $picto, $moreatt = '', $notitle = 0, $morecss = '', $marginleftonlyshort = 2)
+{
+	$picto = (string) $picto;
+
+	$isexplicitfa = (strpos($picto, 'fa-') === 0 || strpos($picto, 'fontawesome_') === 0);
+	if (!$isexplicitfa && $picto !== '' && preg_match('/[.\/@]/', $picto)) {
+		// img_picto() would try to load this as a png/gif/svg file on disk. img_fa() only renders FontAwesome icons.
+		dol_syslog("img_fa: '" . $picto . "' is not a FontAwesome icon name (looks like an image path), returning an empty string", LOG_WARNING);
+		return '';
+	}
+
+	// img_picto() with $pictoisfullpath=0 and $srconly=0 always returns the FontAwesome <span> for such a $picto.
+	return img_picto($titlealt, $picto, $moreatt, 0, 0, $notitle, '', $morecss, $marginleftonlyshort);
+}
+
+/**
  * Get array to convert the Dolibarr picto keys into Font awesome keys
  *
  * @param	string		$mode		'fa' to get conversion array for Font-Awesome

--- a/test/phpunit/FunctionsLibTest.php
+++ b/test/phpunit/FunctionsLibTest.php
@@ -1604,6 +1604,43 @@ class FunctionsLibTest extends CommonClassTest
 	}
 
 	/**
+	 * testImgFa
+	 *
+	 * @return	void
+	 */
+	public function testImgFa()
+	{
+		// Dolibarr picto key -> FontAwesome <span>, no <img>
+		$s = img_fa('title', 'user');
+		print __METHOD__." s=".$s."\n";
+		$this->assertStringContainsStringIgnoringCase('fa-user', $s, 'testImgFa1');
+		$this->assertStringContainsStringIgnoringCase('<span', $s, 'testImgFa1');
+		$this->assertStringNotContainsStringIgnoringCase('<img', $s, 'testImgFa1');
+
+		// Picto key that goes through the getImgPictoConv() mapping
+		$s = img_fa('title', 'project');
+		print __METHOD__." s=".$s."\n";
+		$this->assertStringContainsStringIgnoringCase('fa-project-diagram', $s, 'testImgFa2');
+
+		// Explicit 'fa-<name>_<style>_<color>_<size>' code
+		$s = img_fa('title', 'fa-star_far_#888_1em');
+		print __METHOD__." s=".$s."\n";
+		$this->assertStringContainsStringIgnoringCase('far', $s, 'testImgFa3');
+		$this->assertStringContainsStringIgnoringCase('fa-star', $s, 'testImgFa3');
+		$this->assertStringContainsStringIgnoringCase('font-size: 1em', $s, 'testImgFa3');
+		$this->assertStringContainsStringIgnoringCase('color: #888', $s, 'testImgFa3');
+
+		// An image path is not a FontAwesome icon name -> empty string
+		$s = img_fa('title', 'img.png');
+		print __METHOD__." s=".$s."\n";
+		$this->assertEquals('', $s, 'testImgFa4');
+
+		$s = img_fa('title', '/fullpath/img.png');
+		print __METHOD__." s=".$s."\n";
+		$this->assertEquals('', $s, 'testImgFa5');
+	}
+
+	/**
 	 * testDolNow
 	 *
 	 * @return	void


### PR DESCRIPTION
## What

`img_fa()` — a FontAwesome-only sibling of `img_picto()`, in `htdocs/core/lib/html.lib.php`.

```php
img_fa($titlealt, $picto, $moreatt = '', $notitle = 0, $morecss = '', $marginleftonlyshort = 2)
```

It accepts the same `$picto` values as `img_picto()` for icons — a Dolibarr picto key (`user`, `bill`, `project`, …) or a FontAwesome code (`fa-user`, `fontawesome_user`, `fa-<name>_<style>_<color>_<size>`) — and returns the exact same `<span>` tag, including the `getImgPictoConv()` mapping and the per-key prefix / colour / `infobox-*` css / `em0xx` sizing / `_nocolor` handling.

It drops everything `img_picto()` does for on-disk images: `$pictoisfullpath`, `$srconly`, `$alt`, `$allowothertags`, the `.png`/`.gif`/`.svg` guessing, the `dol_document_root` lookup and the final `<img>` tag.

## How

Thin wrapper (no change to `img_picto()`): if `$picto` looks like an image path (not a `fa-`/`fontawesome_` code, and contains `.`, `/` or `@`) it logs a `LOG_WARNING` and returns `''`; otherwise it calls `img_picto($titlealt, $picto, $moreatt, 0, 0, $notitle, '', $morecss, $marginleftonlyshort)`, which for such a `$picto` always renders the FontAwesome `<span>`. So the output is guaranteed identical to `img_picto()` for every icon input and can't drift.

## Tests

`test/phpunit/FunctionsLibTest.php::testImgFa` — picto key (`user`), `getImgPictoConv()` path (`project` → `fa-project-diagram`), explicit `fa-star_far_#888_1em` (style/colour/size), and image paths (`img.png`, `/fullpath/img.png`) → `''`. Passes together with the existing `testImgPicto`. PHPStan level 9 clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
