### PR TITLE
Fix missing drag and drop file upload on four cards

### DIFF
--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -4129,7 +4129,7 @@ if ($action == 'create') {
 
 	$head = facture_prepare_head($object);
 
-	print dol_get_fiche_head($head, 'compta', $langs->trans('InvoiceCustomer'), -1, 'bill');
+	print dol_get_fiche_head($head, 'compta', $langs->trans('InvoiceCustomer'), -1, 'bill', 0, '', '', 0, '', 1);
 
 	$formconfirm = '';
 

--- a/htdocs/contrat/card.php
+++ b/htdocs/contrat/card.php
@@ -1313,7 +1313,7 @@ if ($action == 'create') {
 		$hselected = 0;
 		$formconfirm = '';
 
-		print dol_get_fiche_head($head, $hselected, $langs->trans("Contract"), -1, 'contract');
+		print dol_get_fiche_head($head, $hselected, $langs->trans("Contract"), -1, 'contract', 0, '', '', 0, '', 1);
 
 
 		if ($action == 'delete') {

--- a/htdocs/expensereport/card.php
+++ b/htdocs/expensereport/card.php
@@ -1573,7 +1573,7 @@ if ($action == 'create') {
 			print '<input type="hidden" name="id" value="'.$id.'">';
 			print '<input type="hidden" name="backtopage" value="'.$backtopage.'">';
 
-			print dol_get_fiche_head($head, 'card', $langs->trans("ExpenseReport"), 0, 'trip');
+			print dol_get_fiche_head($head, 'card', $langs->trans("ExpenseReport"), 0, 'trip', 0, '', '', 0, '', 1);
 
 			if ($object->status == 99) {
 				print '<input type="hidden" name="action" value="updateFromRefuse">';
@@ -1665,7 +1665,7 @@ if ($action == 'create') {
 		} else {
 			$taxlessUnitPriceDisabled = !empty($conf->global->EXPENSEREPORT_FORCE_LINE_AMOUNTS_INCLUDING_TAXES_ONLY) ? ' disabled' : '';
 
-			print dol_get_fiche_head($head, 'card', $langs->trans("ExpenseReport"), -1, 'trip');
+			print dol_get_fiche_head($head, 'card', $langs->trans("ExpenseReport"), -1, 'trip', 0, '', '', 0, '', 1);
 
 			$formconfirm = '';
 

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -1901,7 +1901,7 @@ if ($action == 'create') {
 	$head = ordersupplier_prepare_head($object);
 
 	$title = $langs->trans("SupplierOrder");
-	print dol_get_fiche_head($head, 'card', $title, -1, 'order');
+	print dol_get_fiche_head($head, 'card', $title, -1, 'order', 0, '', '', 0, '', 1);
 
 
 	$formconfirm = '';


### PR DESCRIPTION
Backport to 18.0 of 9418653f3c6, merged on 24.0 as #38585. Forward merges only go upward, so 18.0 through 23.0 never received it, and #40214 is a user hitting it on 23.0.4.

dol_get_fiche_head() only installs the drop area when its $dragdropfile argument is passed (functions.lib.php:3248 calls dragAndDropFileUpload() under that condition). These four cards stopped short of the eleventh argument, so dropping a file on them fell through to the browser, while it worked on the customer order, proposal, product and supplier invoice cards.

On 18.0, 16 cards pass it and 51 do not, so this is an oversight on these four rather than a policy.

All the machinery is already on 18.0: dragAndDropFileUpload(), the cssDragDropArea style and the $dragdropfile parameter itself. Only the calls needed updating.

One difference from the 24.0 diff: the invoice card passes 'bill' there where 24.0 passes $object->picto, so the hunk is adapted rather than copied.
