### PR TITLE
FIX Security: Authorization Bypass in Project/Task Comment Update/Delete (IDOR) - reported by soulaimane bouabid

### DIFF
--- a/htdocs/core/actions_comments.inc.php
+++ b/htdocs/core/actions_comments.inc.php
@@ -75,10 +75,6 @@ if ($action == 'addcomment') {
 }
 if ($action === 'updatecomment') {
 	if ($comment->fetch($idcomment) >= 0) {
-		// Verify the comment belongs to the current object to prevent IDOR
-		if ($comment->fk_element != $id || $comment->element_type != $object->element) {
-			accessforbidden();
-		}
 		$comment->description = GETPOST('comment_description', 'restricthtml');
 		if ($comment->update($user) > 0) {
 			setEventMessages($langs->trans("CommentAdded"), null, 'mesgs');
@@ -92,10 +88,6 @@ if ($action === 'updatecomment') {
 }
 if ($action == 'deletecomment') {
 	if ($comment->fetch($idcomment) >= 0) {
-		// Verify the comment belongs to the current object to prevent IDOR
-		if ($comment->fk_element != $id || $comment->element_type != $object->element) {
-			accessforbidden();
-		}
 		if ($comment->delete($user) > 0) {
 			setEventMessages($langs->trans("CommentDeleted"), null, 'mesgs');
 			header('Location: '.$varpage.'?id='.$id.($withproject ? '&withproject=1' : ''));

--- a/htdocs/core/actions_comments.inc.php
+++ b/htdocs/core/actions_comments.inc.php
@@ -30,7 +30,7 @@
  * @var Translate $langs
  * @var User $user
  *
- * @var Object $object
+ * @var CommonObject $object
  * @var string $contextpage
  * @var ?string $action
  * @var int $withproject

--- a/htdocs/core/actions_comments.inc.php
+++ b/htdocs/core/actions_comments.inc.php
@@ -75,6 +75,10 @@ if ($action == 'addcomment') {
 }
 if ($action === 'updatecomment') {
 	if ($comment->fetch($idcomment) >= 0) {
+		// Verify the comment belongs to the current object to prevent IDOR
+		if ($comment->fk_element != $id || $comment->element_type != $object->element) {
+			accessforbidden();
+		}
 		$comment->description = GETPOST('comment_description', 'restricthtml');
 		if ($comment->update($user) > 0) {
 			setEventMessages($langs->trans("CommentAdded"), null, 'mesgs');
@@ -88,6 +92,10 @@ if ($action === 'updatecomment') {
 }
 if ($action == 'deletecomment') {
 	if ($comment->fetch($idcomment) >= 0) {
+		// Verify the comment belongs to the current object to prevent IDOR
+		if ($comment->fk_element != $id || $comment->element_type != $object->element) {
+			accessforbidden();
+		}
 		if ($comment->delete($user) > 0) {
 			setEventMessages($langs->trans("CommentDeleted"), null, 'mesgs');
 			header('Location: '.$varpage.'?id='.$id.($withproject ? '&withproject=1' : ''));

--- a/htdocs/core/actions_comments.inc.php
+++ b/htdocs/core/actions_comments.inc.php
@@ -30,6 +30,7 @@
  * @var Translate $langs
  * @var User $user
  *
+ * @var Object $object
  * @var string $contextpage
  * @var ?string $action
  * @var int $withproject
@@ -75,6 +76,10 @@ if ($action == 'addcomment') {
 }
 if ($action === 'updatecomment') {
 	if ($comment->fetch($idcomment) >= 0) {
+		// Verify the comment belongs to the current object to prevent IDOR
+		if ($comment->fk_element != $id || $comment->element_type != $object->element) {
+			accessforbidden();
+		}
 		$comment->description = GETPOST('comment_description', 'restricthtml');
 		if ($comment->update($user) > 0) {
 			setEventMessages($langs->trans("CommentAdded"), null, 'mesgs');
@@ -88,6 +93,10 @@ if ($action === 'updatecomment') {
 }
 if ($action == 'deletecomment') {
 	if ($comment->fetch($idcomment) >= 0) {
+		// Verify the comment belongs to the current object to prevent IDOR
+		if ($comment->fk_element != $id || $comment->element_type != $object->element) {
+			accessforbidden();
+		}
 		if ($comment->delete($user) > 0) {
 			setEventMessages($langs->trans("CommentDeleted"), null, 'mesgs');
 			header('Location: '.$varpage.'?id='.$id.($withproject ? '&withproject=1' : ''));

--- a/htdocs/core/actions_linkedfiles.inc.php
+++ b/htdocs/core/actions_linkedfiles.inc.php
@@ -195,6 +195,10 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes' && !empty($permissionto
 		require_once DOL_DOCUMENT_ROOT.'/core/class/link.class.php';
 		$link = new Link($db);
 		$link->fetch($linkid);
+		// Verify the link belongs to the current object to prevent IDOR
+		if (!is_object($object) || $link->objecttype != $object->element || $link->objectid != $object->id) {
+			accessforbidden();
+		}
 		$res = $link->delete($user);
 
 		$langs->load('link');
@@ -225,6 +229,10 @@ if ($action == 'confirm_deletefile' && $confirm == 'yes' && !empty($permissionto
 	$link = new Link($db);
 	$f = $link->fetch(GETPOSTINT('linkid'));
 	if ($f) {
+		// Verify the link belongs to the current object to prevent IDOR
+		if (!is_object($object) || $link->objecttype != $object->element || $link->objectid != $object->id) {
+			accessforbidden();
+		}
 		$link->url = GETPOST('link', 'alpha');
 		if (substr($link->url, 0, 7) != 'http://'
 			&& substr($link->url, 0, 8) != 'https://'

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4851,8 +4851,6 @@ abstract class CommonObject
 			if ($rowid > 0) {
 				// When deleting by rowid, scope to the current object to prevent IDOR
 				$sql .= " rowid = " . ((int) $rowid);
-				$sql .= " AND ((fk_source = " . ((int) $this->id) . " AND sourcetype = '" . $this->db->escape($element) . "')";
-				$sql .= " OR (fk_target = " . ((int) $this->id) . " AND targettype = '" . $this->db->escape($element) . "'))";
 			} else {
 				if ($deletesource) {
 					$sql .= " fk_source = " . ((int) $sourceid) . " AND sourcetype = '" . $this->db->escape($sourcetype) . "'";

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4849,7 +4849,6 @@ abstract class CommonObject
 			$sql = "DELETE FROM " . $this->db->prefix() . "element_element";
 			$sql .= " WHERE";
 			if ($rowid > 0) {
-				// When deleting by rowid, scope to the current object to prevent IDOR
 				$sql .= " rowid = " . ((int) $rowid);
 			} else {
 				if ($deletesource) {

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -4849,7 +4849,10 @@ abstract class CommonObject
 			$sql = "DELETE FROM " . $this->db->prefix() . "element_element";
 			$sql .= " WHERE";
 			if ($rowid > 0) {
+				// When deleting by rowid, scope to the current object to prevent IDOR
 				$sql .= " rowid = " . ((int) $rowid);
+				$sql .= " AND ((fk_source = " . ((int) $this->id) . " AND sourcetype = '" . $this->db->escape($element) . "')";
+				$sql .= " OR (fk_target = " . ((int) $this->id) . " AND targettype = '" . $this->db->escape($element) . "'))";
 			} else {
 				if ($deletesource) {
 					$sql .= " fk_source = " . ((int) $sourceid) . " AND sourcetype = '" . $this->db->escape($sourcetype) . "'";

--- a/htdocs/projet/comment.php
+++ b/htdocs/projet/comment.php
@@ -84,7 +84,10 @@ if ($id > 0 || !empty($ref)) {
 	}
 }
 
-// include comment actions
+// Security check - scoped to the specific project
+restrictedArea($user, 'projet', $object->id, 'projet&project');
+
+// include comment actions (after security check to prevent IDOR)
 include DOL_DOCUMENT_ROOT.'/core/actions_comments.inc.php';
 
 /*

--- a/htdocs/projet/comment.php
+++ b/htdocs/projet/comment.php
@@ -56,6 +56,8 @@ $action = GETPOST('action', 'aZ09');
 $confirm = GETPOST('confirm', 'alpha');
 $withproject = GETPOSTINT('withproject');
 
+$mode = GETPOST('mode');
+
 // Security check
 $socid = 0;
 //if ($user->socid > 0) $socid = $user->socid;    // For external user, no check is done on company because readability is managed by public status of project and assignment.
@@ -84,7 +86,10 @@ if ($id > 0 || !empty($ref)) {
 	}
 }
 
-// include comment actions
+// Security check - scoped to the specific project
+restrictedArea($user, 'projet', $object->id, 'projet&project');
+
+// include comment actions (after security check to prevent IDOR)
 include DOL_DOCUMENT_ROOT.'/core/actions_comments.inc.php';
 
 /*

--- a/htdocs/projet/tasks/comment.php
+++ b/htdocs/projet/tasks/comment.php
@@ -68,9 +68,6 @@ $projectstatic = new Project($db);
 // fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);
 
-// include comment actions
-include DOL_DOCUMENT_ROOT.'/core/actions_comments.inc.php';
-
 // Security check
 $socid = 0;
 // Retrieve First Task ID of Project if withprojet is on to allow project prev next to work
@@ -91,6 +88,9 @@ if ($id > 0 || $ref) {
 }
 
 restrictedArea($user, 'projet', $object->fk_project, 'projet&project');
+
+// include comment actions (after security check to prevent IDOR)
+include DOL_DOCUMENT_ROOT.'/core/actions_comments.inc.php';
 
 
 /*


### PR DESCRIPTION
## Summary

Fixes an IDOR (Insecure Direct Object Reference) vulnerability allowing any authenticated user with generic "read projects" rights to update or delete comments on projects/tasks they have no authorization on.

**CWE-639** (Authorization Bypass Through User-Controlled Key), **CWE-862** (Missing Authorization)

## Problem

The comment update/delete handler in `htdocs/core/actions_comments.inc.php` fetched the target comment using only the caller-supplied `idcomment` parameter, then performed the mutation without ever checking that the comment actually belongs to the project/task the current page is authorized against.

Two additional issues made this worse:

1. **`htdocs/projet/tasks/comment.php`** included `actions_comments.inc.php` *before* calling `restrictedArea()`. Since every successful branch in the comment handler ends with `header()` + `exit`, `restrictedArea()` was never reached on a successful mutation.
2. **`htdocs/projet/comment.php`** did not call `restrictedArea()` at all. The only gate was `$user->hasRight('projet', 'lire')` — a generic read right not scoped to a specific project.

## Reproduction

1. As User B, add a comment on Task B. Note the `idcomment` (sequential, easily guessable).
2. As User A (authorized for Task A only), send: `POST /projet/tasks/comment.php?id=<TaskA_id>&idcomment=<TaskB_comment_id>&action=deletecomment`
3. Task B's comment gets deleted — User A was never authorized on Task B.

## Fix

### `htdocs/core/actions_comments.inc.php`
After `fetch($idcomment)`, verify that `$comment->fk_element == $id` and `$comment->element_type == $object->element` before allowing update or delete. Call `accessforbidden()` on mismatch. This is the core IDOR fix: the comment must belong to the object identified by the `id` parameter in the URL.

### `htdocs/projet/tasks/comment.php`
Moved the `include` of `actions_comments.inc.php` to **after** `restrictedArea()`, so the object-level authorization check runs before any comment mutation can execute.

### `htdocs/projet/comment.php`
Added `restrictedArea($user, 'projet', $object->id, 'projet&project')` — consistent with all other project pages (`card.php`, `note.php`, `agenda.php`, etc.) — and moved the `include` after this check.

## How the layers work together

- `restrictedArea()` validates access to the project/task **before** the comment handler runs.
- The `fk_element` / `element_type` check in the handler prevents the IDOR by ensuring the `idcomment` provided actually belongs to the authorized object.