### PR TITLE
Fix session losing its menus after a login done inside a dialog popup

### DIFF
--- a/htdocs/main.inc.php
+++ b/htdocs/main.inc.php
@@ -1136,10 +1136,13 @@ if (!defined('NOLOGIN')) {
 		$_SESSION["dol_company"] = getDolGlobalString("MAIN_INFO_SOCIETE_NOM");
 		$_SESSION["dol_entity"] = $conf->entity;
 		// Store value into session (values stored only if defined)
-		if (!empty($dol_hide_topmenu)) {
+		// Note: do not store the hide-menu flags when the login was done from inside a dialog popup iframe
+		// (dol_openinpopup set, for example after a session timeout inside a popup opened by
+		// dolButtonToOpenUrlInDialogPopup()), otherwise the whole session loses its menus.
+		if (!empty($dol_hide_topmenu) && !GETPOST('dol_openinpopup', 'aZ09')) {
 			$_SESSION['dol_hide_topmenu'] = $dol_hide_topmenu;
 		}
-		if (!empty($dol_hide_leftmenu)) {
+		if (!empty($dol_hide_leftmenu) && !GETPOST('dol_openinpopup', 'aZ09')) {
 			$_SESSION['dol_hide_leftmenu'] = $dol_hide_leftmenu;
 		}
 		if (!empty($dol_optimize_smallscreen)) {


### PR DESCRIPTION
Backport to 18.0 of fcf3006ddd4, merged on 24.0 as #39312. The two lines are unguarded on 18.0, 21.0, 22.0 and 23.0, and forward merges only go upward so those branches will not receive it.

A popup opened by dolButtonToOpenUrlInDialogPopup() sets dol_hide_topmenu and dol_hide_leftmenu. If the session times out while such a popup is open, the login form inside it stores those flags in the session, and every page loaded afterwards comes up without menus.

Only the popup case changes:

    normal login, hide flag set    stored      stored
    login inside a dialog popup    stored      not stored
    no hide flag                   not stored  not stored

The mechanism is already present on 18.0: dolButtonToOpenUrlInDialogPopup() exists and main.inc.php already reads dol_openinpopup in four other places, so this only adds the guard the newer branches have.
