### PR TITLE
Fix #40289 guard oldcopy before comparing it in Asset::update()

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -475,7 +475,11 @@ class Asset extends CommonObject
 		if ($result > 0 && $this->fk_asset_model > 0 && $this->fk_asset_model != $this->oldcopy->fk_asset_model) {
 			$result = $this->setDataFromAssetModel($user, $notrigger);
 		}
-		if ($result > 0 && (
+		// oldcopy is set by the caller before it modifies the object, which card.php does, but dispose()
+		// and reopen() call update() without it and neither touches the fields compared below. Without
+		// the guard, reading them on null warns on PHP 8 and the comparison is always true, so the
+		// depreciation plan was recomputed on every disposal for nothing.
+		if ($result > 0 && is_object($this->oldcopy) && (
 				$this->date_start != $this->oldcopy->date_start ||
 				$this->acquisition_value_ht != $this->oldcopy->acquisition_value_ht ||
 				$this->reversal_date != $this->oldcopy->reversal_date ||


### PR DESCRIPTION
Asset::update() compares five fields to their previous value on $this->oldcopy, which the caller sets before modifying the object. asset/card.php does, but Asset::dispose() and Asset::reopen() both call update() without it, and neither of them touches any of the compared fields.

Two consequences on PHP 8, both verified:

    no oldcopy, before   comparison = true    warning "Attempt to read property on null" per field
    no oldcopy, after    comparison = false   no warning

The comparison evaluating to true is the part that matters: it calls calculationDepreciation(), so the whole depreciation plan was recomputed on every disposal and every reopen for nothing.

The normal path is unchanged: with oldcopy set, a modified field still triggers the recompute and an unmodified one still does not.

Targeted 18.0, the unguarded read is identical from there through develop.
