### PR TITLE
FIX Depreciation options of an asset cannot be saved from the interface

### DIFF
--- a/htdocs/asset/class/assetdepreciationoptions.class.php
+++ b/htdocs/asset/class/assetdepreciationoptions.class.php
@@ -218,6 +218,33 @@ class AssetDepreciationOptions extends CommonObject
 	}
 
 	/**
+	 * Return whether an 'enabled_field' condition ("mode_key:field_key:value") is satisfied by the
+	 * data of the submitted form.
+	 *
+	 * @param	string	$enabledfield	Condition, as "mode_key:field_key:value"
+	 * @return	bool					True when the driving field was submitted with the expected value
+	 */
+	protected function isEnabledFieldSatisfiedFromPost($enabledfield)
+	{
+		$info = explode(':', $enabledfield);
+		if (count($info) < 3) {
+			return true;
+		}
+
+		$htmlname = $info[0] . '_' . $info[1];
+		if (!GETPOSTISSET($htmlname)) {
+			return false;	// An unchecked checkbox is not submitted at all
+		}
+
+		$value = GETPOST($htmlname, 'alphanohtml');
+		if ($value === 'on') {
+			$value = '1';	// A checked checkbox may be submitted as 'on'
+		}
+
+		return ((string) $value === (string) $info[2]);
+	}
+
+	/**
 	 *  Fill deprecation_options property of object (using for data sent by forms)
 	 *
 	 * @param	int<0,1>			$class_type	Type (0:asset, 1:asset model)
@@ -231,10 +258,23 @@ class AssetDepreciationOptions extends CommonObject
 
 		$deprecation_options = array();
 		foreach ($this->deprecation_options_fields as $mode_key => $mode_info) {
+			// A mode disabled by its enabled_field must not be validated at all. The form submits the
+			// fields of the hidden block anyway, empty, so a required field of that block (the
+			// degressive coefficient) makes the whole page fail. The block is dropped further below,
+			// but only after its fields have been validated, which is too late.
+			if (!empty($mode_info['enabled_field']) && !$this->isEnabledFieldSatisfiedFromPost($mode_info['enabled_field'])) {
+				continue;
+			}
+
 			$this->setInfosForMode($mode_key, $class_type);
 
 			foreach ($mode_info['fields'] as $field_key => $field_info) {
 				if (!empty($field_info['computed'])) {
+					continue;
+				}
+				// Same thing for a single field hidden by its own enabled_field: the degressive
+				// coefficient is required but hidden as soon as the depreciation type is not degressive
+				if (!empty($field_info['enabled_field']) && !$this->isEnabledFieldSatisfiedFromPost($field_info['enabled_field'])) {
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #40286

Saving the page "Depreciation options" of an asset fails with `Is required`, without naming any field, so the depreciation options can never be entered from the interface. With no options, no depreciation plan is generated at all.

`setDeprecationOptionsFromPost()` validates every field of every mode, and only drops the modes disabled by their `enabled_field` afterwards, in the `// Unset not enabled modes` loop at the end of the method. The form submits the fields of a hidden block anyway, empty, so the degressive coefficient of the fiscal block (`notnull`, `validate`) fails the validation of the whole page even though that block is disabled and about to be dropped. The same happens inside the economic block for the degressive coefficient itself, which is hidden as soon as the depreciation type is not degressive — so a straight line depreciation, the most common case, can never be saved.

This skips a mode, and a field, whose `enabled_field` is not satisfied by the submitted form **before** validating it, through the new `isEnabledFieldSatisfiedFromPost()`.

Note on the scope: the failing validation is only reached when `MAIN_FEATURES_LEVEL` >= 1 or `MAIN_ACTIVATE_VALIDATION_RESULT` is set, as discussed in the issue.

**Tested** on a clean 22.0.5 install against MySQL, posting the complete form (economic block filled, fiscal block submitted empty as the browser does):

| Setup | Unpatched | Patched |
|---|---|---|
| `MAIN_FEATURES_LEVEL=0` | options saved | options saved |
| `MAIN_FEATURES_LEVEL=2` | **nothing saved** | options saved |

Also verified on 23.0.4 through the interface: entering straight line / 5 / annually answers "Record saved" and the rate is computed to 20.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
