### PR TITLE
FIX Typo in incoterm location parameter

### DIFF
--- a/htdocs/societe/card.php
+++ b/htdocs/societe/card.php
@@ -2152,7 +2152,7 @@ if (is_object($objcanvas) && $objcanvas->displayCanvasExists($canvasdisplayactio
 				//Incoterms
 				if (isModEnabled('incoterm')) {
 					$object->fk_incoterms = GETPOSTINT('incoterm_id');
-					$object->location_incoterms = GETPOST('lcoation_incoterms', 'alpha');
+					$object->location_incoterms = GETPOST('location_incoterms', 'alpha');
 				}
 
 				//Local Taxes


### PR DESCRIPTION
Fix a typo in the request parameter used to retrieve the Incoterm location in societe/card.php. The code was retrieving "lcoation_incoterms" instead of "location_incoterms", preventing the submitted Incoterm location from being retrieved correctly.

Changed:
`lcoation_incoterms` → `location_incoterms`