### PR TITLE
FIX Asset depreciation prorata temporis mixes two day count conventions

### DIFF
--- a/htdocs/asset/admin/setup.php
+++ b/htdocs/asset/admin/setup.php
@@ -55,9 +55,19 @@ $label = GETPOST('label', 'alpha');
 $scandir = GETPOST('scan_dir', 'alpha');
 $type = 'asset';
 
+// Day count conventions available to compute the prorata temporis of a depreciation.
+// Note: the deprecated setup ASSET_DEPRECIATION_DURATION_PER_YEAR is not editable anymore. It let a
+// count of real calendar days be divided by 360, which is not a convention but a calculation error
+// (it overestimates every partial period by about 1.39%). It is still read to deduce the convention
+// of an installation that has never saved this page (see getAssetDepreciationDayCountConvention()).
+$arrayofdaycountconventions = array();
+foreach (getAssetDepreciationDayCountConventions() as $conventioncode => $conventionlabelkey) {
+	$arrayofdaycountconventions[$conventioncode] = $langs->trans($conventionlabelkey);
+}
+
 $arrayofparameters = array(
 	'ASSET_ACCOUNTANCY_CATEGORY' => array('type' => 'accountancy_category', 'enabled' => 1),
-	'ASSET_DEPRECIATION_DURATION_PER_YEAR' => array('type' => 'string', 'css' => 'minwidth200', 'enabled' => 1),
+	'ASSET_DEPRECIATION_DAY_COUNT_CONVENTION' => array('type' => 'select', 'arrayofkeyval' => $arrayofdaycountconventions, 'default' => getAssetDepreciationDayCountConvention(), 'css' => 'minwidth300', 'enabled' => 1),
 	//'ASSET_MYPARAM2'=>array('type'=>'textarea','enabled'=>1),
 	//'ASSET_MYPARAM3'=>array('type'=>'category:'.Categorie::TYPE_CUSTOMER, 'enabled'=>1),
 	//'ASSET_MYPARAM4'=>array('type'=>'emailtemplate:thirdparty', 'enabled'=>1),
@@ -479,7 +489,15 @@ if ($action == 'edit') {
 			print '<span id="helplink'.$constname.'" class="spanforparamtooltip">'.$form->textwithpicto($langs->trans($constname), $tooltiphelp, 1, 'info', '', 0, 3, 'tootips'.$constname).'</span>';
 			print '</td><td>';
 
-			if ($val['type'] == 'textarea') {
+			if ($val['type'] == 'select') {
+				$selected = getDolGlobalString($constname, isset($val['default']) ? $val['default'] : '');
+				if (!isset($val['arrayofkeyval'][$selected])) {
+					// A value stored outside the list (forged post, deprecated setup) must show the value
+					// really in use, not silently the first entry of the list
+					$selected = isset($val['default']) ? $val['default'] : '';
+				}
+				print $form->selectarray($constname, $val['arrayofkeyval'], $selected, 0, 0, 0, '', 0, 0, 0, '', (empty($val['css']) ? 'minwidth200' : $val['css']));
+			} elseif ($val['type'] == 'textarea') {
 				print '<textarea class="flat" name="'.$constname.'" id="'.$constname.'" cols="50" rows="5" wrap="soft">' . "\n";
 				print getDolGlobalString($constname);
 				print "</textarea>\n";
@@ -593,7 +611,10 @@ if ($action == 'edit') {
 				print $form->textwithpicto($langs->trans($constname), $tooltiphelp);
 				print '</td><td>';
 
-				if ($val['type'] == 'textarea') {
+				if ($val['type'] == 'select') {
+					$selected = getDolGlobalString($constname, isset($val['default']) ? $val['default'] : '');
+					print isset($val['arrayofkeyval'][$selected]) ? $val['arrayofkeyval'][$selected] : dol_escape_htmltag($selected);
+				} elseif ($val['type'] == 'textarea') {
 					print dol_nl2br(getDolGlobalString($constname));
 				} elseif ($val['type'] == 'html') {
 					print getDolGlobalString($constname);

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -26,6 +26,7 @@
  */
 
 require_once DOL_DOCUMENT_ROOT.'/core/class/commonobject.class.php';
+require_once DOL_DOCUMENT_ROOT.'/core/lib/asset.lib.php';
 
 /**
  * Class for Asset
@@ -1096,7 +1097,7 @@ class Asset extends CommonObject
 
 				// futures depreciation lines
 				//-----------------------------------------------------
-				$nb_days_in_year = getDolGlobalInt('ASSET_DEPRECIATION_DURATION_PER_YEAR', 360);
+				$day_count_convention = getAssetDepreciationDayCountConvention();
 				$nb_days_in_month = getDolGlobalInt('ASSET_DEPRECIATION_DURATION_PER_MONTH', 30);
 				$period_amount = (float) ($fields['duration'] > 0 ? price2num($depreciation_period_amount / $fields['duration'], 'MT') : 0);
 				$first_period_found = false;
@@ -1145,13 +1146,33 @@ class Asset extends CommonObject
 							}
 							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_month, 'MT');
 						} else { // Annually, taking care for adjustments to shortened or extended periods (e.g., fiscal years of 9 or 15 months)
-							$nb_days_real = num_between_day($begin_date, $end_date, 1);
-							if (($nb_days_real > 366) || (num_between_day($fiscal_period_start, $fiscal_period_end, 1) < $nb_days_in_year)) { // FY Period changed
-								$nb_days = $nb_days_real;
+							// A standard fiscal year lasts 365 days, or 366 when it covers a leap day. Anything else
+							// is a shortened or an extended fiscal year (e.g. 9 or 15 months), whose depreciation is
+							// prorated with no upper limit.
+							$nb_days_fiscal_period = num_between_day($fiscal_period_start, $fiscal_period_end, 1);
+							$is_standard_fiscal_period = ($nb_days_fiscal_period >= 365 && $nb_days_fiscal_period <= 366);
+
+							if ($is_standard_fiscal_period && $begin_date <= $fiscal_period_start && $end_date >= $fiscal_period_end) {
+								// The asset is depreciated over the whole fiscal year: full annuity, whatever the
+								// convention. Computing a prorata here would give slightly less than a full annuity
+								// with THIRTY_360 when the fiscal year ends in February (a 30/360 count ending on
+								// Feb 28th or 29th is 358 or 359 days instead of 360).
+								$period_fraction = 1;
 							} else {
-								$nb_days = min($nb_days_in_year, $nb_days_real);
+								// The count of the days and the number of days of a full year must always come from
+								// the same day count convention, otherwise every partial period (so the first and the
+								// last year of every asset) is over or under evaluated. Counting the real calendar
+								// days then dividing them by 360 overestimated every prorata by about 1.39% (365/360).
+								// The bounds are anchored on GMT midnight, so the calendar decomposition of
+								// THIRTY_360 and ACT_ACT must be read in GMT too, otherwise a partial period is
+								// prorated on a day shifted by the UTC offset of the server.
+								$period_fraction = getAssetDepreciationPeriodFraction($begin_date, $end_date, $day_count_convention, 'gmt');
+								if ($is_standard_fiscal_period) {
+									// Never more than a full annuity on a standard fiscal year
+									$period_fraction = min(1, $period_fraction);
+								}
 							}
-							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_year, 'MT');
+							$depreciation_ht = (float) price2num($period_amount * $period_fraction, 'MT');
 						}
 						if (getDolGlobalInt('ASSET_ROUND_INTEGER_NUMBER_UPWARDS') == 1) {
 							if ($idx_loop < $max_loop) { // avoid last depreciation value

--- a/htdocs/core/lib/asset.lib.php
+++ b/htdocs/core/lib/asset.lib.php
@@ -232,3 +232,108 @@ function assetModelPrepareHead($object)
 
 	return $head;
 }
+
+/**
+ * Return the list of the day count conventions available to compute the prorata temporis of a
+ * depreciation, with their translation key.
+ *
+ * A convention defines *both* how the days of a partial period are counted and by how many days a
+ * full year is divided. Mixing the two (counting real calendar days then dividing by 360) is not a
+ * convention, it is a calculation error: it overestimates every partial period by about 1.39%.
+ *
+ * @return	array<string,string>	Array of convention code => translation key
+ */
+function getAssetDepreciationDayCountConventions()
+{
+	return array(
+		'THIRTY_360' => 'AssetDayCountConventionThirty360',	// Months of 30 days, year of 360 days (usual in France)
+		'ACT_365' => 'AssetDayCountConventionAct365',		// Real calendar days, year of 365 days
+		'ACT_ACT' => 'AssetDayCountConventionActAct',		// Real calendar days, each year divided by its own length (365 or 366)
+	);
+}
+
+/**
+ * Return the day count convention to use to compute the prorata temporis of a depreciation.
+ *
+ * When the new setup ASSET_DEPRECIATION_DAY_COUNT_CONVENTION is not set, the convention is deduced
+ * from the deprecated setup ASSET_DEPRECIATION_DURATION_PER_YEAR so that existing installations keep
+ * the divisor they were configured with (360 => THIRTY_360, 365 or more => ACT_365).
+ *
+ * @return	string		'THIRTY_360', 'ACT_365' or 'ACT_ACT'
+ */
+function getAssetDepreciationDayCountConvention()
+{
+	global $mysoc;
+
+	$convention = getDolGlobalString('ASSET_DEPRECIATION_DAY_COUNT_CONVENTION');
+	if (array_key_exists($convention, getAssetDepreciationDayCountConventions())) {
+		return $convention;
+	}
+
+	// Backward compatibility with the deprecated ASSET_DEPRECIATION_DURATION_PER_YEAR
+	$nbdaysperyear = getDolGlobalInt('ASSET_DEPRECIATION_DURATION_PER_YEAR');
+	if ($nbdaysperyear == 360) {
+		return 'THIRTY_360';
+	} elseif ($nbdaysperyear >= 365) {
+		return 'ACT_365';
+	}
+
+	// Nothing set up at all: France computes depreciations on a 30/360 basis, other countries usually
+	// count real calendar days.
+	return (is_object($mysoc) && !empty($mysoc->country_code) && $mysoc->country_code == 'FR') ? 'THIRTY_360' : 'ACT_365';
+}
+
+/**
+ * Return the fraction of a year (the prorata temporis) between two dates, for a given day count
+ * convention. Both bounds are included, so a period covering a whole standard year returns a value
+ * very close to 1 (exactly 1 with THIRTY_360).
+ *
+ * WARNING: this function uses the PHP server timezone by default because THIRTY_360 and ACT_ACT work
+ * on the calendar representation of the dates. Force $forcetimezone to 'gmt' for UTC timestamps.
+ *
+ * @param	int		$timestampStart		Timestamp of the first day of the period
+ * @param	int		$timestampEnd		Timestamp of the last day of the period
+ * @param	string	$convention			Day count convention ('' to read the current setup)
+ * @param	string	$forcetimezone		'' to use the PHP server timezone, or 'gmt', 'Europe/Paris', ...
+ * @return	float						Fraction of year
+ */
+function getAssetDepreciationPeriodFraction($timestampStart, $timestampEnd, $convention = '', $forcetimezone = '')
+{
+	if ($convention === '' || !array_key_exists($convention, getAssetDepreciationDayCountConventions())) {
+		// An unknown convention must not be computed as if it were one of the known ones: fall back on
+		// the convention of the installation, the same value the caller would have got with ''.
+		$convention = getAssetDepreciationDayCountConvention();
+	}
+	if ($timestampStart > $timestampEnd) {
+		return 0.0;
+	}
+
+	if ($convention == 'THIRTY_360') {
+		return num_between_day_30_360($timestampStart, $timestampEnd, 1, $forcetimezone) / 360;
+	}
+
+	if ($convention == 'ACT_ACT') {
+		// The period is split per calendar year, each part being divided by the real length of its own
+		// year (365 or 366), which is the only way to get an exact result on a period spanning a leap year.
+		$start = dol_getdate((int) $timestampStart, false, $forcetimezone);
+		$end = dol_getdate((int) $timestampEnd, false, $forcetimezone);
+
+		$daystart = $start['yday'] + 1;		// 'yday' is 0 based
+		$dayend = $end['yday'] + 1;
+
+		if ($start['year'] == $end['year']) {
+			return ($dayend - $daystart + 1) / num_days_in_year($start['year']);
+		}
+
+		$fraction = (num_days_in_year($start['year']) - $daystart + 1) / num_days_in_year($start['year']);
+		for ($year = $start['year'] + 1; $year < $end['year']; $year++) {
+			$fraction += 1;
+		}
+		$fraction += $dayend / num_days_in_year($end['year']);
+
+		return $fraction;
+	}
+
+	// ACT_365
+	return num_between_day($timestampStart, $timestampEnd, 1) / 365;
+}

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -1306,7 +1306,7 @@ function listPublicHoliday($timestampStart, $timestampEnd, $countryCodeOrId = ''
  *	@param	   int			$timestampEnd       Timestamp end UTC
  *	@param     int			$lastday            Last day is included, 0: no, 1:yes
  *	@return    int								Number of days
- *  @see num_public_holiday(), num_open_day()
+ *  @see num_public_holiday(), num_open_day(), num_between_day_30_360()
  */
 function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
 {
@@ -1322,6 +1322,62 @@ function num_between_day($timestampStart, $timestampEnd, $lastday = 0)
 	}
 	//print ($timestampEnd - $timestampStart) - $lastday;
 	return $nbjours;
+}
+
+/**
+ *	Function to return number of days between two dates using the 30/360 day count convention:
+ *  every month counts for 30 days and every year for 360 days.
+ *  Example: 2022-03-10 2023-07-31 => 500 if lastday=0, 501 if lastday=1
+ *
+ *  This convention is the one applied by most accounting firms (and the usual one in France) to
+ *  compute the prorata temporis of a depreciation. The returned value must always be divided by
+ *  360 to get a fraction of year: dividing a count of real calendar days by 360 instead mixes two
+ *  conventions and overestimates every partial period by about 1.39% (365/360).
+ *
+ *  WARNING: this function uses the PHP server timezone by default because it works on the calendar
+ *  representation of the dates. Force $forcetimezone to 'gmt' when the timestamps are UTC dates.
+ *
+ *	@param	   int			$timestampStart     Timestamp start
+ *	@param	   int			$timestampEnd       Timestamp end
+ *	@param     int			$lastday            Last day is included, 0: no, 1:yes
+ *	@param	   string		$forcetimezone		'' to use the PHP server timezone, or 'gmt', 'Europe/Paris', ...
+ *	@return    int								Number of days on a 30/360 basis
+ *  @see num_between_day()
+ */
+function num_between_day_30_360($timestampStart, $timestampEnd, $lastday = 0, $forcetimezone = '')
+{
+	if ($timestampStart > $timestampEnd) {
+		return 0;
+	}
+
+	$start = dol_getdate((int) $timestampStart, false, $forcetimezone);
+	$end = dol_getdate((int) $timestampEnd, false, $forcetimezone);
+
+	// The 31st of a month is brought back to the 30th, so that every month counts for 30 days
+	$daystart = min($start['mday'], 30);
+	$dayend = min($end['mday'], 30);
+
+	$nbdays = ($dayend - $daystart) + 30 * ($end['mon'] - $start['mon']) + 360 * ($end['year'] - $start['year']);
+	if ($lastday == 1) {
+		$nbdays++;
+	}
+
+	return max(0, $nbdays);
+}
+
+/**
+ *	Function to return the real number of days of a year (365, or 366 for a leap year).
+ *
+ *	@param	   int			$year				Year on 4 digits
+ *	@return    int								365 or 366
+ *  @see num_between_day(), num_between_day_30_360()
+ */
+function num_days_in_year($year)
+{
+	$year = (int) $year;
+	$isleapyear = (($year % 4 == 0 && $year % 100 != 0) || $year % 400 == 0);
+
+	return $isleapyear ? 366 : 365;
 }
 
 /**

--- a/htdocs/core/modules/modAsset.class.php
+++ b/htdocs/core/modules/modAsset.class.php
@@ -101,18 +101,12 @@ class modAsset extends DolibarrModules
 		// Example: $this->const=array(0=>array('ASSETS_MYNEWCONST1','chaine','myvalue','This is a constant to add',1),
 		//                             1=>array('ASSETS_MYNEWCONST2','chaine','myvalue','This is another constant to add',0, 'current', 1)
 		// );
+		// Note: ASSET_DEPRECIATION_DAY_COUNT_CONVENTION is on purpose NOT created here. When it is not
+		// set, getAssetDepreciationDayCountConvention() returns the convention of the country of the
+		// company (30/360 for France, real days / 365 elsewhere), or the one deduced from the
+		// deprecated ASSET_DEPRECIATION_DURATION_PER_YEAR for an installation that already used it.
 		$this->const = array();
 		$this->const[1] = array(
-			"ASSET_DEPRECIATION_DURATION_PER_YEAR",
-			"chaine",
-			"360",
-			"Duration per year to calculate depreciation. In some case, can be 365 days",
-			0,
-			'current',
-			1
-		);
-
-		$this->const[2] = array(
 			"ASSET_ASSET_ADDON",
 			"chaine",
 			"mod_asset_standard",

--- a/htdocs/langs/en_US/assets.lang
+++ b/htdocs/langs/en_US/assets.lang
@@ -36,6 +36,11 @@ AssetsTypeLabel=Asset model label
 AssetsTypes=Assets models
 ASSET_ACCOUNTANCY_CATEGORY=Fixed asset accounting group
 ASSET_DEPRECIATION_DURATION_PER_YEAR=Proportional period in days for calculating amortization over one year
+ASSET_DEPRECIATION_DAY_COUNT_CONVENTION=Day count convention of the prorata temporis
+ASSET_DEPRECIATION_DAY_COUNT_CONVENTIONTooltip=How the depreciation of a <b>partial</b> period is computed, which means the first and the last year of an asset. A full annuity is always the value divided by the duration and is never impacted by this setting.<br><br>A convention defines <b>both</b> how the days of the period are counted <b>and</b> by how many days a full year is divided. The two must always match: counting real calendar days and dividing them by 360 overestimates every partial period by about 1.39 percent.<br><br><b>30/360</b>: every month counts 30 days and every year 360 days. The convention applied by most accounting firms in France.<br><b>Real days / 365</b>: real calendar days of the period, divided by 365.<br><b>Real days / real year</b>: real calendar days, each year divided by its own real length, 365 or 366. The most accurate on a period covering a leap day.<br><br>Example on an asset of 13000 depreciated over 5 years, put in service on March 10th and sold on February 23rd of the fourth year, fiscal years running from August to July. Cumulated depreciation at the disposal: 7684.44 with 30/360, 7700.27 with real days / 365, 7697.29 with real days / real year.<br><br><b>Warning</b>: changing this setting does not recompute the plans already generated. Save the depreciation options of an asset again to regenerate its plan.
+AssetDayCountConventionThirty360=30/360 - every month counts 30 days, every year 360 days (usual in France)
+AssetDayCountConventionAct365=Real days / 365 - real calendar days divided by 365
+AssetDayCountConventionActAct=Real days / real year - real calendar days, each year divided by its own length (365 or 366)
 # Menu
 MenuAssets=Assets
 MenuNewAsset=New asset

--- a/test/phpunit/AssetDepreciationTest.php
+++ b/test/phpunit/AssetDepreciationTest.php
@@ -1,0 +1,381 @@
+<?php
+/* Copyright (C) 2026 Association P'tite Tete <asso@ptitetete.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * or see https://www.gnu.org/
+ */
+
+/**
+ *      \file       test/phpunit/AssetDepreciationTest.php
+ *		\ingroup    test
+ *      \brief      PHPUnit test for the day count conventions of the depreciations
+ *		\remarks	To run this script as CLI:  phpunit filename.php
+ */
+
+global $conf,$user,$langs,$db;
+//define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/date.lib.php';
+require_once dirname(__FILE__).'/../../htdocs/core/lib/asset.lib.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->loadRights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class AssetDepreciationTest extends CommonClassTest
+{
+	/**
+	 * Reference asset used by every prorata temporis test below.
+	 * Van of 13000 EUR excl. tax, straight line depreciation over 5 years (annuity of 2600 EUR),
+	 * put in service on 2022-03-10, sold on 2025-02-23, fiscal year from August to July.
+	 */
+	const PERIOD_AMOUNT = 2600;
+
+	/**
+	 * testNumDaysInYear
+	 *
+	 * @return	void
+	 */
+	public function testNumDaysInYear()
+	{
+		$this->assertEquals(365, num_days_in_year(2023));
+		$this->assertEquals(366, num_days_in_year(2024));
+		$this->assertEquals(365, num_days_in_year(1900));		// Divisible by 100 but not by 400
+		$this->assertEquals(366, num_days_in_year(2000));		// Divisible by 400
+	}
+
+	/**
+	 * testNumBetweenDay30360
+	 *
+	 * @return	void
+	 */
+	public function testNumBetweenDay30360()
+	{
+		// A month of 30 or 31 days always counts 30 days: the 31st is brought back to the 30th
+		$this->assertEquals(30, num_between_day_30_360(dol_mktime(0, 0, 0, 1, 1, 2023, 'gmt'), dol_mktime(0, 0, 0, 1, 31, 2023, 'gmt'), 1, 'gmt'));
+		$this->assertEquals(30, num_between_day_30_360(dol_mktime(0, 0, 0, 4, 1, 2023, 'gmt'), dol_mktime(0, 0, 0, 4, 30, 2023, 'gmt'), 1, 'gmt'));
+
+		// February is the exception: this is the plain 30/360 convention, which does NOT bring the end
+		// of February up to the 30th (that is the 30E/360 ISDA variant). A period ending on Feb 28th or
+		// 29th is therefore counted 28 or 29 days, which is why Asset::calculationDepreciation() does
+		// not compute any prorata at all when the asset is depreciated over the whole fiscal year.
+		$this->assertEquals(28, num_between_day_30_360(dol_mktime(0, 0, 0, 2, 1, 2023, 'gmt'), dol_mktime(0, 0, 0, 2, 28, 2023, 'gmt'), 1, 'gmt'));
+		$this->assertEquals(29, num_between_day_30_360(dol_mktime(0, 0, 0, 2, 1, 2024, 'gmt'), dol_mktime(0, 0, 0, 2, 29, 2024, 'gmt'), 1, 'gmt'));
+
+		// A whole year always counts 360 days, leap year included
+		$this->assertEquals(360, num_between_day_30_360(dol_mktime(0, 0, 0, 1, 1, 2023, 'gmt'), dol_mktime(0, 0, 0, 12, 31, 2023, 'gmt'), 1, 'gmt'));
+		$this->assertEquals(360, num_between_day_30_360(dol_mktime(0, 0, 0, 1, 1, 2024, 'gmt'), dol_mktime(0, 0, 0, 12, 31, 2024, 'gmt'), 1, 'gmt'));
+
+		// Periods of the reference asset
+		$this->assertEquals(501, num_between_day_30_360(dol_mktime(0, 0, 0, 3, 10, 2022, 'gmt'), dol_mktime(0, 0, 0, 7, 31, 2023, 'gmt'), 1, 'gmt'));
+		$this->assertEquals(360, num_between_day_30_360(dol_mktime(0, 0, 0, 8, 1, 2023, 'gmt'), dol_mktime(0, 0, 0, 7, 31, 2024, 'gmt'), 1, 'gmt'));
+		$this->assertEquals(203, num_between_day_30_360(dol_mktime(0, 0, 0, 8, 1, 2024, 'gmt'), dol_mktime(0, 0, 0, 2, 23, 2025, 'gmt'), 1, 'gmt'));
+
+		// Without the last day, and with an end date before the start date
+		$this->assertEquals(500, num_between_day_30_360(dol_mktime(0, 0, 0, 3, 10, 2022, 'gmt'), dol_mktime(0, 0, 0, 7, 31, 2023, 'gmt'), 0, 'gmt'));
+		$this->assertEquals(0, num_between_day_30_360(dol_mktime(0, 0, 0, 7, 31, 2023, 'gmt'), dol_mktime(0, 0, 0, 3, 10, 2022, 'gmt'), 1, 'gmt'));
+	}
+
+	/**
+	 * A full fiscal year must always give a full annuity, whatever the convention.
+	 *
+	 * @return	void
+	 */
+	public function testFullYearIsNotImpactedByTheConvention()
+	{
+		$fyStart = dol_mktime(0, 0, 0, 8, 1, 2023, 'gmt');
+		$fyEnd = dol_mktime(0, 0, 0, 7, 31, 2024, 'gmt');
+
+		// 30/360 gives exactly 1
+		$this->assertEquals(1.0, getAssetDepreciationPeriodFraction($fyStart, $fyEnd, 'THIRTY_360', 'gmt'));
+
+		// Counting real days gives a value slightly above 1 (the fiscal year covers the leap day of
+		// 2024), that the depreciation plan caps to a full annuity.
+		$this->assertEquals(366 / 365, getAssetDepreciationPeriodFraction($fyStart, $fyEnd, 'ACT_365', 'gmt'));
+		$this->assertGreaterThan(1, getAssetDepreciationPeriodFraction($fyStart, $fyEnd, 'ACT_ACT', 'gmt'));
+
+		// A standard non leap year gives exactly 1 when each year is divided by its own length
+		$this->assertEquals(1.0, getAssetDepreciationPeriodFraction(dol_mktime(0, 0, 0, 1, 1, 2023, 'gmt'), dol_mktime(0, 0, 0, 12, 31, 2023, 'gmt'), 'ACT_ACT', 'gmt'));
+		$this->assertEquals(1.0, getAssetDepreciationPeriodFraction(dol_mktime(0, 0, 0, 1, 1, 2024, 'gmt'), dol_mktime(0, 0, 0, 12, 31, 2024, 'gmt'), 'ACT_ACT', 'gmt'));
+
+		// A fiscal year ending in February is the reason why Asset::calculationDepreciation() does not
+		// compute any prorata when the asset is depreciated over the whole fiscal year: a 30/360 count
+		// ending on Feb 28th or 29th gives 358 or 359 days instead of 360, so slightly less than a full
+		// annuity.
+		$this->assertEquals(359 / 360, getAssetDepreciationPeriodFraction(dol_mktime(0, 0, 0, 3, 1, 2023, 'gmt'), dol_mktime(0, 0, 0, 2, 29, 2024, 'gmt'), 'THIRTY_360', 'gmt'));
+		$this->assertEquals(358 / 360, getAssetDepreciationPeriodFraction(dol_mktime(0, 0, 0, 3, 1, 2022, 'gmt'), dol_mktime(0, 0, 0, 2, 28, 2023, 'gmt'), 'THIRTY_360', 'gmt'));
+	}
+
+	/**
+	 * Acceptance criteria of the reference asset: the first period and the period of the disposal are
+	 * the only ones computed prorata temporis, and each convention must give its own coherent result.
+	 *
+	 * @return	void
+	 */
+	public function testProrataTemporisOfTheReferenceAsset()
+	{
+		$firstPeriodStart = dol_mktime(0, 0, 0, 3, 10, 2022, 'gmt');	// Put in service
+		$firstPeriodEnd = dol_mktime(0, 0, 0, 7, 31, 2023, 'gmt');
+		$lastPeriodStart = dol_mktime(0, 0, 0, 8, 1, 2024, 'gmt');
+		$lastPeriodEnd = dol_mktime(0, 0, 0, 2, 23, 2025, 'gmt');		// Disposal
+
+		// 30/360, the convention applied by the accounting firm of the reference file
+		$first = round(self::PERIOD_AMOUNT * getAssetDepreciationPeriodFraction($firstPeriodStart, $firstPeriodEnd, 'THIRTY_360', 'gmt'), 2);
+		$last = round(self::PERIOD_AMOUNT * getAssetDepreciationPeriodFraction($lastPeriodStart, $lastPeriodEnd, 'THIRTY_360', 'gmt'), 2);
+		$this->assertEquals(3618.33, $first);
+		$this->assertEquals(1466.11, $last);
+		$this->assertEquals(7684.44, round($first + self::PERIOD_AMOUNT + $last, 2));
+
+		// Real days / 365
+		$first = round(self::PERIOD_AMOUNT * getAssetDepreciationPeriodFraction($firstPeriodStart, $firstPeriodEnd, 'ACT_365', 'gmt'), 2);
+		$last = round(self::PERIOD_AMOUNT * getAssetDepreciationPeriodFraction($lastPeriodStart, $lastPeriodEnd, 'ACT_365', 'gmt'), 2);
+		$this->assertEquals(3625.75, $first);
+		$this->assertEquals(1474.52, $last);
+		$this->assertEquals(7700.27, round($first + self::PERIOD_AMOUNT + $last, 2));
+
+		// Real days / real year: the disposal period covers the leap day of 2024
+		$first = round(self::PERIOD_AMOUNT * getAssetDepreciationPeriodFraction($firstPeriodStart, $firstPeriodEnd, 'ACT_ACT', 'gmt'), 2);
+		$last = round(self::PERIOD_AMOUNT * getAssetDepreciationPeriodFraction($lastPeriodStart, $lastPeriodEnd, 'ACT_ACT', 'gmt'), 2);
+		$this->assertEquals(3625.75, $first);
+		$this->assertEquals(1471.54, $last);
+
+		// The incoherent real days / 360 calculation, that is not a convention anymore, would have
+		// given 3676.11 and 1495.00, so 86.67 EUR too much on the cumulated depreciation.
+		$this->assertNotEquals(3676.11, $first);
+		$this->assertNotEquals(1495.00, $last);
+	}
+
+	/**
+	 * The whole depreciation plan of the reference asset, computed by the production code path
+	 * Asset::calculationDepreciation() and read back from llx_asset_depreciation.
+	 *
+	 * Reference asset: van of 13000 EUR excl. tax, straight line over 5 years, put in service on
+	 * 2022-03-10, sold on 2025-02-23, fiscal years running from August to July. A second asset with
+	 * no disposal checks that a plan reaching its natural term sums up to the acquisition value.
+	 *
+	 * @return	void
+	 */
+	public function testCalculationDepreciationPlan()
+	{
+		global $conf, $user, $langs, $db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		require_once DOL_DOCUMENT_ROOT.'/asset/class/asset.class.php';
+		require_once DOL_DOCUMENT_ROOT.'/asset/class/assetdepreciationoptions.class.php';
+
+		// The plan is stored in the tables of the asset module
+		$resql = $db->query("SELECT rowid FROM ".MAIN_DB_PREFIX."asset_depreciation LIMIT 1");
+		if (!$resql) {
+			$this->markTestSkipped('Tables of the asset module not available on this database.');
+		}
+
+		// A disposal needs an active record of the disposal type dictionary
+		$disposaltypeid = 0;
+		$resql = $db->query("SELECT rowid FROM ".MAIN_DB_PREFIX."c_asset_disposal_type WHERE active = 1 ORDER BY rowid ASC");
+		if ($resql && ($obj = $db->fetch_object($resql))) {
+			$disposaltypeid = (int) $obj->rowid;
+		}
+		if (empty($disposaltypeid)) {
+			$this->markTestSkipped('No active record into the dictionary of the disposal types.');
+		}
+
+		$savconvention = getDolGlobalString('ASSET_DEPRECIATION_DAY_COUNT_CONVENTION');
+		$fiscalyearids = array();
+		$assetids = array();
+
+		try {
+			// Fiscal years from August to July, so that the asset is put in service in the middle of one
+			for ($year = 2021; $year <= 2026; $year++) {
+				$datestart = sprintf('%d-08-01', $year);
+				$dateend = sprintf('%d-07-31', $year + 1);
+				$sql = "INSERT INTO ".MAIN_DB_PREFIX."accounting_fiscalyear";
+				$sql .= " (label, date_start, date_end, statut, entity, datec, fk_user_author)";
+				$sql .= " VALUES ('PHPUNIT ".$year."', '".$db->escape($datestart)."', '".$db->escape($dateend)."'";
+				$sql .= ", 0, ".((int) $conf->entity).", '".$db->idate(dol_now())."', ".((int) $user->id).")";
+				$this->assertNotFalse($db->query($sql), $db->lasterror());
+				$fiscalyearids[] = $db->last_insert_id(MAIN_DB_PREFIX."accounting_fiscalyear");
+			}
+
+			// The reference asset, sold before the end of its plan, and the same one left to its term
+			foreach (array('disposed', 'until_term') as $kind) {
+				$asset = new Asset($db);
+				$asset->label = 'PHPUNIT depreciation '.$kind;
+				$asset->date_acquisition = dol_mktime(0, 0, 0, 3, 10, 2022, 'gmt');
+				$asset->date_start = $asset->date_acquisition;
+				$asset->acquisition_value_ht = 13000;
+				$asset->fk_asset_model = 0;
+
+				$assetid = $asset->create($user);
+				$this->assertGreaterThan(0, $assetid, $asset->errorsToString());
+				$assetids[$kind] = $assetid;
+
+				$options = new AssetDepreciationOptions($db);
+				$options->deprecation_options['economic'] = array(
+					'depreciation_type' => 0,			// Straight line
+					'degressive_coefficient' => 0,
+					'duration' => 5,
+					'duration_type' => 0,				// Annually
+					'accelerated_depreciation_option' => 0,
+					'amount_base_depreciation_ht' => 13000,
+					'amount_base_deductible_ht' => 0,
+					'total_amount_last_depreciation_ht' => 0,
+				);
+				$this->assertGreaterThan(0, $options->updateDeprecationOptions($user, $assetid), $options->errorsToString());
+
+				if ($kind == 'disposed') {
+					$asset->fetch($assetid);
+					$asset->disposal_date = dol_mktime(0, 0, 0, 2, 23, 2025, 'gmt');
+					$asset->disposal_amount_ht = 4000;
+					$asset->fk_disposal_type = $disposaltypeid;
+					$asset->disposal_depreciated = 1;
+					$asset->disposal_subject_to_vat = 0;
+					$this->assertGreaterThan(0, $asset->dispose($user, 0), $asset->errorsToString());
+				}
+			}
+
+			// Only the first and the last period are prorated, the ones in between are full annuities.
+			// The first fiscal year (2022-03-10 to 2022-07-31) plus the next full one give the 3618.33 of
+			// the accounting firm: 1018.33 + 2600.00.
+			$expectedplans = array(
+				'THIRTY_360' => array(1018.33, 2600.00, 2600.00, 1466.11),
+				// These amounts assume the bounds of the fiscal periods are anchored on GMT midnight. That
+				// is the case on a server running on UTC, and on every server once the companion fix
+				// "Asset depreciation plan depends on the timezone of the server" is applied. Without
+				// that fix, on a server whose timezone has a non zero UTC offset, num_between_day()
+				// loses one day on a partial period and the last line becomes 1467.40 instead.
+				'ACT_365' => array(1025.75, 2600.00, 2600.00, 1474.52),
+			);
+			foreach ($expectedplans as $convention => $expectedplan) {
+				$conf->global->ASSET_DEPRECIATION_DAY_COUNT_CONVENTION = $convention;
+
+				$asset = new Asset($db);
+				$this->assertGreaterThan(0, $asset->fetch($assetids['disposed']));
+				$this->assertGreaterThan(0, $asset->calculationDepreciation(), $asset->errorsToString());
+
+				$plan = $this->getDepreciationPlan($assetids['disposed']);
+				$this->assertEquals($expectedplan, $plan, 'Depreciation plan with the convention '.$convention);
+				$this->assertEquals(array_sum($expectedplan), round(array_sum($plan), 2), 'Cumulated depreciation with the convention '.$convention);
+			}
+
+			// Whatever the convention, a plan reaching its natural term depreciates the acquisition value
+			// and nothing more: the last period absorbs the rounding of all the previous ones.
+			foreach (array_keys(getAssetDepreciationDayCountConventions()) as $convention) {
+				$conf->global->ASSET_DEPRECIATION_DAY_COUNT_CONVENTION = $convention;
+
+				$asset = new Asset($db);
+				$this->assertGreaterThan(0, $asset->fetch($assetids['until_term']));
+				$this->assertGreaterThan(0, $asset->calculationDepreciation(), $asset->errorsToString());
+
+				$plan = $this->getDepreciationPlan($assetids['until_term']);
+				$this->assertEquals(13000, round(array_sum($plan), 2), 'Sum of the plan with the convention '.$convention);
+			}
+		} finally {
+			foreach ($assetids as $assetid) {
+				$asset = new Asset($db);
+				if ($asset->fetch($assetid) > 0) {
+					$asset->delete($user);
+				}
+			}
+			if (!empty($fiscalyearids)) {
+				$db->query("DELETE FROM ".MAIN_DB_PREFIX."accounting_fiscalyear WHERE rowid IN (".implode(',', array_map('intval', $fiscalyearids)).")");
+			}
+			$conf->global->ASSET_DEPRECIATION_DAY_COUNT_CONVENTION = $savconvention;
+		}
+	}
+
+	/**
+	 * Return the depreciation amounts of the economic plan of an asset, ordered by date
+	 *
+	 * @param	int				$assetid	Id of the asset
+	 * @return	array<int,float>			Depreciation amounts excl. tax
+	 */
+	private function getDepreciationPlan($assetid)
+	{
+		global $db;
+
+		$sql = "SELECT depreciation_ht FROM ".MAIN_DB_PREFIX."asset_depreciation";
+		$sql .= " WHERE fk_asset = ".((int) $assetid)." AND depreciation_mode = 'economic'";
+		$sql .= " ORDER BY depreciation_date ASC, rowid ASC";
+		$resql = $db->query($sql);
+		$this->assertNotFalse($resql, $db->lasterror());
+
+		$plan = array();
+		while ($obj = $db->fetch_object($resql)) {
+			$plan[] = round((float) $obj->depreciation_ht, 2);
+		}
+
+		return $plan;
+	}
+
+	/**
+	 * testGetAssetDepreciationDayCountConvention
+	 *
+	 * @return	void
+	 */
+	public function testGetAssetDepreciationDayCountConvention()
+	{
+		global $conf, $mysoc;
+		$conf = $this->savconf;
+
+		$savconvention = getDolGlobalString('ASSET_DEPRECIATION_DAY_COUNT_CONVENTION');
+		$savduration = getDolGlobalString('ASSET_DEPRECIATION_DURATION_PER_YEAR');
+		$savcountrycode = $mysoc->country_code;
+
+		try {
+		// The new setup always wins
+		$conf->global->ASSET_DEPRECIATION_DAY_COUNT_CONVENTION = 'ACT_ACT';
+		$conf->global->ASSET_DEPRECIATION_DURATION_PER_YEAR = '360';
+		$this->assertEquals('ACT_ACT', getAssetDepreciationDayCountConvention());
+
+		// An unknown value is ignored
+		$conf->global->ASSET_DEPRECIATION_DAY_COUNT_CONVENTION = 'ACT_360';
+		$this->assertEquals('THIRTY_360', getAssetDepreciationDayCountConvention());
+
+		// Backward compatibility with the deprecated setup
+		$conf->global->ASSET_DEPRECIATION_DAY_COUNT_CONVENTION = '';
+		$conf->global->ASSET_DEPRECIATION_DURATION_PER_YEAR = '360';
+		$this->assertEquals('THIRTY_360', getAssetDepreciationDayCountConvention());
+		$conf->global->ASSET_DEPRECIATION_DURATION_PER_YEAR = '365';
+		$this->assertEquals('ACT_365', getAssetDepreciationDayCountConvention());
+
+		// Nothing set up: the country of the company decides
+		$conf->global->ASSET_DEPRECIATION_DURATION_PER_YEAR = '';
+		$mysoc->country_code = 'FR';
+		$this->assertEquals('THIRTY_360', getAssetDepreciationDayCountConvention());
+		$mysoc->country_code = 'US';
+		$this->assertEquals('ACT_365', getAssetDepreciationDayCountConvention());
+
+		} finally {
+			// Restore the global state even when an assertion above fails, so that the rest of the
+			// suite does not inherit a modified country or a stale setup
+			$mysoc->country_code = $savcountrycode;
+			$conf->global->ASSET_DEPRECIATION_DAY_COUNT_CONVENTION = $savconvention;
+			$conf->global->ASSET_DEPRECIATION_DURATION_PER_YEAR = $savduration;
+		}
+	}
+}


### PR DESCRIPTION
Fixes #40291

The prorata temporis of a depreciation counts the real calendar days of the period, then divides that count by `ASSET_DEPRECIATION_DURATION_PER_YEAR`, whose default value is **360**. A year of 360 days only exists in the 30/360 convention, where every month counts exactly 30 days, so counting real days while dividing by 360 overestimates every partial period by about **1.39%** (365/360). Full annuities are not impacted, the first and the last year of every asset are — and the error reaches the general ledger through the various journal.

This adds `ASSET_DEPRECIATION_DAY_COUNT_CONVENTION`, a real choice of convention:

| Convention | Day count | Divisor |
|---|---|---|
| `THIRTY_360` | months of 30 days | 360 |
| `ACT_365` | real calendar days | 365 |
| `ACT_ACT` | real calendar days | each year by its own length, 365 or 366 |

The incoherent real days / 360 combination is not reachable anymore, the value being validated on read and not only in the setup form.

**Backward compatibility** — when the new setup is empty the convention is deduced from `ASSET_DEPRECIATION_DURATION_PER_YEAR` (360 => `THIRTY_360`, 365 or more => `ACT_365`), and with no setup at all France gets `THIRTY_360` and other countries `ACT_365`. `ACT_365` reproduces the current real days / 365 behaviour to the cent. An installation left on the default 360 does change its amounts, which is the very point of the fix.

Two related defects are also handled: a fiscal year ending in February used to lose a few euros of its annuity, because a 30/360 count ending on Feb 28th or 29th is 358 or 359 days instead of 360 — no prorata is computed at all when the asset is depreciated over the whole fiscal year; and a shortened or extended fiscal year is now detected on its real length rather than by comparison with the configured divisor.

Also adds `num_between_day_30_360()` and `num_days_in_year()` to `date.lib.php`, and unit tests of the three conventions plus a test of the whole plan through `Asset::calculationDepreciation()` against a real database.

**Tested** end to end on 23.0.4 against MySQL, through the interface, on an asset of 13000 EUR excl. tax over 5 years from 2022-03-10, sold on 2025-02-23, fiscal years from August to July:

```
before        1040.00 · 2600.00 · 2600.00 · 1495.00   cumulated 7735.00
THIRTY_360    1018.33 · 2600.00 · 2600.00 · 1466.11   cumulated 7684.44
ACT_365       1025.75 · 2600.00 · 2600.00 · 1474.52   cumulated 7700.27
```

`THIRTY_360` matches the plan of the accounting firm of the file this was found on, to the cent. Transferred through the various journal, the disposal entry then debits the depreciation account for 7684.44 and credits the asset account for 13000.00, and the depreciation account comes back to exactly zero — an asset leaving the balance sheet no longer leaves a residual balance behind.

Note: the monthly depreciation mode (`ASSET_DEPRECIATION_DURATION_PER_MONTH`) is deliberately left untouched and should follow in a separate change. This also needs #40288 to give the same result on every server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
