### PR TITLE
Fix #40290 guard the accountancy codes when computing a depreciation plan

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -963,9 +963,9 @@ class Asset extends CommonObject
 				$disposal_date = isset($this->disposal_date) && $this->disposal_date !== "" ? $this->disposal_date : "";
 				$finish_date = $disposal_date !== "" ? $disposal_date : $depreciation_date_end;
 				$accountancy_code_depreciation_debit_key = $accountancy_codes->accountancy_codes_fields[$mode_key]['depreciation_debit'];
-				$accountancy_code_depreciation_debit = $accountancy_codes->accountancy_codes[$mode_key][$accountancy_code_depreciation_debit_key];
+				$accountancy_code_depreciation_debit = $accountancy_codes->accountancy_codes[$mode_key][$accountancy_code_depreciation_debit_key] ?? '';
 				$accountancy_code_depreciation_credit_key = $accountancy_codes->accountancy_codes_fields[$mode_key]['depreciation_credit'];
-				$accountancy_code_credit = $accountancy_codes->accountancy_codes[$mode_key][$accountancy_code_depreciation_credit_key];
+				$accountancy_code_credit = $accountancy_codes->accountancy_codes[$mode_key][$accountancy_code_depreciation_credit_key] ?? '';
 
 				// Reversal depreciation line
 				//-----------------------------------------------------


### PR DESCRIPTION
AssetAccountancyCodes::fetchAccountancyCodes() only creates $accountancy_codes[$mode_key] when a row exists for the asset, so on an asset whose "Accountancy codes" page was never saved the key is absent and the two reads in calculationDepreciation() emit, per mode:

    Warning: Undefined array key "economic"
    Warning: Trying to access array offset on value of type null

There is a third one the report does not mention: the null returned then reaches trim() in addDepreciationLine(), which emits "Passing null to parameter #1 of type string is deprecated" on PHP 8.

No functional change: trim(null) and trim('') both produce '', so the value stored in llx_asset_depreciation is the same. With codes saved, the read returns them unchanged.

Targeted 18.0, the unguarded read is identical from there through develop.
