### PR TITLE
Fix #40303 do not free an already closed result on stock at date

### DIFF
--- a/htdocs/product/stock/stockatdate.php
+++ b/htdocs/product/stock/stockatdate.php
@@ -186,6 +186,7 @@ if ($date && $dateIsValid) {	// Avoid heavy sql if mandatory date is not defined
 		}
 
 		$db->free($resql);
+		$resql = null;	// so the free() at the end of the page does not run on an already closed result
 	} else {
 		dol_print_error($db);
 	}
@@ -253,6 +254,7 @@ if ($date && $dateIsValid) {
 		}
 
 		$db->free($resql);
+		$resql = null;	// so the free() at the end of the page does not run on an already closed result
 	} else {
 		dol_print_error($db);
 	}


### PR DESCRIPTION
The page frees $resql after each of its early queries, then frees it again at the end under `if (!empty($resql))`. That guard does not protect anything: after `$db->free($r)` the variable is still truthy, so the second call reaches an already closed result and PHP 8 throws.

Reproduced exactly the error from the report:

    after query          not empty
    after free           not empty      <- the !empty() guard passes
    second free          Error: mysqli_result object is already closed

The CSV path is where it surfaces because the main query block sits under `if ($date && $dateIsValid)`; when that guard is not satisfied, $resql still holds the freed result from the earlier query and the trailing free() runs on it.

Clearing the variable after each intermediate free makes the trailing guard behave as intended. The nominal path is unchanged: when the main query re-assigns $resql, the final free() still runs exactly once.

Targeted 18.0, the same trailing guard is present from there through develop.
