### PR TITLE
FIX Depreciation options of an asset cannot be saved from the interface

### DIFF
--- a/htdocs/asset/class/assetdepreciationoptions.class.php
+++ b/htdocs/asset/class/assetdepreciationoptions.class.php
@@ -187,6 +187,33 @@ class AssetDepreciationOptions extends CommonObject
 	}
 
 	/**
+	 * Return whether an 'enabled_field' condition ("mode_key:field_key:value") is satisfied by the
+	 * data of the submitted form.
+	 *
+	 * @param	string	$enabledfield	Condition, as "mode_key:field_key:value"
+	 * @return	bool					True when the driving field was submitted with the expected value
+	 */
+	protected function isEnabledFieldSatisfiedFromPost($enabledfield)
+	{
+		$info = explode(':', $enabledfield);
+		if (count($info) < 3) {
+			return true;
+		}
+
+		$htmlname = $info[0] . '_' . $info[1];
+		if (!GETPOSTISSET($htmlname)) {
+			return false;	// An unchecked checkbox is not submitted at all
+		}
+
+		$value = GETPOST($htmlname, 'alphanohtml');
+		if ($value === 'on') {
+			$value = '1';	// A checked checkbox may be submitted as 'on'
+		}
+
+		return ((string) $value === (string) $info[2]);
+	}
+
+	/**
 	 *  Fill deprecation_options property of object (using for data sent by forms)
 	 *
 	 * @param	int		$class_type		Type (0:asset, 1:asset model)
@@ -200,10 +227,23 @@ class AssetDepreciationOptions extends CommonObject
 
 		$deprecation_options = array();
 		foreach ($this->deprecation_options_fields as $mode_key => $mode_info) {
+			// A mode disabled by its enabled_field must not be validated at all. The form submits the
+			// fields of the hidden block anyway, empty, so a required field of that block (the
+			// degressive coefficient) makes the whole page fail. The block is dropped further below,
+			// but only after its fields have been validated, which is too late.
+			if (!empty($mode_info['enabled_field']) && !$this->isEnabledFieldSatisfiedFromPost($mode_info['enabled_field'])) {
+				continue;
+			}
+
 			$this->setInfosForMode($mode_key, $class_type);
 
 			foreach ($mode_info['fields'] as $field_key => $field_info) {
 				if (!empty($field_info['computed'])) {
+					continue;
+				}
+				// Same thing for a single field hidden by its own enabled_field: the degressive
+				// coefficient is required but hidden as soon as the depreciation type is not degressive
+				if (!empty($field_info['enabled_field']) && !$this->isEnabledFieldSatisfiedFromPost($field_info['enabled_field'])) {
 					continue;
 				}
 


### PR DESCRIPTION
Fixes #40286

Supersedes #40294, which targeted 22.0. Retargeted to 18.0 as suggested in the issue: the code path is identical that far back and forward merges only go upward, so 18.0 reaches 20, 21, 22, 23 and 24 while 22.0 would have left 18 and 20 broken.

Saving the page "Depreciation options" of an asset fails with `Is required`, without naming any field, so the depreciation options can never be entered from the interface. With no options, no depreciation plan is generated at all.

`setDeprecationOptionsFromPost()` validates every field of every mode, and only drops the modes disabled by their `enabled_field` afterwards, in the `// Unset not enabled modes` loop at the end of the method. The form submits the fields of a hidden block anyway, empty, and they are validated before the block is dropped.

**Both levels are handled**, which is what makes the straight line case work:

- a **mode** disabled by its `enabled_field` — the fiscal block, whose degressive coefficient is `notnull` + `validate`;
- a **field** disabled by its own `enabled_field` — the degressive coefficient inside the economic block, hidden as soon as the depreciation type is not degressive. This is the one that makes straight line, the most common setup, impossible to save.

**Scope.** The failure only occurs at `MAIN_FEATURES_LEVEL` >= 1 (or with `MAIN_ACTIVATE_VALIDATION_RESULT` set). As established in the issue, the other failure branch in that loop — `notnull` + empty + `default` null, which raises `ErrorFieldRequired` ungated — cannot fire here, because every `notnull` field in `deprecation_options_fields` carries `'default' => '0'`. So the whole failure goes through `validateField()`, which is gated on the features level. That is why this went unnoticed for so long.

**Tested** on a clean 22.0.5 install against MySQL, posting the complete form as the browser does (economic block filled, fiscal block submitted empty):

| Setup | Unpatched | Patched |
|---|---|---|
| `MAIN_FEATURES_LEVEL=0` | options saved | options saved |
| `MAIN_FEATURES_LEVEL=2` | **nothing saved** | options saved |

Also verified on 23.0.4 through the interface: straight line / 5 / annually answers "Record saved" and the rate is computed to 20.00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
