### PR TITLE
FIX Rate field of the depreciation options shows an error instead of the rate

### DIFF
--- a/htdocs/asset/tpl/depreciation_options_view.tpl.php
+++ b/htdocs/asset/tpl/depreciation_options_view.tpl.php
@@ -124,7 +124,14 @@ if (empty($reshook)) {
 			if (in_array($field_info['type'], array('text', 'html'))) {
 				print '<div class="longmessagecut">';
 			}
-			if ($field_key == 'lang') {
+			if ($field_key == 'rate') {
+				// The rate is computed by the module itself, in getRate(). Rendering it through the
+				// 'computed' property routes it to dol_eval(), which refuses getRate() because it is
+				// not in the white list of $dolibarr_main_restrict_eval_methods, so every asset shows
+				// "Bad string syntax to evaluate ..." instead of its rate. The 'computed' property is
+				// kept, showInputField() relies on it to display the field as read only on the form.
+				print $assetdepreciationoptions->getRate($mode_key);
+			} elseif ($field_key == 'lang') {
 				$langs->load("languages");
 				$labellang = ($value ? $langs->trans('Language_' . $value) : '');
 				print picto_from_langcode($value, 'class="paddingrightonly saturatemedium opacitylow"');


### PR DESCRIPTION
Fixes #40308

On the page "Depreciation options" of an asset, the Rate line displays an error instead of the rate, on every asset of every default installation, because `rate` is a computed field and `dol_eval()` refuses `getRate()`:

```
Bad string syntax to evaluate. A function or method "getRate" was called and is not into
the parameter $dolibarr_main_restrict_eval_methods of white-listed functions and methods
```

This renders the rate directly from `getRate()` in the view template, the way that template already special-cases the `lang` field, instead of routing it through `dol_eval()`.

**The `computed` property is deliberately kept.** `showInputField()` relies on it to render the field as read only on the edition form — removing it would turn the rate into an editable field, which would be a regression. Only the display path changes.

Adding `getRate` to the default white list in `conf.php.example` was the other option, but it would not help any existing installation, whose `conf.php` is already written.

**Tested** on a clean 24.0.1 install against MySQL, asset depreciated over 5 years:

| | Unpatched | Patched |
|---|---|---|
| View, Rate line | `Bad string syntax to evaluate. A function or method "getRate" ...` | `20.00` |
| Edition form | "Automatically calculated" | "Automatically calculated" |

Same family as #40287, which removed another `dol_eval()` dependency in the same module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
