### PR TITLE
SEC: Authorization bypass in leave API update/create (IDOR) (558292081)

### DIFF
--- a/htdocs/holiday/class/api_holidays.class.php
+++ b/htdocs/holiday/class/api_holidays.class.php
@@ -45,6 +45,25 @@ class Holidays extends DolibarrApi
 	);
 
 	/**
+	 * @var string[]	Workflow fields that must not be set through the generic
+	 *					create/update endpoints. They can only be changed via the
+	 *					dedicated routes (validate, approve, refuse, cancel, reopen)
+	 *					that enforce the proper permission checks.
+	 */
+	public static $FIELDS_FORBIDDEN_FOR_API = array(
+		'status',
+		'statut',
+		'fk_validator',
+		'date_valid',
+		'fk_user_valid',
+		'date_approval',
+		'fk_user_approve',
+		'date_refuse',
+		'fk_user_refuse',
+		'detail_refuse',
+	);
+
+	/**
 	 * @var Holiday {@type Holiday}
 	 */
 	public $holiday;
@@ -221,6 +240,9 @@ class Holidays extends DolibarrApi
 				$this->holiday->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
 			}
+			if (in_array($field, self::$FIELDS_FORBIDDEN_FOR_API) && $field !== 'fk_validator') {
+				throw new RestException(400, "Field '".$field."' is not allowed in create endpoint. Use dedicated routes (validate, approve, refuse, cancel, reopen) to change the workflow status.");
+			}
 
 			$this->holiday->$field = $this->_checkValForAPI($field, $value, $this->holiday);
 		}
@@ -270,6 +292,11 @@ class Holidays extends DolibarrApi
 		if (!DolibarrApi::_checkAccessToResource('holiday', $this->holiday)) {
 			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
+
+		if (!is_array($request_data)) {
+			$request_data = array();
+		}
+
 		foreach ($request_data as $field => $value) {
 			if ($field == 'id') {
 				continue;
@@ -278,6 +305,9 @@ class Holidays extends DolibarrApi
 				// Add a mention of caller so on trigger called after action, we can filter to avoid a loop if we try to sync back again with the caller
 				$this->holiday->context['caller'] = sanitizeVal($request_data['caller'], 'aZ09');
 				continue;
+			}
+			if (in_array($field, self::$FIELDS_FORBIDDEN_FOR_API)) {
+				throw new RestException(400, "Field '".$field."' is not allowed in update endpoint. Use dedicated routes (validate, approve, refuse, cancel, reopen) to change the workflow status.");
 			}
 
 			if ($field == 'array_options' && is_array($value)) {


### PR DESCRIPTION
## Security Fix: Authorization Bypass in Leave/Holiday REST API

### Vulnerability

The holiday REST API's generic `put()` and `post()` methods copied every field from the request body onto the `Holiday` object via an unfiltered `foreach` loop. An employee holding only the `holiday/write` permission ("Create/modify leave requests") could:

- Set `status` to `3` (`STATUS_APPROVED`) to **approve their own leave request**, bypassing the separate `holiday/approve` permission
- Set `fk_validator` to their own user id or any arbitrary id, bypassing the `fetch_users_approver_holiday()` validation that the web interface enforces
- Set other approval-related fields (`date_valid`, `fk_user_valid`, `date_approval`, `fk_user_approve`, etc.)

The web interface (`htdocs/holiday/card.php`) correctly checks `holiday/approve` **and** that the approver is the recorded validator (`fk_validator == $user->id`). The API applied neither condition.

**CVSS 4.0:** `CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N` (HIGH)

### Root Cause

`htdocs/holiday/class/api_holidays.class.php` — `put()` method:

```php
foreach ($request_data as $field => $value) {
    if ($field == 'id') { continue; }
    // ... no field allowlist/denylist ...
    $this->holiday->$field = $this->_checkValForAPI($field, $value, $this->holiday);
}
```

`Holiday::update()` then persists `status` into the `statut` column and `fk_validator` directly, reaching the same database state as the dedicated `approve()` method while bypassing its permission check.

### Fix

Added a static denylist `$FIELDS_FORBIDDEN_FOR_API` containing all workflow-sensitive fields:

```php
public static $FIELDS_FORBIDDEN_FOR_API = array(
    'status', 'statut', 'fk_validator',
    'date_valid', 'fk_user_valid',
    'date_approval', 'fk_user_approve',
    'date_refuse', 'fk_user_refuse', 'detail_refuse',
);
```

- **`put()`**: rejects all denied fields with HTTP 400, directing callers to the dedicated routes (`approve`, `refuse`, `cancel`, `validate`, `reopen`) that enforce proper permission checks
- **`post()`**: rejects all denied fields except `fk_validator`, which remains legitimate at creation time (required by `Holiday::create()`)
- Added `is_array($request_data)` guard in `put()` to prevent crash on null input, consistent with `_validate()` in `post()`

### Existing dedicated API routes (unchanged)

The API already had dedicated endpoints with proper permission checks:
- `POST {id}/approve` — checks `holiday/approve`
- `POST {id}/refuse` — checks `holiday/approve`
- `POST {id}/validate` — checks `holiday/write`
- `POST {id}/cancel` — checks `holiday/write`
- `POST {id}/reopen` — checks `holiday/write`

### Reproduction (before fix)

```bash
# User with only holiday/write permission approves their own leave:
curl -X PUT "http://127.0.0.1:8080/api/index.php/holidays/1" \
  -H "DOLAPIKEY: <usermgr_key>" \
  -H 'Content-Type: application/json' \
  -d '{"status":3,"fk_validator":3}'
```

### After fix

The same request returns HTTP 400:
```
Field 'status' is not allowed in update endpoint. Use dedicated routes (validate, approve, refuse, cancel, reopen) to change the workflow status.
```

### Attribution

Reported by Arthur Chan (Google / Ada Logics). Internal tracking: 558292081.