### PR TITLE
FIX : zstd compression always results in a false positive error message

### DIFF
--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -515,7 +515,7 @@ class Utils
 			} elseif ($compression == 'bz') {
 				$handle = bzopen($outputfile, 'r');
 			} elseif ($compression == 'zstd') {
-				$handle = fopen($outputfile, 'r');
+				$handle = fopen("compress.zstd://" . $outputfile, "rb");
 			}
 			if ($handle) {
 				// Get 2048 first chars of error message.


### PR DESCRIPTION
When dumping database with zstd compression, it always return a false positive error message (binary is readed, not mysql text).

<img width="291" height="43" alt="image (81)" src="https://github.com/user-attachments/assets/5276f9cf-5b6d-42cf-8da4-13c350bc5f2e" />

