### PR TITLE
FIX Virtual stock horizon fatals outside web context (follow-up of #39675)

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -6582,6 +6582,7 @@ class Product extends CommonObject
 		$horizoninDays = getDolGlobalString('STOCK_VIRTUAL_HORIZON_IN_DAYS');
 		$dateofvirtualstockmin = 0;
 		if (empty($dateofvirtualstock) && $horizoninDays !== '') {
+			include_once DOL_DOCUMENT_ROOT.'/core/lib/date.lib.php';	// dol_time_plus_duree/dol_get_first_hour are not loaded in CLI/webservice contexts
 			$dateofvirtualstock = dol_time_plus_duree(dol_now(), max(0, (int) $horizoninDays), 'd');
 			$dateofvirtualstockmin = dol_get_first_hour(dol_now());	// The horizon is a window: supply expected before today did not arrive as planned
 		}


### PR DESCRIPTION
## Bug

Follow-up of #39675. `dol_time_plus_duree()` and `dol_get_first_hour()` live in `core/lib/date.lib.php`, which web pages happen to include but CLI scripts, crons and webservice endpoints do not.

As soon as `STOCK_VIRTUAL_HORIZON_IN_DAYS` is set, any `load_virtual_stock()` call from such a context dies with:

```
PHP Fatal error: Call to undefined function dol_time_plus_duree() in htdocs/product/class/product.class.php
```

Found while deploying the feature on a production instance: the web UI worked fine, but the ERP-to-shop stock synchronization (webservice) crashed on the first product read.

## Fix

One `include_once` of `date.lib.php` inside the horizon branch — only paid when the option is set, no behavior change otherwise.