### PR TITLE
FIX BOM net needs cumulated quantities of different units without converting them

### DIFF
--- a/htdocs/bom/class/bom.class.php
+++ b/htdocs/bom/class/bom.class.php
@@ -1557,16 +1557,42 @@ class BOM extends CommonObject
 						$childBom->getNetNeeds($TNetNeeds, $line->qty * $qty);
 					}
 				} else {
-					if (empty($TNetNeeds[$line->fk_product]['qty'])) {
-						$TNetNeeds[$line->fk_product]['qty'] = 0.0;
+					if (!isset($TNetNeeds[$line->fk_product])) {
+						$TNetNeeds[$line->fk_product] = array();
 					}
-					// When using nested level (or not), the qty for needs must always use the same unit to be able to be cumulated.
-					// So if unit in bom is not the same than default, we must recalculate qty after units comparisons.
-					$TNetNeeds[$line->fk_product]['fk_unit'] = $line->fk_unit;
-					$TNetNeeds[$line->fk_product]['qty'] += $line->qty * $qty;
+					$this->cumulateNetNeed($TNetNeeds[$line->fk_product], $line->qty * $qty, $line->fk_unit);
 				}
 			}
 		}
+	}
+
+	/**
+	 * Cumulate a qty into a net need of a product
+	 *
+	 * @param	array<string,mixed>	$netneed	Net need to update. Its 'qty' is always expressed into its 'fk_unit'.
+	 * @param	float				$qty		Qty to cumulate, expressed into $fk_unit
+	 * @param	?int				$fk_unit	Unit of $qty
+	 * @return	void
+	 */
+	private function cumulateNetNeed(&$netneed, $qty, $fk_unit)
+	{
+		if (!isset($netneed['qty'])) {
+			$netneed['qty'] = 0.0;
+			$netneed['fk_unit'] = $fk_unit;
+		}
+
+		// A same product can be used with 2 different units in the tree, so the qty must be converted into the
+		// unit of the net need before being cumulated. Units of 2 different unit types stay cumulated as they are.
+		if ($fk_unit != $netneed['fk_unit']) {
+			require_once DOL_DOCUMENT_ROOT.'/core/class/cunits.class.php';
+			$cunits = new CUnits($this->db);
+			$convertedqty = $cunits->unitConverterSameType($qty, $fk_unit, $netneed['fk_unit']);
+			if ($convertedqty !== false) {
+				$qty = $convertedqty;
+			}
+		}
+
+		$netneed['qty'] += $qty;
 	}
 
 	/**
@@ -1593,19 +1619,13 @@ class BOM extends CommonObject
 						$childBom->getNetNeedsTree($TNetNeeds, $line->qty * $qty, $level + 1);
 					}
 				} else {
-					// When using nested level (or not), the qty for needs must always use the same unit to be able to be cumulated.
-					// So if unit in bom is not the same than default, we must recalculate qty after units comparisons.
 					if (!isset($TNetNeeds[$this->id]['product'])) {
 						$TNetNeeds[$this->id]['product'] = array();
 					}
 					if (!isset($TNetNeeds[$this->id]['product'][$line->fk_product])) {
 						$TNetNeeds[$this->id]['product'][$line->fk_product] = array();
 					}
-					$TNetNeeds[$this->id]['product'][$line->fk_product]['fk_unit'] = $line->fk_unit;
-					if (!isset($TNetNeeds[$this->id]['product'][$line->fk_product]['qty'])) {
-						$TNetNeeds[$this->id]['product'][$line->fk_product]['qty'] = 0.0;
-					}
-					$TNetNeeds[$this->id]['product'][$line->fk_product]['qty'] += $line->qty * $qty;
+					$this->cumulateNetNeed($TNetNeeds[$this->id]['product'][$line->fk_product], $line->qty * $qty, $line->fk_unit);
 					$TNetNeeds[$this->id]['product'][$line->fk_product]['level'] = $level;
 				}
 			}

--- a/htdocs/core/class/cunits.class.php
+++ b/htdocs/core/class/cunits.class.php
@@ -481,6 +481,64 @@ class CUnits extends CommonDict
 	}
 
 	/**
+	 * Convert a value into another unit of the same unit type. Unlike unitConverter(), the value is
+	 * returned unrounded and the conversion is refused when both units are not comparable.
+	 *
+	 * @param	float|string	$value			Value to convert
+	 * @param	?int			$fk_unit		Id of the unit $value is expressed in
+	 * @param	?int			$fk_new_unit	Id of the unit to convert the value into
+	 * @return	float|false						Converted value, or false if the 2 units are not comparable
+	 * @see unitConverter()
+	 */
+	public function unitConverterSameType($value, $fk_unit, $fk_new_unit)
+	{
+		$value = (float) price2num($value);
+		$fk_unit = (int) $fk_unit;
+		$fk_new_unit = (int) $fk_new_unit;
+
+		if ($fk_unit <= 0 || $fk_new_unit <= 0) {
+			return false;
+		}
+		if ($fk_unit == $fk_new_unit) {
+			return $value;
+		}
+
+		$sql = "SELECT rowid, scale, unit_type FROM ".$this->db->prefix()."c_units";
+		$sql .= " WHERE rowid IN (".$fk_unit.", ".$fk_new_unit.")";
+
+		$resql = $this->db->query($sql);
+		if (!$resql) {
+			return false;
+		}
+
+		$unitsofconversion = array();
+		while ($obj = $this->db->fetch_object($resql)) {
+			$unitsofconversion[(int) $obj->rowid] = $obj;
+		}
+
+		if (!isset($unitsofconversion[$fk_unit]) || !isset($unitsofconversion[$fk_new_unit])) {
+			return false;
+		}
+		if ($unitsofconversion[$fk_unit]->unit_type != $unitsofconversion[$fk_new_unit]->unit_type) {
+			return false;
+		}
+		foreach ($unitsofconversion as $unitofconversion) {
+			// Out of the time unit type, a scale is an exponent of ten. Values like 88, 89, 97, 98 and 99 are
+			// placeholders for units having no metric scale (imperial units, litre, gallon): they can't be converted.
+			if ($unitofconversion->unit_type != 'time' && abs((float) $unitofconversion->scale) >= 10) {
+				return false;
+			}
+		}
+
+		$scaleofnewunit = $this->scaleOfUnitPow($fk_new_unit);
+		if (empty($scaleofnewunit)) {
+			return false;
+		}
+
+		return $value * $this->scaleOfUnitPow($fk_unit) / $scaleofnewunit;
+	}
+
+	/**
 	 * Get scale of unit factor
 	 *
 	 * @param 	int 		$id 	Id of unit in dictionary

--- a/test/phpunit/AllTests.php
+++ b/test/phpunit/AllTests.php
@@ -153,6 +153,9 @@ class AllTests
 		require_once dirname(__FILE__).'/CMailFileTest.php';
 		$suite->addTestSuite('CMailFileTest');
 
+		require_once dirname(__FILE__).'/CUnitsTest.php';
+		$suite->addTestSuite('CUnitsTest');
+
 		require_once dirname(__FILE__).'/CommonObjectTest.php';
 		$suite->addTestSuite('CommonObjectTest');
 

--- a/test/phpunit/BOMTest.php
+++ b/test/phpunit/BOMTest.php
@@ -29,6 +29,7 @@ global $conf,$user,$langs,$db;
 //require_once 'PHPUnit/Autoload.php';
 require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
 require_once dirname(__FILE__).'/../../htdocs/bom/class/bom.class.php';
+require_once dirname(__FILE__).'/../../htdocs/core/class/cunits.class.php';
 require_once dirname(__FILE__).'/CommonClassTest.class.php';
 
 if (empty($user->id)) {
@@ -97,5 +98,56 @@ class BOMTest extends CommonClassTest
 		print __METHOD__." id=".$id." result=".$result."\n";
 		$this->assertLessThan($result, 0);
 		return $result;
+	}
+
+	/**
+	 * A product used at several levels of the tree with different units of the same unit type
+	 * must be cumulated once converted, not added raw.
+	 *
+	 * @return void
+	 */
+	public function testBOMGetNetNeedsCumulatesMixedUnits()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		$cunits = new CUnits($db);
+		$idhour = $cunits->getUnitFromCode('H', 'code', 'time');
+		$idminute = $cunits->getUnitFromCode('MI', 'code', 'time');
+
+		$childline = new BOMLine($db);
+		$childline->fk_product = 101;
+		$childline->qty = 15;
+		$childline->fk_unit = $idminute;
+
+		$childbom = new BOM($db);
+		$childbom->id = 2;
+		$childbom->qty = 1;
+		$childbom->lines = array($childline);
+
+		$serviceline = new BOMLine($db);
+		$serviceline->fk_product = 101;
+		$serviceline->qty = 1;
+		$serviceline->fk_unit = $idhour;
+
+		$subassemblyline = new BOMLine($db);
+		$subassemblyline->fk_product = 200;
+		$subassemblyline->qty = 1;
+		$subassemblyline->childBom = array($childbom);
+
+		$localobject = new BOM($db);
+		$localobject->id = 1;
+		$localobject->qty = 1;
+		$localobject->lines = array($serviceline, $subassemblyline);
+
+		$TNetNeeds = array();
+		$localobject->getNetNeeds($TNetNeeds, 1);
+
+		print __METHOD__." qty=".$TNetNeeds[101]['qty']."\n";
+		$this->assertEquals($idhour, $TNetNeeds[101]['fk_unit']);
+		$this->assertEquals(1.25, $TNetNeeds[101]['qty']);
 	}
 }

--- a/test/phpunit/CUnitsTest.php
+++ b/test/phpunit/CUnitsTest.php
@@ -1,0 +1,132 @@
+<?php
+/* Copyright (C) 2026 Nicolas Vidal <nicolas.vidal@atm-consulting.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    test/phpunit/CUnitsTest.php
+ * \ingroup core
+ * \brief   PHPUnit test for CUnits class.
+ */
+
+global $conf,$user,$langs,$db;
+//define('TEST_DB_FORCE_TYPE','mysql');	// This is to force using mysql driver
+//require_once 'PHPUnit/Autoload.php';
+require_once dirname(__FILE__).'/../../htdocs/master.inc.php';
+require_once dirname(__FILE__).'/../../htdocs/core/class/cunits.class.php';
+require_once dirname(__FILE__).'/CommonClassTest.class.php';
+
+if (empty($user->id)) {
+	print "Load permissions for admin user nb 1\n";
+	$user->fetch(1);
+	$user->loadRights();
+}
+$conf->global->MAIN_DISABLE_ALL_MAILS = 1;
+
+$langs->load("main");
+
+
+/**
+ * Class for PHPUnit tests
+ *
+ * @backupGlobals disabled
+ * @backupStaticAttributes enabled
+ * @remarks	backupGlobals must be disabled to have db,conf,user and lang not erased.
+ */
+class CUnitsTest extends CommonClassTest
+{
+	/**
+	 * testUnitConverterSameTypeInsideTimeUnits
+	 *
+	 * @return void
+	 */
+	public function testUnitConverterSameTypeInsideTimeUnits()
+	{
+		global $db;
+
+		$cunits = new CUnits($db);
+		$idhour = $cunits->getUnitFromCode('H', 'code', 'time');
+		$idminute = $cunits->getUnitFromCode('MI', 'code', 'time');
+
+		$this->assertEquals(60, $cunits->unitConverterSameType(1, $idhour, $idminute));
+		$this->assertEquals(0.25, $cunits->unitConverterSameType(15, $idminute, $idhour));
+	}
+
+	/**
+	 * A conversion to a larger unit must keep the value, so that a small need is not lost.
+	 *
+	 * @return void
+	 */
+	public function testUnitConverterSameTypeKeepsValueOfSmallQuantities()
+	{
+		global $db;
+
+		$cunits = new CUnits($db);
+		$idkg = $cunits->getUnitFromCode('KG', 'code', 'weight');
+		$idg = $cunits->getUnitFromCode('G', 'code', 'weight');
+
+		$this->assertEquals(0.001, $cunits->unitConverterSameType(1, $idg, $idkg));
+		$this->assertEquals(1000, $cunits->unitConverterSameType(1, $idkg, $idg));
+	}
+
+	/**
+	 * testUnitConverterSameTypeRefusesTwoDifferentUnitTypes
+	 *
+	 * @return void
+	 */
+	public function testUnitConverterSameTypeRefusesTwoDifferentUnitTypes()
+	{
+		global $db;
+
+		$cunits = new CUnits($db);
+		$idunit = $cunits->getUnitFromCode('P', 'code', 'qty');
+		$idminute = $cunits->getUnitFromCode('MI', 'code', 'time');
+
+		$this->assertFalse($cunits->unitConverterSameType(1, $idunit, $idminute));
+	}
+
+	/**
+	 * Units with no metric scale (imperial units, litre, gallon) carry a placeholder scale, not an exponent.
+	 *
+	 * @return void
+	 */
+	public function testUnitConverterSameTypeRefusesUnitWithoutMetricScale()
+	{
+		global $db;
+
+		$cunits = new CUnits($db);
+		$idkg = $cunits->getUnitFromCode('KG', 'code', 'weight');
+		$idpound = $cunits->getUnitFromCode('LB', 'code', 'weight');
+
+		$this->assertFalse($cunits->unitConverterSameType(1, $idpound, $idkg));
+		$this->assertFalse($cunits->unitConverterSameType(1, $idkg, $idpound));
+	}
+
+	/**
+	 * testUnitConverterSameTypeRefusesUnknownUnit
+	 *
+	 * @return void
+	 */
+	public function testUnitConverterSameTypeRefusesUnknownUnit()
+	{
+		global $db;
+
+		$cunits = new CUnits($db);
+		$idhour = $cunits->getUnitFromCode('H', 'code', 'time');
+
+		$this->assertFalse($cunits->unitConverterSameType(1, 0, $idhour));
+		$this->assertFalse($cunits->unitConverterSameType(1, $idhour, 0));
+	}
+}


### PR DESCRIPTION
# FIX BOM net needs cumulated quantities of different units without converting them

On the **Net needs** tab of a BOM, when a same product is used at several levels of the tree with different units of the same unit type, the quantities are cumulated raw and the unit displayed is the one of the last line read.

Reproduced on a 2 levels BOM:

| level | product | qty | unit |
|---|---|---|---|
| BOM | service CUT | 1 | hour |
| child BOM | service CUT | 15 | minute |

The tab shows `CUT 16.00 Minute` (1 + 15) instead of 75 minutes (= 1.25 hour). A product used in kg in a BOM and in g in another one gives the same wrong total. When both levels use the same unit the total is right, so the defect only shows up when units differ from one level to the other.

The comment sitting above the 2 faulty lines in `Bom::getNetNeeds()` already describes the expected treatment ("the qty for needs must always use the same unit to be able to be cumulated. So if unit in bom is not the same than default, we must recalculate qty after units comparisons"), it was never implemented. `getNetNeedsTree()`, used by the tree view, overwrites the unit of a product the same way.

### What this PR does

- `Bom::getNetNeeds()` and `Bom::getNetNeedsTree()` now keep the unit of the first line read for a product and convert the following quantities into it before cumulating them. Both go through a new private `Bom::cumulateNetNeed()` so the rule lives in one place.
- New `CUnits::unitConverterSameType()` does the conversion. It differs from `unitConverter()` on two points that matter here:
  - it returns the value **unrounded** (`unitConverter()` rounds to 2 decimals, so 1 g converted into kg was reduced to 0),
  - it **refuses** to convert units of 2 different unit types (converting 1 piece into minutes returns 0.02 today), and units having no metric scale, whose `scale` column holds a placeholder (88, 89, 97, 98, 99) instead of an exponent of ten: imperial units, litre, gallon.

  When the conversion is refused the quantities stay cumulated as they are, exactly like before this PR, rather than producing a wrong value that looks plausible.

The shape of the `$TNetNeeds` array is unchanged: `qty` is still expressed into `fk_unit`, so `bom/bom_net_needs.php` needs no change.

### Tests

- `test/phpunit/CUnitsTest.php` (new): conversion inside a unit type, small quantities kept accurate, refusal of 2 different unit types, refusal of a unit without metric scale, refusal of an unknown unit.
- `test/phpunit/BOMTest.php`: the 2 levels case above, which returns 16 before the fix and 1.25 hour after.

### Target branch

Targeted on 22.0, the oldest maintained branch. The code is identical on 21.0, 23.0, 24.0 and develop, the defect is not a regression of a recent version. Tell me if you prefer another base.
