### PR TITLE
FIX AssetDepreciationOptions creates dynamic properties, deprecated on PHP 8.2+

### DIFF
--- a/htdocs/asset/class/assetdepreciationoptions.class.php
+++ b/htdocs/asset/class/assetdepreciationoptions.class.php
@@ -145,6 +145,22 @@ class AssetDepreciationOptions extends CommonObject
 	 * @var int<0,1>
 	 */
 	public $accelerated_depreciation_option;
+	/**
+	 * @var float	Depreciation rate, computed by getRate() and not stored in database
+	 */
+	public $rate;
+	/**
+	 * @var float
+	 */
+	public $amount_base_depreciation_ht;
+	/**
+	 * @var float
+	 */
+	public $amount_base_deductible_ht;
+	/**
+	 * @var float
+	 */
+	public $total_amount_last_depreciation_ht;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
Fixes #40320, spun off from #40308 where @pixodeo noticed the deprecation next to the rate defect and asked that the writing line be pinned down before a report was opened. It is inside the asset module: `setInfosForMode()` assigns each option field with a variable property name, which is why grepping for `->rate =` finds nothing.

```php
// Set value of the field in the object (for createCommon and setDeprecationOptionsFromPost functions)
$this->{$field_key} = $this->deprecation_options[$mode][$field_key] ?? null;
```

Five of the nine field keys are declared on the class, four were missed: `rate`, `amount_base_depreciation_ht`, `amount_base_deductible_ht` and `total_amount_last_depreciation_ht`. This declares them next to the others. No behaviour change — the properties were already being created, just dynamically.

## Measured

Clean installs, PHP 8.5.7, notices raised by a single call:

| call | before | after |
|---|---|---|
| `setInfosForMode('economic', 0, false)` | 3 | **0** |
| `setInfosForMode('economic', 0, true)` | 4 | **0** |

Identical counts on 22.0.5, 23.0.4 and 24.0.1. The `true` variant is what the view template uses, which is why an asset card raises four.

## Why develop only

The declarations are missing from 18.0 through develop, but on 18.0 the class declares no property at all, so the fix there would mean declaring the whole set rather than four. Since this raises deprecation notices and breaks nothing functionally, a maintenance branch seemed the wrong place for a change that size. Tell me if you would rather have it backported and I will prepare it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)