### PR TITLE
FIX remove all extrafields filters on bank account list for remove filters action

### DIFF
--- a/htdocs/compta/bank/list.php
+++ b/htdocs/compta/bank/list.php
@@ -165,6 +165,7 @@ if (empty($reshook)) {
 		$search_number = '';
 		$search_status = '';
 		$search_category_list = array();
+		$search_array_options = array();
 	}
 
 	// Mass actions


### PR DESCRIPTION
FIX remove all extrafields filters on bank account list for remove filters action

**To reproduce**
1. Create an extrafield on bank
2. Go to bank account list
3. Filter on this extrafield
4. Remove all filters

The extrafield filter is'nt removed
