### PR TITLE
FIX: Login button can render invisible (white on white) when top-menu color is white

### DIFF
--- a/htdocs/theme/eldy/btn.inc.php
+++ b/htdocs/theme/eldy/btn.inc.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+/* Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -23,7 +23,6 @@ if (!defined('ISLOADEDBYSTEELSHEET')) {
  * @var User $user
  *
  * @var string $butactionbg
- * @var string $colorbackhmenu1
  * @var string $colortextlink
  * @var int $dol_optimize_smallscreen
  * @var string $fontlist
@@ -35,7 +34,6 @@ if (!defined('ISLOADEDBYSTEELSHEET')) {
 
 '
 @phan-var-force string $butactionbg
-@phan-var-force string $colorbackhmenu1
 @phan-var-force string $colortextlink
 @phan-var-force int<0,1> $dol_optimize_smallscreen
 @phan-var-force string $fontlist
@@ -49,14 +47,14 @@ if (!defined('ISLOADEDBYSTEELSHEET')) {
 /* IDE Hack <style type="text/css"> */
 
 :root {
-			--btncolortext: rgb(<?php print $colortextlink; ?>);
-			--btncolorbg: #fbfbfb;
-			--btncolorborderhover: none;
-			--btncolorborder: #FFF;
-			--butactiondeletebg: rgb(234,228,225);
-			--butactioncancelbg: #e3e3e3;
-			--butactionbg: rgb(<?php print $butactionbg; ?>);
-			--textbutaction: rgb(<?php print $textbutaction; ?>);
+	--btncolortext: rgb(<?php print $colortextlink; ?>);
+	--btncolorbg: #fbfbfb;
+	--btncolorborderhover: none;
+	--btncolorborder: #FFF;
+	--butactiondeletebg: rgb(234,228,225);
+	--butactioncancelbg: #e3e3e3;
+	--butactionbg: rgb(<?php print $butactionbg; ?>);
+	--textbutaction: rgb(<?php print $textbutaction; ?>);
 }
 
 <?php
@@ -278,7 +276,7 @@ span.butActionNewRefused>span.fa, span.butActionNewRefused>span.fa:hover
 }
 
 .butActionLogin, .butActionLogin:link, .butActionLogin:visited, .butActionLogin:hover, .butActionLogin:active {
-	background-color: rgb(<?php echo $colorbackhmenu1; ?>);
+	background-color: var(--butactionbg);
 	padding: 1em 1em;
 }
 

--- a/htdocs/theme/md/btn.inc.php
+++ b/htdocs/theme/md/btn.inc.php
@@ -1,5 +1,5 @@
 <?php
-/* Copyright (C) 2024-2025  Frédéric France         <frederic.france@free.fr>
+/* Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -316,7 +316,7 @@ span.butActionNewRefused>span.fa, span.butActionNewRefused>span.fa:hover
 }
 
 .butActionLogin {
-	background-color: rgb(<?php echo $colorbackhmenu1; ?>);
+	background-color: var(--butactionbg);
 }
 
 


### PR DESCRIPTION
## Bug

\`.butActionLogin\` (the "Connexion" login-page button, eldy and md themes) used \`$colorbackhmenu1\` — the top-menu bar's background color — for its own background, instead of \`--butactionbg\`, the color every other \`.butAction\` button in the app actually uses.

\`.butAction\` already forces white text on the login button via \`color: var(--textbutaction) !important;\`. So whenever an admin sets their top-menu background to white (a perfectly normal choice, e.g. \`THEME_ELDY_TOPMENU_BACK1 = 255,255,255\`), the login button ends up white text on a white background — completely invisible, while still fully functional (the blank area still submits the form on click).

## Reproduction

With \`THEME_ELDY_TOPMENU_BACK1=255,255,255\`:
- Before: \`.butActionLogin\` computes to \`background-color: rgb(255,255,255)\` / \`color: rgb(255,255,255)\` — invisible.
- After: background correctly follows \`--butactionbg\` (the theme's actual button color), independent of the top-menu color.

Verified visually before/after with a rendered screenshot of the login page.

Same issue existed identically in both the eldy and md themes; fixed in both. Also dropped the now-unused \`\$colorbackhmenu1\` var from eldy's docblock/phan annotations and normalized indentation to tabs in the \`:root\` block it sat in.

## Test

- Set a light/white top-menu background color, load the login page, confirm the "Connexion" button is visible with the theme's actual button color.
- \`php -l\` clean on both files.