### PR TITLE
Fix title was not complete on error

### DIFF
--- a/htdocs/public/payment/paymentok.php
+++ b/htdocs/public/payment/paymentok.php
@@ -2214,7 +2214,7 @@ if ($ispaymentok) {
 		} elseif ($ispostactionok == 0) {
 			$content .= $companylangs->transnoentitiesnoconv("None");
 		} else {
-			$topic .= ($ispostactionok ? '' : ' ('.$companylangs->trans("WarningPostActionErrorAfterPayment").')');
+			$topic .= ' ('.$companylangs->trans("WarningPostActionErrorAfterPayment").')';
 			$content .= '<span class="star">'.$companylangs->transnoentitiesnoconv("Error").'</span>';
 		}
 		$content .= '<br>'."\n";


### PR DESCRIPTION
## Fix: title was not complete on error

### Problem
In `htdocs/public/payment/paymentok.php`, when a post-action error occurred after a successful payment (`$ispaymentok` true but `$ispostactionok` false), the page title (`$topic`) did not include the warning suffix. The conditional `($ispostactionok ? '' : ' ...')` left the topic without the warning text in the error branch.

### Change
Simplified the assignment so the warning suffix is always appended in the error case:
```php
$topic .= ' ('.$companylangs->trans("WarningPostActionErrorAfterPayment").')';
```

This ensures the title reflects the error state consistently.