### PR TITLE
SEC: Check access to source proposal in createOrderFromProposal (reported by Arthur Chan, tracking #558292080)

### DIFF
--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -1203,6 +1203,10 @@ class Orders extends DolibarrApi
 			throw new RestException(404, 'Proposal not found');
 		}
 
+		if (!DolibarrApi::_checkAccessToResource('propal', $propal->id)) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+		}
+
 		$result = $this->commande->createFromProposal($propal, DolibarrApiAccess::$user);
 		if ($result < 0) {
 			throw new RestException(405, $this->commande->error);


### PR DESCRIPTION
## Security fix: IDOR in `POST /orders/createfromproposal/{id}`

### Problem

The `createOrderFromProposal` endpoint in `htdocs/commande/class/api_orders.class.php` checked module-level permissions (`propal/lire` and `commande/creer`) but did **not** call `_checkAccessToResource()` on the source proposal object before copying from it.

An internal user without the *"Read all third parties (and their objects) by internal users"* permission (right 262, off by default) could convert **any** commercial proposal into a customer order — including proposals of third parties for which they are not the sales representative — bypassing Dolibarr's sales representative confinement.

### Root cause

`Propal::fetch()` loads by primary key and does not enforce access control. The API layer enforces it separately via `DolibarrApi::_checkAccessToResource()`, as already done in `api_proposals.class.php::_fetch()` (line ~144). The conversion endpoint omitted that second check.

### Fix

Added `_checkAccessToResource('propal', $propal->id)` after `fetch()` and before `createFromProposal()`, matching the existing pattern in the proposals API:

```php
$propal = new Propal($this->db);
$result = $propal->fetch($proposalid);
if (!$result) {
    throw new RestException(404, 'Proposal not found');
}

if (!DolibarrApi::_checkAccessToResource('propal', $propal->id)) {
    throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
}

$result = $this->commande->createFromProposal($propal, DolibarrApiAccess::$user);
```

### Impact

Internal users restricted to their own sales-representative third parties can no longer create orders from proposals they do not have access to. Users with permission 262 or external users are unaffected.

### CVSS 4.0

`CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:L/VA:N/SC:N/SI:N/SA:N` (High)