### PR TITLE
FIX: zstd backup dump is written uncompressed despite the .zst extension

### DIFF
--- a/htdocs/core/class/utils.class.php
+++ b/htdocs/core/class/utils.class.php
@@ -409,7 +409,7 @@ class Utils
 				} elseif ($compression == 'bz') {
 					$handle = bzopen($outputfile, 'w');
 				} elseif ($compression == 'zstd') {
-					$handle = fopen($outputfile, 'w');
+					$handle = fopen("compress.zstd://" . $outputfile, "wb");
 				}
 			} else {
 				// TODO Add a pipe into script to decrypt dolCrypted values


### PR DESCRIPTION
## Summary
- Companion fix to #40315, which corrected the *read-back* side of a `zstd`-compressed DB backup (`Utils::dumpDatabase()`), reading the freshly-created dump through the `compress.zstd://` stream wrapper.
- The non-lowmemory *write* path still opened the output file with a plain `fopen($outputfile, 'w')`, so the `mysqldump` output was written as plain text even though the file is named `*.zst` and `$compression` is `'zstd'`.
- After #40315's read-side fix, reading that plain-text file back through `compress.zstd://` now fails with `fgets(): zstd: Unknown frame descriptor` because the file was never actually zstd-compressed.
- This fixes the write side to also use the `compress.zstd://` stream wrapper (`"wb"` mode), matching how `gz`/`bz` already produce real compressed output via `gzopen()`/`bzopen()`.

## Test plan
- [x] `php -l htdocs/core/class/utils.class.php`
- [x] Run a DB backup from Setup > Backup with compression set to `zstd` and `MAIN_EXEC_USE_POPEN` unset (non-lowmemory path) and confirm the resulting `.zst` file is valid zstd data (`zstd -t file.sql.zst`) and no more `Unknown frame descriptor` warning appears when the backup completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)