### PR TITLE
Fix intervention service duration calculation

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -444,6 +444,12 @@ if (empty($reshook)) {
 
 										if ($prod->duration_value && getDolGlobalString('FICHINTER_USE_SERVICE_DURATION')) {
 											switch ($prod->duration_unit) {
+												case 's':
+													$mult = 1;
+													break;
+												case 'mn':
+													$mult = 60;
+													break;
 												default:
 												case 'h':
 													$mult = 3600;
@@ -461,7 +467,7 @@ if (empty($reshook)) {
 													$mult = 3600 * 24 * 365;
 													break;
 											}
-											$duration = (int) $prod->duration_value * $mult * $lines[$i]->qty;
+											$duration = (int) round(((float) $prod->duration_value) * $mult * $lines[$i]->qty);
 										}
 
 										$desc = $lines[$i]->product_ref;


### PR DESCRIPTION
When creating an Intervention from a source document, service duration handling does not currently support seconds or minutes and fractional duration values are truncated before conversion.

This change:

adds support for the canonical Dolibarr time units s (seconds) and mn (minutes);
keeps the existing handling of hours, days, weeks, months and years;
preserves fractional duration values during the calculation;
rounds the final result before converting it to integer seconds.

For example, a service duration of 1.5 h now correctly produces 5400 seconds instead of being truncated to 1 hour.