### PR TITLE
SEC: Check access to source order in getOrderShipments/createOrderShipment

### DIFF
--- a/htdocs/commande/class/api_orders.class.php
+++ b/htdocs/commande/class/api_orders.class.php
@@ -1207,6 +1207,9 @@ class Orders extends DolibarrApi
 		if (!DolibarrApiAccess::$user->hasRight('expedition', 'lire')) {
 			throw new RestException(403);
 		}
+		if (!DolibarrApi::_checkAccessToResource('commande', $id)) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
+		}
 		$obj_ret = array();
 		$sql = "SELECT e.rowid";
 		$sql .= " FROM ".MAIN_DB_PREFIX."expedition as e";
@@ -1271,6 +1274,9 @@ class Orders extends DolibarrApi
 		$result = $this->commande->fetch($id);
 		if (!$result) {
 			throw new RestException(404, 'Order not found');
+		}
+		if (!DolibarrApi::_checkAccessToResource('commande', $this->commande->id)) {
+			throw new RestException(403, 'Access not allowed for login '.DolibarrApiAccess::$user->login);
 		}
 		$shipment = new Expedition($this->db);
 		$shipment->socid = $this->commande->socid;


### PR DESCRIPTION
## Security fix: IDOR in `GET /orders/{id}/shipment` and `POST /orders/{id}/shipment/{warehouse_id}`

### Problem

While reviewing #40333 (IDOR in `POST /orders/createfromproposal/{id}`), I found the same missing-access-check pattern twice more in the same file, `htdocs/commande/class/api_orders.class.php`:

- `getOrderShipments($id)` — lists the shipments linked to order `$id` via a raw SQL join, with no check that the caller can access order `$id`.
- `createOrderShipment($id, $warehouse_id)` — fetches order `$id`, then copies its `socid` and lines into a newly created `Expedition`, again with no check that the caller can access order `$id`.

Every other method in this class that operates on `$this->commande` (`get`, `put`, `delete`, `validate`, `reopen`, `setinvoiced`, `close`, `settodraft`, line/contact endpoints, and `createOrderFromProposal` after #40333) calls `DolibarrApi::_checkAccessToResource('commande', $this->commande->id)` right after fetching. These two were the only ones missing it.

### Impact

An internal user with `expedition/lire` or `expedition/creer` rights, but without the *"Read all third parties (and their objects) by internal users"* permission (right 262, off by default), could:
- List the shipments of any order (`GET {id}/shipment`), including orders of third parties they are not the sales representative for.
- Create a shipment from any order (`POST {id}/shipment/{warehouse_id}`), extracting that order's customer id and lines into a new document they do have access to.

### Fix

Added `_checkAccessToResource('commande', $id)` (or `$this->commande->id` where the order is already fetched) before touching order data, matching the pattern used everywhere else in this class and the fix applied in #40333.


🤖 Generated with [Claude Code](https://claude.com/claude-code)