### PR TITLE
NEW Show unit of measure in intervention line quantity

### DIFF
--- a/htdocs/fichinter/card.php
+++ b/htdocs/fichinter/card.php
@@ -472,7 +472,12 @@ if (empty($reshook)) {
 									// Common part (predefined or free line)
 									$desc .= dol_htmlentitiesbr($lines[$i]->desc);
 									$desc .= '<br>';
-									$desc .= ' ('.$langs->trans('Quantity').': '.$lines[$i]->qty.')';
+									$unit_label = '';
+									if ($lines[$i]->fk_unit) {
+										$langs->load('measuring_units');
+										$unit_label = $langs->trans($lines[$i]->getLabelOfUnit('short'));
+									}
+									$desc .= ' ('.$langs->trans('Quantity').': '.$lines[$i]->qty.($unit_label ? ' '.$unit_label : '').')';
 
 									$timearray = dol_getdate(dol_now());
 									$date_intervention = dol_mktime(0, 0, 0, $timearray['mon'], $timearray['mday'], $timearray['year']);


### PR DESCRIPTION
When an Intervention is created from a source document, the generated description currently includes the quantity but not its unit of measure.

This change appends the translated short unit label when a unit is defined on the source line.

For example:

Quantity: 40

becomes:

Quantity: 40 m

Lines without a unit keep the existing output unchanged.