### PR TITLE
FIX Depreciation plan depends on the timezone of the server and can lose a whole annuity

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -887,6 +887,28 @@ class Asset extends CommonObject
 	}
 
 	/**
+	 * Return the timestamp of the GMT midnight of the calendar day of a timestamp read from a date
+	 * column with the timezone of the server.
+	 *
+	 * A date column carries no hour, so the only meaningful information of such a timestamp is its
+	 * calendar day. Re-anchoring it on GMT midnight makes every comparison and every calendar
+	 * decomposition of the depreciation plan independent from the timezone of the server.
+	 *
+	 * @param	int|string	$timestamp	Timestamp to re-anchor
+	 * @return	int|string				GMT midnight of the same day, input returned as is if not a timestamp
+	 */
+	protected function dateToGmtMidnight($timestamp)
+	{
+		if (!is_numeric($timestamp) || empty($timestamp)) {
+			return $timestamp;
+		}
+
+		$parts = dol_getdate((int) $timestamp);
+
+		return dol_mktime(0, 0, 0, $parts['mon'], $parts['mday'], $parts['year'], 'gmt');
+	}
+
+	/**
 	 * Calculation depreciation lines (reversal and future) for each mode
 	 *
 	 * @return	int							Return integer <0 if KO, Id of created object if OK
@@ -957,8 +979,19 @@ class Asset extends CommonObject
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
 			require_once DOL_DOCUMENT_ROOT . '/core/lib/accounting.lib.php';
 
+			// The depreciation plan compares and decomposes dates that do not come from the same
+			// anchoring: the date fields of the asset are read from date columns with the timezone of
+			// the server, the fiscal periods after the first one are read with GMT
+			// (getNextFiscalYear() below), and the end of a fiscal period carries 23:59:59. Mixing them
+			// shifts a calendar day as soon as the UTC offset of the server is not zero, which prorates
+			// a partial period on the wrong number of days and, on a negative offset, makes the loop
+			// skip a whole fiscal period. Everything is therefore brought back to GMT midnight here.
+			$date_start = $this->dateToGmtMidnight($this->date_start);
+			$date_acquisition = $this->dateToGmtMidnight($this->date_acquisition);
+			$reversal_date = is_numeric($this->reversal_date) ? $this->dateToGmtMidnight($this->reversal_date) : $this->reversal_date;
+
 			// @FIXME getCurrentPeriodOfFiscalYear return the first period found. What if there is several ? And what if not closed ? And what if end date not yet defined.
-			$dates = getCurrentPeriodOfFiscalYear($this->db, $conf, $this->date_start > $this->date_acquisition ? $this->date_start : $this->date_acquisition);
+			$dates = getCurrentPeriodOfFiscalYear($this->db, $conf, $date_start > $date_acquisition ? $date_start : $date_acquisition, 'gmt');
 			$init_fiscal_period_start = $dates['date_start'];
 			$init_fiscal_period_end = $dates['date_end'];
 			/*
@@ -1040,16 +1073,16 @@ class Asset extends CommonObject
 				}
 
 				// Get depreciation period
-				$depreciation_date_start = $this->date_start > $this->date_acquisition ? $this->date_start : $this->date_acquisition;
+				$depreciation_date_start = $date_start > $date_acquisition ? $date_start : $date_acquisition;
 				$depreciation_date_end = dol_time_plus_duree(dol_time_plus_duree((int) $depreciation_date_start, (float) $fields['duration'], $fields['duration_type'] == 1 ? 'm' : ($fields['duration_type'] == 2 ? 'd' : 'y')), -1, 'd');
 				$depreciation_amount = $fields['amount_base_depreciation_ht'];
 				if ($fields['duration_type'] == 2) { // Daily
 					$fiscal_period_start = $depreciation_date_start;
 					$fiscal_period_end = $depreciation_date_start;
 				} elseif ($fields['duration_type'] == 1) { // Monthly
-					$date_temp = dol_getdate((int) $depreciation_date_start);
-					$fiscal_period_start = dol_get_first_day($date_temp['year'], $date_temp['mon'], false);
-					$fiscal_period_end = dol_get_last_day($date_temp['year'], $date_temp['mon'], false);
+					$date_temp = dol_getdate((int) $depreciation_date_start, false, 'gmt');
+					$fiscal_period_start = dol_get_first_day($date_temp['year'], $date_temp['mon'], true);
+					$fiscal_period_end = dol_get_last_day($date_temp['year'], $date_temp['mon'], true);
 				} else { // Annually
 					$fiscal_period_start = $init_fiscal_period_start;
 					$fiscal_period_end = $init_fiscal_period_end;
@@ -1057,7 +1090,7 @@ class Asset extends CommonObject
 				$cumulative_depreciation_ht = (float) $last_cumulative_depreciation_ht;
 				$depreciation_period_amount = $depreciation_amount - (float) $this->reversal_amount_ht;
 				$start_date = $depreciation_date_start;
-				$disposal_date = isset($this->disposal_date) && $this->disposal_date !== "" ? $this->disposal_date : "";
+				$disposal_date = isset($this->disposal_date) && $this->disposal_date !== "" ? $this->dateToGmtMidnight($this->disposal_date) : "";
 				$finish_date = $disposal_date !== "" ? $disposal_date : $depreciation_date_end;
 				$accountancy_code_depreciation_debit_key = $accountancy_codes->accountancy_codes_fields[$mode_key]['depreciation_debit'];
 				$accountancy_code_depreciation_debit = $accountancy_codes->accountancy_codes[$mode_key][$accountancy_code_depreciation_debit_key];
@@ -1066,9 +1099,9 @@ class Asset extends CommonObject
 
 				// Reversal depreciation line
 				//-----------------------------------------------------
-				if ($last_depreciation_date === "" && ($depreciation_date_start < $fiscal_period_start || is_numeric($this->reversal_date))) {
-					if (is_numeric($this->reversal_date)) {
-						if ($this->reversal_date < $fiscal_period_start) {
+				if ($last_depreciation_date === "" && ($depreciation_date_start < $fiscal_period_start || is_numeric($reversal_date))) {
+					if (is_numeric($reversal_date)) {
+						if ($reversal_date < $fiscal_period_start) {
 							$this->errors[] = $langs->trans('AssetErrorReversalDateNotGreaterThanCurrentBeginFiscalDateForMode', $mode_key);
 							$error++;
 							break;
@@ -1080,7 +1113,7 @@ class Asset extends CommonObject
 							break;
 						}
 
-						$start_date = $this->reversal_date;
+						$start_date = $reversal_date;
 						$result = $this->addDepreciationLine($mode_key, '', $start_date, (float) $this->reversal_amount_ht, (float) $this->reversal_amount_ht, $accountancy_code_depreciation_debit, $accountancy_code_credit);
 						if ($result < 0) {
 							$error++;
@@ -1123,8 +1156,11 @@ class Asset extends CommonObject
 
 						$first_period_found = true;
 
-						$period_begin = dol_print_date($fiscal_period_start, $ref_date_format);
-						$period_end = dol_print_date($fiscal_period_end, $ref_date_format);
+						// The bounds are anchored on GMT midnight, so the label of the period must be
+						// rendered in GMT too, otherwise it names the previous day or month on a server
+						// whose UTC offset is negative.
+						$period_begin = dol_print_date($fiscal_period_start, $ref_date_format, 'gmt');
+						$period_end = dol_print_date($fiscal_period_end, $ref_date_format, 'gmt');
 						$ref = $period_begin . ($period_begin != $period_end ? ' - ' . $period_end : '');
 						if ($fiscal_period_start <= $disposal_date && $disposal_date <= $fiscal_period_end) {
 							$ref .= ' - ' . $langs->transnoentitiesnoconv('AssetDisposal');
@@ -1137,7 +1173,7 @@ class Asset extends CommonObject
 						} elseif ($fields['duration_type'] == 1) { // Monthly
 							$nb_days = min($nb_days_in_month, num_between_day($begin_date, $end_date, 1));
 							if ($nb_days >= 28) {
-								$date_temp = dol_getdate($begin_date);
+								$date_temp = dol_getdate($begin_date, false, 'gmt');
 								if ($date_temp['mon'] == 2) {
 									$nb_days = 30;
 								}

--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -870,7 +870,10 @@ class Asset extends CommonObject
 		$sql .= " " . (int) $this->id;
 		$sql .= ", '" . $this->db->escape($mode) . "'";
 		$sql .= ", '" . $this->db->escape($ref) . "'";
-		$sql .= ", '" . $this->db->idate($depreciation_date) . "'";
+		// The period bounds are anchored on GMT midnight, so the date must be written in GMT too.
+		// Formatting it in the server timezone would store the next calendar day for any server
+		// east of UTC, since the bound is the last second of the period.
+		$sql .= ", '" . $this->db->idate($depreciation_date, 'gmt') . "'";
 		$sql .= ", " . (float) $depreciation_ht;
 		$sql .= ", " . (float) $cumulative_depreciation_ht;
 		$sql .= ", '" . $this->db->escape($accountancy_code_debit) . "'";


### PR DESCRIPTION
Replaces #40296, which targeted 22.0. Retargeted to 24.0 following @eldy on #40296:

> Note that the asset module is in experiment or de status on v22. So no PR can be accepted on in this branch. Module as set as stable in v24. So fix must be pushed in v24

Checked and it holds — `modAsset.class.php`, `$this->version`:

    18.0            'development'
    22.0, 23.0      'experimental'
    24.0, develop   'dolibarr'

Same commit, cherry-picked onto 24.0, applies with no conflict. Reported as #40288.

## The defect

`Asset::calculationDepreciation()` mixes two time anchors for the bounds of a fiscal period. `getCurrentPeriodOfFiscalYear()` is called with its default `tzserver`, while `getNextFiscalYear()` is called with `'gmt'`. The two dates the loop has to order are then built on different anchors, so under a negative UTC offset the comparison flips and a whole annuity disappears from the plan.

## The change

Anchor every period bound on GMT midnight through a new `Asset::dateToGmtMidnight()`, pass `'gmt'` to `getCurrentPeriodOfFiscalYear()`, and use `'gmt'` on the `dol_getdate()` / `dol_get_first_day()` / `dol_get_last_day()` calls of the monthly branch, plus `dol_print_date(..., 'gmt')` for the period labels — without that last one the monthly labels come out shifted by one month.

## Measured

Reference asset, 13 000 HT, straight line 5 years, in service 2022-03-10, disposed 2025-02-23, fiscal years August to July. Full plan computed against a real MySQL database under four timezones:

| timezone | before | after |
|---|---|---|
| UTC | correct | correct |
| Europe/Paris | correct | correct |
| Pacific/Honolulu | **one annuity missing** | correct |
| Pacific/Kiritimati | correct | correct |

After the fix the four give the identical plan, 1 018,33 / 2 600,00 / 2 600,00 / 1 466,11, cumulative 7 684,44 — the figures of the accounting firm.

Also verified end to end through the web interface, and in production on a 24.0.1 install: the 45 assets of that installation regenerate with no structural change to any plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)