### PR TITLE
FIX Depreciation options of an asset cannot be saved from the interface

### DIFF
--- a/htdocs/asset/class/assetdepreciationoptions.class.php
+++ b/htdocs/asset/class/assetdepreciationoptions.class.php
@@ -219,6 +219,33 @@ class AssetDepreciationOptions extends CommonObject
 	}
 
 	/**
+	 * Return whether an 'enabled_field' condition ("mode_key:field_key:value") is satisfied by the
+	 * data of the submitted form.
+	 *
+	 * @param	string	$enabledfield	Condition, as "mode_key:field_key:value"
+	 * @return	bool					True when the driving field was submitted with the expected value
+	 */
+	protected function isEnabledFieldSatisfiedFromPost($enabledfield)
+	{
+		$info = explode(':', $enabledfield);
+		if (count($info) < 3) {
+			return true;
+		}
+
+		$htmlname = $info[0] . '_' . $info[1];
+		if (!GETPOSTISSET($htmlname)) {
+			return false;	// An unchecked checkbox is not submitted at all
+		}
+
+		$value = GETPOST($htmlname, 'alphanohtml');
+		if ($value === 'on') {
+			$value = '1';	// A checked checkbox may be submitted as 'on'
+		}
+
+		return ((string) $value === (string) $info[2]);
+	}
+
+	/**
 	 *  Fill deprecation_options property of object (using for data sent by forms)
 	 *
 	 * @param	int<0,1>			$class_type	Type (0:asset, 1:asset model)
@@ -232,10 +259,23 @@ class AssetDepreciationOptions extends CommonObject
 
 		$deprecation_options = array();
 		foreach ($this->deprecation_options_fields as $mode_key => $mode_info) {
+			// A mode disabled by its enabled_field must not be validated at all. The form submits the
+			// fields of the hidden block anyway, empty, so a required field of that block (the
+			// degressive coefficient) makes the whole page fail. The block is dropped further below,
+			// but only after its fields have been validated, which is too late.
+			if (!empty($mode_info['enabled_field']) && !$this->isEnabledFieldSatisfiedFromPost($mode_info['enabled_field'])) {
+				continue;
+			}
+
 			$this->setInfosForMode($mode_key, $class_type);
 
 			foreach ($mode_info['fields'] as $field_key => $field_info) {
 				if (!empty($field_info['computed'])) {
+					continue;
+				}
+				// Same thing for a single field hidden by its own enabled_field: the degressive
+				// coefficient is required but hidden as soon as the depreciation type is not degressive
+				if (!empty($field_info['enabled_field']) && !$this->isEnabledFieldSatisfiedFromPost($field_info['enabled_field'])) {
 					continue;
 				}
 


### PR DESCRIPTION
Replaces #40306, which targeted 18.0. Retargeted to 24.0 following @eldy on #40306:

> The asset module have status "development" in version 18.0 So no maintenance PR should be pushed on this module in this branch. First version were this module was annouced "stable" was v24, so PR should target v24 or develop.

Checked and it holds — `modAsset.class.php`, `$this->version`:

    18.0            'development'
    22.0, 23.0      'experimental'
    24.0, develop   'dolibarr'

Same commit, cherry-picked onto 24.0, applies with no conflict. Reported as #40286.

## The defect

In `AssetDepreciationOptions::setDeprecationOptionsFromPost()` the validation loop runs over every mode and every field first, and the "unset not enabled modes" loop only runs afterwards. A field belonging to a block the form has hidden is therefore still validated.

`degressive_coefficient` is what makes this blocking rather than an edge case: it is `'notnull' => 1, 'default' => '0', 'validate' => 1` with `'enabled_field' => 'economic:depreciation_type:1'`, so it is hidden as soon as the type is not degressive, submitted empty, and validated anyway. Straight line, the most common setup, can never be saved — the form comes back with an unnamed "Is required".

Note on scope, corrected after measuring on clean installs rather than reading the code: the failure goes through `validateField()`, which is gated on `MAIN_FEATURES_LEVEL >= 1`. Every `notnull` field here carries `'default' => '0'`, so the `ErrorFieldRequired` branch is dead and cannot fire. Installations at features level 0 save normally; those at level 1 or 2 cannot. That is why this went unnoticed for so long.

## The change

Skip a mode **and** a field whose own `enabled_field` is unsatisfied before validating it, via a new `isEnabledFieldSatisfiedFromPost()`. Both levels matter: skipping only the mode leaves the straight line case broken, since `degressive_coefficient` is hidden by its own `enabled_field` inside an enabled mode.

## Measured

Clean installs, straight line 5 years, saving the depreciation options from the web interface:

| `MAIN_FEATURES_LEVEL` | before | after |
|---|---|---|
| 0 | saved | saved |
| 1 | **not saved**, "Is required" | saved |
| 2 | **not saved**, "Is required" | saved |

Verified through the interface on 22.0.5, 23.0.4 and 24.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)