### PR TITLE
QUAL: Widen $arrayofparameters type hint in asset setup to fix PHPStan loose-comparison false positives

### DIFF
--- a/htdocs/asset/admin/setup.php
+++ b/htdocs/asset/admin/setup.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2004-2017  Laurent Destailleur  <eldy@users.sourceforge.net>
  * Copyright (C) 2018-2024  Alexandre Spangaro   <alexandre@inovea-conseil.com>
  * Copyright (C) 2024-2026	MDW                  <mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France      <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France      <frederic.france@free.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,6 +65,9 @@ foreach (getAssetDepreciationDayCountConventions() as $conventioncode => $conven
 	$arrayofdaycountconventions[$conventioncode] = $langs->trans($conventionlabelkey);
 }
 
+/**
+ * @var array<string,array{type:string,enabled:int,arrayofkeyval?:array<int|string,string>,default?:string,css?:string}> $arrayofparameters
+ */
 $arrayofparameters = array(
 	'ASSET_ACCOUNTANCY_CATEGORY' => array('type' => 'accountancy_category', 'enabled' => 1),
 	'ASSET_DEPRECIATION_DAY_COUNT_CONVENTION' => array('type' => 'select', 'arrayofkeyval' => $arrayofdaycountconventions, 'default' => getAssetDepreciationDayCountConvention(), 'css' => 'minwidth300', 'enabled' => 1),


### PR DESCRIPTION
## Summary

develop's daily "PHPStan baseline" scheduled workflow has been red since 2026-09-11 with 12 fresh (unbaselined) errors, all in `htdocs/asset/admin/setup.php`:

```
Loose comparison using == between 'accountancy_category' and 'textarea' will always evaluate to false.
...
Loose comparison using == between 'accountancy_category' and 'accountancy_category' will always evaluate to true.
```

### Root cause

`$arrayofparameters` only has 2 active entries — the rest are commented-out examples for future config types:

```php
$arrayofparameters = array(
	'ASSET_ACCOUNTANCY_CATEGORY' => array('type' => 'accountancy_category', 'enabled' => 1),
	'ASSET_DEPRECIATION_DAY_COUNT_CONVENTION' => array('type' => 'select', ...),
	//'ASSET_MYPARAM2'=>array('type'=>'textarea','enabled'=>1),
	//'ASSET_MYPARAM3'=>array('type'=>'category:'.Categorie::TYPE_CUSTOMER, 'enabled'=>1),
	// ... more commented-out examples (yesno, thirdparty_type, securekey, product)
);
```

PHPStan infers `$val['type']`'s type from the array literal's *actual* contents, so it narrows it to the 2-value union `'accountancy_category'|'select'`. In the `foreach`, once the `$val['type'] == 'select'` branch is eliminated, only `'accountancy_category'` remains possible — so every later `==` check in the elseif chain (`'textarea'`, `'html'`, `'yesno'`, `'securekey'`, `'product'`, `'accountancy_code'`) is now provably always-false, and the final `'accountancy_category'` check provably always-true.

This isn't a real bug — the elseif chain intentionally keeps those branches for when the commented-out examples get uncommented — but it is genuinely dead code *today*, which PHPStan correctly (if unhelpfully) flags.

### Fix

Add a `@var` PHPDoc hint above `$arrayofparameters` declaring `'type'` as a plain `string`, so PHPStan stops over-narrowing from the array's current literal contents. No runtime change; the commented-out extensibility examples are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
