### PR TITLE
QUAL: Widen $arrayofparameters type hint in hrm setup to fix PHPStan loose-comparison false positives

### DIFF
--- a/htdocs/admin/hrm.php
+++ b/htdocs/admin/hrm.php
@@ -5,7 +5,7 @@
  * Copyright (C) 2021 Jean-Pascal BOUDET <jean-pascal.boudet@atm-consulting.fr>
  * Copyright (C) 2021 Grégory BLEMAND <gregory.blemand@atm-consulting.fr>
  * Copyright (C) 2024-2026	MDW							<mdeweerd@users.noreply.github.com>
- * Copyright (C) 2024-2025  Frédéric France             <frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France             <frederic.france@free.fr>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -63,6 +63,9 @@ $modulepart = GETPOST('modulepart', 'aZ09');	// Used by actions_setmoduleoptions
 $scandir = GETPOST('scan_dir', 'alpha');
 $type = 'evaluation';
 
+/**
+ * @var array<string,array{type:string,enabled:int,css?:string}> $arrayofparameters
+ */
 $arrayofparameters = array(
 	'HRM_MAXRANK' => array('type' => 'integer','enabled' => 1, 'css' => ''),
 	'HRM_DEFAULT_SKILL_DESCRIPTION' => array('type' => 'varchar','enabled' => 1, 'css' => ''),


### PR DESCRIPTION
## Summary

Same pattern and same fix as #40345, applied to `htdocs/admin/hrm.php` (9 baseline entries there, e.g. `equal.alwaysFalse`/`equal.alwaysTrue` on `'integer'|'varchar'` vs `'textarea'`/`'html'`/`'yesno'`/`'product'`/`'securekey'`).

### Root cause

```php
$arrayofparameters = array(
	'HRM_MAXRANK' => array('type' => 'integer','enabled' => 1, 'css' => ''),
	'HRM_DEFAULT_SKILL_DESCRIPTION' => array('type' => 'varchar','enabled' => 1, 'css' => ''),
);
```

Only 2 `'type'` values are used today, so PHPStan narrows `$val['type']` to that 2-value union in the `foreach`. The elseif chain still handles more types (`textarea`, `html`, `yesno`, `securekey`, `product`) for forward compatibility, so PHPStan proves those branches unreachable given the array's current contents — not a real bug, just PHPStan being precise about today's dead code.

### Fix

Add a `@var` PHPDoc hint declaring `'type'` as a plain `string`, matching #40345. No runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
