### PR TITLE
FIX: __LINES__/__QUANTITY__ substitution keys never added in FormMail::getAvailableSubstitKey()

### DIFF
--- a/htdocs/core/class/html.formmail.class.php
+++ b/htdocs/core/class/html.formmail.class.php
@@ -4,7 +4,7 @@
  * Copyright (C) 2010-2011	Juanjo Menent			<jmenent@2byte.es>
  * Copyright (C) 2015-2017	Marcos García			<marcosgdf@gmail.com>
  * Copyright (C) 2015-2017	Nicolas ZABOURI			<info@inovea-conseil.com>
- * Copyright (C) 2018-2025  Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2022		Charlene Benke			<charlene@patas-monkey.com>
  * Copyright (C) 2023		Anthony Berton			<anthony.berton@bb2a.fr>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
@@ -2210,10 +2210,10 @@ class FormMail extends Form
 			$tmparray = getCommonSubstitutionArray($langs, 2, null, $object); // Note: On email template creation, this may be null because it is related to all type of objects
 			complete_substitutions_array($tmparray, $langs, null, $parameters);
 
-			if ($mode == 'formwithlines') {
+			if ($mode == 'formemailwithlines') {
 				$tmparray['__LINES__'] = '__LINES__'; // Will be set by the get_form function
 			}
-			if ($mode == 'formforlines') {
+			if ($mode == 'formemailforlines') {
 				$tmparray['__QUANTITY__'] = '__QUANTITY__'; // Will be set by the get_form function
 			}
 		}


### PR DESCRIPTION
## Summary

Found while looking at PHPStan baseline errors similar to #40345/#40346, but this one is a real behavioral bug rather than a type-narrowing false positive.

### Root cause

```php
public static function getAvailableSubstitKey($mode = 'formemail', $object = null)
{
	...
	if ($mode == 'formemail' || $mode == 'formemailwithlines' || $mode == 'formemailforlines') {
		...
		if ($mode == 'formwithlines') {          // <- missing "email"
			$tmparray['__LINES__'] = '__LINES__';
		}
		if ($mode == 'formforlines') {            // <- missing "email"
			$tmparray['__QUANTITY__'] = '__QUANTITY__';
		}
	}
```

The outer guard only lets `'formemail'`, `'formemailwithlines'` or `'formemailforlines'` through (matching the docblock and both call sites in `admin/mails_templates.php:218` and `:226`). The two inner checks compare against `'formwithlines'`/`'formforlines'` instead — values that can never be true at this point — so PHPStan's baseline had these flagged as `equal.alwaysFalse`.

### Impact

When editing an email template with lines (`FormMail::getAvailableSubstitKey('formemailwithlines', ...)` / `'formemailforlines'`), the substitution-key tooltip list on `admin/mails_templates.php` never included `__LINES__`/`__QUANTITY__`, even though that mode is exactly what requests them.

### Fix

Correct the two inner comparisons to the actual mode names (`'formemailwithlines'` / `'formemailforlines'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
