### PR TITLE
FIX: Customer price edit form never showed extrafields flagged list=4

### DIFF
--- a/dev/build/phpstan/phpstan-baseline.neon
+++ b/dev/build/phpstan/phpstan-baseline.neon
@@ -6271,8 +6271,8 @@ parameters:
 			path: ../../../htdocs/product/price.php
 
 		-
-			message: '#^Loose comparison using \=\= between ''edit_customer_price'' and ''edit_price'' will always evaluate to false\.$#'
-			identifier: equal.alwaysFalse
+			message: '#^Loose comparison using \=\= between ''edit_customer_price'' and ''edit_customer_price'' will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
 			count: 2
 			path: ../../../htdocs/product/price.php
 
@@ -7951,8 +7951,8 @@ parameters:
 			path: ../../../htdocs/societe/price.php
 
 		-
-			message: '#^Loose comparison using \=\= between ''edit_customer_price'' and ''edit_price'' will always evaluate to false\.$#'
-			identifier: equal.alwaysFalse
+			message: '#^Loose comparison using \=\= between ''edit_customer_price'' and ''edit_customer_price'' will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
 			count: 2
 			path: ../../../htdocs/societe/price.php
 

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -2191,7 +2191,7 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 		if (!empty($extralabels)) {
 			if (empty($object->id)) {
 				foreach ($extralabels as $key => $value) {
-					if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
+					if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_customer_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
 						if (!empty($extrafields->attributes["product_customer_price"]['langfile'][$key])) {
 							$langs->load($extrafields->attributes["product_customer_price"]['langfile'][$key]);
 						}
@@ -2217,7 +2217,7 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 				if ($resql) {
 					$obj = $db->fetch_object($resql);
 					foreach ($extralabels as $key => $value) {
-						if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
+						if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_customer_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
 							if (!empty($extrafields->attributes["product_customer_price"]['langfile'][$key])) {
 								$langs->load($extrafields->attributes["product_customer_price"]['langfile'][$key]);
 							}

--- a/htdocs/societe/price.php
+++ b/htdocs/societe/price.php
@@ -6,7 +6,7 @@
  * Copyright (C) 2006		Andre Cianfarani		<acianfa@free.fr>
  * Copyright (C) 2015       Marcos García           <marcosgdf@gmail.com>
  * Copyright (C) 2023	    Alexandre Spangaro		<aspangaro@open-dsi.fr>
- * Copyright (C) 2024		Frédéric France			<frederic.france@free.fr>
+ * Copyright (C) 2024-2026  Frédéric France			<frederic.france@free.fr>
  * Copyright (C) 2024		Mélina Joum				<melina.joum@altairis.fr>
  * Copyright (C) 2025		MDW						<mdeweerd@users.noreply.github.com>
  *
@@ -549,7 +549,7 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 			if (!empty($extralabels)) {
 				if (empty($object->id)) {
 					foreach ($extralabels as $key => $value) {
-						if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
+						if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_customer_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
 							if (!empty($extrafields->attributes["product_customer_price"]['langfile'][$key])) {
 								$langs->load($extrafields->attributes["product_customer_price"]['langfile'][$key]);
 							}
@@ -575,7 +575,7 @@ if (getDolGlobalString('PRODUIT_CUSTOMER_PRICES') || getDolGlobalString('PRODUIT
 					if ($resql) {
 						$obj = $db->fetch_object($resql);
 						foreach ($extralabels as $key => $value) {
-							if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
+							if (!empty($extrafields->attributes["product_customer_price"]['list'][$key]) && ($extrafields->attributes["product_customer_price"]['list'][$key] == 1 || $extrafields->attributes["product_customer_price"]['list'][$key] == 3 || ($action == "edit_customer_price" && $extrafields->attributes["product_customer_price"]['list'][$key] == 4))) {
 								if (!empty($extrafields->attributes["product_customer_price"]['langfile'][$key])) {
 									$langs->load($extrafields->attributes["product_customer_price"]['langfile'][$key]);
 								}


### PR DESCRIPTION
## Summary

Found while triaging more `equal.alwaysFalse` PHPStan baseline entries (same identifier as #40345/#40346, different root cause — a real bug this time, like #40347).

### Root cause

Both `htdocs/product/price.php` and `htdocs/societe/price.php` have an `elseif ($action == 'edit_customer_price')` branch. Inside it, whether to display a `product_customer_price` extrafield with visibility level 4 is decided by:

```php
if (!empty(...['list'][$key]) && (...['list'][$key] == 1 || ...['list'][$key] == 3 || ($action == "edit_price" && ...['list'][$key] == 4))) {
```

But `$action` is `'edit_customer_price'` throughout this branch — `'edit_price'` is the *other*, non-customer price edit action, unreachable here. PHPStan flagged this as `equal.alwaysFalse` (2 occurrences per file, 4 total).

### Impact

An extrafield on `product_customer_price` configured with visibility `list = 4` is silently never shown when editing a customer-specific price, on either the product card's price tab or the third-party's price tab.

### Fix

Change `$action == "edit_price"` to `$action == "edit_customer_price"`, matching the enclosing branch and the equivalent `$action == "add_customer_price"` check used in the sibling `add_customer_price` branch just above.

This makes the check a redundant-but-harmless self-comparison (PHPStan now reports `equal.alwaysTrue` instead) — the same pattern already baselined elsewhere in both files (e.g. `'add_customer_price' == 'add_customer_price'`), so the baseline is updated accordingly rather than left red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
