### PR TITLE
QUAL: Remove dead 'fourn' alias check in getNumberInvoicesPieChart()

### DIFF
--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -455,7 +455,7 @@ function getNumberInvoicesPieChart($mode)
 		if ($mode == 'customers') {
 			$element = 'invoice';
 			$sql .= " FROM ".MAIN_DB_PREFIX."facture as f";
-		} elseif ($mode == 'fourn' || $mode == 'suppliers') {
+		} elseif ($mode == 'suppliers') {
 			$element = 'supplier_invoice';
 			$sql .= " FROM ".MAIN_DB_PREFIX."facture_fourn as f";
 		} else {
@@ -514,7 +514,7 @@ function getNumberInvoicesPieChart($mode)
 			$result .= '<td>'.$langs->trans("NbOfOpenInvoices").' - ';
 			if ($mode == 'customers') {
 				$result .= $langs->trans("CustomerInvoice");
-			} elseif ($mode == 'fourn' || $mode == 'suppliers') {
+			} elseif ($mode == 'suppliers') {
 				$result .= $langs->trans("SupplierInvoice");
 			} else {
 				return '';
@@ -539,7 +539,7 @@ function getNumberInvoicesPieChart($mode)
 				//$dolgraph->setBarWidth('15');
 				if ($mode == 'customers') {
 					$dolgraph->draw('idgraphcustomerinvoices');
-				} elseif ($mode == 'fourn' || $mode == 'suppliers') {
+				} elseif ($mode == 'suppliers') {
 					$dolgraph->draw('idgraphfourninvoices');
 				} else {
 					return '';


### PR DESCRIPTION
## Summary

Another PHPStan baseline `equal.alwaysFalse`/`equal.alwaysTrue` cleanup, this time a confirmed-dead branch rather than a typo bug (see #40345/#40346 for the type-narrowing case and #40347/#40348 for the typo-bug case).

### Root cause

```php
/**
 * @param 	string 	$mode 		Can be 'customers' or 'suppliers'
 */
function getNumberInvoicesPieChart($mode)
{
	if (($mode == 'customers' && ...) || ($mode == 'suppliers' && ...)) {
		...
		} elseif ($mode == 'fourn' || $mode == 'suppliers') {   // <- 3 occurrences
		...
```

The function's own docblock and its outer guard only ever let `$mode` be `'customers'` or `'suppliers'` — every one of the 3 real call sites (`compta/facture/index.php`, `compta/index.php`, `fourn/facture/index.php`) passes exactly one of those two, never `'fourn'`. So the 3 inner `$mode == 'fourn' ||` checks can never be true; PHPStan flagged each as `equal.alwaysFalse` (plus the following `'suppliers'` check as `equal.alwaysTrue` and the `||` itself as `booleanOr.alwaysTrue`).

### Fix

Drop the dead `'fourn'` alternative, keeping just `$mode == 'suppliers'`. No behavior change — verified with `git grep` that no caller anywhere passes `'fourn'` to this function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
