### PR TITLE
FIX: Cast trim() args to string in Task::create() (PHP 8.1 deprecation)

### DIFF
--- a/htdocs/projet/class/task.class.php
+++ b/htdocs/projet/class/task.class.php
@@ -2,7 +2,7 @@
 /* Copyright (C) 2008-2014	Laurent Destailleur	<eldy@users.sourceforge.net>
  * Copyright (C) 2010-2012	Regis Houssin		<regis.houssin@inodbox.com>
  * Copyright (C) 2014       Marcos García       <marcosgdf@gmail.com>
- * Copyright (C) 2018-2025  Frédéric France     <frederic.france@free.fr>
+ * Copyright (C) 2018-2026  Frédéric France     <frederic.france@free.fr>
  * Copyright (C) 2020       Juanjo Menent		<jmenent@2byte.es>
  * Copyright (C) 2022-2025  Charlene Benke		<charlene@patas-monkey.com>
  * Copyright (C) 2023      	Gauthier VERDOL     <gauthier.verdol@atm-consulting.fr>
@@ -423,10 +423,10 @@ class Task extends CommonObjectLine
 		$error = 0;
 
 		// Clean parameters
-		$this->label = trim($this->label);
-		$this->description = trim($this->description);
-		$this->note_public = trim($this->note_public);
-		$this->note_private = trim($this->note_private);
+		$this->label = trim((string) $this->label);
+		$this->description = trim((string) $this->description);
+		$this->note_public = trim((string) $this->note_public);
+		$this->note_private = trim((string) $this->note_private);
 
 		if (!empty($this->date_start) && !empty($this->date_end) && $this->date_start > $this->date_end) {
 			$this->errors[] = $langs->trans('StartDateCannotBeAfterEndDate');


### PR DESCRIPTION
## Summary

Same fix as #40137 (societe.class.php), #40191 (contact.class.php) and #40350 (product.class.php): `Task::create()` calls `trim()` on 4 untyped properties (`label`, `description`, `note_public`, `note_private`), which default to `null`, triggering PHP 8.1+'s deprecation:

> trim(): Passing null to parameter #1 ($string) of type string is deprecated

### Scope note

`task.class.php` actually has 13 raw `trim($this->...)` call sites on these same properties, but 9 of them (in `update()`, `addTimeSpent()`, `updateTimeSpent()`) are already guarded by `isset($this->prop)` checks and are not affected by this deprecation — only the 4 in `create()` are genuinely unguarded, so only those are touched here.

### Fix

Cast the 4 unguarded call sites to `trim((string) $this->...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
