### PR TITLE
FIX: Cast trim() args to string in Commande::addline() (PHP 8.1 deprecation)

### DIFF
--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -1677,8 +1677,8 @@ class Commande extends CommonOrder
 			} else {
 				$pu = $pu_ttc;
 			}
-			$label = trim($label);
-			$desc = trim($desc);
+			$label = trim((string) $label);
+			$desc = trim((string) $desc);
 
 			// Check parameters
 			if ($type < 0) {


### PR DESCRIPTION
## Summary

Same fix as #40137 (societe.class.php), #40191 (contact.class.php), #40350 (product.class.php) and #40351 (task.class.php): `Commande::addline()`'s `$desc` (required, no default) and `$label` (default `''`) parameters are untyped, so a caller passing `null` for either hits PHP 8.1+'s deprecation:

> trim(): Passing null to parameter #1 ($string) of type string is deprecated

### Scope note

This file has 9 raw `trim($this->...)`/`trim($var)` call sites touching this deprecation pattern, but 7 of them (`ref`, `ref_client`, `ref_customer`, `note`/`note_private`, `note_public`, `model_pdf`, `import_key` in `update()`) are already guarded by `isset($this->prop)` checks and are not affected — only the 2 in `addline()` are genuinely unguarded, so only those are touched here.

### Fix

Cast the 2 unguarded call sites to `trim((string) $desc)` / `trim((string) $label)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
