### PR TITLE
FIX: Cast trim() args to string in don.class.php (PHP 8.1 deprecation)

### DIFF
--- a/htdocs/don/class/don.class.php
+++ b/htdocs/don/class/don.class.php
@@ -316,29 +316,29 @@ class Don extends CommonObject
 		$err = 0;
 		$amount_invalid = 0;
 
-		if (dol_strlen(trim($this->societe)) == 0) {
-			if ((dol_strlen(trim($this->lastname)) + dol_strlen(trim($this->firstname))) == 0) {
+		if (dol_strlen(trim((string) $this->societe)) == 0) {
+			if ((dol_strlen(trim((string) $this->lastname)) + dol_strlen(trim((string) $this->firstname))) == 0) {
 				$error_string[] = $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Company').'/'.$langs->transnoentitiesnoconv('Firstname').'-'.$langs->transnoentitiesnoconv('Lastname'));
 				$err++;
 			}
 		}
 
-		if (dol_strlen(trim($this->address)) == 0) {
+		if (dol_strlen(trim((string) $this->address)) == 0) {
 			$error_string[] = $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Address'));
 			$err++;
 		}
 
-		if (dol_strlen(trim($this->zip)) == 0) {
+		if (dol_strlen(trim((string) $this->zip)) == 0) {
 			$error_string[] = $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Zip'));
 			$err++;
 		}
 
-		if (dol_strlen(trim($this->town)) == 0) {
+		if (dol_strlen(trim((string) $this->town)) == 0) {
 			$error_string[] = $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('Town'));
 			$err++;
 		}
 
-		if (dol_strlen(trim($this->email)) == 0) {
+		if (dol_strlen(trim((string) $this->email)) == 0) {
 			$error_string[] = $langs->trans('ErrorFieldRequired', $langs->transnoentitiesnoconv('EMail'));
 			$err++;
 		}
@@ -543,9 +543,9 @@ class Don extends CommonObject
 		$sql .= ", note_public=".(!empty($this->note_public) ? ("'".$this->db->escape($this->note_public)."'") : "NULL");
 		$sql .= ", datedon='".$this->db->idate($this->date)."'";
 		$sql .= ", date_valid=".($this->date_valid ? "'".$this->db->idate($this->date)."'" : "null");
-		$sql .= ", email='".$this->db->escape(trim($this->email))."'";
-		$sql .= ", phone='".$this->db->escape(trim($this->phone))."'";
-		$sql .= ", phone_mobile='".$this->db->escape(trim($this->phone_mobile))."'";
+		$sql .= ", email='".$this->db->escape(trim((string) $this->email))."'";
+		$sql .= ", phone='".$this->db->escape(trim((string) $this->phone))."'";
+		$sql .= ", phone_mobile='".$this->db->escape(trim((string) $this->phone_mobile))."'";
 		$sql .= ", fk_statut=".((int) $this->status);
 		$sql .= " WHERE rowid = ".((int) $this->id);
 


### PR DESCRIPTION
## Summary

Same fix as #40137, #40191, #40350, #40351 and #40352: `Don`'s `societe`, `lastname`, `firstname`, `address`, `zip`, `town`, `email`, `phone` and `phone_mobile` are all untyped or undeclared-dynamic properties, defaulting to `null`, so passing them straight to `trim()` in `check()` and `update()` triggers PHP 8.1+'s deprecation:

> trim(): Passing null to parameter #1 ($string) of type string is deprecated

### Scope note

The same 3 properties (`email`, `phone`, `phone_mobile`) are trimmed a second time in `create()`, but those calls are already guarded by `!empty($this->prop) ? trim(...) : ""` ternaries and are unaffected — only the unconditional calls in `check()` (validation) and `update()` (SQL building) needed the cast.

### Fix

Cast the 10 unguarded call sites to `trim((string) $this->...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
