### PR TITLE
FIX: Ticket::update() overwrites timing with type/category/severity_code instead of trimming them

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1076,15 +1076,15 @@ class Ticket extends CommonObject
 		}
 
 		if (isset($this->type_code)) {
-			$this->timing = trim($this->type_code);
+			$this->type_code = trim($this->type_code);
 		}
 
 		if (isset($this->category_code)) {
-			$this->timing = trim($this->category_code);
+			$this->category_code = trim($this->category_code);
 		}
 
 		if (isset($this->severity_code)) {
-			$this->timing = trim($this->severity_code);
+			$this->severity_code = trim($this->severity_code);
 		}
 		if (isset($this->model_pdf)) {
 			$this->model_pdf = trim($this->model_pdf);


### PR DESCRIPTION
## Summary

Found while auditing `ticket.class.php` for the PHP 8.1 `trim(null)` deprecation pattern from #40137/#40191/#40350/#40351/#40352/#40353. In this particular file none of the 24 `trim()` call sites needed a `(string)` cast — they're all already `isset()`-guarded, or come from `explode()` results (which never yield `null`) — but the audit surfaced a real, separate data-corruption bug instead.

### Root cause

In `Ticket::update()`:

```php
if (isset($this->type_code)) {
    $this->timing = trim($this->type_code);
}

if (isset($this->category_code)) {
    $this->timing = trim($this->category_code);
}

if (isset($this->severity_code)) {
    $this->timing = trim($this->severity_code);
}
```

All 3 blocks assign their trimmed result into `$this->timing` instead of back into their own property. The UPDATE SQL built just below (lines 1113-1116) writes `timing`, `type_code`, `category_code` and `severity_code` each from its own respective `$this->` property, so the practical effect on any update touching one of these fields is:

- `type_code`/`category_code`/`severity_code` are never actually trimmed before being persisted.
- `$this->timing` gets silently overwritten with whichever of the three was set last (`severity_code`, if set), so the wrong value gets saved to the `timing` column — even when the caller never touched `timing` at all.

The identical block in `create()` (a few hundred lines above) does this correctly, assigning each trimmed value back to its own property — this `update()` copy just diverged from it.

### Fix

Assign each trimmed value back to its own property (`type_code`, `category_code`, `severity_code`), matching `create()`.

### Test plan
- [x] `php -l htdocs/ticket/class/ticket.class.php`
- [x] `phpstan analyze htdocs/ticket/class/ticket.class.php` → 0 errors
- [x] Local pre-commit hooks (PHPStan, Phan, PHP CodeSniffer) pass
- [ ] Manually verify: update a ticket's type/category/severity, confirm `timing` is no longer altered and the 3 code fields are trimmed as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)