### PR TITLE
FIX: Use currentToken() instead of newToken() for QuickMemo AJAX calls

### DIFF
--- a/htdocs/quickmemo/class/memo.class.php
+++ b/htdocs/quickmemo/class/memo.class.php
@@ -1660,7 +1660,7 @@ class Memo extends CommonObject
 			'elementId' => 0,
 			'elementType' => '',
 			'context' => null,
-			'token' => newToken(),
+			'token' => currentToken(),
 			'colors' => Memo::getColorPreset(),
 			'userReadRight' => $user->hasRight('quickmemo', 'memo', 'read'),
 			'userWriteRight' => $user->hasRight('quickmemo', 'memo', 'write'),


### PR DESCRIPTION
## Summary
- QuickMemo's `interface.php` sets `NOTOKENRENEWAL` because it is called via same-page AJAX requests (notes list, create/update/delete, position updates, etc.).
- Per the convention documented on `currentToken()` ("For ajax call, you must use this token... the called ajax php page must also set constant NOTOKENRENEWAL"), and as already done by core's own `takepos` module, the token embedded for such calls must be `currentToken()` (`$_SESSION['token']`, valid for the current page), not `newToken()` (`$_SESSION['newtoken']`, reserved for the next page's form submissions).
- `Memo::loadQuickMemoJsInterface()` was using `newToken()`, which caused intermittent CSRF "invalid token" rejections (logged as `Access to POST /quickmemo/interface.php refused by CSRF protection (invalid token)`) when the widget tried to load/save notes, most noticeably right after login.

## Test plan
- [x] Reproduced the CSRF rejection in `dolibarr.log` before the fix.
- [x] Applied the one-line fix (`newToken()` -> `currentToken()`).
- [x] Confirmed the same POST to `/quickmemo/interface.php?action=list` no longer triggers a CSRF rejection in the log.
- [x] `php -l` on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)