### PR TITLE
SEC: port the AI assistant CRUD/CSRF hardening of #39393 to develop

### DIFF
--- a/htdocs/ai/assistant/download_pdf.php
+++ b/htdocs/ai/assistant/download_pdf.php
@@ -33,6 +33,7 @@ require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/ai/lib/ai.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/includes/tecnickcom/tcpdf/tcpdf.php';
 
 // Security check
@@ -41,6 +42,15 @@ if (!isModEnabled('ai') || !getDolGlobalString('AI_ASSISTANT_ENABLED')) {
 }
 
 global $user, $langs;
+
+// Same per-user gate as the assistant page and the other assistant endpoints
+if (!$user->hasRight('ai', 'assistant', 'use')) {
+	accessforbidden();
+}
+
+// Must not be reachable from another site
+aiCheckCsrfToken('ai/assistant/download_pdf.php');
+
 $langs->loadLangs(array('products', 'stocks', 'suppliers', 'companies', 'margins', 'bills', 'main', 'reports@reports'));
 
 /**

--- a/htdocs/ai/assistant/execute_tool.php
+++ b/htdocs/ai/assistant/execute_tool.php
@@ -35,12 +35,15 @@ if (!defined('NOREQUIREHTML')) {
 if (!defined('NOREQUIREAJAX')) {
 	define('NOREQUIREAJAX', 1);
 }
-if (!defined('NOCSRFCHECK')) {		// TODO Enable the CSRF check
+// The payload is read from the raw php://input body, so the CSRF token cannot be checked by
+// main.inc.php. It is checked explicitly below by aiCheckCsrfToken().
+if (!defined('NOCSRFCHECK')) {
 	define('NOCSRFCHECK', 1);
 }
 
 require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT . '/ai/class/mcp.class.php';
+require_once DOL_DOCUMENT_ROOT . '/ai/lib/ai.lib.php';
 
 // Security check
 if (!isModEnabled('ai') || !getDolGlobalString('AI_ASSISTANT_ENABLED')) {
@@ -53,6 +56,10 @@ global $db, $user, $conf;
 if (!$user->hasRight('ai', 'assistant', 'use')) {
 	accessforbidden();
 }
+
+// This endpoint creates, updates and deletes documents, so it must not be reachable from
+// another site. Must stay after the login is done by main.inc.php (the session is needed).
+aiCheckCsrfToken('ai/assistant/execute_tool.php');
 
 top_httphead('application/json');
 

--- a/htdocs/ai/assistant/parse_intent.php
+++ b/htdocs/ai/assistant/parse_intent.php
@@ -37,7 +37,9 @@ if (!defined('NOREQUIREHTML')) {
 if (!defined('NOREQUIREAJAX')) {
 	define('NOREQUIREAJAX', 1);
 }
-if (!defined('NOCSRFCHECK')) {		// TODO Enable the CSRF check
+// The payload is read from the raw php://input body, so the CSRF token cannot be checked by
+// main.inc.php. It is checked explicitly below by aiCheckCsrfToken().
+if (!defined('NOCSRFCHECK')) {
 	define('NOCSRFCHECK', 1);
 }
 
@@ -61,6 +63,10 @@ global $db, $user, $conf, $langs;
 if (!$user->hasRight('ai', 'assistant', 'use')) {
 	accessforbidden();
 }
+
+// This endpoint sends data to the LLM provider on behalf of the user and can chain tool
+// executions, so it must not be reachable from another site.
+aiCheckCsrfToken('ai/assistant/parse_intent.php');
 
 ob_start();
 top_httphead('application/json');

--- a/htdocs/ai/lib/ai.lib.php
+++ b/htdocs/ai/lib/ai.lib.php
@@ -937,3 +937,62 @@ function getAiChatAssistantHtml($mode = 'page')
 
 	return $out;
 }
+
+/**
+ * Check the anti-CSRF token of a request sent to one of the AI Assistant endpoints.
+ *
+ * The check cannot be delegated to main.inc.php for those endpoints:
+ *  - it only runs when MAIN_SECURITY_CSRF_WITH_TOKEN is enabled (it is optional),
+ *  - it reads the token from $_GET/$_POST only,
+ *  - and when the token is present but invalid it merely clears $_POST, which does not
+ *    protect an endpoint reading its payload from the raw php://input body.
+ *
+ * The token is read from the X-CSRF-Token header, then from the 'token' parameter (the chat
+ * frontend appends it to the endpoint URL, see getAiChatAssistantConfig() and epUrl() in
+ * ai/js/ai_assistant.js). It is compared to both session tokens because the endpoints define
+ * NOTOKENRENEWAL and therefore never rotate them: 'newtoken' is the value handed to the
+ * frontend by newToken(), 'token' is the value it has been promoted to by a page that does
+ * rotate. Both are legitimate for a call issued from a page of the current session.
+ * (Port of #39393 to develop.)
+ *
+ * @param	string	$context	Endpoint name, used for logging only
+ * @return	void				Emits a 403 JSON response and exits when the token is invalid
+ */
+function aiCheckCsrfToken($context = '')
+{
+	$token = '';
+	if (!empty($_SERVER['HTTP_X_CSRF_TOKEN'])) {
+		$token = (string) $_SERVER['HTTP_X_CSRF_TOKEN'];
+	} else {
+		$token = GETPOST('token', 'alpha');
+	}
+
+	$sessiontokens = array();
+	if (!empty($_SESSION['token'])) {
+		$sessiontokens[] = (string) $_SESSION['token'];
+	}
+	if (!empty($_SESSION['newtoken'])) {
+		$sessiontokens[] = (string) $_SESSION['newtoken'];
+	}
+
+	$valid = false;
+	foreach ($sessiontokens as $sessiontoken) {
+		if (!empty($token) && hash_equals($sessiontoken, $token)) {
+			$valid = true;
+			break;
+		}
+	}
+
+	if (!$valid) {
+		dol_syslog(
+			'[AI] Request to '.($context !== '' ? $context : $_SERVER['PHP_SELF'])
+			.' refused by CSRF protection (invalid or missing token).',
+			LOG_WARNING
+		);
+
+		http_response_code(403);
+		header('Content-Type: application/json');
+		echo json_encode(array('error' => 'Invalid CSRF token'));
+		exit;
+	}
+}

--- a/htdocs/ai/tools/crud_objects.class.php
+++ b/htdocs/ai/tools/crud_objects.class.php
@@ -129,20 +129,95 @@ class ToolCrudObjects extends McpTool
 	];
 
 	/**
-	 * Permission map for CRUD operations.
-	 * Maps object types to their required Dolibarr permission (module, permission).
+	 * Permission map for write (create/update) operations.
 	 *
-	 * @var array<string, array{0:string, 1:string}>
+	 * Each object type maps to a list of alternative permissions, given as
+	 * (module, level1[, level2]); holding any of them is enough. Purchase orders and vendor
+	 * invoices need two alternatives because their permissions exist in two namespaces since
+	 * v24: the legacy 'fournisseur' one and the one of the modSupplierOrder / modSupplierInvoice
+	 * modules they have been split into. The core does the same, see the computation of
+	 * $permissiontoadd in fourn/commande/list.php. (Port of #39393 to develop.)
+	 *
+	 * @var array<string, array<int, array{0:string, 1:string, 2?:string}>>
 	 */
 	private const PERM_MAP = [
-		'proposal'          => ['propal', 'creer'],
-		'order'             => ['commande', 'creer'],
-		'invoice'           => ['facture', 'creer'],
-		'supplier_proposal' => ['supplier_proposal', 'creer'],
-		'supplier_order'    => ['fournisseur', 'commande'],
-		'supplier_invoice'  => ['fournisseur', 'facture'],
-		'shipment'          => ['expedition', 'creer'],
-		'reception'         => ['reception', 'creer'],
+		'proposal'          => [['propal', 'creer']],
+		'order'             => [['commande', 'creer']],
+		'invoice'           => [['facture', 'creer']],
+		'supplier_proposal' => [['supplier_proposal', 'creer']],
+		'supplier_order'    => [['fournisseur', 'commande', 'creer'], ['supplier_order', 'creer']],
+		'supplier_invoice'  => [['fournisseur', 'facture', 'creer'], ['supplier_invoice', 'creer']],
+		'shipment'          => [['expedition', 'creer']],
+		'reception'         => [['reception', 'creer']],
+	];
+
+	/**
+	 * Permission map for delete operations.
+	 * A write permission must never be enough to delete a record, so deletion is checked
+	 * against its own dedicated permission. Same two-namespaces remark as PERM_MAP.
+	 *
+	 * @var array<string, array<int, array{0:string, 1:string, 2?:string}>>
+	 */
+	private const DELETE_PERM_MAP = [
+		'proposal'          => [['propal', 'supprimer']],
+		'order'             => [['commande', 'supprimer']],
+		'invoice'           => [['facture', 'supprimer']],
+		'supplier_proposal' => [['supplier_proposal', 'supprimer']],
+		'supplier_order'    => [['fournisseur', 'commande', 'supprimer'], ['supplier_order', 'supprimer']],
+		'supplier_invoice'  => [['fournisseur', 'facture', 'supprimer'], ['supplier_invoice', 'supprimer']],
+		'shipment'          => [['expedition', 'supprimer']],
+		'reception'         => [['reception', 'supprimer']],
+	];
+
+	/**
+	 * Parameters used to call restrictedArea() on an already fetched object, so that the
+	 * entity and the thirdparty restrictions of the user are enforced on that object.
+	 *
+	 * 'feature' mirrors the restrictedArea() calls made by the matching card.php pages.
+	 * 'tableandshare' must always be provided here: restrictedArea() does not fall back to
+	 * the feature name, and checkUserAccessToObject() needs the table to run its entity
+	 * check when the multicompany module is enabled.
+	 *
+	 * @var array<string, array{feature:string, tableandshare:string}>
+	 */
+	private const ACCESS_MAP = [
+		'proposal'          => ['feature' => 'propal',            'tableandshare' => 'propal'],
+		'order'             => ['feature' => 'commande',          'tableandshare' => 'commande'],
+		'invoice'           => ['feature' => 'facture',           'tableandshare' => 'facture'],
+		'supplier_proposal' => ['feature' => 'supplier_proposal', 'tableandshare' => 'supplier_proposal'],
+		'supplier_order'    => ['feature' => 'fournisseur',       'tableandshare' => 'commande_fournisseur'],
+		'supplier_invoice'  => ['feature' => 'fournisseur',       'tableandshare' => 'facture_fourn'],
+		'shipment'          => ['feature' => 'expedition',        'tableandshare' => 'expedition'],
+		'reception'         => ['feature' => 'reception',         'tableandshare' => 'reception'],
+	];
+
+	/**
+	 * Whitelist of header properties that a caller is allowed to set on a document.
+	 *
+	 * The header comes from an LLM or from an external MCP client, so it must never be
+	 * assigned to the object as-is: properties such as 'id', 'entity', 'ref' or
+	 * 'fk_user_author' would otherwise be attacker controlled. In particular, setting both
+	 * 'id' and 'entity' makes setEntity() (called by every create() method) honor the
+	 * submitted entity, which allows creating a document inside another entity.
+	 *
+	 * Keys listed here are the ones advertised by getDefinitions() (including the develop
+	 * additions 'ref_supplier' and the 'create_missing_products' behavior flag), plus every
+	 * per-type date field declared in $this->map.
+	 *
+	 * @var array<int, string>
+	 */
+	private const ALLOWED_HEADER_FIELDS = [
+		'socid',
+		'note',
+		'note_public',
+		'note_private',
+		'duree_validite',
+		'ref_supplier',
+		'create_missing_products',	// behavior flag, filtered out before property assignment
+		// Date fields, generic name and per object type name (see $this->map)
+		'date',
+		'datep',
+		'date_commande',
 	];
 
 	/**
@@ -419,6 +494,8 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 	 */
 	private function createDocument(array $args)
 	{
+		global $conf;
+
 		$type = (string) $args['object_type'];
 
 		// Validate type against map
@@ -444,13 +521,46 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 		/** @var array{class: string, path: string, card: string, date_field: string, soc_field: string} $confMap */
 		$confMap = $this->map[$type];
 
+		if (empty($args['header']) || ! is_array($args['header'])) {
+			return ["error" => "Missing or invalid header for object type: " . $type];
+		}
+
+		// Drop every header property that is not explicitly allowed. The header is produced by
+		// an LLM or by an external MCP client, so an unfiltered assignment would let the caller
+		// overwrite 'id', 'entity', 'ref', 'fk_user_author', 'total_ttc', ... on the object.
+		$header = array_intersect_key($args['header'], array_flip(self::ALLOWED_HEADER_FIELDS));
+
+		$rejectedfields = array_diff(array_keys($args['header']), array_keys($header));
+		if (! empty($rejectedfields)) {
+			dol_syslog(
+				'[ToolCrudObjects] Ignored non allowed header fields for ' . $type . ': '
+				. implode(', ', array_map('strval', $rejectedfields)),
+				LOG_WARNING
+			);
+		}
+
+		// A thirdparty is always required to build a document
+		if (empty($header['socid'])) {
+			return ["error" => "Missing socid in header for object type: " . $type];
+		}
+
+		// An external user must not be able to create a document for another thirdparty
+		if ($this->user->socid > 0 && $this->user->socid != (int) $header['socid']) {
+			dol_syslog(
+				'[ToolCrudObjects] User id=' . $this->user->id . ' (socid=' . $this->user->socid
+				. ') tried to create a ' . $type . ' for socid=' . ((int) $header['socid']) . '.',
+				LOG_WARNING
+			);
+			return ["error" => "Access denied to this thirdparty."];
+		}
+
 		// Instantiate the specific Dolibarr class (Propal, Commande, etc.)
 		// We treat it as 'mixed' or generic object here to allow dynamic property assignment
 		$obj = $this->instantiate($type);
 
 		// Process Header with Field Mapping
-		$createMissingProducts = ! empty($args['header']['create_missing_products']);
-		foreach ($args['header'] as $k => $v) {
+		$createMissingProducts = ! empty($header['create_missing_products']);
+		foreach ($header as $k => $v) {
 			$key = (string) $k;
 
 			// Behavior flag, not an object property
@@ -465,7 +575,7 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 			// Map 'socid' to specific soc field
 			if ($key === 'socid' && isset($confMap['soc_field'])) {
 				$key = $confMap['soc_field'];
-				$obj->fk_soc = $v; // Standard Dolibarr field for thirdparty linkage
+				$obj->fk_soc = (int) $v; // Standard Dolibarr field for thirdparty linkage
 			}
 
 			// Convert date strings to timestamp if needed
@@ -494,6 +604,13 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 		if ($type === 'proposal' && empty($obj->duree_validite)) {
 			$obj->duree_validite = 15;
 		}
+
+		// Belt and braces: the whitelist above already filters them out, but a new document must
+		// never carry an id nor an entity coming from the caller. setEntity(), called by every
+		// create() method, returns $currentobject->entity as soon as the object has both an id
+		// and an entity, which would create the document inside the submitted entity.
+		$obj->id = 0;
+		$obj->entity = $conf->entity;
 
 		// Attempt Creation
 		$id = $obj->create($this->user);
@@ -845,6 +962,13 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 			return ["success" => false, "error" => "Parent document not found with ID: " . $parentId];
 		}
 
+		// fetch() does not filter on the entity, so the parent document must be checked against
+		// the entity and the thirdparty restrictions of the user before adding a line to it.
+		$accessError = $this->checkAccessToObject($type, $obj);
+		if ($accessError !== null) {
+			return ["success" => false, "error" => $accessError['error']];
+		}
+
 		// Map Schema arguments to Helper arguments
 		// The helper expects 'product' (which can be an ID or Ref), but schema sends 'product_id'
 		if (! empty($args['product_id'])) {
@@ -960,8 +1084,8 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 		$type = (string) $args['object_type'];
 		$id = (int) $args['id'];
 
-		// Check permissions
-		$permError = $this->checkPermission($type);
+		// Check permissions. Deletion requires the delete permission, not the write one.
+		$permError = $this->checkPermission($type, 'delete');
 		if ($permError !== null) {
 			return $permError;
 		}
@@ -972,6 +1096,13 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 		// Fetch object
 		if ($obj->fetch($id) <= 0) {
 			return ["error" => "Object not found with ID: " . $id];
+		}
+
+		// fetch() does not filter on the entity, so the loaded object must be checked against
+		// the entity and the thirdparty restrictions of the user before going any further.
+		$accessError = $this->checkAccessToObject($type, $obj);
+		if ($accessError !== null) {
+			return $accessError;
 		}
 
 		// Check Status: Can only delete drafts (statut == 0)
@@ -997,18 +1128,63 @@ If user says 'order' without any qualifier, they mean a SALES ORDER - use this t
 	 * Check if the current user has permission for the given object type.
 	 *
 	 * @param   string $type  Object type key.
+	 * @param   string $mode  'write' to check the create/update permission, 'delete' to check
+	 *                        the dedicated delete permission.
 	 *
 	 * @return  array{error: string}|null  Null if allowed, error array if denied.
 	 */
-	private function checkPermission(string $type): ?array
+	private function checkPermission(string $type, string $mode = 'write'): ?array
 	{
-		if (! isset(self::PERM_MAP[$type])) {
+		$map = ($mode === 'delete' ? self::DELETE_PERM_MAP : self::PERM_MAP);
+
+		if (! isset($map[$type])) {
 			return ["error" => "Unknown type for permission check: " . $type];
 		}
-		[$module, $perm] = self::PERM_MAP[$type];
-		if (! $this->user->hasRight($module, $perm)) {
-			return ["error" => "Permission denied for action on " . $type];
+
+		// Holding any of the listed alternatives is enough
+		foreach ($map[$type] as $perm) {
+			if ($this->user->hasRight($perm[0], $perm[1], $perm[2] ?? '')) {
+				return null;
+			}
 		}
+
+		return ["error" => "Permission denied for action on " . $type];
+	}
+
+	/**
+	 * Check that the current user is allowed to work on an already fetched object.
+	 *
+	 * fetch() selects on the rowid only and does not filter on the entity, so a bare fetch()
+	 * is an IDOR: it happily returns a record of another entity or of a thirdparty the user
+	 * has no access to. restrictedArea() called with $mode = 1 returns 0/1 instead of
+	 * emitting an HTML error page, which is what we need in this JSON API context.
+	 *
+	 * @param   string       $type    Object type key.
+	 * @param   CommonObject $object  Object already loaded with fetch().
+	 *
+	 * @return  array{error: string}|null  Null if allowed, error array if denied.
+	 */
+	private function checkAccessToObject(string $type, CommonObject $object): ?array
+	{
+		if (! isset(self::ACCESS_MAP[$type])) {
+			return ["error" => "Unknown type for access check: " . $type];
+		}
+
+		$access = self::ACCESS_MAP[$type];
+
+		// Pass the object itself (not its id) so restrictedArea() can derive $feature2 from
+		// $object->element for the objects of the 'fournisseur' module.
+		$ok = restrictedArea($this->user, $access['feature'], $object, $access['tableandshare'], '', 'fk_soc', 'rowid', 0, 1);
+
+		if ($ok <= 0) {
+			dol_syslog(
+				'[ToolCrudObjects] Access denied to ' . $type . ' id=' . $object->id
+				. ' for user id=' . $this->user->id . ' (entity or thirdparty restriction).',
+				LOG_WARNING
+			);
+			return ["error" => "Access denied to this " . $type . "."];
+		}
+
 		return null;
 	}
 


### PR DESCRIPTION
## What

Manual port to `develop` of @atm-maxime's #39393 (based on 24.0) — the AI files have diverged too much for a cherry-pick, but the design is entirely his. The vulnerability was verified real on develop by @momodemo333 ([his test](https://github.com/Dolibarr/dolibarr/pull/39393#issuecomment-5618770314)): a user holding `facture/lire` + `facture/creer` but **not** `facture/supprimer` could delete a draft invoice through the `delete_object` tool.

### crud_objects.class.php
- **Dedicated `DELETE_PERM_MAP`**: a write permission is no longer enough to delete; each type checks its own `supprimer` permission
- **Permission alternatives** for purchase orders / vendor invoices (legacy `fournisseur` namespace + the split `supplier_order`/`supplier_invoice` modules, mirroring `$permissiontoadd` in `fourn/commande/list.php`)
- **`restrictedArea()` on every fetched object** (create / add_line_item / delete): `fetch()` selects on rowid only, so a bare fetch is an IDOR across entities and thirdparty restrictions
- **Header field whitelist**: the header comes from an LLM or an external MCP client — unfiltered assignment let a caller set `id`, `entity`, `ref`, `fk_user_author`, `total_ttc`… (with `id`+`entity`, `setEntity()` even creates the document inside the submitted entity). Develop-specific fields (`ref_supplier`, `create_missing_products`) are kept
- External-user `socid` guard, belt-and-braces `id=0`/`entity=$conf->entity` before `create()`

### CSRF (parse_intent, execute_tool, download_pdf)
`aiCheckCsrfToken()` in ai.lib.php, enforced on the three endpoints — their payload is read from raw `php://input`, so main.inc.php's optional CSRF check cannot protect them. No frontend change: the chat already appends the session token to every endpoint URL (`epUrl()`). `download_pdf.php` also gains the `ai/assistant/use` per-user gate it lacked.

## Tested

Live on a v25 instance:
- header injection (`entity=999`, `ref='HACK999'`, `total_ttc=123456`) → document created with `ref=(PROV…)`, `entity=1`, `total_ttc=0`, rejected fields logged
- `delete_object` with a user holding `lire`+`creer` but not `supprimer` → **refused**; same call with the delete permission → works (drafts only, unchanged)
- valid-token CSRF path passes; the chat flow is untouched

Refs #39393 — closing the develop side of it; the 24.0 PR remains the authority for 24.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
