### PR TITLE
FIX Payment card shows the technical error page for a deleted payment

### DIFF
--- a/htdocs/compta/paiement/card.php
+++ b/htdocs/compta/paiement/card.php
@@ -7,6 +7,7 @@
  * Copyright (C) 2015	   Juanjo Menent		 <jmenent@2byte.es>
  * Copyright (C) 2024-2026	MDW						<mdeweerd@users.noreply.github.com>
  * Copyright (C) 2024-2026  Frédéric France         <frederic.france@free.fr>
+ * Copyright (C) 2026		Jose Martinez			<jose.martinez@pichinov.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/htdocs/compta/paiement/card.php
+++ b/htdocs/compta/paiement/card.php
@@ -283,8 +283,7 @@ $thirdpartystatic = new Societe($db);
 
 $result = $object->fetch($id, $ref);
 if ($result <= 0) {
-	dol_print_error($db, 'Payment '.$id.' not found in database');
-	exit;
+	recordNotFound('', 0);
 }
 
 $form = new Form($db);


### PR DESCRIPTION
## Bug

Opening or refreshing the card of a payment that no longer exists (typically a tab left open while the payment gets deleted elsewhere, or a stale link) renders the **full technical error page** — "Dolibarr has detected a technical error", server details, modules list — for a perfectly ordinary situation.

`compta/paiement/card.php` still handles a failed fetch with `dol_print_error()`, while modern cards (`societe/card.php`, bank entries, contacts…) use `recordNotFound()` and show the clean "record not found" page.

## Fix

Use `recordNotFound('', 0)` (the header is already printed at this point). One occurrence — the rest of the payment family already behaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)