### PR TITLE
FIX: MCPServer constructor calls loadTools() on the wrong object

### DIFF
--- a/htdocs/ai/class/mcp_protocol.class.php
+++ b/htdocs/ai/class/mcp_protocol.class.php
@@ -1,6 +1,7 @@
 <?php
 /* Copyright (C) 2026	Laurent Destailleur		<eldy@users.sourceforge.net>
  * Copyright (C) 2026	Nick Fragoulis
+ * Copyright (C) 2026       Frédéric France         <frederic.france@free.fr>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,7 +76,7 @@ class MCPServer
 		// External clients (Claude Desktop, Cursor, etc.) will only see and be able to
 		// call tools that the admin has explicitly allowed for this context.
 		$this->mcpHandler = new McpHandler($this->db, $this->user, $this->conf, McpHandler::CTX_MCP_SERVER);
-		$this->loadTools();
+		$this->mcpHandler->loadTools();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- `MCPServer::__construct()` (`htdocs/ai/class/mcp_protocol.class.php`) called `$this->loadTools()`, but `loadTools()` is a method of `McpHandler`, not `MCPServer`. `MCPServer` has no such method, so instantiating it throws a fatal `Call to undefined method MCPServer::loadTools()` — breaking the MCP server entirely.
- Introduced in 5287e53ce47 ("Debug MCP"), which moved the `loadTools()` call out of `McpHandler`'s own constructor and into `MCPServer`'s constructor, but called it on the wrong object (`$this` instead of `$this->mcpHandler`).
- Also the cause of the current `phan` CI failure on `develop` (`PhanUndeclaredMethod: Call to undeclared method \MCPServer::loadTools`).
- develop only: confirmed `24.0` still has the original, unaffected code, and `23.0` doesn't have this file at all.


🤖 Generated with [Claude Code](https://claude.com/claude-code)