### PR TITLE
FIX #40317 Supplier invoice transferred into accountancy can be deleted

### DIFF
--- a/htdocs/fourn/class/api_supplier_invoices.class.php
+++ b/htdocs/fourn/class/api_supplier_invoices.class.php
@@ -343,8 +343,11 @@ class SupplierInvoices extends DolibarrApi
 			throw new RestException(404, 'Supplier invoice not found');
 		}
 
-		if ($this->invoice->delete(DolibarrApiAccess::$user) < 0) {
+		$result = $this->invoice->delete(DolibarrApiAccess::$user);
+		if ($result < 0) {
 			throw new RestException(500, 'Error when deleting invoice');
+		} elseif ($result == 0) {
+			throw new RestException(403, 'Invoice not erasable');
 		}
 
 		return array(

--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -1451,7 +1451,7 @@ class FactureFournisseur extends CommonInvoice
 	 *
 	 *  @param      User	$user		    User object
 	 *	@param	    int		$notrigger	    1=Does not execute triggers, 0= execute triggers
-	 *	@return		int						Return integer <0 if KO, >0 if OK
+	 *	@return		int						Return integer <0 if KO, 0=Refused, >0 if OK
 	 */
 	public function delete(User $user, $notrigger = 0)
 	{
@@ -1461,7 +1461,12 @@ class FactureFournisseur extends CommonInvoice
 
 		dol_syslog("FactureFournisseur::delete rowid=".$rowid, LOG_DEBUG);
 
-		// TODO Test if there is at least on payment. If yes, refuse to delete.
+		// Test to avoid invoice deletion (invoice transferred into accountancy, with payment, ...), same test as Facture::delete()
+		$result = $this->is_erasable();
+		if ($result <= 0) {
+			dol_syslog(get_class($this)."::delete refused, invoice is not erasable (code ".$result.")", LOG_WARNING);
+			return 0;
+		}
 
 		$error = 0;
 		$this->db->begin();


### PR DESCRIPTION
# FIX #40317 Supplier invoice transferred into accountancy can be deleted

`Facture::delete()` calls `is_erasable()` and refuses when the invoice was transferred into the ledger. `FactureFournisseur::delete()` never called it — the only trace was a `// TODO Test if there is at least on payment` comment at the top of the method.

The supplier invoice card hides the delete button when `is_erasable()` fails, so the screen looks protected. Every other caller went straight through: the REST API `DELETE /supplierinvoices/{id}`, scripts, external modules. The invoice disappeared and its rows in `llx_accounting_bookkeeping` stayed behind, pointing at a document that no longer exists.

The same test now runs at the top of `delete()`. It also covers the payment case the TODO described, since `is_erasable()` returns `-4` when `getSommePaiement()` is not zero.

**Why the API file is in the same PR.** `delete()` can now return `0`, as its customer counterpart already does. `api_supplier_invoices.class.php` only tested `< 0`, so a refusal would have fallen into the success branch and answered `200 Supplier invoice deleted` for an invoice still in the database — a worse report than the bug. The three lines added mirror `api_invoices.class.php` exactly. The other callers are already correct: the card checks `is_erasable()` before calling `delete()`, and the mass action treats `empty($result)` as a refusal.

## Verified on a real instance

Dolibarr **22.0.5**, MariaDB, accounting module enabled, with these two files replaced:

| case | `is_erasable()` | `delete()` | invoice |
|---|---|---|---|
| validated supplier invoice, nothing in the ledger | `2` | `1` | deleted, as before |
| same invoice with a row in `llx_accounting_bookkeeping` | `-1` | `0` | **kept** |

And through the REST API, with `DOLAPIKEY`:

| case | answer |
|---|---|
| invoice transferred into accountancy | **403** `Invoice not erasable`, invoice still present |
| invoice with nothing in the ledger | **200** `Supplier invoice deleted` |

`phpstan` level 10 with the project configuration and baseline: no error on either file. `php -l`: clean.

## Note for the reviewer

`is_erasable()` also honours `INVOICE_CAN_NEVER_BE_REMOVED` and the `isErasable` hook, which supplier invoices did not go through before. That is the same rule customer invoices already follow, and it is what makes the option mean what its name says, but it is a behaviour change for an installation that has the option set.

Targeting **22.0** as the contributing guide asks: the bug is present at least since that version, the method has never had the test.
