### PR TITLE
FIX Sales journal keeps only the last deposit when an invoice consumes several

### DIFF
--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -352,9 +352,11 @@ if ($result) {
 					while ($obj2 = $db->fetch_object($resql2)) {
 						$customerDiscount = new DiscountAbsolute($db);
 						$customerDiscount->fetch($obj2->rowid);
-						$tabCustomerDiscountHT[$obj->rowid][$accountCustomerDeposit] = -$customerDiscount->total_ht;
-						$tabCustomerDiscountVAT[$obj->rowid][$accountCustomerDepositVAT] = -$customerDiscount->total_tva;
-						$tabCustomerDiscountTTC[$obj->rowid][$compta_soc] = -$customerDiscount->total_ttc;
+						// Accumulate: an invoice can consume several deposits, and the (DEPOSIT) lines are
+						// excluded from the main query, so this reversal is their only trace in the journal.
+						$tabCustomerDiscountHT[$obj->rowid][$accountCustomerDeposit] -= $customerDiscount->total_ht;
+						$tabCustomerDiscountVAT[$obj->rowid][$accountCustomerDepositVAT] -= $customerDiscount->total_tva;
+						$tabCustomerDiscountTTC[$obj->rowid][$compta_soc] -= $customerDiscount->total_ttc;
 					}
 				}
 				$db->free($resql2);


### PR DESCRIPTION
Fixes #40374.

`sellsjournal.php` loops over the deposits an invoice consumes but assigns instead of accumulating, so only the last one is reversed:

```php
while ($obj2 = $db->fetch_object($resql2)) {
    ...
    $tabCustomerDiscountHT[$obj->rowid][$accountCustomerDeposit] = -$customerDiscount->total_ht;
```

Three things show this is an overwrite rather than intent: the query above selects **all** the deposits of the invoice (its own comment says so, and the `WHERE` matches `re.fk_facture` as well as every `re.fk_facture_line`); the three accumulators are initialised to `0` just above behind `isset()` guards, which is only meaningful for accumulation; and the `(DEPOSIT)` lines are excluded from the main query when the option is on, so this reversal is their only trace in the journal.

The resulting entry stays balanced, so it passes the check at line 1130 and reaches the ledger with no error.

## Effect

Order 1 000 HT / 1 200 TTC, two deposits converted into discounts (250 HT / 300 TTC, then 200 HT / 240 TTC), final invoice 660 TTC:

| account | written | expected |
|---|---|---|
| 411 | 960 | 660 |
| 4191 | 200 debit | 450 debit |
| 44571 | 160 | 110 |

Account 411 overstated by 300, 250 of credit left on the deposit account, collected VAT in the ledger overstated by 50.

## Scope

`tabCustomerDiscountHT` is absent from 21.0, 22.0 and 23.0 — the feature arrived in 24.0, checked on each branch — so this targets 24.0 and forward merges to develop.

Two deposits on one invoice is ordinary in construction work: one at order, one during the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)