### PR TITLE
FIX Monthly asset depreciation mixes real days with a conventional 30 day month

### DIFF
--- a/htdocs/asset/class/asset.class.php
+++ b/htdocs/asset/class/asset.class.php
@@ -1097,7 +1097,6 @@ class Asset extends CommonObject
 				// futures depreciation lines
 				//-----------------------------------------------------
 				$day_count_convention = getAssetDepreciationDayCountConvention();
-				$nb_days_in_month = getDolGlobalInt('ASSET_DEPRECIATION_DURATION_PER_MONTH', 30);
 				$period_amount = (float) ($fields['duration'] > 0 ? price2num($depreciation_period_amount / $fields['duration'], 'MT') : 0);
 				$first_period_found = false;
 
@@ -1136,14 +1135,13 @@ class Asset extends CommonObject
 						if ($fields['duration_type'] == 2) { // Daily
 							$depreciation_ht = $period_amount;
 						} elseif ($fields['duration_type'] == 1) { // Monthly
-							$nb_days = min($nb_days_in_month, num_between_day($begin_date, $end_date, 1));
-							if ($nb_days >= 28) {
-								$date_temp = dol_getdate($begin_date);
-								if ($date_temp['mon'] == 2) {
-									$nb_days = 30;
-								}
-							}
-							$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_month, 'MT');
+							// Same rule as the annual branch: the count of the days and the length of a full
+							// month must come from the same day count convention. Counting the real calendar
+							// days then dividing them by a conventional month of 30 made the depreciation of a
+							// partial month depend on the length of that month, and required a special case to
+							// give a full February a whole monthly amount.
+							$period_fraction = getAssetDepreciationMonthFraction($begin_date, $end_date, $day_count_convention, 'gmt');
+							$depreciation_ht = (float) price2num($period_amount * $period_fraction, 'MT');
 						} else { // Annually, taking care for adjustments to shortened or extended periods (e.g., fiscal years of 9 or 15 months)
 							// A standard fiscal year lasts 365 days, or 366 when it covers a leap day. Anything else
 							// is a shortened or an extended fiscal year (e.g. 9 or 15 months), whose depreciation is

--- a/htdocs/core/lib/asset.lib.php
+++ b/htdocs/core/lib/asset.lib.php
@@ -337,3 +337,51 @@ function getAssetDepreciationPeriodFraction($timestampStart, $timestampEnd, $con
 	// ACT_365
 	return num_between_day($timestampStart, $timestampEnd, 1) / 365;
 }
+
+/**
+ * Return the fraction of a month covered by a period, for the given day count convention.
+ *
+ * The monthly depreciation used to count the real calendar days of the period then divide them by
+ * ASSET_DEPRECIATION_DURATION_PER_MONTH, a conventional month of 30 days. Numerator and denominator
+ * came from two different systems, so the depreciation of a partial month depended on the length of
+ * that month: placed in service on the 3rd, a 31 day month gave 29/30 of the monthly amount while a
+ * 30 day month gave 28/30.
+ *
+ * @param	int		$timestampStart		Start of the period
+ * @param	int		$timestampEnd		End of the period
+ * @param	string	$convention			'THIRTY_360', 'ACT_365' or 'ACT_ACT'. Empty to use the setup.
+ * @param	string	$forcetimezone		'' to use the server timezone, 'gmt' to read the dates in GMT
+ * @return	float						Fraction of a month, between 0 and 1
+ */
+function getAssetDepreciationMonthFraction($timestampStart, $timestampEnd, $convention = '', $forcetimezone = '')
+{
+	if ($convention === '' || !array_key_exists($convention, getAssetDepreciationDayCountConventions())) {
+		$convention = getAssetDepreciationDayCountConvention();
+	}
+	if ($timestampStart > $timestampEnd) {
+		return 0.0;
+	}
+
+	$start = dol_getdate((int) $timestampStart, false, $forcetimezone);
+	$end = dol_getdate((int) $timestampEnd, false, $forcetimezone);
+
+	if ($convention == 'THIRTY_360') {
+		// Every month is 30 days long, so the last day of a month counts as its 30th. Without that
+		// rule a full February would be worth 28/30 of a monthly amount instead of a whole one.
+		$lastdayofendmonth = dol_getdate(dol_get_last_day($end['year'], $end['mon'], true), false, $forcetimezone);
+		$dayend = ($end['mday'] >= $lastdayofendmonth['mday'] ? 30 : min($end['mday'], 30));
+		$daystart = min($start['mday'], 30);
+
+		return max(0.0, min(1.0, ($dayend - $daystart + 1) / 30));
+	}
+
+	// ACT_365 and ACT_ACT: real days divided by the real length of the month, so that both sides of
+	// the ratio belong to the same system.
+	$lastdayofstartmonth = dol_getdate(dol_get_last_day($start['year'], $start['mon'], true), false, $forcetimezone);
+	$nbdaysinmonth = (int) $lastdayofstartmonth['mday'];
+	if ($nbdaysinmonth <= 0) {
+		return 0.0;
+	}
+
+	return min(1.0, num_between_day($timestampStart, $timestampEnd, 1) / $nbdaysinmonth);
+}


### PR DESCRIPTION
Fixes #40376. Continuation of #40300, which fixed the same defect family in the annual branch only.

## The defect

```php
$nb_days = min($nb_days_in_month, num_between_day($begin_date, $end_date, 1));
if ($nb_days >= 28) {
    $date_temp = dol_getdate($begin_date);
    if ($date_temp['mon'] == 2) {
        $nb_days = 30;
    }
}
$depreciation_ht = (float) price2num($period_amount * $nb_days / $nb_days_in_month, 'MT');
```

The numerator is a real calendar day count, the denominator a conventional month of 30 days. The depreciation of a partial month therefore depends on how many days that month happens to have. The February block is a partial patch of the same symptom: it gives a **full** February a whole monthly amount but leaves every partial month alone.

## The change

`getAssetDepreciationMonthFraction()` keeps both sides of the ratio in the same system, the way the annual branch now does:

- `THIRTY_360` — a month is 30 days and the last day of a month counts as its 30th, so a full February is a whole month and the 3rd of any month is the same fraction;
- `ACT_365` / `ACT_ACT` — real days divided by the **real** length of the month.

`ASSET_DEPRECIATION_DURATION_PER_MONTH` is no longer read, as `ASSET_DEPRECIATION_DURATION_PER_YEAR` stopped being read by the annual branch: it is the convention that decides, and it still resolves from the legacy yearly constant for existing installations.

## Measured

Monthly amount of 300, asset placed in service on the 3rd:

| month | before | THIRTY_360 | ACT_365 |
|---|---|---|---|
| January | 290,00 | **280,00** | 280,65 |
| February | 260,00 | **280,00** | 278,57 |
| March | 290,00 | **280,00** | 280,65 |
| April | 280,00 | **280,00** | 280,00 |

Before, the same 3rd of the month was worth anywhere between 260,00 and 290,00. With 30/360 it is 280,00 everywhere; with an actual-days convention it varies slightly, which is what that convention means.

Full months, all four: **300,00** in every convention, so the February special case is no longer needed and is removed.

## Scope

The code is identical on 24.0 and develop, but the convention constant only exists on develop, so this targets develop. The module is `experimental` before 24.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)