### PR TITLE
 FIX CSRF "Token not provided" error on "Classify abandoned" invoice button (backport to 24.0)

### DIFF
--- a/htdocs/compta/bank/card.php
+++ b/htdocs/compta/bank/card.php
@@ -77,6 +77,10 @@ $hookmanager->initHooks(array('bankcard', 'globalcard'));
 // Security check
 $id = GETPOSTINT("id") ? GETPOSTINT("id") : GETPOST('ref');
 $fieldid = GETPOSTINT("id") ? 'rowid' : 'ref';
+if ($action == 'create' || $action == 'add') {
+	// On creation, the posted ref is the ref of the record to create, not the ref of an existing record to check permission on
+	$id = '';
+}
 
 if (GETPOSTINT("id") || GETPOST("ref")) {
 	if (GETPOSTINT("id")) {


### PR DESCRIPTION
# FIX CSRF "Token not provided" error on "Classify abandoned" invoice button

  On 24.0, clicking **Classify 'Abandoned'** on a validated, unpaid customer invoice
  (`compta/facture/card.php`) or supplier invoice (`fourn/facture/card.php`) fails with:

  > Access to this page this way (POST method or GET with a sensible value for 'action'
  > parameter) is refused by CSRF protection in main.inc.php. Token not provided.

  **Cause:** the button is a GET link with `action=canceled` and no `token` parameter.
  Since v24, `MAIN_SECURITY_CSRF_WITH_TOKEN` defaults to 3, so any GET action that is not
  in the `$legitimate_actions` list of `main.inc.php` must carry a token. `canceled` is not
  in that list (and should not be: the link opens the confirmation popup), so the request is
  rejected before the page is rendered. The feature is unusable with the default setup.

  **Fix:** add `&token='.newToken()` to both links, like the neighbouring
  "Classify paid" / "Classify paid partially" buttons already do.

  This is a backport of fd938b07d87 ("Fix missing token param"), already merged in
  `develop`. The change is identical (2 files, 1 line each), so no conflict is expected
  when 24.0 is merged into develop.

  **How to reproduce (24.0, default security settings):**
  1. Create and validate a customer invoice, with no payment.
  2. Click "Classify 'Abandoned'".
  3. Blank page with the CSRF error above instead of the confirmation popup.
  Same steps on a supplier invoice.
